### PR TITLE
[Teacher][Automation][MBL-12549]: Fix flaky Teacher UI tests

### DIFF
--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/AssignmentDetailsPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/AssignmentDetailsPageTest.kt
@@ -178,6 +178,7 @@ class AssignmentDetailsPageTest : TeacherTest() {
 
         tokenLogin(teacher)
         routeTo("courses/${course.id}/assignments/${assignment.assignmentList[0].id}")
+        assignmentDetailsPage.waitForRender()
         return assignment.assignmentList[0]
     }
 

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/QuizDetailsPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/QuizDetailsPageTest.kt
@@ -126,6 +126,7 @@ class QuizDetailsPageTest: TeacherTest() {
 
         tokenLogin(teacher)
         routeTo("courses/${course.id}/quizzes/${quiz.id}")
+        quizDetailsPage.waitForRender()
         return quiz
     }
 

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/AssignmentDetailsPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/AssignmentDetailsPage.kt
@@ -16,12 +16,14 @@
 package com.instructure.teacher.ui.pages
 
 import androidx.test.InstrumentationRegistry
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import com.instructure.dataseeding.model.AssignmentApiModel
 import com.instructure.espresso.*
 import com.instructure.espresso.page.BasePage
 
 
 import com.instructure.espresso.page.scrollTo
+import com.instructure.espresso.page.waitForView
 import com.instructure.teacher.R
 
 @Suppress("unused")
@@ -135,5 +137,9 @@ class AssignmentDetailsPage : BasePage(pageResId = R.id.assignmentDetailsPage) {
     fun assertNotSubmitted() {
         val resources = InstrumentationRegistry.getTargetContext()
         notSubmittedDonutWrapper.assertHasContentDescription(resources.getString(R.string.content_description_submission_donut_unsubmitted).format(1, 1))
+    }
+
+    fun waitForRender() {
+        waitForView(withId(R.id.assignmentDetailsPage))
     }
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/QuizDetailsPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/QuizDetailsPage.kt
@@ -16,10 +16,13 @@
 package com.instructure.teacher.ui.pages
 
 import androidx.test.InstrumentationRegistry
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import com.instructure.dataseeding.model.QuizApiModel
 import com.instructure.espresso.*
 import com.instructure.espresso.page.BasePage
 import com.instructure.espresso.page.scrollTo
+import com.instructure.espresso.page.waitForView
 import com.instructure.teacher.R
 
 class QuizDetailsPage : BasePage(pageResId = R.id.quizDetailsPage) {
@@ -119,5 +122,9 @@ class QuizDetailsPage : BasePage(pageResId = R.id.quizDetailsPage) {
 
     fun assertAccessCodeChanged(newCode: String) {
         //TODO: accessCodeTextView.assertHasText(newCode)
+    }
+
+    fun waitForRender() {
+        waitForView(withId(R.id.quizDetailsPage))
     }
 }


### PR DESCRIPTION
Speculative fix for intermittent failures in Teacher UI tests due to not waiting for activity launched via routeTo() to complete rendering before asserting against it.