### PR TITLE
[Student][MBL-11098] A11y fix for expand/collapse notifications

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/adapter/AssignmentDateListRecyclerAdapter.kt
+++ b/apps/student/src/main/java/com/instructure/student/adapter/AssignmentDateListRecyclerAdapter.kt
@@ -171,7 +171,7 @@ open class AssignmentDateListRecyclerAdapter(
         }
     }
 
-    override fun contextReady() = Unit
+    override fun contextReady() {}
 
     override fun isPaginated() = false
 
@@ -200,7 +200,7 @@ open class AssignmentDateListRecyclerAdapter(
             canvasContext,
             holder as ExpandableViewHolder,
             assignmentGroup,
-            assignmentGroup.name,
+            assignmentGroup.name ?: "",
             isExpanded,
             viewHolderHeaderClicked
         )

--- a/apps/student/src/main/java/com/instructure/student/binders/ExpandableHeaderBinder.java
+++ b/apps/student/src/main/java/com/instructure/student/binders/ExpandableHeaderBinder.java
@@ -22,6 +22,8 @@ import android.animation.ObjectAnimator;
 import android.content.Context;
 import android.view.View;
 
+import android.view.accessibility.AccessibilityManager;
+import com.instructure.pandautils.utils.A11yUtilsKt;
 import com.instructure.student.R;
 import com.instructure.student.holders.ExpandableViewHolder;
 import com.instructure.canvasapi2.models.CanvasContext;
@@ -44,22 +46,26 @@ public class ExpandableHeaderBinder extends BaseBinder {
             holder.expandCollapse.setRotation(180);
         }
 
-        holder.itemView.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                viewHolderHeaderClicked.viewClicked(v, genericHeader);
-                int animationType;
-                if (holder.isExpanded) {
-                    animationType = R.animator.rotation_from_neg90_to_0;
-                } else {
-                    animationType = R.animator.rotation_from_0_to_neg90;
+        AccessibilityManager a11yManager = (AccessibilityManager) context.getSystemService(Context.ACCESSIBILITY_SERVICE);
+        // Expand/collapse is disabled when TalkBack is enabled, so we prevent TalkBack announcing that functionality by not adding a click listener
+        if (!A11yUtilsKt.getHasSpokenFeedback(a11yManager)) {
+            holder.itemView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    viewHolderHeaderClicked.viewClicked(v, genericHeader);
+                    int animationType;
+                    if (holder.isExpanded) {
+                        animationType = R.animator.rotation_from_neg90_to_0;
+                    } else {
+                        animationType = R.animator.rotation_from_0_to_neg90;
+                    }
+                    holder.isExpanded = !holder.isExpanded;
+                    final ObjectAnimator flipAnimator = (ObjectAnimator) AnimatorInflater.loadAnimator(v.getContext(), animationType);
+                    flipAnimator.setTarget(holder.expandCollapse);
+                    flipAnimator.setDuration(200);
+                    flipAnimator.start();
                 }
-                holder.isExpanded = !holder.isExpanded;
-                final ObjectAnimator flipAnimator = (ObjectAnimator) AnimatorInflater.loadAnimator(v.getContext(), animationType);
-                flipAnimator.setTarget(holder.expandCollapse);
-                flipAnimator.setDuration(200);
-                flipAnimator.start();
-            }
-        });
+            });
+        }
     }
 }


### PR DESCRIPTION
Click listeners in the notification list headers cause TalkBack to announce that the items can be 'activated', but doesn't let the user know if they've collapsed or expanded the corresponding list. 

Since expand/collapse is disabled when TalkBack is enabled this doesn't make sense to have, so here we're just not adding the click listener if TalkBack is enabled.