### PR TITLE
[Student][MBL-11329] Support viewing quizzes in submission details

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/renderPages/QuizSubmissionViewRenderPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/renderPages/QuizSubmissionViewRenderPage.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2019 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package com.instructure.student.ui.pages.renderPages
+
+import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.web.assertion.WebViewAssertions.webMatches
+import androidx.test.espresso.web.model.Atoms.getCurrentUrl
+import androidx.test.espresso.web.sugar.Web.onWebView
+import com.instructure.espresso.OnViewWithId
+import com.instructure.espresso.assertDisplayed
+import com.instructure.espresso.assertNotDisplayed
+import com.instructure.espresso.page.BasePage
+import com.instructure.espresso.waitForCheck
+import com.instructure.student.R
+import org.hamcrest.CoreMatchers.containsString
+
+class QuizSubmissionViewRenderPage : BasePage(R.id.activity_root) {
+
+    private val progressBar by OnViewWithId(R.id.webViewLoading)
+    private val webView by OnViewWithId(R.id.canvasWebView)
+
+    fun assertDisplaysProgressBar() {
+        progressBar.assertDisplayed()
+    }
+
+    fun assertDisplaysLoadedPage() {
+        webView.waitForCheck(ViewAssertions.matches(ViewMatchers.isCompletelyDisplayed()))
+        progressBar.assertNotDisplayed() // progress is hidden when webView is done loading
+    }
+
+    fun assertUrlMatches(url: String) {
+        onWebView().check(webMatches(getCurrentUrl(), containsString(url)))
+    }
+
+}

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/QuizSubmissionViewRenderTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/QuizSubmissionViewRenderTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2019 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package com.instructure.student.ui.renderTests
+
+import com.instructure.espresso.assertNotDisplayed
+import com.instructure.espresso.page.onViewWithId
+import com.instructure.student.R
+import com.instructure.student.espresso.StudentRenderTest
+import com.instructure.student.mobius.assignmentDetails.submissionDetails.content.QuizSubmissionViewFragment
+import com.instructure.student.ui.pages.renderPages.QuizSubmissionViewRenderPage
+import org.junit.Test
+
+class QuizSubmissionViewRenderTest : StudentRenderTest() {
+
+    private val url = "https://www.google.com"
+    private val page = QuizSubmissionViewRenderPage()
+
+    @Test
+    fun notDisplaysToolbar() {
+        loadPageWithUrl(url)
+        page.onViewWithId(R.id.toolbar).assertNotDisplayed()
+    }
+
+    @Test
+    fun displaysProgressBarPriorToLoading() {
+        loadPageWithUrl(url)
+        page.assertDisplaysProgressBar()
+    }
+
+    @Test
+    fun showsWebViewAndHidesProgressBarAfterLoading() {
+        loadPageWithUrl(url)
+        page.assertDisplaysLoadedPage()
+    }
+
+    @Test
+    fun linkOpensWebView() {
+        loadPageWithUrl(url)
+        page.assertUrlMatches(url)
+    }
+
+    private fun loadPageWithUrl(url: String) {
+        val fragment = QuizSubmissionViewFragment.newInstance(url)
+        activityRule.activity.loadFragment(fragment)
+    }
+
+}

