### PR TITLE
[Teacher][MBL-12707] Fix duplicate empty message on favorrites screen.

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/EditFavoritesFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/EditFavoritesFragment.kt
@@ -93,7 +93,7 @@ class EditFavoritesFragment : BaseSyncFragment<
 
     override fun onPresenterPrepared(presenter: EditFavoritesPresenter) {
         mRecyclerView = RecyclerViewUtils.buildRecyclerView(mRootView, requireContext(), adapter, presenter, R.id.swipeRefreshLayout,
-                R.id.favoritesRecyclerView, R.id.emptyPandaView, getString(R.string.noCoursesSubtext))
+                R.id.favoritesRecyclerView, R.id.emptyPandaView, getString(R.string.noCourses))
         mRecyclerView.itemAnimator = null
     }
 


### PR DESCRIPTION
The empty message was showing for both the title and the message on the empty screen:
"It looks like there aren't any courses associated with this account. Visit the web to create a course today."