### PR TITLE
[All][MBL-12449] Remove special 504 handling from StatusCallback

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/dialog/CanvasContextListDialog.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/dialog/CanvasContextListDialog.kt
@@ -101,7 +101,7 @@ class CanvasContextListDialog : AppCompatDialogFragment() {
                 }
 
                 updateCanvasContexts(courses, groups)
-            } catch (ignore: Exception) {
+            } catch (ignore: Throwable) {
                 if (activity != null) {
                     Toast.makeText(requireActivity(), R.string.error_occurred, Toast.LENGTH_SHORT).show()
                 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/dialog/PeopleListFilterDialog.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/dialog/PeopleListFilterDialog.kt
@@ -124,7 +124,7 @@ class PeopleListFilterDialog : AppCompatDialogFragment() {
                 }
 
                 updateCanvasContexts(sections, groups)
-            } catch (ignore: Exception) {
+            } catch (ignore: Throwable) {
                 if (activity != null) {
                     Toast.makeText(requireActivity(), R.string.error_occurred, Toast.LENGTH_SHORT).show()
                 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/MessageThreadFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/MessageThreadFragment.kt
@@ -422,6 +422,11 @@ class MessageThreadFragment : BaseSyncFragment<Message, MessageThreadPresenter, 
         }
     }
 
+    override fun onConversationLoadFailed() {
+        toast(R.string.errorOccurred)
+        activity?.onBackPressed()
+    }
+
     override fun showUserMessage(userMessageResId: Int) {
         showToast(userMessageResId)
     }

--- a/apps/teacher/src/main/java/com/instructure/teacher/presenters/MessageThreadPresenter.java
+++ b/apps/teacher/src/main/java/com/instructure/teacher/presenters/MessageThreadPresenter.java
@@ -16,9 +16,6 @@
 
 package com.instructure.teacher.presenters;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
 import com.instructure.canvasapi2.StatusCallback;
 import com.instructure.canvasapi2.apis.InboxApi;
 import com.instructure.canvasapi2.managers.InboxManager;
@@ -30,10 +27,14 @@ import com.instructure.canvasapi2.utils.LinkHeaders;
 import com.instructure.teacher.R;
 import com.instructure.teacher.viewinterface.MessageThreadView;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import instructure.androidblueprint.SyncPresenter;
 import retrofit2.Call;
 import retrofit2.Response;
@@ -132,6 +133,13 @@ public class MessageThreadPresenter extends SyncPresenter<Message, MessageThread
             if (getViewCallback() != null) {
                 getViewCallback().onRefreshFinished();
                 getViewCallback().checkIfEmpty();
+            }
+        }
+
+        @Override
+        public void onFail(@Nullable Call<Conversation> call, @NotNull Throwable error, @Nullable Response<?> response) {
+            if (getViewCallback() != null) {
+                getViewCallback().onConversationLoadFailed();
             }
         }
     };

--- a/apps/teacher/src/main/java/com/instructure/teacher/presenters/StudentContextPresenter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/presenters/StudentContextPresenter.kt
@@ -88,7 +88,7 @@ class StudentContextPresenter(
                 }
             }
         } catch { error ->
-            val isDesigner = student.enrollments.any { it.type == EnrollmentType.DESIGNERENROLLMENT }
+            val isDesigner = this::student.isInitialized && student.enrollments.any { it.type == EnrollmentType.DESIGNERENROLLMENT }
             viewCallback?.onErrorLoading(isDesigner)
             error.printStackTrace()
         }

--- a/apps/teacher/src/main/java/com/instructure/teacher/viewinterface/MessageThreadView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/viewinterface/MessageThreadView.kt
@@ -31,5 +31,5 @@ interface MessageThreadView : SyncManager<Message> {
     fun onMessageDeleted()
     fun showUserMessage(userMessageResId: Int)
     fun setupConversationDetails()
-
+    fun onConversationLoadFailed()
 }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/RequestInterceptor.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/RequestInterceptor.kt
