### PR TITLE
[Teacher][MBL-12537] Fix viewing submissions for teacher

### DIFF
--- a/apps/parent/src/main/java/com/instructure/parentapp/binders/CalendarWeekBinder.java
+++ b/apps/parent/src/main/java/com/instructure/parentapp/binders/CalendarWeekBinder.java
@@ -75,7 +75,7 @@ public class CalendarWeekBinder extends BaseBinder {
                 int drawable;
 
                 if(assignment != null) {
-                    int assignmentState = AssignmentUtils2.INSTANCE.getAssignmentState(assignment, assignment.getSubmission());
+                    int assignmentState = AssignmentUtils2.INSTANCE.getAssignmentState(assignment, assignment.getSubmission(), false);
 
                     holder.icon.setContentDescription(context.getString(R.string.assignment));
                     switch(assignmentState){

--- a/apps/teacher/src/main/java/com/instructure/teacher/presenters/AssignmentSubmissionListPresenter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/presenters/AssignmentSubmissionListPresenter.kt
@@ -151,9 +151,9 @@ class AssignmentSubmissionListPresenter(val mAssignment: Assignment, private var
         mFilteredSubmissions = mUnfilteredSubmissions.filter {
             when (mFilter) {
                 SubmissionListFilter.ALL -> true
-                SubmissionListFilter.LATE -> it.submission?.let { mAssignment.getState(it) == AssignmentUtils2.ASSIGNMENT_STATE_SUBMITTED_LATE || mAssignment.getState(it) == AssignmentUtils2.ASSIGNMENT_STATE_GRADED_LATE } ?: false
-                SubmissionListFilter.NOT_GRADED -> it.submission?.let { mAssignment.getState(it) == AssignmentUtils2.ASSIGNMENT_STATE_SUBMITTED ||  mAssignment.getState(it) == AssignmentUtils2.ASSIGNMENT_STATE_SUBMITTED_LATE || !it.isGradeMatchesCurrentSubmission } ?: false
-                SubmissionListFilter.GRADED -> it.submission?.let { mAssignment.getState(it) in listOf(AssignmentUtils2.ASSIGNMENT_STATE_GRADED, AssignmentUtils2.ASSIGNMENT_STATE_GRADED_LATE, AssignmentUtils2.ASSIGNMENT_STATE_GRADED_MISSING)  && it.isGradeMatchesCurrentSubmission} ?: false
+                SubmissionListFilter.LATE -> it.submission?.let { mAssignment.getState(it, true) in listOf(AssignmentUtils2.ASSIGNMENT_STATE_SUBMITTED_LATE, AssignmentUtils2.ASSIGNMENT_STATE_GRADED_LATE) } ?: false
+                SubmissionListFilter.NOT_GRADED -> it.submission?.let { mAssignment.getState(it, true) in listOf(AssignmentUtils2.ASSIGNMENT_STATE_SUBMITTED, AssignmentUtils2.ASSIGNMENT_STATE_SUBMITTED_LATE) || !it.isGradeMatchesCurrentSubmission } ?: false
+                SubmissionListFilter.GRADED -> it.submission?.let { mAssignment.getState(it, true) in listOf(AssignmentUtils2.ASSIGNMENT_STATE_GRADED, AssignmentUtils2.ASSIGNMENT_STATE_GRADED_LATE, AssignmentUtils2.ASSIGNMENT_STATE_GRADED_MISSING)  && it.isGradeMatchesCurrentSubmission} ?: false
                 SubmissionListFilter.ABOVE_VALUE -> it.submission?.let { it.isGraded && it.score >= mFilterValue } ?: false
                 SubmissionListFilter.BELOW_VALUE -> it.submission?.let { it.isGraded && it.score < mFilterValue } ?: false
                 // Filtering by ASSIGNMENT_STATE_MISSING here doesn't work because it assumes that the due date has already passed, which isn't necessarily the case when the teacher wants to see

--- a/apps/teacher/src/main/java/com/instructure/teacher/utils/AssignmentExtensions.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/utils/AssignmentExtensions.kt
@@ -292,7 +292,7 @@ fun getPointsPossibleWithParenthesis(points: Double, pointsPossible: Double): St
     return "(" + NumberHelper.formatDecimal(points, 2, true) + "/" + NumberHelper.formatDecimal(pointsPossible, 2, true) + ")"
 }
 
-fun Assignment?.getState(submission: Submission?) = AssignmentUtils2.getAssignmentState(this, submission)
+fun Assignment?.getState(submission: Submission?, isTeacher: Boolean = false) = AssignmentUtils2.getAssignmentState(this, submission, isTeacher)
 
 /**
  *

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/AssignmentUtils2.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/AssignmentUtils2.kt
@@ -35,7 +35,7 @@ object AssignmentUtils2 {
     const val ASSIGNMENT_STATE_IN_CLASS = 1008
     const val ASSIGNMENT_STATE_DROPPED = 1009 //not yet used....
 
-    fun getAssignmentState(assignment: Assignment?, submission: Submission?): Int {
+    fun getAssignmentState(assignment: Assignment?, submission: Submission?, isTeacher: Boolean = false): Int {
         // Case - Error
         if (assignment == null) {
             return ASSIGNMENT_STATE_UNKNOWN
@@ -67,7 +67,7 @@ object AssignmentUtils2 {
             } else if (submission.missing) {
                 ASSIGNMENT_STATE_GRADED_MISSING
             } else {
-                checkOnTimeOrLate(submission, hasNoGrade(assignment, submission))
+                checkOnTimeOrLate(submission, hasNoGrade(assignment, submission, isTeacher))
             }
 
         }
@@ -77,8 +77,8 @@ object AssignmentUtils2 {
     // 1. Has not been graded
     // 2. Is "Pending Review"
     // 3. Is muted
-    private fun hasNoGrade(assignment: Assignment, submission: Submission): Boolean {
-        return !submission.isGraded || Const.PENDING_REVIEW == submission.workflowState || assignment.muted
+    private fun hasNoGrade(assignment: Assignment, submission: Submission, isTeacher: Boolean): Boolean {
+        return !submission.isGraded || Const.PENDING_REVIEW == submission.workflowState || (!isTeacher && assignment.muted)
     }
 
     // Edge Case - Assignment is either due in the future or an unknown "paper" hand in

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/unit/AssignmentUtils2Test.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/unit/AssignmentUtils2Test.kt
@@ -174,4 +174,46 @@ class AssignmentUtils2Test : Assert() {
         Assert.assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_EXCUSED.toLong())
     }
 
+    @Test
+    @Throws(Exception::class)
+    fun getAssignmentState_isTeacher_mutedGradeWithNoSubmission_stateGraded() {
+        val time = Calendar.getInstance().timeInMillis + 100000
+        val date = Date(time)
+
+        val submission = Submission(
+            attempt = 0,
+            grade = "A"
+        )
+        val assignment = Assignment(
+            submission = submission,
+            dueAt = date.toApiString(),
+            muted = true
+        )
+
+        val testValue = AssignmentUtils2.getAssignmentState(assignment, submission, true)
+
+        Assert.assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_GRADED.toLong())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun getAssignmentState_isStudent_mutedGradeWithNoSubmission_stateGraded() {
+        val time = Calendar.getInstance().timeInMillis + 100000
+        val date = Date(time)
+
+        val submission = Submission(
+            attempt = 0,
+            grade = "A"
+        )
+        val assignment = Assignment(
+            submission = submission,
+            dueAt = date.toApiString(),
+            muted = true
+        )
+
+        val testValue = AssignmentUtils2.getAssignmentState(assignment, submission)
+
+        Assert.assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_SUBMITTED.toLong())
+    }
+
 }


### PR DESCRIPTION
There was a bug where a graded student that didn’t submit an assignment that was muted, would not show up when clicking the “graded” donut in teacher speed grader. They instead showed up with the filter “submitted” without a grade.