### PR TITLE
[MBL-11604][Student][Teacher] Fix notification crash

### DIFF
--- a/libs/login-api-2/src/main/java/com/instructure/loginapi/login/tasks/LogoutTask.kt
+++ b/libs/login-api-2/src/main/java/com/instructure/loginapi/login/tasks/LogoutTask.kt
@@ -27,6 +27,7 @@ import com.instructure.canvasapi2.utils.ContextKeeper
 import com.instructure.canvasapi2.utils.MasqueradeHelper
 import com.instructure.canvasapi2.utils.weave.weave
 import com.instructure.loginapi.login.util.PreviousUsersUtils
+import com.instructure.pandautils.models.PushNotification
 import com.instructure.pandautils.utils.FilePrefs
 import com.instructure.pandautils.utils.ThemePrefs
 import com.instructure.pandautils.utils.Utils
@@ -61,6 +62,7 @@ abstract class LogoutTask(val type: Type) {
                 RestBuilder.clearCacheDirectory()
                 Utils.getAttachmentsDirectory(ContextKeeper.appContext).deleteRecursively()
                 File(ContextKeeper.appContext.filesDir, "cache").deleteRecursively()
+                PushNotification.clearPushHistory()
 
                 // Clear prefs
                 ApiPrefs.clearAllData()

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/receivers/PushExternalReceiver.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/receivers/PushExternalReceiver.kt
@@ -98,9 +98,10 @@ abstract class PushExternalReceiver : GcmListenerService() {
                 return
             }
 
-            val pushes = PushNotification.getStoredPushes()
+            // Only the first few lines get shown in the notification, and taking all could result in a crash (given an EXTREMELY large amount)
+            val pushes = PushNotification.getStoredPushes().takeLast(10)
 
-            if (pushes.size == 0 && extras == null) {
+            if (pushes.isEmpty() && extras == null) {
                 // Nothing to post, situation would occur from the BootReceiver
                 return
             }


### PR DESCRIPTION
To test, in the PushExternalReceiver onMessageReceived method, I looped and added the push notification 1000 times each receive to get a lot of messages stored locally. Once I had the crash, removing that loop and just getting one notification resulted in the same crash.
Replace this:
```
            val push = PushNotification(htmlUrl, from, alert, collapseKey, userId)
            if (PushNotification.store(push)) {
                postNotification(this, msg, getAppName(this), getStartingActivityClass(), getAppColor())
            }
```
with
```
            val push = PushNotification(htmlUrl, from, alert, collapseKey, userId)
            for (i in 0..1000) {
                PushNotification.store(push)
            }
            if (PushNotification.store(push)) {
                postNotification(this, msg, getAppName(this), getStartingActivityClass(), getAppColor())
            }
```

This does take a little time to store all the notifications, so the notification popping or the error showing can take up to ~10 seconds or more.