--- a/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
@@ -324,7 +324,7 @@ open class InternalWebviewFragment : ParentFragment() {
     //endregion
 
     companion object {
-        private const val SHOULD_ROUTE_INTERNALLY = "shouldRouteInternally"
+        internal const val SHOULD_ROUTE_INTERNALLY = "shouldRouteInternally"
 
         fun newInstance(route: Route): InternalWebviewFragment? {
             return InternalWebviewFragment().withArgs(route.argsWithContext)

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsModels.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsModels.kt
@@ -51,11 +51,7 @@ data class SubmissionDetailsModel(
 
 sealed class SubmissionDetailsContentType {
     data class QuizContent(
-        val courseId: Long,
-        val assignmentId: Long,
-        val studentId: Long,
-        val url: String,
-        val pendingReview: Boolean
+        val url: String
     ) : SubmissionDetailsContentType()
 
     data class MediaContent(

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsUpdate.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsUpdate.kt
@@ -20,6 +20,7 @@ package com.instructure.student.mobius.assignmentDetails.submissionDetails
 import android.net.Uri
 import android.webkit.MimeTypeMap
 import com.instructure.canvasapi2.models.*
+import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.canvasapi2.utils.validOrNull
 import com.instructure.pandautils.utils.AssignmentUtils2
 import com.instructure.student.mobius.common.ui.UpdateInit
@@ -53,7 +54,6 @@ class SubmissionDetailsUpdate : UpdateInit<SubmissionDetailsModel, SubmissionDet
                         model.rootSubmission?.dataOrNull?.submissionHistory?.find { it?.attempt == event.submissionAttempt },
                         model.assignment?.dataOrNull,
                         model.canvasContext,
-                        model.assignmentId,
                         model.isArcEnabled
                     )
                     Next.next<SubmissionDetailsModel, SubmissionDetailsEffect>(
@@ -68,7 +68,6 @@ class SubmissionDetailsUpdate : UpdateInit<SubmissionDetailsModel, SubmissionDet
                     event.rootSubmission.dataOrNull,
                     event.assignment.dataOrNull,
                     model.canvasContext,
-                    model.assignmentId,
                     event.isArcEnabled)
                 Next.next(
                     model.copy(
@@ -93,7 +92,7 @@ class SubmissionDetailsUpdate : UpdateInit<SubmissionDetailsModel, SubmissionDet
         }
     }
 
-    private fun getSubmissionContentType(submission: Submission?, assignment: Assignment?, canvasContext: CanvasContext, assignmentId: Long, isArcEnabled: Boolean?): SubmissionDetailsContentType {
+    private fun getSubmissionContentType(submission: Submission?, assignment: Assignment?, canvasContext: CanvasContext, isArcEnabled: Boolean?): SubmissionDetailsContentType {
         return when {
             Assignment.SubmissionType.NONE.apiString in assignment?.submissionTypesRaw ?: emptyList() -> SubmissionDetailsContentType.NoneContent
             Assignment.SubmissionType.ON_PAPER.apiString in assignment?.submissionTypesRaw ?: emptyList() -> SubmissionDetailsContentType.OnPaperContent
@@ -128,11 +127,7 @@ class SubmissionDetailsUpdate : UpdateInit<SubmissionDetailsModel, SubmissionDet
 
                 // Quiz Submission
                 Assignment.SubmissionType.ONLINE_QUIZ -> SubmissionDetailsContentType.QuizContent(
-                        canvasContext.id,
-                        assignmentId,
-                        submission.userId,
-                        submission.previewUrl ?: "",
-                        QuizSubmission.parseWorkflowState(submission.workflowState!!) == QuizSubmission.WorkflowState.PENDING_REVIEW
+                    ApiPrefs.fullDomain + "/courses/${canvasContext.id}/quizzes/${assignment!!.quizId}/history?version=${submission.attempt}&headless=1"
                 )
 
                 // Discussion Submission

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/QuizSubmissionViewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/QuizSubmissionViewFragment.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.student.mobius.assignmentDetails.submissionDetails.content
+
+import android.os.Bundle
+import android.webkit.WebChromeClient
+import android.webkit.WebView
+import com.instructure.pandautils.utils.Const
+import com.instructure.pandautils.utils.setGone
+import com.instructure.pandautils.utils.setInvisible
+import com.instructure.pandautils.utils.setVisible
+import com.instructure.student.R
+import com.instructure.student.activity.InternalWebViewActivity
+import com.instructure.student.fragment.InternalWebviewFragment
+import kotlinx.android.synthetic.main.fragment_webview.*
+
+class QuizSubmissionViewFragment : InternalWebviewFragment() {
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        getCanvasLoading()?.setVisible() // Set visible so we can test it
+
+        canvasWebView.setInitialScale(100)
+        canvasWebView.setInvisible() // Set invisible so we can test it
+        canvasWebView.webChromeClient = object : WebChromeClient() {
+            override fun onProgressChanged(view: WebView?, newProgress: Int) {
+                super.onProgressChanged(view, newProgress)
+                if (!isAdded) return
+
+                // Update visibilities
+                if (newProgress >= 100) {
+                    getCanvasLoading()?.setGone()
+                    canvasWebView.setVisible()
+                } else {
+                    getCanvasLoading()?.announceForAccessibility(getString(R.string.loading))
+                }
+            }
+        }
+        super.onActivityCreated(savedInstanceState)
+    }
+
+    companion object {
+        fun newInstance(quizUrl: String): QuizSubmissionViewFragment {
+            return QuizSubmissionViewFragment().apply {
+                arguments = Bundle().apply {
+                    putString(Const.INTERNAL_URL, quizUrl)
+                    putBoolean(InternalWebViewActivity.HIDE_TOOLBAR, true)
+                    putBoolean(Const.AUTHENTICATE, true)
+                    putBoolean(SHOULD_ROUTE_INTERNALLY, false)
+                }
+            }
+        }
+    }
+}

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/ui/SubmissionDetailsView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/ui/SubmissionDetailsView.kt
@@ -36,6 +36,7 @@ import com.instructure.pandautils.utils.*
 import com.instructure.student.R
 import com.instructure.student.mobius.assignmentDetails.submissionDetails.SubmissionDetailsContentType
 import com.instructure.student.mobius.assignmentDetails.submissionDetails.SubmissionDetailsEvent
+import com.instructure.student.mobius.assignmentDetails.submissionDetails.content.QuizSubmissionViewFragment
 import com.instructure.student.mobius.assignmentDetails.submissionDetails.content.TextSubmissionViewFragment
 import com.instructure.student.mobius.assignmentDetails.submissionDetails.content.UrlSubmissionViewFragment
 import com.instructure.student.mobius.assignmentDetails.submissionDetails.content.emptySubmission.ui.SubmissionDetailsEmptyContentFragment
@@ -187,6 +188,7 @@ class SubmissionDetailsView(
         return when (type) {
             is SubmissionDetailsContentType.NoSubmissionContent -> SubmissionDetailsEmptyContentFragment.newInstance(type.canvasContext as Course, type.assignment, type.isArcEnabled)
             is SubmissionDetailsContentType.UrlContent -> UrlSubmissionViewFragment.newInstance(type.url, type.previewUrl)
+            is SubmissionDetailsContentType.QuizContent -> QuizSubmissionViewFragment.newInstance(type.url)
             is SubmissionDetailsContentType.TextContent -> TextSubmissionViewFragment.newInstance(type.text)
             else -> PlaceholderFragment().apply {
                 typeName = type::class.java.simpleName


### PR DESCRIPTION
We are loading a unique url here to mimic iOS and get the best user experience. It will load right to the quiz submission to let the user see their answers, rather than to the generic quiz submission page that always loads the most recent submission (even when trying to load the preview url for a previous submission).