### PR TITLE
[Canvas][Pact][MBL-12312]: Canvas Pact fixes

### DIFF
--- a/libs/canvas-api-2/build.gradle
+++ b/libs/canvas-api-2/build.gradle
@@ -136,3 +136,21 @@ dependencies {
     /* Paper No SQl Storage */
     api 'io.paperdb:paperdb:2.6'
 }
+
+// MBL-12312: I added this as a way to publish Pact contract updates.
+// Ultimately, we should do something like we did for Bridge, and
+// run this job (and populate some of these fields) from Bitrise.  But,
+// for now, if you need to re-publish these in a pinch, just fill
+// in the username/password fields manually, and increment the version.
+//
+// Define our pact-publish object
+pact {
+    publish {
+        pactDirectory = '../libs/canvas-api-2/target/pacts'
+        pactBrokerUrl = 'https://inst-pact-broker.inseng.net/'
+        pactBrokerUsername = '' // Must fill in manually
+        pactBrokerPassword = '' // Must fill in manually
+        tags = ['master']
+        version = '1.0.1'
+    }
+}

--- a/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/pact/docviewer/student/GetNoteAnnotationPact.kt
+++ b/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/pact/docviewer/student/GetNoteAnnotationPact.kt
@@ -18,6 +18,7 @@
 package com.instructure.canvasapi2.pact.docviewer.student
 
 import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody
 import au.com.dius.pact.consumer.dsl.PactDslWithProvider
 import au.com.dius.pact.model.RequestResponsePact
 import com.google.gson.GsonBuilder
@@ -39,15 +40,28 @@ class GetNoteAnnotationPact : DocViewerPact() {
             rect = arrayListOf(arrayListOf(496.33f, 750.0f), arrayListOf(505.67f, 763.33f)),
             color = "#008EE2")
 