@@ -61,11 +61,12 @@ class RequestInterceptor : Interceptor {
         // Add Accept-Language header for a11y
         builder.addHeader("accept-language", params.acceptLanguageOverride ?: acceptedLanguageString)
 
-        if (!APIHelper.hasNetworkConnection() || params.isForceReadFromCache) {
-            // Offline or only want cached data
+        if (params.isForceReadFromCache) {
+            // Only want cached data
             builder.cacheControl(CacheControl.FORCE_CACHE)
-        } else if (params.isForceReadFromNetwork) {
-            // Typical from a pull-to-refresh
+        } else if (APIHelper.hasNetworkConnection() && params.isForceReadFromNetwork) {
+            // Typical from a pull-to-refresh. We do not use this when the network is unavailable because we want
+            // requests to fall back to cached responses for a better offline experience.
             builder.cacheControl(CacheControl.FORCE_NETWORK)
         }
 

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/StatusCallback.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/StatusCallback.kt
@@ -48,12 +48,6 @@ abstract class StatusCallback<DATA> : Callback<DATA> {
                 response.raw(),
                 APIHelper.parseLinkHeaderResponse(response.headers())
             )
-            response.code() == 504 -> {
-                // Cached response does not exist.
-                Logger.e("StatusCallback: GOT A 504")
-                // No response
-                onCallbackFinished(ApiType.CACHE)
-            }
             else -> {
                 onFail(data, Throwable("StatusCallback: " + response.code() + " Error"), response)
                 if (response.code() == 401) tryOrNull {
@@ -74,6 +68,7 @@ abstract class StatusCallback<DATA> : Callback<DATA> {
         } else {
             Logger.e("StatusCallback: Failure: " + t.message)
             onFail(data, t, null)
+            onFinished(ApiType.API)
         }
     }
 

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/weave/ApiAsync.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/weave/ApiAsync.kt
@@ -40,27 +40,12 @@ fun <T> apiAsync(managerCall: ManagerCall<T>): Deferred<DataResult<T>> {
 
     val callback = object : StatusCallback<T>() {
 
-        var succeededOrFailed = false
-
         override fun onResponse(response: Response<T>, linkHeaders: LinkHeaders, type: ApiType) {
-            succeededOrFailed = true
-            if (response.isSuccessful) {
-                @Suppress("UNCHECKED_CAST")
-                deferred.complete(DataResult.Success(response.body() as T))
-            } else {
-                val failure = Failure.Exception(StatusCallbackError(response = response))
-                deferred.complete(DataResult.Fail(failure))
-            }
-        }
-
-        override fun onFinished(type: ApiType) {
-            if (!succeededOrFailed && type != ApiType.CACHE) {
-                deferred.complete(DataResult.Fail(Failure.Network("StatusCallback: 504 Error")))
-            }
+            @Suppress("UNCHECKED_CAST")
+            deferred.complete(DataResult.Success(response.body() as T))
         }
 
         override fun onFail(call: Call<T>?, error: Throwable, response: Response<*>?) {
-            succeededOrFailed = true
             val failure = if (response?.code() == 401) {
                 Failure.Authorization(response.message())
             } else {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/weave/AwaitApis.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/weave/AwaitApis.kt
@@ -27,28 +27,16 @@ import retrofit2.Response
 
 class ContinuationCallback<T>(private val continuation: CancellableContinuation<*>, private val onSuccess: SuccessCall<T>, var onError: ErrorCall = {}) : StatusCallback<T>() {
 
-    private var succeededOrFailed = false
-
     override fun onResponse(response: Response<T>, linkHeaders: LinkHeaders, type: ApiType) {
         synchronized(continuation) {
-            succeededOrFailed = true
             if (continuation.isCancelled) return
-            if (response.isSuccessful) {
-                @Suppress("UNCHECKED_CAST")
-                onSuccess(response.body() as T)
-            } else {
-                onError(StatusCallbackError(response = response))
-            }
+            @Suppress("UNCHECKED_CAST")
+            onSuccess(response.body() as T)
         }
-    }
-
-    override fun onFinished(type: ApiType) {
-        if (!succeededOrFailed && type != ApiType.CACHE) onError(StatusCallbackError())
     }
 
     override fun onFail(call: Call<T>?, error: Throwable, response: Response<*>?) {
         synchronized(continuation) {
-            succeededOrFailed = true
             if (continuation.isCancelled) return
             onError(StatusCallbackError(call, error, response))
         }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/weave/AwaitParallel.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/weave/AwaitParallel.kt
@@ -37,28 +37,16 @@ suspend fun inParallel(block: ParallelWaiter.() -> Unit) {
 
 class ParallelCallback<T>(private val managerCall: ManagerCall<T>) : StatusCallback<T>() {
 
-    private var succeededOrFailed = false
-
     var onSuccess: SuccessCall<T> = {}
 
     var onError: ErrorCall = {}
 
     override fun onResponse(response: Response<T>, linkHeaders: LinkHeaders, type: ApiType) {
-        succeededOrFailed = true
-        if (response.isSuccessful) {
-            @Suppress("UNCHECKED_CAST")
-            onSuccess(response.body() as T)
-        } else {
-            onError(StatusCallbackError(response = response))
-        }
-    }
-
-    override fun onFinished(type: ApiType) {
-        if (!succeededOrFailed && type != ApiType.CACHE) onError(StatusCallbackError())
+        @Suppress("UNCHECKED_CAST")
+        onSuccess(response.body() as T)
     }
 
     override fun onFail(call: Call<T>?, error: Throwable, response: Response<*>?) {
-        succeededOrFailed = true
         onError(StatusCallbackError(call, error, response))
     }
 


### PR DESCRIPTION
Repro:
- Install apps (student, teacher, and parent)
- Log into an account
- Kill the app and clear its cache
- Enable airplane mode on the device
- Open the app
	
Old behavior:
- Student: Only shows navigation tabs and blank pages
- Teacher: Pages load indefinitely
- Parent: Shows splash screen indefinitely

New behavior:
- Student: All pages display. Some still load indefinitely, others display empty state
- Teacher: Dashboard shows empty state, other pages still load indefinitely
- Parent: Still shows splash screen indefinitely