### PR TITLE
[MBL-9020] Updated the annotation converter text size for largest font

### DIFF
--- a/libs/annotations/src/main/java/com/instructure/annotations/AnnotationConverter.kt
+++ b/libs/annotations/src/main/java/com/instructure/annotations/AnnotationConverter.kt
@@ -137,7 +137,7 @@ private fun getTextSizeFromFont(font: String?): Float{
     return when {
         font?.contains("14pt") == true -> 10f
         font?.contains("22pt") == true -> 18f
-        font?.contains("38pt") == true -> 34f
+        font?.contains("38pt") == true -> 32f
         else -> 10f
     }
 }


### PR DESCRIPTION
The fixes from web made the two smallest sizes work properly now, but the last size was still being cropped. This is the largest size that works without being cropped.