+    private val expectedAnnotationBody = PactDslJsonBody()
+            .array("data")
+            .`object`()
+            .stringValue("id", expectedAnnotation.annotationId) // ID is the serialized name of annotationId
+            .numberValue("page", expectedAnnotation.page)
+            .booleanValue("isEditable", expectedAnnotation.isEditable)
+            .stringValue("color", expectedAnnotation.color)
+            .array("rect")
+            .array()
+            .numberValue(expectedAnnotation.rect!![0][0])
+            .numberValue(expectedAnnotation.rect!![0][1])
+            .closeArray()
+            .array()
+            .numberValue(expectedAnnotation.rect!![1][0])
+            .numberValue(expectedAnnotation.rect!![1][1])
+            .closeArray()
+            .closeArray() // close rect 2-D array
+            .closeObject() // close only object in data array
+            .closeArray() // close data array
+            .asBody()
+
     override fun createPact(builder: PactDslWithProvider): RequestResponsePact {
-        @Language("JSON")
-        val jsonObj = GsonBuilder().create().toJsonTree(expectedAnnotation).asJsonObject
-        if(jsonObj.get("deleted").asBoolean == false ) {
-            jsonObj.remove("deleted") // "deleted" should not be present if it is false.  MBL-12312.
-        }
-        val body = """
-            { "data": [ ${jsonObj.toString()} ] }
-            """
 
         return builder
                 .given("a session id")
@@ -56,7 +70,8 @@ class GetNoteAnnotationPact : DocViewerPact() {
                 .method("GET")
                 .willRespondWith()
                 .status(200)
-                .body(body)
+                .headers(mapOf("Content-Type" to "application/json; charset=utf-8")) // MBL-12312
+                .body(expectedAnnotationBody)
                 .toPact()
     }
 

--- a/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/pact/docviewer/student/GetNoteAnnotationPact.kt
+++ b/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/pact/docviewer/student/GetNoteAnnotationPact.kt
@@ -41,8 +41,12 @@ class GetNoteAnnotationPact : DocViewerPact() {
 
     override fun createPact(builder: PactDslWithProvider): RequestResponsePact {
         @Language("JSON")
+        val jsonObj = GsonBuilder().create().toJsonTree(expectedAnnotation).asJsonObject
+        if(jsonObj.get("deleted").asBoolean == false ) {
+            jsonObj.remove("deleted") // "deleted" should not be present if it is false.  MBL-12312.
+        }
         val body = """
-            { "data": [ ${GsonBuilder().create().toJson(expectedAnnotation)} ] }
+            { "data": [ ${jsonObj.toString()} ] }
             """
 
         return builder

--- a/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/pact/docviewer/student/GetSessionPact.kt
+++ b/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/pact/docviewer/student/GetSessionPact.kt
@@ -44,6 +44,7 @@ class GetSessionPact : DocViewerPact() {
                 .path("/1/sessions/some_session_id") // Must have leading slash.
                 .method("GET")
                 .willRespondWith()
+                .headers(mapOf("Content-Type" to "application/json; charset=utf-8")) // MBL-12312
                 .status(200)
                 .body(body)
                 .toPact()

--- a/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/pact/docviewer/teacher/GetNoteAnnotationPact.kt
+++ b/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/pact/docviewer/teacher/GetNoteAnnotationPact.kt
@@ -18,6 +18,7 @@
 package com.instructure.canvasapi2.pact.docviewer.teacher
 
 import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody
 import au.com.dius.pact.consumer.dsl.PactDslWithProvider
 import au.com.dius.pact.model.RequestResponsePact
 import com.google.gson.GsonBuilder
@@ -39,15 +40,28 @@ class GetNoteAnnotationPact : DocViewerPact() {
             rect = arrayListOf(arrayListOf(496.33f, 750.0f), arrayListOf(505.67f, 763.33f)),
             color = "#008EE2")
 
+    private val expectedAnnotationBody = PactDslJsonBody()
+            .array("data")
+            .`object`()
+            .stringValue("id", expectedAnnotation.annotationId) // ID is the serialized name of annotationId
+            .numberValue("page", expectedAnnotation.page)
+            .booleanValue("isEditable", expectedAnnotation.isEditable)
+            .stringValue("color", expectedAnnotation.color)
+            .array("rect")
+            .array()
+            .numberValue(expectedAnnotation.rect!![0][0])
+            .numberValue(expectedAnnotation.rect!![0][1])
+            .closeArray()
+            .array()
+            .numberValue(expectedAnnotation.rect!![1][0])
+            .numberValue(expectedAnnotation.rect!![1][1])
+            .closeArray()
+            .closeArray() // close rect 2-D array
+            .closeObject() // close only object in data array
+            .closeArray() // close data array
+            .asBody()
+
     override fun createPact(builder: PactDslWithProvider): RequestResponsePact {
-        @Language("JSON")
-        val jsonObj = GsonBuilder().create().toJsonTree(expectedAnnotation).asJsonObject
-        if(jsonObj.get("deleted").asBoolean == false ) {
-            jsonObj.remove("deleted") // "deleted" should not be present if it is false.  MBL-12312.
-        }
-        val body = """
-            { "data": [ ${jsonObj.toString()} ] }
-            """
 
         return builder
                 .given("a session id")
@@ -56,7 +70,8 @@ class GetNoteAnnotationPact : DocViewerPact() {
                 .method("GET")
                 .willRespondWith()
                 .status(200)
-                .body(body)
+                .headers(mapOf("Content-Type" to "application/json; charset=utf-8")) //MBL-12312
+                .body(expectedAnnotationBody)
                 .toPact()
     }
 

--- a/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/pact/docviewer/teacher/GetNoteAnnotationPact.kt
+++ b/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/pact/docviewer/teacher/GetNoteAnnotationPact.kt
@@ -41,8 +41,12 @@ class GetNoteAnnotationPact : DocViewerPact() {
 
     override fun createPact(builder: PactDslWithProvider): RequestResponsePact {
         @Language("JSON")
+        val jsonObj = GsonBuilder().create().toJsonTree(expectedAnnotation).asJsonObject
+        if(jsonObj.get("deleted").asBoolean == false ) {
+            jsonObj.remove("deleted") // "deleted" should not be present if it is false.  MBL-12312.
+        }
         val body = """
-            { "data": [ ${GsonBuilder().create().toJson(expectedAnnotation)} ] }
+            { "data": [ ${jsonObj.toString()} ] }
             """
 
         return builder

--- a/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/pact/docviewer/teacher/GetSessionPact.kt
+++ b/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/pact/docviewer/teacher/GetSessionPact.kt
@@ -44,6 +44,7 @@ class GetSessionPact : DocViewerPact() {
                 .path("/1/sessions/some_session_id") // Must have leading slash.
                 .method("GET")
                 .willRespondWith()
+                .headers(mapOf("Content-Type" to "application/json; charset=utf-8")) //MBL-12312
                 .status(200)
                 .body(body)
                 .toPact()


### PR DESCRIPTION
Changed encoding in Content-Type header from "UTF-8" to "utf-8".  Got rid of "deleted" field in annotation object.

As near as I can tell, this will fix the problems called out in https://instructure.atlassian.net/browse/MBL-12312.

But I'll still need some help with publishing the tweaked contracts.