### PR TITLE
[Teacher][Accessibility][MBL-11805, MBL-12179, MBL-11802, MBL-11808]: Accessibility fixes

### DIFF
--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/utils/TeacherTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/utils/TeacherTest.kt
@@ -20,12 +20,23 @@ import com.instructure.canvas.espresso.CanvasTest
 import com.instructure.teacher.BuildConfig
 import com.instructure.teacher.activities.LoginActivity
 import com.instructure.teacher.ui.pages.*
+import org.junit.Before
 
 abstract class TeacherTest : CanvasTest() {
 
     override val activityRule = TeacherActivityTestRule(LoginActivity::class.java)
 
     override val isTesting = BuildConfig.IS_TESTING
+
+    // Overriding this to turn on accessibility tests for all teacher tests
+    @Before
+    override fun preLaunchSetup() {
+        // Enable accessibility checks
+        enableAndConfigureAccessibilityChecks()
+
+        // Call the super method
+        super.preLaunchSetup()
+    }
 
     /**
      * Required for auto complete of page objects within tests

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/utils/TeacherTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/utils/TeacherTest.kt
@@ -28,16 +28,6 @@ abstract class TeacherTest : CanvasTest() {
 
     override val isTesting = BuildConfig.IS_TESTING
 
-    // Overriding this to turn on accessibility tests for all teacher tests
-    @Before
-    override fun preLaunchSetup() {
-        // Enable accessibility checks
-        enableAndConfigureAccessibilityChecks()
-
-        // Call the super method
-        super.preLaunchSetup()
-    }
-
     /**
      * Required for auto complete of page objects within tests
      */

--- a/apps/teacher/src/main/res/layout/fragment_edit_quiz_details.xml
+++ b/apps/teacher/src/main/res/layout/fragment_edit_quiz_details.xml
@@ -214,14 +214,19 @@
                 android:id="@+id/accessCodeTextInput"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:labelFor="@+id/editAccessCode"
-                android:contentDescription="@string/accessCode"
                 android:layout_marginEnd="10dp"
                 android:layout_marginStart="10dp"
                 android:layout_marginTop="16dp"
                 android:background="@android:color/transparent"
                 android:textColorHint="@color/defaultTextGray"
                 app:hintTextAppearance="@style/TextInputLabel">
+
+                <TextView
+                    android:layout_width="1dp"
+                    android:layout_height="1dp"
+                    android:visibility="gone"
+                    android:labelFor="@+id/editAccessCode"
+                    android:text="@string/accessCode"/>
 
                 <androidx.appcompat.widget.AppCompatEditText
                     android:id="@+id/editAccessCode"

--- a/apps/teacher/src/main/res/layout/view_assignment_override.xml
+++ b/apps/teacher/src/main/res/layout/view_assignment_override.xml
@@ -54,6 +54,7 @@
             android:id="@+id/removeOverride"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:minHeight="48dp"
             android:layout_gravity="top|end"
             android:text="@string/remove"
             android:paddingStart="4dp"

--- a/apps/teacher/src/main/res/layout/view_comment.xml
+++ b/apps/teacher/src/main/res/layout/view_comment.xml
@@ -14,8 +14,9 @@
 
         <de.hdodenhof.circleimageview.CircleImageView
             android:id="@+id/avatarView"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:padding="4dp"
             tools:src="@color/defaultTextGray"/>
 
         <LinearLayout

--- a/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasTest.kt
+++ b/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasTest.kt
@@ -1,10 +1,16 @@
 package com.instructure.canvas.espresso
 
+import android.content.res.Resources
+import android.util.Log
+import android.view.View
 import androidx.test.espresso.matcher.ViewMatchers
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityViewCheckResult
 import com.instructure.espresso.AccessibilityChecker
 import com.instructure.espresso.matchers.withOnlyWidthLessThan
 import com.instructure.espresso.page.InstructureTest
+import org.hamcrest.BaseMatcher
+import org.hamcrest.Description
 import org.hamcrest.Matchers
 import org.junit.Before
 
@@ -26,13 +32,68 @@ abstract class CanvasTest : InstructureTest() {
                 // Causes all views to be checked, instead of just the views with which the test interacts
                 ?.setRunChecksFromRootView(true)
 
-                // Suppress, for now, errors about overflow menus being too narrow
+                // Suppression (exclusion) rules
                 ?.setSuppressingResultMatcher(
-                        Matchers.allOf(
-                                AccessibilityCheckResultUtils.matchesViews(ViewMatchers.withContentDescription("More options")),
-                                withOnlyWidthLessThan(48)
+                        Matchers.anyOf(
+                            // Suppress issues in PsPDFKit, date/time picker
+                            isExcludedNamedView( listOf("pspdf", "_picker_", "timePicker")),
+
+                            // Suppress, for now, errors about overflow menus being too narrow
+                            Matchers.allOf(
+                                    AccessibilityCheckResultUtils.matchesViews(ViewMatchers.withContentDescription("More options")),
+                                    withOnlyWidthLessThan(48)
+                            )
                         )
 
                 )
+    }
+
+    // Very inefficient matcher that identifies views whose resource name (or the resource name
+    // of any of its ancestors up to five levels up) contains any of the strings in the "excludes" list.
+    //
+    // It would be so much more efficient if the accessibility test framework first flagged a
+    // view as bad, then asked us if we wanted to suppress it.  Then we would only have to run this
+    // logic on a few views.  But, instead, the framework asks if we want to suppress the view before
+    // it gets checked, which means that this logic will run on *all* views being tested.  :-(.
+    private fun isExcludedNamedView(excludes: List<String>) : BaseMatcher<AccessibilityViewCheckResult> {
+
+        return object: BaseMatcher<AccessibilityViewCheckResult>() {
+            override fun describeTo(description: Description?) {
+                description?.appendText("Checks whether the view's resource name is in the exclusion list")
+            }
+
+            // Matches if the view being tested, or any of its parents going up 5
+            // levels, has any of the excluded strings in its resource name.
+            override fun matches(item: Any): Boolean {
+                when(item) {
+                    is AccessibilityViewCheckResult -> {
+                        var view = item.view
+                        var upCount = 0
+                        while(view != null && upCount < 5)
+                        {
+                            try {
+                                var resourceName = view.context.resources.getResourceName(view.id)
+                                for(excludedName in excludes) {
+                                    if(resourceName.contains(excludedName)) {
+                                        //Log.v("AccessibilityExclude", "Caught $resourceName")
+                                        return true
+                                    }
+                                }
+                            }
+                            catch(e: Resources.NotFoundException) { }
+
+                            var parent = view.parent
+                            when(parent) {
+                                is View -> view = parent
+                                else -> view = null
+                            }
+                            upCount += 1
+                        }
+                        //Log.v("AccessibilityExclude", "Whiffed on ${item.view}")
+                    }
+                }
+                return false
+            }
+        }
     }
 }


### PR DESCRIPTION
There are a few things going on here:

- Now excluding/ignoring accessibility issues with pspdfkit and date/time picker.  This required a fairly horrendous hack.
- Mopped up a few random accessibility failures.
- Accessibility testing now enabled by default for Teacher tests.  (UPDATE: Backed off of this.)

I also created tickets https://instructure.atlassian.net/browse/MBL-12258 and https://instructure.atlassian.net/browse/MBL-12259 for us to revisit / actually address the accessibility problems with pspdfkit and date/time picker at a later date if we so choose.  But ignoring them for now allows us to enable accessibility testing by default for the teacher app.