### PR TITLE
[Student][MBL-12230] Wire up Notorious service to SubmissionService

### DIFF
--- a/apps/student/src/main/db/com/instructure/student/Submission.sq
+++ b/apps/student/src/main/db/com/instructure/student/Submission.sq
@@ -31,18 +31,22 @@ CREATE TABLE submission (
     errorFlag INTEGER as Boolean NOT NULL DEFAULT 0,
     assignmentGroupCategoryId INTEGER
 );
---
+
 insertOnlineTextSubmission:
-INSERT INTO submission (submissionEntry, assignmentName, assignmentId, canvasContext, submissionType) --, canvasContext, submissionType)
+INSERT INTO submission (submissionEntry, assignmentName, assignmentId, canvasContext, submissionType)
 VALUES (?, ?, ?, ?, "online_text_entry");
---
+
 insertOnlineUrlSubmission:
 INSERT INTO submission (submissionEntry, assignmentName, assignmentId, canvasContext, submissionType)
 VALUES (?, ?, ?, ?, "online_url"); --"basic_lti_launch" else "online_url"
---
+
 insertOnlineUploadSubmission:
 INSERT INTO submission (assignmentName, assignmentId, assignmentGroupCategoryId, canvasContext, submissionType)
 VALUES (?, ?, ?, ?, "online_upload");
+
+insertMediaSubmission:
+INSERT INTO submission(assignmentName, assignmentId, canvasContext, submissionType)
+VALUES(?, ?, ?, ?);
 
 getAllSubmissions:
 SELECT *

--- a/apps/student/src/main/db/com/instructure/student/Submission.sq
+++ b/apps/student/src/main/db/com/instructure/student/Submission.sq
@@ -44,10 +44,6 @@ insertOnlineUploadSubmission:
 INSERT INTO submission (assignmentName, assignmentId, assignmentGroupCategoryId, canvasContext, submissionType)
 VALUES (?, ?, ?, ?, "online_upload");
 
-insertMediaSubmission:
-INSERT INTO submission(assignmentName, assignmentId, canvasContext, submissionType)
-VALUES(?, ?, ?, ?);
-
 getAllSubmissions:
 SELECT *
 FROM submission;

--- a/apps/student/src/main/java/com/instructure/student/fragment/AddSubmissionFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/AddSubmissionFragment.kt
@@ -52,6 +52,7 @@ import com.instructure.pandautils.activities.NotoriousMediaUploadPicker
 import com.instructure.pandautils.dialogs.UploadFilesDialog
 import com.instructure.pandautils.utils.*
 import com.instructure.student.R
+import com.instructure.student.mobius.common.ui.SubmissionService
 import com.instructure.student.router.RouteMatcher
 import com.instructure.student.util.Analytics
 import com.instructure.student.util.VisibilityAnimator

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/PickerSubmissionUploadEffectHandler.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/PickerSubmissionUploadEffectHandler.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.net.Uri
 import com.instructure.canvasapi2.utils.exhaustive
 import com.instructure.pandautils.models.FileSubmitObject
+import com.instructure.pandautils.services.NotoriousUploadService
 import com.instructure.pandautils.utils.FileUploadUtils
 import com.instructure.student.mobius.assignmentDetails.submission.picker.ui.PickerSubmissionUploadView
 import com.instructure.student.mobius.common.ui.EffectHandler
@@ -107,7 +108,9 @@ class PickerSubmissionUploadEffectHandler(private val context: Context) :
                 context,
                 model.canvasContext,
                 model.assignmentId,
-                model.assignmentName
+                model.assignmentName,
+                model.files.first().fullPath,
+                NotoriousUploadService.ACTION.ASSIGNMENT_SUBMISSION // TODO: Make this more dynamic when everything else is wired up
             )
         } else {
             SubmissionService.startFileSubmission(

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/PickerSubmissionUploadEffectHandler.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/PickerSubmissionUploadEffectHandler.kt
@@ -109,6 +109,7 @@ class PickerSubmissionUploadEffectHandler(private val context: Context) :
                 model.canvasContext,
                 model.assignmentId,
                 model.assignmentName,
+                model.assignmentGroupCategoryId,
                 model.files.first().fullPath,
                 NotoriousUploadService.ACTION.ASSIGNMENT_SUBMISSION // TODO: Make this more dynamic when everything else is wired up
             )

--- a/apps/student/src/main/java/com/instructure/student/mobius/common/ui/SubmissionService.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/common/ui/SubmissionService.kt
@@ -395,7 +395,7 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
             startService(context, Action.FILE_ENTRY, bundle)
         }
 
