### PR TITLE
[Student][MBL-12211] Force refresh on initial load of grades screen

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/adapter/GradesListRecyclerAdapter.kt
+++ b/apps/student/src/main/java/com/instructure/student/adapter/GradesListRecyclerAdapter.kt
@@ -159,6 +159,7 @@ open class GradesListRecyclerAdapter(
                 }
 
                 if (isAllGradingPeriodsSelected) {
+                    isRefresh = true
                     loadAssignment()
                     return
                 }
@@ -183,6 +184,7 @@ open class GradesListRecyclerAdapter(
                 }
 
                 // if we've made it this far, MGP is not enabled, so we do the standard behavior
+                isRefresh = true
                 loadAssignment()
             }
         }


### PR DESCRIPTION
There was an issue where assignment group weights were not being refreshed (except by unchecking the ‘what if’ grade box) and caused the grades screen to use stale weights for a long time.

There is a 'weighted course' in my sandbox that can be used to your hearts content while testing.