### PR TITLE
[Teacher][MBL-12467] Fix unread icon for announcements

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/holders/DiscussionListHolder.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/holders/DiscussionListHolder.kt
@@ -85,7 +85,7 @@ class DiscussionListHolder(view: View) : RecyclerView.ViewHolder(view) {
         val unreadDisplayCount = if (discussionTopicHeader.unreadCount > 99) context.getString(R.string.max_count)
                                  else discussionTopicHeader.unreadCount.toString()
 
-        statusIndicator.setVisible(discussionTopicHeader.unreadCount != 0)
+        statusIndicator.setVisible(discussionTopicHeader.status == DiscussionTopicHeader.ReadState.UNREAD)
 
         readUnreadCounts.text = context.getString(R.string.discussions_unread_replies_blank,
                                 context.getString(R.string.discussions_replies, entryCount.toString()),


### PR DESCRIPTION
Test Plan:
Create a new announcement (from a different account but with no replies)
Open teacher app
Navigate to announcements in the course
Verify the new announcement has an unread icon