### PR TITLE
[Student][MBL-12229] File upload persistence

### DIFF
--- a/apps/student/src/main/db/com/instructure/student/FileSubmission.sq
+++ b/apps/student/src/main/db/com/instructure/student/FileSubmission.sq
@@ -57,6 +57,11 @@ SELECT *
 FROM fileSubmission
 WHERE dbSubmissionId = ?;
 
+getFilesWithoutAttachmentsForSubmissionId:
+SELECT *
+FROM fileSubmission
+WHERE dbSubmissionId = ? AND attachmentId IS NULL;
+
 deleteFilesById:
 DELETE
 FROM fileSubmission
@@ -74,7 +79,7 @@ WHERE id = ?;
 
 setAttachmentId:
 UPDATE fileSubmission
-SET attachmentId = ?
+SET attachmentId = ?, errorFlag = ?, error = ?
 WHERE id = ?;
 
 getLastInsert:

--- a/apps/student/src/main/db/com/instructure/student/FileSubmission.sq
+++ b/apps/student/src/main/db/com/instructure/student/FileSubmission.sq
@@ -1,0 +1,81 @@
+ --
+ -- Copyright (C) 2019 - present Instructure, Inc.
+ --
+ --     Licensed under the Apache License, Version 2.0 (the "License");
+ --     you may not use this file except in compliance with the License.
+ --     You may obtain a copy of the License at
+ --
+ --     http://www.apache.org/licenses/LICENSE-2.0
+ --
+ --     Unless required by applicable law or agreed to in writing, software
+ --     distributed under the License is distributed on an "AS IS" BASIS,
+ --     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ --     See the License for the specific language governing permissions and
+ --     limitations under the License.
+ --
+
+import com.instructure.canvasapi2.models.CanvasContext;
+-- import com.instructure.student.db.sqlColAdapters.Date;
+import com.instructure.student.db.sqlColAdapters.ErrorColAdapter;
+import com.instructure.pandautils.models.FileSubmitObject;
+
+CREATE TABLE fileSubmission (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    dbSubmissionId INTEGER NOT NULL,
+    attachmentId INTEGER,
+    name TEXT,
+    size INTEGER,
+    contentType TEXT,
+    fullPath TEXT,
+    error TEXT,
+    errorFlag INTEGER as Boolean NOT NULL DEFAULT 0
+);
+
+CREATE INDEX fileSubmission_dbSubmissionId ON fileSubmission(dbSubmissionId);
+
+--
+insertFile:
+INSERT INTO fileSubmission (dbSubmissionId, name, size, contentType, fullPath)
+VALUES (?, ?, ?, ?, ?);
+--
+insertFileWithError:
+INSERT INTO fileSubmission (dbSubmissionId, name, size, contentType, fullPath, error)
+VALUES (?, ?, ?, ?, ?, ?);
+--
+
+getAllFiles:
+SELECT *
+FROM fileSubmission;
+
+getFileById:
+SELECT *
+FROM fileSubmission
+WHERE id = ?;
+
+getFilesForSubmissionId:
+SELECT *
+FROM fileSubmission
+WHERE dbSubmissionId = ?;
+
+deleteFilesById:
+DELETE
+FROM fileSubmission
+WHERE id = ?;
+
+deleteFilesForSubmissionId:
+DELETE
+FROM fileSubmission
+WHERE dbSubmissionId = ?;
+
+setFileError:
+UPDATE fileSubmission
+SET errorFlag = ?, error = ?
+WHERE id = ?;
+
+setAttachmentId:
+UPDATE fileSubmission
+SET attachmentId = ?
+WHERE id = ?;
+
+getLastInsert:
+SELECT last_insert_rowid();

--- a/apps/student/src/main/db/com/instructure/student/FileSubmission.sq
+++ b/apps/student/src/main/db/com/instructure/student/FileSubmission.sq
@@ -15,7 +15,6 @@
  --
 
 import com.instructure.canvasapi2.models.CanvasContext;
--- import com.instructure.student.db.sqlColAdapters.Date;
 import com.instructure.student.db.sqlColAdapters.ErrorColAdapter;
 import com.instructure.pandautils.models.FileSubmitObject;
 
@@ -38,10 +37,6 @@ insertFile:
 INSERT INTO fileSubmission (dbSubmissionId, name, size, contentType, fullPath)
 VALUES (?, ?, ?, ?, ?);
 --
-insertFileWithError:
-INSERT INTO fileSubmission (dbSubmissionId, name, size, contentType, fullPath, error)
-VALUES (?, ?, ?, ?, ?, ?);
---
 
 getAllFiles:
 SELECT *
@@ -62,7 +57,7 @@ SELECT *
 FROM fileSubmission
 WHERE dbSubmissionId = ? AND attachmentId IS NULL;
 
-deleteFilesById:
+deleteFileById:
 DELETE
 FROM fileSubmission
 WHERE id = ?;
