### PR TITLE
[Teacher][MBL-12252] Fix encoding issue when sending messages

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/presenters/AddMessagePresenter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/presenters/AddMessagePresenter.kt
@@ -31,6 +31,7 @@ import instructure.androidblueprint.FragmentPresenter
 import kotlinx.coroutines.Job
 import retrofit2.Call
 import retrofit2.Response
+import java.net.URLEncoder
 import java.util.*
 
 class AddMessagePresenter(val conversation: Conversation?, private val mParticipants: ArrayList<BasicUser>?, private val mMessages: ArrayList<Message>?, val isReply: Boolean) : FragmentPresenter<AddMessageView>() {
@@ -95,7 +96,9 @@ class AddMessagePresenter(val conversation: Conversation?, private val mParticip
             recipientIds.add(entry.destination)
         }
 
-        InboxManager.createConversation(recipientIds, message, subject, contextId, attachmentIDs, isBulk, mCreateConversationCallback)
+        val encodedMessage = URLEncoder.encode(message, "UTF-8")
+        val encodedSubject = URLEncoder.encode(subject, "UTF-8")
+        InboxManager.createConversation(recipientIds, encodedMessage, encodedSubject, contextId, attachmentIDs, isBulk, mCreateConversationCallback)
     }
 
     fun sendMessage(selectedRecipients: List<RecipientEntry>, message: String) {
@@ -121,7 +124,8 @@ class AddMessagePresenter(val conversation: Conversation?, private val mParticip
         }
 
         // Send message
-        InboxManager.addMessage(conversation?.id ?: 0, message, recipientIds, messageIds, attachmentIDs, mAddConversationCallback)
+        val encodedMessage = URLEncoder.encode(message, "UTF-8")
+        InboxManager.addMessage(conversation?.id ?: 0, encodedMessage, recipientIds, messageIds, attachmentIDs, mAddConversationCallback)
     }
 
     private val mAddConversationCallback = object : StatusCallback<Conversation>() {


### PR DESCRIPTION
This fixes an issue where line breaks were being stripped out of messages sent from Inbox in the Teacher app. The issue appears to have been introduced in [this commit](https://github.com/instructure/android-uno/pull/1908) (related to GSON and semicolon encoding). Specifically, the Inbox API was updated to specify that the message subject and body are pre-encoded - and those Strings are indeed pre-encoded in the Student app - but the Teacher app was never updated to match that behavior.

To test: Send a new message from Inbox in Teacher that includes line breaks and semicolons. The sent message should exactly match the input text.