### PR TITLE
[Teacher][Automation][MBL-12698]: Fix broken Teacher UI test

### DIFF
--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/CoursesListPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/CoursesListPageTest.kt
@@ -20,6 +20,7 @@ package com.instructure.teacher.ui
 import com.instructure.espresso.TestRail
 import com.instructure.teacher.ui.utils.*
 import com.instructure.espresso.ditto.Ditto
+import com.instructure.espresso.ditto.DittoMode
 import org.junit.Test
 
 class CoursesListPageTest : TeacherTest() {
@@ -33,7 +34,7 @@ class CoursesListPageTest : TeacherTest() {
     }
 
     @Test
-    @Ditto
+    @Ditto(mode = DittoMode.LIVE)
     @TestRail(ID = "C3109494")
     fun displaysNoCoursesView() {
         logIn(defaultToPastCourse = true)


### PR DESCRIPTION
Simple fix for CoursesListPageTest.displaysNoCoursesView.

I think that the problem was that we were trying to do a live operation using a token from taped data, and the token expired.  This shouldn't happen if we change the test to run in "Live" mode.