### PR TITLE
[Student][MBL-10249] Text submission mobius loop

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/TextSubmissionEffectHandler.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/TextSubmissionEffectHandler.kt
@@ -14,25 +14,21 @@
  *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-
 package com.instructure.student.mobius.assignmentDetails.submission
 
-import com.instructure.canvasapi2.models.CanvasContext
+import com.instructure.canvasapi2.utils.exhaustive
+import com.instructure.student.mobius.assignmentDetails.submission.ui.TextSubmissionView
+import com.instructure.student.mobius.common.ui.EffectHandler
 
-sealed class TextSubmissionEvent {
-    data class TextChanged(val text: String) : TextSubmissionEvent()
-    data class SubmitClicked(val text: String) : TextSubmissionEvent()
+class TextSubmissionEffectHandler : EffectHandler<TextSubmissionView, TextSubmissionEvent, TextSubmissionEffect>() {
+    override fun accept(effect: TextSubmissionEffect) {
+        when (effect) {
+            is TextSubmissionEffect.SubmitText -> {
+                view?.onTextSubmitted(effect.text, effect.canvasContext, effect.assignmentId)
+            }
+            is TextSubmissionEffect.InitializeText -> {
+                view?.setInitialSubmissionText(effect.text)
+            }
+        }.exhaustive
+    }
 }
-
-sealed class TextSubmissionEffect {
-    data class SubmitText(val text: String, val canvasContext: CanvasContext, val assignmentId: Long) : TextSubmissionEffect()
-    data class InitializeText(val text: String) : TextSubmissionEffect()
-}
-
-data class TextSubmissionModel(
-        val canvasContext: CanvasContext,
-        val assignmentId: Long,
-        val initialText: String? = null,
-        val failureMessage: String? = null,
-        val isSubmittable: Boolean = false
-)

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/TextSubmissionUpdate.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/TextSubmissionUpdate.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2019 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.student.mobius.assignmentDetails.submission
+
+import com.instructure.student.mobius.common.ui.UpdateInit
+import com.spotify.mobius.Effects.effects
+import com.spotify.mobius.First
+import com.spotify.mobius.Next
+
+class TextSubmissionUpdate : UpdateInit<TextSubmissionModel, TextSubmissionEvent, TextSubmissionEffect>() {
+    override fun performInit(model: TextSubmissionModel): First<TextSubmissionModel, TextSubmissionEffect> {
+        return First.first(model, setOf<TextSubmissionEffect>(TextSubmissionEffect.InitializeText(model.initialText ?: "")))
+    }
+
+    override fun update(model: TextSubmissionModel, event: TextSubmissionEvent): Next<TextSubmissionModel, TextSubmissionEffect> {
+        return when(event) {
+            is TextSubmissionEvent.TextChanged -> {
+                Next.next(model.copy(isSubmittable = event.text.isNotEmpty()))
+            }
+            is TextSubmissionEvent.SubmitClicked -> {
+                Next.dispatch(effects(TextSubmissionEffect.SubmitText(event.text, model.canvasContext, model.assignmentId)))
+            }
+        }
+    }
+}

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/ui/TextSubmissionView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/ui/TextSubmissionView.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2019 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.student.mobius.assignmentDetails.submission.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import com.instructure.canvasapi2.models.CanvasContext
+import com.instructure.student.mobius.assignmentDetails.submission.TextSubmissionEvent
+import com.instructure.student.mobius.common.ui.MobiusView
+import com.instructure.student.util.Const
+import com.spotify.mobius.functions.Consumer
+
+class TextSubmissionView(inflater: LayoutInflater, parent: ViewGroup) : MobiusView<TextSubmissionViewState, TextSubmissionEvent>(0, inflater, parent) {
+    override fun onConnect(output: Consumer<TextSubmissionEvent>) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun render(state: TextSubmissionViewState) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun onDispose() {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun applyTheme() {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    fun setInitialSubmissionText(text: String) {
+        TODO("not implemented")
+    }
+
+    fun onTextSubmitted(text: String, canvasContext: CanvasContext, assignmentId: Long) {
+        // Create the bundle in the view, so we don't leak android resources into testable classes
+        val bundle = Bundle().apply {
+            putParcelable(Const.CANVAS_CONTEXT, canvasContext)
+            putLong(Const.ASSIGNMENT_ID, assignmentId)
+            putString(Const.MESSAGE, text)
+        }
+
+        // TODO: Call submission service
+//        SubmissionService.enqueueWork(context, SubmissionAction.SUBMIT_TEXT_ENTRY, bundle)
+        // TODO: close screen (back press)
+    }
+}

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/ui/TextSubmissionViewState.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/ui/TextSubmissionViewState.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2019 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.student.mobius.assignmentDetails.submission.ui
+
+sealed class TextSubmissionViewState

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/TextSubmissionEffectHandlerTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/TextSubmissionEffectHandlerTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2019 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package com.instructure.student.test.assignment.details.submission
+
+import com.instructure.canvasapi2.models.Course
+import com.instructure.student.mobius.assignmentDetails.submission.TextSubmissionEffect
+import com.instructure.student.mobius.assignmentDetails.submission.TextSubmissionEffectHandler
+import com.instructure.student.mobius.assignmentDetails.submission.TextSubmissionEvent
+import com.instructure.student.mobius.assignmentDetails.submission.ui.TextSubmissionView
+import com.spotify.mobius.functions.Consumer
+import io.mockk.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.Executors
+
+class TextSubmissionEffectHandlerTest : Assert() {
+    private val view: TextSubmissionView = mockk(relaxed = true)
+    private val eventConsumer: Consumer<TextSubmissionEvent> = mockk(relaxed = true)
+    private val effectHandler = TextSubmissionEffectHandler()
+    private val connection = effectHandler.connect(eventConsumer)
+
+    @ExperimentalCoroutinesApi
+    @Before
+    fun setup() {
+        effectHandler.view = view
+        Dispatchers.setMain(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
+    }
+
+    @Test
+    fun `SubmitText results in submission`() {
+        val text = "Some text here"
+        val assignmentId = 1234L
+        val course = Course()
+
+        connection.accept(TextSubmissionEffect.SubmitText(text, course, assignmentId))
+
+        verify(timeout = 100) {
+            view.onTextSubmitted(text, course, assignmentId)
+        }
+
+        confirmVerified(view)
+    }
+
+    @Test
+    fun `SubmitText with no view does not crash`() {
+        val text = "Some text here"
+        val assignmentId = 1234L
+        val course = Course()
+        effectHandler.view = null
+
+        connection.accept(TextSubmissionEffect.SubmitText(text, course, assignmentId))
+
+        verify(exactly = 0) {
+            view.onTextSubmitted(any(), any(), any())
+        }
+
+        confirmVerified(view)
+    }
+
+    @Test
+    fun `InitializeText results in view calling setInitialSubmissionText`() {
+        val text = "Some text"
+        connection.accept(TextSubmissionEffect.InitializeText(text))
+
+        verify(timeout = 100) {
+            view.setInitialSubmissionText(text)
+        }
+
+        confirmVerified(view)
+    }
+
+    @Test
+    fun `InitializeText with no view does not crash`() {
+        val text = "Some text"
+        effectHandler.view = null
+
+        connection.accept(TextSubmissionEffect.InitializeText(text))
+
+        verify(exactly = 0) {
+            view.setInitialSubmissionText(any())
+        }
+
+        confirmVerified(view)
+    }
+}

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/TextSubmissionUpdateTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/TextSubmissionUpdateTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2019 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.student.test.assignment.details.submission
+
+import com.instructure.canvasapi2.models.Assignment
+import com.instructure.canvasapi2.models.Course
+import com.instructure.student.mobius.assignmentDetails.submission.TextSubmissionEffect
+import com.instructure.student.mobius.assignmentDetails.submission.TextSubmissionEvent
+import com.instructure.student.mobius.assignmentDetails.submission.TextSubmissionModel
+import com.instructure.student.mobius.assignmentDetails.submission.TextSubmissionUpdate
+import com.instructure.student.test.util.matchesEffects
+import com.instructure.student.test.util.matchesFirstEffects
+import com.spotify.mobius.test.FirstMatchers
+import com.spotify.mobius.test.InitSpec
+import com.spotify.mobius.test.InitSpec.assertThatFirst
+import com.spotify.mobius.test.NextMatchers
+import com.spotify.mobius.test.UpdateSpec
+import com.spotify.mobius.test.UpdateSpec.assertThatNext
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class TextSubmissionUpdateTest : Assert() {
+    private val initSpec = InitSpec(TextSubmissionUpdate()::init)
+    private val updateSpec = UpdateSpec(TextSubmissionUpdate()::update)
+
+    private lateinit var course: Course
+    private lateinit var assignment: Assignment
+    private lateinit var initModel: TextSubmissionModel
+
+    @Before
+    fun setup() {
+        course = Course()
+        assignment = Assignment(id = 1234L, courseId = course.id)
+        initModel = TextSubmissionModel(assignmentId = assignment.id, canvasContext = course)
+    }
+
+    @Test
+    fun `Initializes with an InitializeText effect`() {
+        val text = "Some text from a save"
+        val startModel = initModel.copy(initialText = text)
+        initSpec
+                .whenInit(startModel)
+                .then(
+                        assertThatFirst(
+                                FirstMatchers.hasModel(startModel),
+                                matchesFirstEffects<TextSubmissionModel, TextSubmissionEffect>(TextSubmissionEffect.InitializeText(text))
+                        )
+                )
+    }
+
+    @Test
+    fun `TextChanged event with non empty text results in model change to isSubmittable`() {
+        val text = "Some text to submit"
+        val startModel = initModel.copy(isSubmittable = false)
+        val expectedModel = startModel.copy(isSubmittable = true)
+
+        updateSpec
+                .given(startModel)
+                .whenEvent(TextSubmissionEvent.TextChanged(text))
+                .then(
+                        assertThatNext(
+                                NextMatchers.hasModel(expectedModel)
+                        )
+                )
+    }
+
+    @Test
+    fun `TextChanged event with empty text results in model change to not isSubmittable`() {
+        val text = ""
+        val startModel = initModel.copy(isSubmittable = true)
+        val expectedModel = startModel.copy(isSubmittable = false)
+
+        updateSpec
+                .given(startModel)
+                .whenEvent(TextSubmissionEvent.TextChanged(text))
+                .then(
+                        assertThatNext(
+                                NextMatchers.hasModel(expectedModel)
+                        )
+                )
+    }
+
+    @Test
+    fun `SubmitClicked event results in SubmitText effect`() {
+        val text = "Some text to submit"
+
+        updateSpec
+                .given(initModel)
+                .whenEvent(TextSubmissionEvent.SubmitClicked(text))
+                .then(
+                        assertThatNext(
+                                matchesEffects<TextSubmissionModel, TextSubmissionEffect>(TextSubmissionEffect.SubmitText(text, course, assignment.id))
+                        )
+                )
+    }
+
+}


### PR DESCRIPTION
We don't have a submission service layer yet, but I was imagining that the view would have to start any kind of service as it holds a context. We will have to research the service layer further to get something that meets our needs. I was basing this work off of a JobIntentService, though we may need to use a foreground service so that the actions happen immediately.

Here's the example class I was thinking of:
```
class SubmissionService: JobIntentService() {

    override fun onHandleWork(intent: Intent) {
        when (intent.action) {
            SubmissionAction.SUBMIT_TEXT_ENTRY.name -> {
                val submission = apiAsync<Submission> {
                    SubmissionManager.postTextSubmission(
                            intent.getParcelableExtra(Const.CANVAS_CONTEXT),
                            intent.getLongExtra(Const.ASSIGNMENT_ID, -1),
                            intent.getStringExtra(Const.MESSAGE),
                            it)
                }
                // TODO: await submission and report back the results
            }
        }
    }

    companion object {
        private const val JOB_ID = 10249

        fun enqueueWork(context: Context, action: SubmissionAction, bundle: Bundle) {
            val intent = Intent(context, SubmissionService::class.java)
            intent.action = action.name
            intent.putExtras(bundle) // TODO: persist the bundle/action in local DB as well?

            enqueueWork(context, SubmissionService::class.java, JOB_ID, intent)
        }
    }
}

enum class SubmissionAction {
    SUBMIT_TEXT_ENTRY
}
```