### PR TITLE
[Student][MBL-12343] Support deep linking to module group in list

### DIFF
--- a/libs/recyclerview/src/main/java/com/instructure/pandarecycler/BaseExpandableRecyclerAdapter.java
+++ b/libs/recyclerview/src/main/java/com/instructure/pandarecycler/BaseExpandableRecyclerAdapter.java
@@ -429,6 +429,10 @@ public abstract class BaseExpandableRecyclerAdapter<GROUP, ITEM, VIEWHOLDER exte
         return mGroupSortedList.getGroupVisualPosition(position);
     }
 
+    public int getGroupItemPosition(long itemId) {
+        return mGroupSortedList.getGroupPosition(itemId);
+    }
+
     /**
      * See {@link GroupSortedList#isVisualGroupPosition(int)}
      * @param position

--- a/libs/recyclerview/src/main/java/com/instructure/pandarecycler/util/GroupSortedList.java
+++ b/libs/recyclerview/src/main/java/com/instructure/pandarecycler/util/GroupSortedList.java
@@ -488,6 +488,22 @@ public class GroupSortedList<GROUP, ITEM> {
     }
 
     /**
+     * @param groupId the group ID to look for
+     * @return the visible position in the adapter, or -1 if not found
+     */
+    public int getGroupPosition(long groupId) {
+        int expandedItems = 0;
+        for (int i = 0; i < mGroupObjects.size(); i++) {
+            if (getGroupId(mGroupObjects.get(i)) == groupId) {
+                return i + expandedItems;
+            } else {
+                expandedItems += calculatedChildrenCount(i);
+            }
+        }
+        return -1;
+    }
+
+    /**
      * Gets the group based on id.
      *
      * Returns {@link #GROUP_NOT_FOUND} if group doesn't exist


### PR DESCRIPTION
See ticket for test instance.
Old behavior, always opened to the top of modules when doing a deep link to the module list for a specific module.
New behavior, open the desired module to the top of the list and expand it as the default.