### PR TITLE
[Student][MBL-12846] Add user ID to submissions in database

### DIFF
--- a/apps/student/src/main/db/com/instructure/student/Submission.sq
+++ b/apps/student/src/main/db/com/instructure/student/Submission.sq
@@ -29,20 +29,21 @@ CREATE TABLE submission (
     canvasContext TEXT as CanvasContext,
     submissionType TEXT,
     errorFlag INTEGER as Boolean NOT NULL DEFAULT 0,
-    assignmentGroupCategoryId INTEGER
+    assignmentGroupCategoryId INTEGER,
+    userId INTEGER
 );
 
 insertOnlineTextSubmission:
-INSERT INTO submission (submissionEntry, assignmentName, assignmentId, canvasContext, submissionType)
-VALUES (?, ?, ?, ?, "online_text_entry");
+INSERT INTO submission (submissionEntry, assignmentName, assignmentId, canvasContext, userId, lastActivityDate, submissionType)
+VALUES (?, ?, ?, ?, ?, ?, "online_text_entry");
 
 insertOnlineUrlSubmission:
-INSERT INTO submission (submissionEntry, assignmentName, assignmentId, canvasContext, submissionType)
-VALUES (?, ?, ?, ?, "online_url"); --"basic_lti_launch" else "online_url"
+INSERT INTO submission (submissionEntry, assignmentName, assignmentId, canvasContext, userId, lastActivityDate, submissionType)
+VALUES (?, ?, ?, ?, ?, ?, "online_url"); --"basic_lti_launch" else "online_url"
 
 insertOnlineUploadSubmission:
-INSERT INTO submission (assignmentName, assignmentId, assignmentGroupCategoryId, canvasContext, submissionType)
-VALUES (?, ?, ?, ?, "online_upload");
+INSERT INTO submission (assignmentName, assignmentId, assignmentGroupCategoryId, canvasContext, userId, lastActivityDate, submissionType)
+VALUES (?, ?, ?, ?, ?, ?, "online_upload");
 
 getAllSubmissions:
 SELECT *
@@ -56,7 +57,8 @@ WHERE id = ?;
 getSubmissionsByAssignmentId:
 SELECT *
 FROM submission
-WHERE assignmentId = ?;
+WHERE assignmentId = ?
+AND userId = ?;
 
 deleteSubmissionById:
 DELETE

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsModels.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsModels.kt
@@ -27,7 +27,7 @@ sealed class AssignmentDetailsEvent {
     object ViewUploadStatusClicked : AssignmentDetailsEvent()
     object PullToRefresh : AssignmentDetailsEvent()
     data class SubmissionTypeClicked(val submissionType: Assignment.SubmissionType) : AssignmentDetailsEvent()
-    data class DataLoaded(val assignmentResult: DataResult<Assignment>?, val isArcEnabled: Boolean, val ltiTool: DataResult<LTITool>?) : AssignmentDetailsEvent()
+    data class DataLoaded(val assignmentResult: DataResult<Assignment>?, val isArcEnabled: Boolean, val ltiTool: DataResult<LTITool>?, val submissionId: Long?) : AssignmentDetailsEvent()
     data class SubmissionStatusUpdated(val status: SubmissionUploadStatus) : AssignmentDetailsEvent()
     data class InternalRouteRequested(val url: String) : AssignmentDetailsEvent()
 }
