### PR TITLE
[Student][MBL-12536] Fix issue with unpublished courses in student

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/adapter/DashboardRecyclerAdapter.kt
+++ b/apps/student/src/main/java/com/instructure/student/adapter/DashboardRecyclerAdapter.kt
@@ -153,7 +153,8 @@ class DashboardRecyclerAdapter(
                 EnrollmentManager.getSelfEnrollments(null, listOf(EnrollmentAPI.STATE_INVITED), isRefresh, it)
             }
 
-            val favoriteCourses = dashboardCards.map { mCourseMap[it.id] }
+            // Map not null is needed because the dashboard api can return unpublished courses
+            val favoriteCourses = dashboardCards.mapNotNull { mCourseMap[it.id] }
 
             // Add courses
             addOrUpdateAllItems(ItemType.COURSE_HEADER, favoriteCourses)


### PR DESCRIPTION
Super weird minor bug. To repro, you need to have a teacher with only a single unpublished course. The dashboard api returns the value but the courses api doesn't (because we are only including available courses). I stumbled onto this issue while testing against a canvas portal.