-        fun startMediaSubmission(context: Context, canvasContext: CanvasContext, assignmentId: Long, assignmentName: String?, mediaFilePath: String?, notoriousAction: NotoriousUploadService.ACTION, assignmentGroupCategoryId: Long = 0) {
+        fun startMediaSubmission(context: Context, canvasContext: CanvasContext, assignmentId: Long, assignmentName: String?, assignmentGroupCategoryId: Long, mediaFilePath: String?, notoriousAction: NotoriousUploadService.ACTION) {
             val bundle = Bundle().apply {
                 putParcelable(Const.CANVAS_CONTEXT, canvasContext)
                 putParcelable(Const.ASSIGNMENT, Assignment(id = assignmentId, name = assignmentName, groupCategoryId = assignmentGroupCategoryId))

--- a/apps/student/src/main/java/com/instructure/student/mobius/common/ui/SubmissionService.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/common/ui/SubmissionService.kt
@@ -16,12 +16,15 @@
  */
 package com.instructure.student.mobius.common.ui
 
-import android.app.*
+import android.app.IntentService
+import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Bundle
+import android.os.Parcelable
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.instructure.canvasapi2.managers.SubmissionManager
@@ -35,6 +38,7 @@ import com.instructure.canvasapi2.utils.weave.apiAsync
 import com.instructure.pandautils.models.FileSubmitObject
 import com.instructure.pandautils.models.PushNotification
 import com.instructure.pandautils.services.FileUploadService
+import com.instructure.pandautils.services.NotoriousUploadService
 import com.instructure.pandautils.utils.Const
 import com.instructure.student.R
 import com.instructure.student.activity.NavigationActivity
@@ -42,13 +46,14 @@ import com.instructure.student.db.Db
 import com.instructure.student.db.getInstance
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import java.io.File
 import java.util.*
 
 class SubmissionFileUploadReceiver(private val dbSubmissionId: Long) : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
         context ?: return
 
-        val submissionId = intent?.extras?.getLong(Const.SUBMISSION)
+        val submissionId = intent?.extras?.getLong(Const.SUBMISSION_ID)
         val assignmentName = intent?.extras?.getString(Const.ASSIGNMENT_NAME)
 
         if (submissionId == null || submissionId != dbSubmissionId) return // Only handle our submission
@@ -97,19 +102,6 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
     init {
         setIntentRedelivery(true)
     }
-
-//    override fun onCreate() {
-//        super.onCreate()
-//
-//        // perform one-time setup procedures when the service is initially created (before it calls
-//        // either onStartCommand() or onBind()). If the service is already running, this method is not called.
-//    }
-//
-//    override fun onDestroy() {
-//        super.onDestroy()
-//
-//        // clean up any resources such as threads, registered listeners, or receivers
-//    }
 
     override fun onHandleIntent(intent: Intent) {
         val action = intent.action!!
@@ -176,11 +168,59 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
     }
 
     private fun uploadMedia(intent: Intent) {
-        // TODO: Save to persistence
-        // TODO: Upload files to server
-        // TODO: On broadcast, upload submission with file references
-        // TODO: Show progress notification (one already shown for each file)
-        // TODO: Update persistence, either delete on success or update with error and show notification
+        val mediaFilePath = intent.getStringExtra(Const.MEDIA_FILE_PATH)
+        var assignment = intent.getParcelableExtra<Assignment>(Const.ASSIGNMENT)
+        val canvasContext = intent.getParcelableExtra<CanvasContext>(Const.CANVAS_CONTEXT)
+        val action = intent.getSerializableExtra(Const.ACTION) as NotoriousUploadService.ACTION
+
+        val dbSubmissionId: Long
+        val filesDb = Db.getInstance(this).fileSubmissionQueries
+        val submissionsDb = Db.getInstance(this).submissionQueries
+
+        // Check if we're retrying a submission or if it's a new one that needs to be persisted
+        if (intent.hasExtra(Const.SUBMISSION_ID)) {
+            // Get previously attempted submission information so we can retry
+            dbSubmissionId = intent.extras!!.getLong(Const.SUBMISSION_ID)
+            val submission = submissionsDb.getSubmissionById(dbSubmissionId).executeAsOne()
+
+            assignment = Assignment(
+                id = submission.assignmentId!!.toLong(),
+                name = submission.assignmentName,
+                groupCategoryId = submission.assignmentGroupCategoryId ?: 0
+            )
+        } else {
+            // New submission - store submission details in the db
+            submissionsDb.insertOnlineUploadSubmission(
+                assignment.name,
+                assignment.id,
+                assignment.groupCategoryId,
+                canvasContext
+            )
+            dbSubmissionId = submissionsDb.getLastInsert().executeAsOne()
+
+            val file = File(mediaFilePath)
+            filesDb.insertFile(dbSubmissionId, file.name, file.length(), "", mediaFilePath)
+        }
+
+        // Don't show the notification in the foreground so it doesn't disappear when this service dies
+        showProgressNotification(assignment.name, dbSubmissionId, false)
+
+        // Handle broadcasts from file upload service
+        // Register the receiver on the application context so this service can die and handle the next submission
+        val receiver = SubmissionFileUploadReceiver(dbSubmissionId)
+
+        val filter = IntentFilter(FileUploadService.ALL_UPLOADS_COMPLETED)
+        filter.addAction(FileUploadService.UPLOAD_ERROR)
+        applicationContext.registerReceiver(receiver, filter)
+
+        val mediaFileUploadIntent = Intent(this, NotoriousUploadService::class.java).apply {
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            putExtra(Const.MEDIA_FILE_PATH, mediaFilePath)
+            putExtra(Const.ACTION, action)
+            putExtra(Const.ASSIGNMENT, assignment.copy(courseId = canvasContext.id) as Parcelable)
+            putExtra(Const.SUBMISSION_ID, dbSubmissionId)
+        }
+        startService(mediaFileUploadIntent)
     }
 
     private fun uploadFile(intent: Intent) {
@@ -195,8 +235,8 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
         val filesDb = db.fileSubmissionQueries
 
         // Check if we're retrying a submission or if it's a new one that needs to be persisted
-        if (intent.hasExtra(Const.SUBMISSION)) {
-            dbSubmissionId = intent.extras!!.getLong(Const.SUBMISSION)
+        if (intent.hasExtra(Const.SUBMISSION_ID)) {
+            dbSubmissionId = intent.extras!!.getLong(Const.SUBMISSION_ID)
             val submission = db.submissionQueries.getSubmissionById(dbSubmissionId).executeAsOne()
             val dbFiles = db.fileSubmissionQueries.getFilesForSubmissionId(dbSubmissionId).executeAsList()
 
@@ -349,17 +389,18 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
         fun retryFileSubmission(context: Context, canvasContext: CanvasContext, dbSubmissionId: Long) {
             val bundle = Bundle().apply {
                 putParcelable(Const.CANVAS_CONTEXT, canvasContext)
-                putLong(Const.SUBMISSION, dbSubmissionId)
+                putLong(Const.SUBMISSION_ID, dbSubmissionId)
             }
 
             startService(context, Action.FILE_ENTRY, bundle)
         }
 
-        fun startMediaSubmission(context: Context, canvasContext: CanvasContext, assignmentId: Long, assignmentName: String?) {
+        fun startMediaSubmission(context: Context, canvasContext: CanvasContext, assignmentId: Long, assignmentName: String?, mediaFilePath: String?, notoriousAction: NotoriousUploadService.ACTION, assignmentGroupCategoryId: Long = 0) {
             val bundle = Bundle().apply {
                 putParcelable(Const.CANVAS_CONTEXT, canvasContext)
-                putLong(Const.ASSIGNMENT_ID, assignmentId)
-                putString(Const.ASSIGNMENT_NAME, assignmentName)
+                putParcelable(Const.ASSIGNMENT, Assignment(id = assignmentId, name = assignmentName, groupCategoryId = assignmentGroupCategoryId))
+                putString(Const.MEDIA_FILE_PATH, mediaFilePath)
+                putSerializable(Const.ACTION, notoriousAction)
             }
 
             startService(context, Action.MEDIA_ENTRY, bundle)

--- a/apps/student/src/test/java/com/instructure/student/test/SubmissionServiceTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/SubmissionServiceTest.kt
@@ -22,6 +22,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.Course
 import com.instructure.pandautils.models.FileSubmitObject
+import com.instructure.pandautils.services.NotoriousUploadService
 import com.instructure.pandautils.utils.Const
 import com.instructure.student.mobius.common.ui.SubmissionService
 import io.mockk.*
@@ -35,6 +36,8 @@ class SubmissionServiceTest : Assert() {
 
     private var assignmentId: Long = 0
     private var assignmentName: String = "Assignment Name"
+    private var mediaFilePath = "/some/path/to/a/file"
+    private var notoriousAction = NotoriousUploadService.ACTION.ASSIGNMENT_SUBMISSION
 
     private lateinit var context: Context
     private lateinit var canvasContext: Course
@@ -113,15 +116,18 @@ class SubmissionServiceTest : Assert() {
     @Test
     fun `startMediaSubmission starts the service with an intent`() {
         val intent = slot<Intent>()
+        val assignmentGroupCategoryId = 0L
+        val assignment = Assignment(id = assignmentId, name = assignmentName, groupCategoryId = assignmentGroupCategoryId)
 
         every { context.startService(capture(intent)) } returns null
 
-        SubmissionService.startMediaSubmission(context, canvasContext, assignmentId, assignmentName)
+        SubmissionService.startMediaSubmission(context, canvasContext, assignment.id, assignment.name, mediaFilePath, notoriousAction)
 
         assertEquals(SubmissionService.Action.MEDIA_ENTRY.name, intent.captured.action)
         assertEquals(canvasContext, intent.captured.getParcelableExtra(Const.CANVAS_CONTEXT))
-        assertEquals(assignmentId, intent.captured.getLongExtra(Const.ASSIGNMENT_ID, -1))
-        assertEquals(assignmentName, intent.captured.getStringExtra(Const.ASSIGNMENT_NAME))
+        assertEquals(assignment, intent.captured.getParcelableExtra(Const.ASSIGNMENT))
+        assertEquals(mediaFilePath, intent.captured.getStringExtra(Const.MEDIA_FILE_PATH))
+        assertEquals(notoriousAction, intent.captured.getSerializableExtra(Const.ACTION))
     }
 
     @Test

--- a/apps/student/src/test/java/com/instructure/student/test/SubmissionServiceTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/SubmissionServiceTest.kt
@@ -121,7 +121,7 @@ class SubmissionServiceTest : Assert() {
 
         every { context.startService(capture(intent)) } returns null
 
-        SubmissionService.startMediaSubmission(context, canvasContext, assignment.id, assignment.name, mediaFilePath, notoriousAction)
+        SubmissionService.startMediaSubmission(context, canvasContext, assignment.id, assignment.name, assignment.groupCategoryId, mediaFilePath, notoriousAction)
 
         assertEquals(SubmissionService.Action.MEDIA_ENTRY.name, intent.captured.action)
         assertEquals(canvasContext, intent.captured.getParcelableExtra(Const.CANVAS_CONTEXT))

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/PickerSubmissionUploadEffectHandlerTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/PickerSubmissionUploadEffectHandlerTest.kt
@@ -21,6 +21,7 @@ import android.net.Uri
 import com.instructure.canvasapi2.models.CanvasContext
 import com.instructure.canvasapi2.utils.ProgressEvent
 import com.instructure.pandautils.models.FileSubmitObject
+import com.instructure.pandautils.services.NotoriousUploadService
 import com.instructure.pandautils.utils.Const
 import com.instructure.pandautils.utils.FileUploadUtils
 import com.instructure.student.FileSubmission
@@ -238,17 +239,19 @@ class PickerSubmissionUploadEffectHandlerTest : Assert() {
 
     @Test
     fun `HandleSubmit and isMediaSubmission results in starting media submission`() {
+        val file = FileSubmitObject("file.mp4", 1L, "mimeType", "/path/to/the/file.mp4")
         val model = PickerSubmissionUploadModel(
             canvasContext = CanvasContext.emptyCourseContext(1L),
             assignmentId = 2L,
             assignmentGroupCategoryId = 3L,
             assignmentName = "AssignmentName",
             allowedExtensions = emptyList(),
-            isMediaSubmission = true
+            isMediaSubmission = true,
+            files = listOf(file)
         )
 
         mockkObject(SubmissionService.Companion)
-        every { SubmissionService.startMediaSubmission(any(), any(), any(), any()) } returns Unit
+        every { SubmissionService.startMediaSubmission(any(), any(), any(), any(), any(), any(), any()) } returns Unit
 
         connection.accept(PickerSubmissionUploadEffect.HandleSubmit(model))
 
@@ -257,7 +260,9 @@ class PickerSubmissionUploadEffectHandlerTest : Assert() {
                 context,
                 model.canvasContext,
                 model.assignmentId,
-                model.assignmentName
+                model.assignmentName,
+                model.files.first().fullPath,
+                NotoriousUploadService.ACTION.ASSIGNMENT_SUBMISSION
             )
             view.closeSubmissionView()
         }

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/PickerSubmissionUploadEffectHandlerTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/PickerSubmissionUploadEffectHandlerTest.kt
@@ -16,18 +16,11 @@
 package com.instructure.student.test.assignment.details.submission
 
 import android.content.Context
-import android.content.Intent
 import android.net.Uri
 import com.instructure.canvasapi2.models.CanvasContext
-import com.instructure.canvasapi2.utils.ProgressEvent
 import com.instructure.pandautils.models.FileSubmitObject
 import com.instructure.pandautils.services.NotoriousUploadService
-import com.instructure.pandautils.utils.Const
 import com.instructure.pandautils.utils.FileUploadUtils
-import com.instructure.student.FileSubmission
-import com.instructure.student.db.Db
-import com.instructure.student.db.StudentDb
-import com.instructure.student.db.getInstance
 import com.instructure.student.mobius.assignmentDetails.submission.picker.PickerSubmissionUploadEffect
 import com.instructure.student.mobius.assignmentDetails.submission.picker.PickerSubmissionUploadEffectHandler
 import com.instructure.student.mobius.assignmentDetails.submission.picker.PickerSubmissionUploadEvent
@@ -261,6 +254,7 @@ class PickerSubmissionUploadEffectHandlerTest : Assert() {
                 model.canvasContext,
                 model.assignmentId,
                 model.assignmentName,
+                model.assignmentGroupCategoryId,
                 model.files.first().fullPath,
                 NotoriousUploadService.ACTION.ASSIGNMENT_SUBMISSION
             )

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/loaders/OpenMediaAsyncTaskLoader.java
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/loaders/OpenMediaAsyncTaskLoader.java
@@ -204,8 +204,6 @@ public class OpenMediaAsyncTaskLoader extends AsyncTaskLoader<OpenMediaAsyncTask
                 bundle.putString(Const.INTERNAL_URL, url);
                 bundle.putString(Const.ACTION_BAR_TITLE, filename);
                 loadedMedia.setHtmlBundle(bundle);
-            } else if (Utils.isAmazonDevice()) {
-                attemptDownloadFile(context, intent, loadedMedia, url, filename);
             } else {
                 loadedMedia.setHtmlFile(isHtmlFile());
                 Uri uri = attemptConnection(url);

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/services/FileUploadService.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/services/FileUploadService.kt
@@ -73,7 +73,7 @@ class FileUploadService @JvmOverloads constructor(name: String = FileUploadServi
         val notificationId = notificationId(bundle)
         val fileSubmitObjects = bundle?.getParcelableArrayList<FileSubmitObject>(Const.FILES) ?: return
         val assignment = bundle.getParcelable<Assignment>(Const.ASSIGNMENT)
-        val submissionId = if (bundle.containsKey(Const.SUBMISSION)) bundle.getLong(Const.SUBMISSION) else null
+        val submissionId = if (bundle.containsKey(Const.SUBMISSION_ID)) bundle.getLong(Const.SUBMISSION_ID) else null
 
         uploadCount = fileSubmitObjects.size
         showNotification(notificationId, uploadCount)
@@ -98,7 +98,7 @@ class FileUploadService @JvmOverloads constructor(name: String = FileUploadServi
         val position = bundle.getInt(Const.POSITION)
         val parentFolderId = if (bundle.containsKey(Const.PARENT_FOLDER_ID)) bundle.getLong(Const.PARENT_FOLDER_ID) else null
         val notificationId = notificationId(bundle)
-        val submissionId = if (bundle.containsKey(Const.SUBMISSION)) bundle.getLong(Const.SUBMISSION) else null
+        val submissionId = if (bundle.containsKey(Const.SUBMISSION_ID)) bundle.getLong(Const.SUBMISSION_ID) else null
 
         val attachments = mutableListOf<Attachment>()
 
@@ -168,7 +168,7 @@ class FileUploadService @JvmOverloads constructor(name: String = FileUploadServi
         bundle: Bundle
     ) {
         val notificationId = notificationId(bundle)
-        val submissionId = if (bundle.containsKey(Const.SUBMISSION)) bundle.getLong(Const.SUBMISSION) else null
+        val submissionId = if (bundle.containsKey(Const.SUBMISSION_ID)) bundle.getLong(Const.SUBMISSION_ID) else null
         SubmissionManager.postSubmissionAttachmentsSynchronous(courseId, assignment.id, attachmentsIds)?.let {
             updateSubmissionComplete(notificationId)
             broadcastAllUploadsCompleted(attachments, submissionId, assignment.name)
@@ -181,7 +181,7 @@ class FileUploadService @JvmOverloads constructor(name: String = FileUploadServi
     private fun broadcastAllUploadsCompleted(attachments: List<Attachment>, submissionId: Long? = null, assignmentName: String? = null) {
         val status = Intent(ALL_UPLOADS_COMPLETED)
         status.putParcelableArrayListExtra(Const.ATTACHMENTS, ArrayList(attachments))
-        submissionId?.let { status.putExtra(Const.SUBMISSION, it) }
+        submissionId?.let { status.putExtra(Const.SUBMISSION_ID, it) }
         assignmentName?.let { status.putExtra(Const.ASSIGNMENT_NAME, it) }
 
         FileUploadEvent(FileUploadNotification(status, attachments)).postSticky()
@@ -238,7 +238,7 @@ class FileUploadService @JvmOverloads constructor(name: String = FileUploadServi
 
         val bundle = Bundle()
         bundle.putString(Const.MESSAGE, message)
-        submissionId?.let { bundle.putLong(Const.SUBMISSION, it) }
+        submissionId?.let { bundle.putLong(Const.SUBMISSION_ID, it) }
         assignmentName?.let { bundle.putString(Const.ASSIGNMENT_NAME, it) }
         attachments?.let { bundle.putParcelableArrayList(Const.ATTACHMENTS, ArrayList(it)) }
 
@@ -288,8 +288,8 @@ class FileUploadService @JvmOverloads constructor(name: String = FileUploadServi
     }
 
     private fun notificationId(extras: Bundle?): Int {
-        return if (extras?.containsKey(Const.SUBMISSION) == true) {
-            extras.getLong(Const.SUBMISSION).toInt()
+        return if (extras?.containsKey(Const.SUBMISSION_ID) == true) {
+            extras.getLong(Const.SUBMISSION_ID).toInt()
         } else {
             NOTIFICATION_ID
         }
@@ -415,7 +415,7 @@ class FileUploadService @JvmOverloads constructor(name: String = FileUploadServi
             putParcelableArrayList(Const.FILES, fileSubmitObjects)
             putLong(Const.COURSE_ID, courseId)
             putParcelable(Const.ASSIGNMENT, assignment)
-            dbSubmissionId?.let { putLong(Const.SUBMISSION, dbSubmissionId) }
+            dbSubmissionId?.let { putLong(Const.SUBMISSION_ID, dbSubmissionId) }
             additionalAttachmentIds?.let { putLongArray(Const.ATTACHMENTS, it.toLongArray()) }
         }
 

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/Const.java
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/Const.java
@@ -52,6 +52,7 @@ public class Const {
     public static final String CALENDAR_DIALOG_CONTEXT_COURSE_IDS = "calendarDialogContextCourseIds";
     public static final String CALENDAR_EVENT_START_DATE = "calendarEventStartDate";
     public static final String CANVAS_CONTEXT = "canvasContext";
+    public static final String CANVAS_CONTEXT_ID = "canvasContextId";
     public static final String CANVAS_LOGIN = "canvas_login";
     public static final String CANVAS_USER_GUIDES = "https://community.canvaslms.com/community/answers/guides/mobile-guide/content?filterID=contentstatus%5Bpublished%5D~category%5Btable-of-contents%5D";
     public static final String CHANGED = "changed";
@@ -174,6 +175,7 @@ public class Const {
     public static final String REFRESH = "refresh";
     public static final String SUBMISSION_COMMENT_SUBMITTED = "submission-comment-submitted";
     public static final String SUBMISSION = "submission";
+    public static final String SUBMISSION_ID = "submission_id";
     public static final String SUBMISSION_TARGET = "submission_target";
     public static final String DISCUSSION_REPLY_SUBMITTED = "discussion_reply_submitted";
 

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/Utils.java
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/Utils.java
@@ -18,11 +18,7 @@
 package com.instructure.pandautils.utils;
 
 import android.app.Activity;
-import android.content.ActivityNotFoundException;
-import android.content.ClipData;
-import android.content.ClipboardManager;
-import android.content.Context;
-import android.content.Intent;
+import android.content.*;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.net.ConnectivityManager;
@@ -33,7 +29,6 @@ import android.text.TextUtils;
 import android.util.TypedValue;
 import android.view.View;
 import android.widget.Toast;
-
 import com.instructure.canvasapi2.utils.ApiPrefs;
 import com.instructure.pandautils.R;
 
@@ -46,12 +41,9 @@ public class Utils {
 
     /**
      * Check if the device has a camera. If it doesn't, return false
-     * and show a crouton so the user can see something
-     *
      */
     public static boolean hasCameraAvailable(Activity activity) {
         PackageManager pm = activity.getPackageManager();
-
         return pm.hasSystemFeature(PackageManager.FEATURE_CAMERA) || pm.hasSystemFeature(PackageManager.FEATURE_CAMERA_FRONT);
     }
 
@@ -63,28 +55,6 @@ public class Utils {
             file = context.getFilesDir();
         }
         return file;
-    }
-
-    public static boolean isAmazonDevice() {
-        String manufacture = Build.MANUFACTURER.toLowerCase(Locale.getDefault());
-        String brand = Build.BRAND.toLowerCase(Locale.getDefault());
-        String board = Build.BOARD.toLowerCase(Locale.getDefault());
-        String device = Build.DEVICE.toLowerCase(Locale.getDefault());
-
-        if(!TextUtils.isEmpty(manufacture) && manufacture.contains("amazon")) {
-            return true;
-        }
-
-        if(!TextUtils.isEmpty(brand) && brand.contains("amazon")) {
-            return true;
-        }
-
-        if(!TextUtils.isEmpty(board) && board.contains("amazon")) {
-            return true;
-        }
-
-        return !TextUtils.isEmpty(device) && device.contains("amazon");
-
     }
 
     public static boolean isNetworkAvailable(Context context) {
@@ -166,39 +136,25 @@ public class Utils {
     }
 
     public static void goToAppStore(AppType appType, Context context) {
-        if(com.instructure.pandautils.utils.Utils.isAmazonDevice()) {
-            String marketURL = "";
-            if(appType == AppType.STUDENT) {
-                marketURL = "http://www.amazon.com/gp/mas/dl/android?p=com.instructure.candroid";
-            }
-            else if(appType == AppType.POLLING) {
-
-            }
-            Intent goToAppstore = new Intent(Intent.ACTION_VIEW);
-            goToAppstore.setData(Uri.parse(marketURL));
-            context.startActivity(goToAppstore);
+        String packageName = "";
+        if (appType == AppType.STUDENT) {
+            packageName = "com.instructure.candroid";
+        } else if (appType == AppType.POLLING) {
+            packageName = "com.instructure.androidpolling";
+        } else if (appType == AppType.PARENT) {
+            packageName = "com.instructure.parentapp";
+        } else if (appType == AppType.TEACHER) {
+            packageName = "com.instructure.teacher";
         }
-        else {
-            String packageName = "";
-            if (appType == AppType.STUDENT) {
-                packageName = "com.instructure.candroid";
-            } else if (appType == AppType.POLLING) {
-                packageName = "com.instructure.androidpolling";
-            } else if (appType == AppType.PARENT) {
-                packageName = "com.instructure.parentapp";
-            } else if (appType == AppType.TEACHER) {
-                packageName = "com.instructure.teacher";
-            }
-            try {
-                Intent goToMarket = new Intent(Intent.ACTION_VIEW);
-                goToMarket.setData(Uri.parse("market://details?id=" + packageName));
-                context.startActivity(goToMarket);
-            } catch (ActivityNotFoundException e) {
-                //the device might not have the play store installed, open it in a webview
-                Intent goToMarket = new Intent(Intent.ACTION_VIEW);
-                goToMarket.setData(Uri.parse("https://play.google.com/store/apps/details?id=" + packageName));
-                context.startActivity(goToMarket);
-            }
+        try {
+            Intent goToMarket = new Intent(Intent.ACTION_VIEW);
+            goToMarket.setData(Uri.parse("market://details?id=" + packageName));
+            context.startActivity(goToMarket);
+        } catch (ActivityNotFoundException e) {
+            //the device might not have the play store installed, open it in a webview
+            Intent goToMarket = new Intent(Intent.ACTION_VIEW);
+            goToMarket.setData(Uri.parse("https://play.google.com/store/apps/details?id=" + packageName));
+            context.startActivity(goToMarket);
         }
     }
 


### PR DESCRIPTION
To test, make sure you’re not using the new file submission flow.

Go to an assignment that accepts media recording submissions.

Make sure line 205 and 206 look like this in `NotoriousMediaUploadPicker`:
```kotlin
callback?.invoke(mediaUri.path, NotoriousUploadService.ACTION.ASSIGNMENT_SUBMISSION)
// startService(serviceIntent)
```

and add this as part of the companion object of the same class:
```kotlin
var callback: ((String, NotoriousUploadService.ACTION) -> Unit)? = null
```


Add this in `NotoriousUploadService`, line 262:

```kotlin
val uploadCompleteIntent = Intent(FileUploadService.ALL_UPLOADS_COMPLETED)
uploadCompleteIntent.putExtra(Const.SUBMISSION_ID, notificationId.toLong())
assignment?.name?.let { uploadCompleteIntent.putExtra(Const.ASSIGNMENT_NAME, it)}
sendBroadcast(uploadCompleteIntent)
```

In the same class, for testing errors, make sure `sendErrorBroadcast()` looks like this:
```kotlin 
private fun sendErrorBroadcast() {
    showErrorNotification()
//    val errorIntent = Intent(Const.ACTION_MEDIA_UPLOAD_FAIL).apply {
//        putExtra(Const.MEDIA_FILE_PATH, mediaPath)
//        putExtra(Const.PAGE_ID, pageId)
//        putExtra(Const.ERROR, true)
//    }
//    LocalBroadcastManager.getInstance(context).sendBroadcast(errorIntent)
    }
```

In `AddSubmissionFragment`, make sure the click listener for `mediaSubmission` (line 363) looks like this:
```kotlin
  mediaSubmission.setOnClickListener {
            val intent = NotoriousMediaUploadPicker.createIntentForAssignmentSubmission(requireContext(), assignment)
            NotoriousMediaUploadPicker.callback = { filePath, action ->
                SubmissionService.startMediaSubmission(context!!, canvasContext, assignment.id, assignment.name, filePath, action)
//                activity?.startService(intent)
            }
            startActivityForResult(intent, RequestCodes.NOTORIOUS_REQUEST)
        }
```