@@ -35,7 +35,7 @@ sealed class AssignmentDetailsEvent {
 sealed class AssignmentDetailsEffect {
     data class ShowSubmitDialogView(val assignment: Assignment, val course: Course, val isArcEnabled: Boolean) : AssignmentDetailsEffect()
     data class ShowSubmissionView(val assignmentId: Long, val course: Course) : AssignmentDetailsEffect()
-    data class ShowUploadStatusView(val assignmentId: Long, val course: Course) : AssignmentDetailsEffect()
+    data class ShowUploadStatusView(val submissionId: Long) : AssignmentDetailsEffect()
     data class ShowCreateSubmissionView(val submissionType: Assignment.SubmissionType, val course: Course, val assignment: Assignment, val ltiUrl: String? = null) : AssignmentDetailsEffect()
     data class LoadData(val assignmentId: Long, val courseId: Long, val forceNetwork: Boolean) : AssignmentDetailsEffect()
     data class ObserveSubmissionStatus(val assignmentId: Long) : AssignmentDetailsEffect()
@@ -53,7 +53,8 @@ data class AssignmentDetailsModel(
     val assignmentResult: DataResult<Assignment>? = null,
     val isArcEnabled: Boolean = false,
     val status: SubmissionUploadStatus = SubmissionUploadStatus.Empty,
-    val ltiTool: DataResult<LTITool>? = null
+    val ltiTool: DataResult<LTITool>? = null,
+    val databaseSubmissionId: Long? = null
 )
 
 sealed class SubmissionUploadStatus {

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsUpdate.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsUpdate.kt
@@ -43,7 +43,8 @@ class AssignmentDetailsUpdate : UpdateInit<AssignmentDetailsModel, AssignmentDet
             Next.dispatch(setOf(AssignmentDetailsEffect.ShowSubmissionView(model.assignmentId, model.course)))
         }
         AssignmentDetailsEvent.ViewUploadStatusClicked -> {
-            Next.dispatch(setOf(AssignmentDetailsEffect.ShowUploadStatusView(model.assignmentId, model.course)))
+            // Force non null, we should only have a click if there is a submission ID
+            Next.dispatch(setOf(AssignmentDetailsEffect.ShowUploadStatusView(model.databaseSubmissionId!!)))
         }
         AssignmentDetailsEvent.PullToRefresh -> {
             Next.next(model.copy(isLoading = true), setOf(AssignmentDetailsEffect.LoadData(model.assignmentId, model.course.id, true)))
@@ -56,7 +57,8 @@ class AssignmentDetailsUpdate : UpdateInit<AssignmentDetailsModel, AssignmentDet
                 isLoading = false,
                 assignmentResult = event.assignmentResult,
                 isArcEnabled = event.isArcEnabled,
-                ltiTool = event.ltiTool
+                ltiTool = event.ltiTool,
+                databaseSubmissionId = event.submissionId
             ))
         }
         is AssignmentDetailsEvent.SubmissionTypeClicked -> {

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsFragment.kt
@@ -37,7 +37,7 @@ class AssignmentDetailsFragment :
     @get:PageViewUrlParam(name = "assignmentId")
     val assignmentId by LongArg(key = Const.ASSIGNMENT_ID)
 
-    override fun makeEffectHandler() = AssignmentDetailsEffectHandler()
+    override fun makeEffectHandler() = AssignmentDetailsEffectHandler(requireContext())
 
     override fun makeUpdate() = AssignmentDetailsUpdate()
 

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsView.kt
@@ -206,9 +206,7 @@ class AssignmentDetailsView(
         RouteMatcher.route(context, SubmissionDetailsFragment.makeRoute(course, assignmentId))
     }
 
-    fun showUploadStatusView(assignmentId: Long, course: Course) {
-        // TODO
-        context.toast("Route to status page")
+    fun showUploadStatusView(submissionId: Long) {
     }
 
     fun showOnlineTextEntryView(assignmentId: Long, assignmentName: String?, submittedText: String? = null) {

--- a/apps/student/src/main/java/com/instructure/student/mobius/common/ui/SubmissionService.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/common/ui/SubmissionService.kt
@@ -46,6 +46,7 @@ import com.instructure.student.db.Db
 import com.instructure.student.db.getInstance
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import org.threeten.bp.OffsetDateTime
 import java.io.File
 import java.util.*
 
@@ -106,6 +107,8 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
         setIntentRedelivery(true)
     }
 
+    private fun getUserId() = ApiPrefs.user!!.id
+
     override fun onHandleIntent(intent: Intent) {
         val action = intent.action!!
 
@@ -127,7 +130,7 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
         val db = Db.getInstance(this).submissionQueries
 
         // Save to persistence
-        db.insertOnlineTextSubmission(text, assignmentName, assignmentId, context)
+        db.insertOnlineTextSubmission(text, assignmentName, assignmentId, context, getUserId(), OffsetDateTime.now())
         dbSubmissionId = db.getLastInsert().executeAsOne()
 
         showProgressNotification(assignmentName, dbSubmissionId)
@@ -153,7 +156,7 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
         val db = Db.getInstance(this).submissionQueries
 
         // Save to persistence
-        db.insertOnlineUrlSubmission(url, assignmentName, assignmentId, context)
+        db.insertOnlineUrlSubmission(url, assignmentName, assignmentId, context, getUserId(), OffsetDateTime.now())
         dbSubmissionId = db.getLastInsert().executeAsOne()
 
         showProgressNotification(assignmentName, dbSubmissionId)
@@ -197,7 +200,9 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
                 assignment.name,
                 assignment.id,
                 assignment.groupCategoryId,
-                canvasContext
+                canvasContext,
+                getUserId(),
+                OffsetDateTime.now()
             )
             dbSubmissionId = submissionsDb.getLastInsert().executeAsOne()
 
@@ -256,7 +261,9 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
                 assignment.name,
                 assignment.id,
                 assignment.groupCategoryId,
-                context
+                context,
+                getUserId(),
+                OffsetDateTime.now()
             )
             dbSubmissionId = submissionsDb.getLastInsert().executeAsOne()
 

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsUpdateTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsUpdateTest.kt
@@ -38,11 +38,13 @@ class AssignmentDetailsUpdateTest : Assert() {
     private lateinit var initModel: AssignmentDetailsModel
     private lateinit var course: Course
     private lateinit var assignment: Assignment
+    private var submissionId: Long = 0
     private var assignmentId: Long = 0
     private var courseId: Long = 0
 
     @Before
     fun setup() {
+        submissionId = 2468L
         assignmentId = 4321L
         courseId = 1234L
         course = Course(id = courseId)
@@ -195,14 +197,13 @@ class AssignmentDetailsUpdateTest : Assert() {
     @Test
     fun `ViewUploadStatusClicked event results in ShowUploadStatusView effect`() {
         updateSpec
-            .given(initModel)
+            .given(initModel.copy(databaseSubmissionId = submissionId))
             .whenEvent(AssignmentDetailsEvent.ViewUploadStatusClicked)
             .then(
                 assertThatNext(
                     matchesEffects<AssignmentDetailsModel, AssignmentDetailsEffect>(
                         AssignmentDetailsEffect.ShowUploadStatusView(
-                            assignmentId,
-                            course
+                            submissionId
                         )
                     )
                 )
@@ -241,7 +242,8 @@ class AssignmentDetailsUpdateTest : Assert() {
             status = SubmissionUploadStatus.Uploading,
             assignmentResult = DataResult.Success(assignment),
             isArcEnabled = true,
-            ltiTool = DataResult.Fail(null)
+            ltiTool = DataResult.Fail(null),
+            databaseSubmissionId = submissionId
         )
         updateSpec
             .given(startModel)
@@ -249,7 +251,8 @@ class AssignmentDetailsUpdateTest : Assert() {
                 AssignmentDetailsEvent.DataLoaded(
                     assignmentResult = expectedModel.assignmentResult,
                     isArcEnabled = true,
-                    ltiTool = expectedModel.ltiTool
+                    ltiTool = expectedModel.ltiTool,
+                    submissionId = submissionId
                 )
             )
             .then(assertThatNext(NextMatchers.hasModel(expectedModel)))
@@ -262,7 +265,8 @@ class AssignmentDetailsUpdateTest : Assert() {
             isLoading = false,
             status = SubmissionUploadStatus.Uploading,
             assignmentResult = DataResult.Fail(),
-            ltiTool = DataResult.Fail()
+            ltiTool = DataResult.Fail(),
+            databaseSubmissionId = submissionId
         )
         updateSpec
             .given(startModel)
@@ -270,7 +274,8 @@ class AssignmentDetailsUpdateTest : Assert() {
                 AssignmentDetailsEvent.DataLoaded(
                     assignmentResult = expectedModel.assignmentResult,
                     isArcEnabled = false,
-                    ltiTool = expectedModel.ltiTool
+                    ltiTool = expectedModel.ltiTool,
+                    submissionId = submissionId
                 )
             )
             .then(assertThatNext(NextMatchers.hasModel(expectedModel)))
@@ -279,15 +284,21 @@ class AssignmentDetailsUpdateTest : Assert() {
     @Test
     fun `DataLoaded event with a null assignment updates the model`() {
         val startModel = initModel.copy(status = SubmissionUploadStatus.Uploading)
-        val expectedModel =
-            initModel.copy(isLoading = false, status = SubmissionUploadStatus.Uploading, assignmentResult = null, ltiTool = null)
+        val expectedModel = initModel.copy(
+            isLoading = false,
+            status = SubmissionUploadStatus.Uploading,
+            assignmentResult = null,
+            ltiTool = null,
+            databaseSubmissionId = submissionId
+        )
         updateSpec
             .given(startModel)
             .whenEvent(
                 AssignmentDetailsEvent.DataLoaded(
                     assignmentResult = expectedModel.assignmentResult,
                     isArcEnabled = false,
-                    ltiTool = expectedModel.ltiTool
+                    ltiTool = expectedModel.ltiTool,
+                    submissionId = submissionId
                 )
             )
             .then(assertThatNext(NextMatchers.hasModel(expectedModel)))


### PR DESCRIPTION
Also added time when creating database submissions. This will let us diff in the assignment details screen to know if we have a (failed) persisted submission that's newer than what's given from the API.