@@ -77,10 +72,10 @@ UPDATE fileSubmission
 SET errorFlag = ?, error = ?
 WHERE id = ?;
 
-setAttachmentId:
+setFileAttachmentIdAndError:
 UPDATE fileSubmission
 SET attachmentId = ?, errorFlag = ?, error = ?
 WHERE id = ?;
 
-getLastInsert:
+getLastInsertId:
 SELECT last_insert_rowid();

--- a/apps/student/src/main/db/com/instructure/student/Submission.sq
+++ b/apps/student/src/main/db/com/instructure/student/Submission.sq
@@ -16,7 +16,6 @@
 
 import com.instructure.canvasapi2.models.CanvasContext;
 import com.instructure.student.db.sqlColAdapters.Date;
-import com.instructure.student.db.sqlColAdapters.SubmissionFailure;
 import com.instructure.student.db.sqlColAdapters.ErrorColAdapter;
 
 CREATE TABLE submission (
@@ -29,7 +28,8 @@ CREATE TABLE submission (
     assignmentId INTEGER,
     canvasContext TEXT as CanvasContext,
     submissionType TEXT,
-    errorFlag INTEGER as Boolean NOT NULL DEFAULT 0
+    errorFlag INTEGER as Boolean NOT NULL DEFAULT 0,
+    assignmentGroupCategoryId INTEGER
 );
 --
 insertOnlineTextSubmission:
@@ -40,10 +40,9 @@ insertOnlineUrlSubmission:
 INSERT INTO submission (submissionEntry, assignmentName, assignmentId, canvasContext, submissionType)
 VALUES (?, ?, ?, ?, "online_url"); --"basic_lti_launch" else "online_url"
 --
--- insertOnlineUploadSubmission:
--- INSERT INTO submission (submission, assignmentName, assignmentId, canvasContext, submissionType)
--- VALUES (?, ?, ?, ?, "online_upload");
--- SELECT last_insert_rowid();
+insertOnlineUploadSubmission:
+INSERT INTO submission (assignmentName, assignmentId, assignmentGroupCategoryId, canvasContext, submissionType)
+VALUES (?, ?, ?, ?, "online_upload");
 
 getAllSubmissions:
 SELECT *

--- a/apps/student/src/main/java/com/instructure/student/mobius/common/ui/SubmissionService.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/common/ui/SubmissionService.kt
@@ -64,7 +64,7 @@ class SubmissionFileUploadReceiver(private val dbSubmissionId: Long) : Broadcast
                 db.submissionQueries.setSubmissionError(true, submissionId)
                 files.forEachIndexed { index, file ->
                     if (index < attachments.size) {
-                        db.fileSubmissionQueries.setAttachmentId(attachments[index].id, false, null, file.id)
+                        db.fileSubmissionQueries.setFileAttachmentIdAndError(attachments[index].id, false, null, file.id)
                     } else {
                         db.fileSubmissionQueries.setFileError(true, message, file.id)
                     }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/CanvasRestAdapter.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/CanvasRestAdapter.kt
@@ -184,7 +184,7 @@ protected constructor(var statusCallback: StatusCallback<*>?, private val authUs
             else params
     )
 
-    fun buildAdapterNoRetry(params: RestParams): Retrofit {
+    fun buildAdapterUpload(params: RestParams): Retrofit {
         val params = if (params.domain.isNullOrEmpty()) params.copy(domain = ApiPrefs.fullDomain) else params
 
         statusCallback?.onCallbackStarted()

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/FileUploadAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/FileUploadAPI.kt
@@ -21,7 +21,7 @@ import com.instructure.canvasapi2.builders.RestParams
 import com.instructure.canvasapi2.models.Attachment
 import com.instructure.canvasapi2.models.FileUploadParams
 import com.instructure.canvasapi2.models.StorageQuotaExceededError
-import okhttp3.MediaType
+import com.instructure.canvasapi2.utils.ProgressResponseBody
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import org.greenrobot.eventbus.EventBus
@@ -97,12 +97,13 @@ internal object FileUploadAPI {
             uploadParams: FileUploadParams,
             file: File,
             adapter: RestBuilder,
-            params: RestParams
+            params: RestParams,
+            dbSubmissionId: Long? = null
     ): Attachment? {
-        val requestFile = RequestBody.create(MediaType.parse("application/octet-stream"), file)
+        val requestFile = ProgressResponseBody(file, dbSubmissionId)
         val requestFilePart = MultipartBody.Part.createFormData("file", file.name, requestFile)
         return try {
-            adapter.buildNoRetry(FileUploadInterface::class.java, params)
+            adapter.buildUpload(FileUploadInterface::class.java, params)
                     .uploadFile(
                             uploadParams.uploadUrl.orEmpty(),
                             uploadParams.getPlainTextUploadParams(),

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/builders/RestBuilder.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/builders/RestBuilder.kt
@@ -61,9 +61,9 @@ class RestBuilder(callback: StatusCallback<*> = object : StatusCallback<Any>(){}
         return restAdapter.create(clazz)
     }
 
-    fun <T> buildNoRetry(clazz: Class<T>, params: RestParams): T {
+    fun <T> buildUpload(clazz: Class<T>, params: RestParams): T {
         val restParams = params.copy(isForceReadFromCache = false)
-        val restAdapter = buildAdapterNoRetry(restParams)
+        val restAdapter = buildAdapterUpload(restParams)
 
         return restAdapter.create(clazz)
     }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/FileUploadManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/FileUploadManager.kt
@@ -53,14 +53,17 @@ object FileUploadManager {
     }
 
     @JvmStatic
-    private fun performUploadSynchronous(file: File, uploadParams: FileUploadParams): Attachment? {
+    private fun performUploadSynchronous(file: File, uploadParams: FileUploadParams, dbSubmissionId: Long? = null): Attachment? {
         val adapter = RestBuilder()
         val params = RestParams(shouldIgnoreToken = true)
-        return FileUploadAPI.uploadSynchronous(uploadParams, file, adapter, params)
+        return FileUploadAPI.uploadSynchronous(uploadParams, file, adapter, params, dbSubmissionId)
     }
 
+    /**
+     * @param dbSubmissionId - An optional parameter to specify submission id to get progress updates
+     */
     @JvmStatic
-    fun uploadFileSynchronous(uploadContext: UploadContextProvider, config: FileUploadConfig): Attachment? {
+    fun uploadFileSynchronous(uploadContext: UploadContextProvider, config: FileUploadConfig, dbSubmissionId: Long? = null): Attachment? {
         if (config.parentFolderId != null && config.parentFolderPath != null) {
             throw IllegalArgumentException("Specifying both the parent folder ID and parent folder path is disallowed.")
         }
@@ -72,7 +75,7 @@ object FileUploadManager {
             config.parentFolderId,
             config.parentFolderPath,
             config.renameOnDuplicate
-        )?.let { performUploadSynchronous(File(config.filePath), it) }
+        )?.let { performUploadSynchronous(File(config.filePath), it, dbSubmissionId) }
     }
 
     @JvmStatic

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/ProgressResponseBody.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/ProgressResponseBody.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2019 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package com.instructure.canvasapi2.utils
+
+import okhttp3.MediaType
+import okhttp3.RequestBody
+import okio.*
+import org.greenrobot.eventbus.EventBus
+import java.io.File
+import java.io.FileInputStream
+
+
+class ProgressResponseBody(private val file: File, private val submissionId: Long?) :
+    RequestBody() {
+
+    override fun contentLength() = file.length()
+
+    override fun contentType() = MediaType.parse("application/octet-stream")
+
+    override fun writeTo(sink: BufferedSink) {
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        var uploaded: Long = 0
+
+        FileInputStream(file).use { stream ->
+            var read: Int = stream.read(buffer)
+            while (read != -1) {
+
+                // Send out updates if we have a submission id
+                if (submissionId != null) {
+                    val event = ProgressEvent(submissionId, uploaded, contentLength())
+                    EventBus.getDefault().postSticky(event)
+                }
+
+                uploaded += read.toLong()
+                sink.write(buffer, 0, read)
+                read = stream.read(buffer)
+            }
+        }
+    }
+}
+
+data class ProgressEvent(val submissionId: Long, val uploaded: Long, val contentLength: Long)

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/services/FileUploadService.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/services/FileUploadService.kt
@@ -137,7 +137,7 @@ class FileUploadService @JvmOverloads constructor(name: String = FileUploadServi
                 }
             }
             // Submit fileIds to the assignment
-            val attachmentsIds = attachments.map { it.id }
+            val attachmentsIds = attachments.map { it.id }.plus(bundle.getLongArray(Const.ATTACHMENTS)?.toList() ?: emptyList())
             when (action) {
                 ACTION_ASSIGNMENT_SUBMISSION -> submitAttachmentsForSubmission(courseId, assignment, attachments, attachmentsIds, bundle)
                 ACTION_DISCUSSION_ATTACHMENT -> broadcastDiscussionSuccess(notificationId, attachments)
@@ -409,12 +409,14 @@ class FileUploadService @JvmOverloads constructor(name: String = FileUploadServi
                 fileSubmitObjects: ArrayList<FileSubmitObject>,
                 courseId: Long,
                 assignment: Assignment,
-                dbSubmissionId: Long? = null
+                dbSubmissionId: Long? = null,
+                additionalAttachmentIds: ArrayList<Long>? = null
         ) = Bundle().apply {
             putParcelableArrayList(Const.FILES, fileSubmitObjects)
             putLong(Const.COURSE_ID, courseId)
             putParcelable(Const.ASSIGNMENT, assignment)
             dbSubmissionId?.let { putLong(Const.SUBMISSION, dbSubmissionId) }
+            additionalAttachmentIds?.let { putLongArray(Const.ATTACHMENTS, it.toLongArray()) }
         }
 
         @JvmStatic

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/services/FileUploadService.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/services/FileUploadService.kt
@@ -30,9 +30,12 @@ import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.Attachment
 import com.instructure.canvasapi2.models.Conversation
 import com.instructure.canvasapi2.utils.ContextKeeper
+import com.instructure.canvasapi2.utils.ProgressEvent
 import com.instructure.pandautils.R
 import com.instructure.pandautils.models.FileSubmitObject
 import com.instructure.pandautils.utils.*
+import org.greenrobot.eventbus.EventBus
+import org.greenrobot.eventbus.Subscribe
 import java.util.*
 import kotlin.collections.ArrayList
 
@@ -47,8 +50,13 @@ class FileUploadService @JvmOverloads constructor(name: String = FileUploadServi
     private var uploadCount: Int = 0
     private var isCanceled = false
 
-    lateinit private var notificationBuilder: NotificationCompat.Builder
+    private lateinit var notificationBuilder: NotificationCompat.Builder
     private val notificationManager by lazy { getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager }
+
+    override fun onCreate() {
+        super.onCreate()
+        EventBus.getDefault().register(this)
+    }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         // Handle 'cancel' action in onStartCommand instead of onHandleIntent, because threading.
@@ -62,18 +70,20 @@ class FileUploadService @JvmOverloads constructor(name: String = FileUploadServi
         
         if (isCanceled) return
 
-        val fileSubmitObjects = bundle.getParcelableArrayList<FileSubmitObject>(Const.FILES) ?: return
+        val notificationId = notificationId(bundle)
+        val fileSubmitObjects = bundle?.getParcelableArrayList<FileSubmitObject>(Const.FILES) ?: return
         val assignment = bundle.getParcelable<Assignment>(Const.ASSIGNMENT)
+        val submissionId = if (bundle.containsKey(Const.SUBMISSION)) bundle.getLong(Const.SUBMISSION) else null
 
         uploadCount = fileSubmitObjects.size
-        showNotification(uploadCount)
+        showNotification(notificationId, uploadCount)
 
         if (assignment != null && assignment.groupCategoryId != 0L) {
             // This is a group assignment, we need to get the list of groups before starting uploads
             GroupManager.getGroupsSynchronous(true)
                     .find { it.groupCategoryId == assignment.groupCategoryId }
                     ?.let { startUploads(action, fileSubmitObjects, bundle, it.id) }
-                    ?: broadcastError(getString(R.string.errorSubmittingFiles))
+                    ?: broadcastError(notificationId, getString(R.string.errorSubmittingFiles), submissionId, assignment.name)
         } else {
             startUploads(action, fileSubmitObjects, bundle, null)
         }
@@ -87,17 +97,19 @@ class FileUploadService @JvmOverloads constructor(name: String = FileUploadServi
         val quizId = bundle.getLong(Const.QUIZ)
         val position = bundle.getInt(Const.POSITION)
         val parentFolderId = if (bundle.containsKey(Const.PARENT_FOLDER_ID)) bundle.getLong(Const.PARENT_FOLDER_ID) else null
+        val notificationId = notificationId(bundle)
+        val submissionId = if (bundle.containsKey(Const.SUBMISSION)) bundle.getLong(Const.SUBMISSION) else null
 
         val attachments = mutableListOf<Attachment>()
 
         try {
             fileSubmitObjects.forEachIndexed { idx, fso ->
-                updateNotificationCount(fso.name, idx + 1)
+                updateNotificationCount(notificationId, fso.name, idx + 1)
                 val config = FileUploadConfig(fso.name, fso.fullPath, fso.size, fso.contentType)
                 when (action) {
                     ACTION_ASSIGNMENT_SUBMISSION -> {
                         val uploadContext = if (groupId == null) SubmissionUploadContext(courseId, assignment!!.id) else GroupUploadContext(groupId)
-                        attachments += FileUploadManager.uploadFileSynchronous(uploadContext, config)!!
+                        attachments += FileUploadManager.uploadFileSynchronous(uploadContext, config, submissionId)!!
                     }
                     ACTION_COURSE_FILE -> {
                         config.parentFolderId = parentFolderId
@@ -127,41 +139,53 @@ class FileUploadService @JvmOverloads constructor(name: String = FileUploadServi
             // Submit fileIds to the assignment
             val attachmentsIds = attachments.map { it.id }
             when (action) {
-                ACTION_ASSIGNMENT_SUBMISSION -> submitAttachmentsForSubmission(courseId, assignment, attachments, attachmentsIds)
-                ACTION_DISCUSSION_ATTACHMENT -> broadcastDiscussionSuccess(attachments)
-                ACTION_QUIZ_FILE -> broadcastQuizSuccess(attachments[0], quizQuestionId, position)
+                ACTION_ASSIGNMENT_SUBMISSION -> submitAttachmentsForSubmission(courseId, assignment, attachments, attachmentsIds, bundle)
+                ACTION_DISCUSSION_ATTACHMENT -> broadcastDiscussionSuccess(notificationId, attachments)
+                ACTION_QUIZ_FILE -> broadcastQuizSuccess(notificationId, attachments[0], quizQuestionId, position)
                 ACTION_MESSAGE_ATTACHMENTS -> broadcastAllUploadsCompleted(attachments)
-                ACTION_SUBMISSION_COMMENT -> broadcastSubmissionCommentSuccess(attachments)
+                ACTION_SUBMISSION_COMMENT -> broadcastSubmissionCommentSuccess(notificationId, attachments)
                 else -> {
                     FileUploadEvent(FileUploadNotification(null, attachments)).postSticky()
-                    updateNotificationComplete()
+                    updateNotificationComplete(notificationId)
                 }
             }
         } catch (exception: Exception) {
-            updateNotification(getString(R.string.errorUploadingFile))
+            updateNotification(notificationId, getString(R.string.errorUploadingFile))
+
             if (quizQuestionId != INVALID_ID) {
-                broadcastQuizError(exception.message.orEmpty(), quizQuestionId, position)
+                broadcastQuizError(notificationId, exception.message.orEmpty(), quizQuestionId, position)
             } else {
-                broadcastError(exception.message.orEmpty())
+                broadcastError(notificationId, exception.message.orEmpty(), submissionId, assignment?.name, attachments)
             }
         }
-
-        stopSelf()
     }
 
-    private fun submitAttachmentsForSubmission(courseId: Long, assignment: Assignment, attachments: List<Attachment>, attachmentsIds: List<Long>) {
+    private fun submitAttachmentsForSubmission(
+        courseId: Long,
+        assignment: Assignment,
+        attachments: List<Attachment>,
+        attachmentsIds: List<Long>,
+        bundle: Bundle
+    ) {
+        val notificationId = notificationId(bundle)
+        val submissionId = if (bundle.containsKey(Const.SUBMISSION)) bundle.getLong(Const.SUBMISSION) else null
         SubmissionManager.postSubmissionAttachmentsSynchronous(courseId, assignment.id, attachmentsIds)?.let {
-            updateSubmissionComplete()
-            broadcastAllUploadsCompleted(attachments)
-        } ?: broadcastError(getString(R.string.errorSubmittingFiles))
+            updateSubmissionComplete(notificationId)
+            broadcastAllUploadsCompleted(attachments, submissionId, assignment.name)
+        } ?:
+        broadcastError(notificationId, getString(R.string.errorSubmittingFiles), submissionId, assignment.name, attachments)
     }
     // endregion Upload
 
     // region Notifications
-    private fun broadcastAllUploadsCompleted(attachments: List<Attachment>) {
+    private fun broadcastAllUploadsCompleted(attachments: List<Attachment>, submissionId: Long? = null, assignmentName: String? = null) {
         val status = Intent(ALL_UPLOADS_COMPLETED)
         status.putParcelableArrayListExtra(Const.ATTACHMENTS, ArrayList(attachments))
+        submissionId?.let { status.putExtra(Const.SUBMISSION, it) }
+        assignmentName?.let { status.putExtra(Const.ASSIGNMENT_NAME, it) }
+
         FileUploadEvent(FileUploadNotification(status, attachments)).postSticky()
+        sendBroadcast(status)
     }
 
     private fun broadcastMessageSuccess(conversation: Conversation) {
@@ -175,22 +199,22 @@ class FileUploadService @JvmOverloads constructor(name: String = FileUploadServi
         FileUploadEvent(FileUploadNotification(status, ArrayList(0))).postSticky()
     }
 
-    private fun broadcastSubmissionCommentSuccess(attachments: List<Attachment>) {
-        updateNotificationComplete()
+    private fun broadcastSubmissionCommentSuccess(notificationId: Int, attachments: List<Attachment>) {
+        updateNotificationComplete(notificationId)
         val status = Intent(ALL_UPLOADS_COMPLETED)
         status.putParcelableArrayListExtra(Const.ATTACHMENTS, ArrayList(attachments))
         sendBroadcast(status)
     }
 
-    private fun broadcastDiscussionSuccess(attachments: List<Attachment>) {
-        updateNotificationComplete()
+    private fun broadcastDiscussionSuccess(notificationId: Int, attachments: List<Attachment>) {
+        updateNotificationComplete(notificationId)
         val status = Intent(ALL_UPLOADS_COMPLETED)
         status.putParcelableArrayListExtra(Const.ATTACHMENTS, ArrayList(attachments))
         FileUploadEvent(FileUploadNotification(status, attachments)).postSticky()
     }
 
-    private fun broadcastQuizSuccess(attachment: Attachment, quizQuestionId: Long, position: Int) {
-        updateNotificationComplete()
+    private fun broadcastQuizSuccess(notificationId: Int, attachment: Attachment, quizQuestionId: Long, position: Int) {
+        updateNotificationComplete(notificationId)
         val status = Intent(QUIZ_UPLOAD_COMPLETE)
         status.putExtra(Const.ATTACHMENT, attachment as Parcelable)
         status.putExtra(Const.QUIZ_ANSWER_ID, quizQuestionId)
@@ -198,8 +222,8 @@ class FileUploadService @JvmOverloads constructor(name: String = FileUploadServi
         FileUploadEvent(FileUploadNotification(status, ArrayList<Attachment>(1).apply { add(attachment) })).postSticky()
     }
 
-    private fun broadcastQuizError(message: String, quizQuestionId: Long, position: Int) {
-        updateNotificationError(message)
+    private fun broadcastQuizError(notificationId: Int, message: String, quizQuestionId: Long, position: Int) {
+        updateNotificationError(notificationId, message)
         val bundle = Bundle()
         val status = Intent(UPLOAD_ERROR)
         status.putExtra(Const.QUIZ_ANSWER_ID, quizQuestionId)
@@ -209,96 +233,94 @@ class FileUploadService @JvmOverloads constructor(name: String = FileUploadServi
         FileUploadEvent(FileUploadNotification(status, ArrayList(0))).postSticky()
     }
 
-    private fun broadcastError(message: String) {
-        updateNotificationError(message)
+    private fun broadcastError(notificationId: Int, message: String, submissionId: Long? = null, assignmentName: String? = null, attachments: List<Attachment>? = null) {
+        updateNotificationError(notificationId, message)
+
         val bundle = Bundle()
-        val status = Intent(UPLOAD_ERROR)
         bundle.putString(Const.MESSAGE, message)
+        submissionId?.let { bundle.putLong(Const.SUBMISSION, it) }
+        assignmentName?.let { bundle.putString(Const.ASSIGNMENT_NAME, it) }
+        attachments?.let { bundle.putParcelableArrayList(Const.ATTACHMENTS, ArrayList(it)) }
+
+        val status = Intent(UPLOAD_ERROR)
         status.putExtras(bundle)
+
         FileUploadEvent(FileUploadNotification(status, ArrayList(0))).postSticky()
+        sendBroadcast(status)
     }
 
-    private fun showNotification(size: Int) {
-        createNotificationChannel(CHANNEL_ID)
+    private fun showNotification(notificationId: Int, size: Int) {
+        createNotificationChannel(notificationManager)
         notificationBuilder = NotificationCompat.Builder(this, CHANNEL_ID)
                 .setSmallIcon(R.drawable.ic_notification_canvas_logo)
                 .setContentTitle(String.format(Locale.US, getString(R.string.uploadingFileNum), 1, size))
                 .setProgress(0, 0, true)
-        startForeground(NOTIFICATION_ID, notificationBuilder.build())
+        startForeground(notificationId, notificationBuilder.build())
     }
 
-    private fun updateNotificationCount(fileName: String, currentItem: Int) {
+    private fun updateNotificationCount(notificationId: Int, fileName: String, currentItem: Int) {
         notificationBuilder.setContentTitle(String.format(Locale.US, getString(R.string.uploadingFileNum), currentItem, uploadCount))
                 .setContentText(fileName)
-        notificationManager.notify(NOTIFICATION_ID, notificationBuilder.build())
+        notificationManager.notify(notificationId, notificationBuilder.build())
     }
 
-
-    private fun updateNotification(message: String) {
+    private fun updateNotification(notificationId: Int, message: String) {
         notificationBuilder.setContentText(message)
-        notificationManager.notify(NOTIFICATION_ID, notificationBuilder.build())
+        notificationManager.notify(notificationId, notificationBuilder.build())
     }
 
-    private fun updateNotificationError(message: String) {
+    private fun updateNotificationError(notificationId: Int, message: String) {
         notificationBuilder.setContentText(message)
                 .setProgress(0, 0, false)
-        notificationManager.notify(NOTIFICATION_ID, notificationBuilder.build())
+        notificationManager.notify(notificationId, notificationBuilder.build())
     }
 
-    private fun updateNotificationComplete() {
+    private fun updateNotificationComplete(notificationId: Int) {
         notificationBuilder.setProgress(0, 0, false)
                 .setContentTitle(getString(R.string.filesUploadedSuccessfully))
-        notificationManager.notify(NOTIFICATION_ID, notificationBuilder.build())
+        notificationManager.notify(notificationId, notificationBuilder.build())
     }
 
-    private fun updateSubmissionComplete() {
+    private fun updateSubmissionComplete(notificationId: Int) {
         notificationBuilder.setProgress(0, 0, false)
                 .setContentTitle(getString(R.string.filesSubmittedSuccessfully))
-        notificationManager.notify(NOTIFICATION_ID, notificationBuilder.build())
+        notificationManager.notify(notificationId, notificationBuilder.build())
     }
 
-    private fun updateMessageComplete() {
-        notificationBuilder.setProgress(0, 0, false)
-                .setContentTitle(getString(R.string.messageSentSuccessfully))
-        notificationManager.notify(NOTIFICATION_ID, notificationBuilder.build())
+    private fun notificationId(extras: Bundle?): Int {
+        return if (extras?.containsKey(Const.SUBMISSION) == true) {
+            extras.getLong(Const.SUBMISSION).toInt()
+        } else {
+            NOTIFICATION_ID
+        }
     }
 
-    private fun createNotificationChannel(channelId: String) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
-
-        // Prevents recreation of notification channel if it exists.
-        if (notificationManager.notificationChannels.any { it.id == channelId }) return
-
-        val name = ContextKeeper.appContext.getString(R.string.notificationChannelNameFileUploadsName)
-        val description = ContextKeeper.appContext.getString(R.string.notificationChannelNameFileUploadsDescription)
-
-        // Create the channel and add the group
-        val importance = NotificationManager.IMPORTANCE_HIGH
-        val channel = NotificationChannel(channelId, name, importance)
-        channel.description = description
-        channel.enableLights(false)
-        channel.enableVibration(false)
-
-        // Create the channel
-        notificationManager.createNotificationChannel(channel)
+    @Suppress("unused", "UNUSED_PARAMETER")
+    @Subscribe
+    fun onUploadProgress(event: ProgressEvent) {
+        notificationBuilder.setProgress(100, (event.uploaded * 100f / event.contentLength).toInt(), false)
+        notificationManager.notify(event.submissionId.toInt(), notificationBuilder.build())
     }
+
     // endregion Notifications
 
     override fun onDestroy() {
         shutDown(applicationContext)
+        EventBus.getDefault().unregister(this)
         super.onDestroy()
     }
 
     companion object {
-        private const val NOTIFICATION_ID = 1
+        private const val NOTIFICATION_ID = -2
         private const val INVALID_ID = -1L
-        const val CHANNEL_ID = "fileUploadChannel"
+        const val CHANNEL_ID = "uploadChannel"
 
-        // Upload broadcasts
-        const val ALL_UPLOADS_COMPLETED = "ALL_UPLOADS_COMPLETED"
-        const val QUIZ_UPLOAD_COMPLETE = "QUIZ_UPLOAD_COMPLETE"
-        const val UPLOAD_COMPLETED = "UPLOAD_COMPLETED"
-        const val UPLOAD_ERROR = "UPLOAD_ERROR"
+        // Upload broadcasts, extended string to ensure unique strings across the device
+        private const val BROADCAST_BASE = "com.instructure.pandautils.services"
+        const val ALL_UPLOADS_COMPLETED = "$BROADCAST_BASE.ALL_UPLOADS_COMPLETED"
+        const val QUIZ_UPLOAD_COMPLETE = "$BROADCAST_BASE.QUIZ_UPLOAD_COMPLETE"
+        const val UPLOAD_COMPLETED = "$BROADCAST_BASE.UPLOAD_COMPLETED"
+        const val UPLOAD_ERROR = "$BROADCAST_BASE.UPLOAD_ERROR"
 
         // Upload Actions
         const val ACTION_ASSIGNMENT_SUBMISSION = "ACTION_ASSIGNMENT_SUBMISSION"
@@ -315,8 +337,34 @@ class FileUploadService @JvmOverloads constructor(name: String = FileUploadServi
 
         @JvmStatic
         fun shutDown(context: Context) {
-            (context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager).cancel(NOTIFICATION_ID)
+            // We won't want to cancel the notification if it's shared with another service, so only cancel our NOTIFICATION_ID
+            try {
+                (context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager).cancel(
+                    NOTIFICATION_ID
+                )
+            } catch (e: Exception) {}
             FileUploadUtils.deleteTempDirectory(context)
+        }
+
+        fun createNotificationChannel(notificationManager: NotificationManager) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+
+            // Prevents recreation of notification channel if it exists.
+            if (notificationManager.notificationChannels.any { it.id == CHANNEL_ID }) return
+
+            val name = ContextKeeper.appContext.getString(R.string.notificationChannelNameFileUploadsName)
+            val description = ContextKeeper.appContext.getString(R.string.notificationChannelNameFileUploadsDescription)
+
+            // Create the channel and add the group
+            val importance = NotificationManager.IMPORTANCE_HIGH
+            val channel = NotificationChannel(CHANNEL_ID, name, importance)
+            channel.description = description
+            channel.enableLights(false)
+            channel.enableVibration(false)
+            channel.setSound(null, null)
+
+            // Create the channel
+            notificationManager.createNotificationChannel(channel)
         }
 
         @JvmStatic
@@ -360,11 +408,13 @@ class FileUploadService @JvmOverloads constructor(name: String = FileUploadServi
         fun getAssignmentSubmissionBundle(
                 fileSubmitObjects: ArrayList<FileSubmitObject>,
                 courseId: Long,
-                assignment: Assignment
+                assignment: Assignment,
+                dbSubmissionId: Long? = null
         ) = Bundle().apply {
             putParcelableArrayList(Const.FILES, fileSubmitObjects)
             putLong(Const.COURSE_ID, courseId)
             putParcelable(Const.ASSIGNMENT, assignment)
+            dbSubmissionId?.let { putLong(Const.SUBMISSION, dbSubmissionId) }
         }
 
         @JvmStatic

--- a/libs/pandautils/src/main/res/values/strings.xml
+++ b/libs/pandautils/src/main/res/values/strings.xml
@@ -40,8 +40,8 @@
     <string name="upload">Upload</string>
     <string name="errorSendingMessage">An error occurred sending your message. Please try again.</string>
 
-    <string name="notificationChannelNameFileUploadsName">File Upload Notifications</string>
-    <string name="notificationChannelNameFileUploadsDescription">Canvas notifications for ongoing file uploads.</string>
+    <string name="notificationChannelNameFileUploadsName">Upload Notifications</string>
+    <string name="notificationChannelNameFileUploadsDescription">Canvas notifications for ongoing uploads.</string>
 
 
     <!-- Turn in Files -->
@@ -98,11 +98,9 @@
     <string name="filePermissionDenied">The file cannot be downloaded without granting permission.</string>
     <string name="pleaseTryAgain">Permission Granted, please try again.</string>
     <string name="pickVideo">Select a Video</string>
-    <string name="assignmentSubmissionUpload">Uploading submission for "%s"</string>
-    <string name="assignmentSubmissionError">Submission failed for "%s"</string>
-
-    <string name="notificationChannelNameSubmissionUploadsName">Submission Upload Notifications</string>
-    <string name="notificationChannelNameSubmissionUploadsDescription">Canvas notifications for ongoing submission uploads.</string>
+    <string name="assignmentSubmissionUpload">Uploading submission for %s</string>
+    <string name="assignmentSubmissionError">Submission failed for %s</string>
+    <string name="assignmentSubmissionComplete">Successfully submitted %s</string>
 
     <!--Errors-->
     <string name="errorOccurred">An unexpected error occurred.</string>


### PR DESCRIPTION
Save file uploads to our database to persist for the new submission flow.
Also adds a progress body for file uploads, updates sent through eventbus ProgressEvent so that anything can receive events.

To test:
This is a pain to actually test. It's not hooked up to any screens yet, so you have to go manually change some files to be able to test it directly.

First - change UploadFilesDialog.kt at line 457 (bottom of `uploadFiles` function) to look like this:
```
            if(bundle != null) {
                dialogCallback?.invoke(EVENT_ON_UPLOAD_BEGIN)
                dialogAttachmentCallback?.invoke(EVENT_ON_UPLOAD_BEGIN, fileList.first())
//                intent.putExtras(bundle)
//                activity?.startService(intent)
                dismiss()
            }
```
Second - change AddSubmissionFragment.kt at line 281 (top of `setupListeners` function) to look like this:
```
        fileUpload.setOnClickListener {
            // TODO: Test new submission service here
            UploadFilesDialog.show(fragmentManager, UploadFilesDialog.createAssignmentBundle(null, canvasContext as Course, assignment)) { _, file ->
//                context?.let { SubmissionService.startFileSubmission(it, canvasContext, assignment.id, assignment.name, assignment.groupCategoryId, arrayListOf(file!!, file, file, file, file, file)) } // to test file submissions, can repeat `file` as many times as desired
//                context?.let { SubmissionService.retryFileSubmission(it, canvasContext, 29) } // to test retries, you need the submission id from the db (set a breakpoint in the submission service and use it)
            }
        }
```

In AddSubmissionFragment, you can uncomment whichever line you want to use for the current thing your testing. You can pull the db files from the device and view them in a db browser, or you can set a breakpoint at the bottom of the SubmissionFileUploadReceiver in SubmissionService.kt to make calls to view the database like:
`db.fileSubmissionQueries.getFilesForSubmissionId(submissionId).executeAsList()`

You can use that to verify that files were input correctly, deleted correctly, set to errors correctly, etc...

Some of the test cases that would be good to hit:
* Submitting one large file or a file over a slower network (to be able to see the progress update in the notification)
* Submitting multiple files
* Submitting multiple files that have an error (the only error I could get is File Quota Exceeded, I can help with getting that test case ready; errors for wrong file type should be caught before submitting the files to the service; the file upload service also stops uploading files as soon as one errors)
* Retrying a submission with some files that uploaded