### PR TITLE
[Student][MBL-12672]: Initial attempt at incorporating Firebase Remote Config

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/util/AppManager.kt
+++ b/apps/student/src/main/java/com/instructure/student/util/AppManager.kt
@@ -25,6 +25,7 @@ import com.google.android.gms.analytics.GoogleAnalytics
 import com.google.android.gms.analytics.HitBuilders
 import com.google.android.gms.analytics.Tracker
 import com.instructure.canvasapi2.utils.Logger
+import com.instructure.canvasapi2.utils.RemoteConfigUtils
 import com.instructure.canvasapi2.utils.pageview.PageViewUploadService
 import com.instructure.loginapi.login.tasks.LogoutTask
 import com.instructure.pandautils.utils.ColorKeeper
@@ -46,6 +47,7 @@ class AppManager : com.instructure.canvasapi2.AppManager(), AnalyticsEventHandli
     }
 
     override fun onCreate() {
+        RemoteConfigUtils.initialize()
         super.onCreate()
         initPSPDFKit()
 

--- a/buildSrc/src/main/java/GlobalDependencies.kt
+++ b/buildSrc/src/main/java/GlobalDependencies.kt
@@ -30,6 +30,7 @@ object Versions {
     const val ANDROIDX = "1.0.0"
     const val FIREBASE_CORE = "16.0.7"
     const val FIREBASE_JOB_DISPATCHER = "0.8.6"
+    const val FIREBASE_CONFIG = "18.0.0"
 
     /* Others */
     const val APOLLO = "1.0.0-alpha5"
@@ -76,6 +77,7 @@ object Libs {
     const val PLAY_SERVICES_AUTH = "com.google.android.gms:play-services-auth:16.0.1"
     const val FIREBASE_CORE = "com.google.firebase:firebase-core:${Versions.FIREBASE_CORE}"
     const val FIREBASE_JOB_DISPATCHER = "com.firebase:firebase-jobdispatcher:${Versions.FIREBASE_JOB_DISPATCHER}"
+    const val FIREBASE_CONFIG = "com.google.firebase:firebase-config:${Versions.FIREBASE_CONFIG}"
 
     /* Mobius */
     const val MOBIUS_CORE = "com.spotify.mobius:mobius-core:${Versions.MOBIUS}"

--- a/libs/canvas-api-2/build.gradle
+++ b/libs/canvas-api-2/build.gradle
@@ -135,6 +135,9 @@ dependencies {
 
     /* Paper No SQl Storage */
     api 'io.paperdb:paperdb:2.6'
+
+    // Remote Config
+    implementation Libs.FIREBASE_CONFIG
 }
 
 // MBL-12312: I added this as a way to publish Pact contract updates.

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/PrefRepoInterface.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/PrefRepoInterface.kt
@@ -1,0 +1,20 @@
+package com.instructure.canvasapi2.utils
+
+// Common interface for shared preference repositories/managers.
+// This made testing a little easier.
+interface PrefRepoInterface {
+    fun getInt(key: String, default: Int = 0) : Int
+    fun putInt(key: String, value: Int)
+
+    fun getBoolean(key: String, default: Boolean = false) : Boolean
+    fun putBoolean(key: String, value: Boolean)
+
+    fun getString(key: String, default: String? = null) : String?
+    fun putString(key: String, value: String)
+
+    fun getFloat(key: String, default: Float = 0f) : Float
+    fun putFloat(key: String, value: Float)
+
+    fun getLong(key: String, default: Long = 0L) : Long
+    fun putLong(key: String, value: Long)
+}

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/PrefUtils.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/PrefUtils.kt
@@ -85,7 +85,7 @@ import kotlin.reflect.KProperty
  * ```
  */
 @SuppressLint("CommitPrefEdits")
-abstract class PrefManager(prefFileName: String) {
+abstract class PrefManager(prefFileName: String) : PrefRepoInterface {
 
     /* The [SharedPreferences] instance which serves as the core persistence mechanism */
     internal val prefs by lazy {
@@ -148,20 +148,20 @@ abstract class PrefManager(prefFileName: String) {
 
     private inline fun Editor.save(block: Editor.() -> Unit) { block(); apply() }
 
-    fun getInt(key: String, default: Int = 0): Int = prefs.getInt(key, default)
-    fun putInt(key: String, value: Int) = editor.save { putInt(key, value) }
+    override fun getInt(key: String, default: Int): Int = prefs.getInt(key, default)
+    override fun putInt(key: String, value: Int) = editor.save { putInt(key, value) }
 
-    fun getBoolean(key: String, default: Boolean = false): Boolean = prefs.getBoolean(key, default)
-    fun putBoolean(key: String, value: Boolean) = editor.save { putBoolean(key, value) }
+    override fun getBoolean(key: String, default: Boolean): Boolean = prefs.getBoolean(key, default)
+    override fun putBoolean(key: String, value: Boolean) = editor.save { putBoolean(key, value) }
 
-    fun getString(key: String, default: String? = null): String? = prefs.getString(key, default)
-    fun putString(key: String, value: String) = editor.save { putString(key, value) }
+    override fun getString(key: String, default: String?): String? = prefs.getString(key, default)
+    override fun putString(key: String, value: String) = editor.save { putString(key, value) }
 
-    fun getFloat(key: String, default: Float = 0f): Float = prefs.getFloat(key, default)
-    fun putFloat(key: String, value: Float) = editor.save { putFloat(key, value) }
+    override fun getFloat(key: String, default: Float): Float = prefs.getFloat(key, default)
+    override fun putFloat(key: String, value: Float) = editor.save { putFloat(key, value) }
 
-    fun getLong(key: String, default: Long = 0L): Long = prefs.getLong(key, default)
-    fun putLong(key: String, value: Long) = editor.save { putLong(key, value) }
+    override fun getLong(key: String, default: Long): Long = prefs.getLong(key, default)
+    override fun putLong(key: String, value: Long) = editor.save { putLong(key, value) }
 
     fun remove(key: String) = editor.remove(key).apply()
 }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/RemoteConfigPrefs.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/RemoteConfigPrefs.kt
@@ -1,0 +1,8 @@
+package com.instructure.canvasapi2.utils
+
+const val REMOTE_CONFIG_PREFS_FILE = "remote-config-prefs"
+
+// A separate prefs repo for remote config
+object RemoteConfigPrefs : PrefManager(REMOTE_CONFIG_PREFS_FILE) {
+
+}

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/RemoteConfigUtils.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/RemoteConfigUtils.kt
@@ -1,0 +1,96 @@
+package com.instructure.canvasapi2.utils
+
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
+
+/**
+ * All access to remote config data from our code must go through these enum values.
+ * [rc_name] is the name of the parameter as specified in the remote config console.
+ * [safeValueAsString] is the "safe to use" value for the parameter, specified in string form.  This
+ * will be the value used before the actual value can be read from the remote config service.
+ */
+enum class RemoteConfigParam(val rc_name: String, val safeValueAsString: String) {
+    TEST_BOOL("test_bool", "false"),
+    TEST_FLOAT("test_float", "0f"),
+    TEST_STRING("test_string", "hey there"),
+    TEST_LONG("test_long", "42")
+}
+
+/**
+ * Singleton object for accessing remote config settings.
+ *
+ * The "source of truth" for remote config param values is the remote config shared preference
+ * repo.  We will grab the current remote config values once at startup and update the
+ * shared prefs from the result.
+ */
+object RemoteConfigUtils {
+
+    lateinit var remoteConfig : FirebaseRemoteConfig
+    lateinit var prefs : PrefRepoInterface
+    var initialized : Boolean = false
+
+    // Normal initializer
+    fun initialize() {
+        initialize(FirebaseRemoteConfig.getInstance(), RemoteConfigPrefs)
+    }
+
+    // Test initializer
+    fun initialize(config: FirebaseRemoteConfig, prefs: PrefRepoInterface) {
+        // Don't allow multiple initializations
+        if(initialized) {
+            throw IllegalStateException("RemoteConfigUtils initialized twice")
+        }
+
+        this.remoteConfig = config
+        this.prefs = prefs
+
+        val configSettings = FirebaseRemoteConfigSettings.Builder()
+                .setMinimumFetchIntervalInSeconds(3600) // once an hour allowed; you may want to adjust when debugging
+                .build()
+        remoteConfig.setConfigSettings(configSettings)
+
+        initialized = true
+
+        remoteConfig.fetchAndActivate().addOnCompleteListener() { task ->
+            //println("rc: listener called.  successful=${task.isSuccessful}, updated=${task.result}")
+            if(task.isSuccessful) {
+                val updated = task.getResult()
+                if(updated != null && updated) {
+                    remoteConfig.getKeysByPrefix("").forEach() {
+                        //println("rc: on completion: putting ($it, ${remoteConfig.getString(it)}) into prefs")
+                        prefs.putString(it, remoteConfig.getString(it))
+                        //println("rc: on completion: retrieved ${prefs.getString(it)}")
+                    }
+                }
+            }
+        }
+    }
+
+    /** Get the remote config value for a RemoteConfigParam in string form. */
+    fun getString(key: RemoteConfigParam): String? {
+        if(!initialized) {
+            throw IllegalStateException("RemoteConfigUtils not initialized")
+        }
+
+        val result = prefs.getString(key.rc_name,  key.safeValueAsString)
+        //println("RemoteConfigUtils.getString: rc_name=${key.rc_name}, default=${key.safeValueAsString}, result=$result")
+        return result
+    }
+
+    //
+    // We store all values in string form.  But if you know that your value should be Boolean/Long/Float,
+    // these convenience methods are provided to make the conversion.
+    //
+
+    fun getBoolean(key: RemoteConfigParam) : Boolean? {
+        return getString(key)?.toBoolean()
+    }
+
+    fun getLong(key: RemoteConfigParam) : Long? {
+        return getString(key)?.toLong()
+    }
+
+    fun getFloat(key: RemoteConfigParam) : Float? {
+        return getString(key)?.toFloat()
+    }
+}

--- a/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/unit/RemoteConfigUtilsTest.kt
+++ b/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/unit/RemoteConfigUtilsTest.kt
@@ -1,0 +1,150 @@
+package com.instructure.canvasapi2.unit
+
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.instructure.canvasapi2.utils.PrefRepoInterface
+import com.instructure.canvasapi2.utils.RemoteConfigParam
+import com.instructure.canvasapi2.utils.RemoteConfigUtils
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+// Class emulates a shared preference repository
+class FakeRepo : PrefRepoInterface {
+    val localVals = emptyMap<String,Any>().toMutableMap()
+
+    override fun getInt(key: String, default: Int): Int {
+        return localVals.getOrDefault(key, default) as Int
+    }
+
+    override fun putInt(key: String, value: Int) {
+        localVals.put(key, value)
+    }
+
+    override fun getBoolean(key: String, default: Boolean): Boolean {
+        return localVals.getOrDefault(key, default) as Boolean
+    }
+
+    override fun putBoolean(key: String, value: Boolean) {
+        localVals.put(key, value)
+    }
+
+    override fun getString(key: String, default: String?): String? {
+        return localVals.get(key)?.toString() ?: default
+    }
+
+    override fun putString(key: String, value: String) {
+        localVals.put(key, value)
+    }
+
+    override fun getFloat(key: String, default: Float): Float {
+        return localVals.getOrDefault(key, default) as Float
+    }
+
+    override fun putFloat(key: String, value: Float) {
+        localVals.put(key, value)
+    }
+
+    override fun getLong(key: String, default: Long): Long {
+        return localVals.getOrDefault(key, default) as Long
+    }
+
+    override fun putLong(key: String, value: Long) {
+        localVals.put(key, value)
+    }
+
+    fun clear() {
+        localVals.clear()
+    }
+
+}
+
+class RemoteConfigUtilsTest : Assert() {
+
+    val localPrefs = FakeRepo()
+    lateinit var config : FirebaseRemoteConfig
+
+    @Before
+    fun setUp() {
+        localPrefs.clear()
+        config = mockk<FirebaseRemoteConfig>(relaxed = true)
+
+        // Reset the "initialized" field in RemoteConfigUtils
+        var field = RemoteConfigUtils::class.java.getDeclaredField("initialized")
+        field.isAccessible = true
+        field.set(RemoteConfigUtils, false)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    // Simulate a successful fetch of the values and verify that all works as expected.
+    @Test
+    fun `test simulated fetch`() {
+        // Simulate fetched values in the FirebaseRemoteConfig object
+        every {config.getString("test_bool")} returns "true"
+        every {config.getString("test_string")} returns "hello"
+        every {config.getString("test_float")} returns "3.14"
+        every {config.getString("test_long")} returns  "101010"
+        every {config.getKeysByPrefix("")} returns setOf("test_bool", "test_string", "test_float", "test_long")
+        every {config.fetchAndActivate().addOnCompleteListener(any<OnCompleteListener<Boolean>>())} answers {
+            val rval = Tasks.forResult(true)
+            (this.args[0] as OnCompleteListener<Boolean>).onComplete(rval)
+            rval
+        }
+
+        RemoteConfigUtils.initialize(config, localPrefs)
+
+        assertEquals("true",RemoteConfigUtils.getString(RemoteConfigParam.TEST_BOOL))
+        assertEquals(true, RemoteConfigUtils.getBoolean(RemoteConfigParam.TEST_BOOL)!!)
+        assertEquals("hello",RemoteConfigUtils.getString(RemoteConfigParam.TEST_STRING))
+        assertEquals("3.14", RemoteConfigUtils.getString(RemoteConfigParam.TEST_FLOAT))
+        assertEquals(3.14f, RemoteConfigUtils.getFloat(RemoteConfigParam.TEST_FLOAT)!!, 0.01f)
+        assertEquals("101010",RemoteConfigUtils.getString(RemoteConfigParam.TEST_LONG))
+        assertEquals(101010L, RemoteConfigUtils.getLong(RemoteConfigParam.TEST_LONG)!!)
+    }
+
+    // Grab vals when initialization does no fetch and verify that the "safe" vals are returned
+    @Test
+    fun `test default vals`() {
+        RemoteConfigUtils.initialize(config, localPrefs)
+        RemoteConfigParam.values().forEach {
+            assertEquals(it.safeValueAsString, RemoteConfigUtils.getString(it))
+        }
+    }
+
+    // Verifies that type conversions are working as expected.
+    @Test
+    fun `test type conversions`() {
+        RemoteConfigUtils.initialize(config, localPrefs)
+
+        localPrefs.putBoolean(RemoteConfigParam.TEST_BOOL.rc_name, true)
+        assertEquals(true, RemoteConfigUtils.getBoolean(RemoteConfigParam.TEST_BOOL))
+        assertEquals("true", RemoteConfigUtils.getString(RemoteConfigParam.TEST_BOOL))
+
+        localPrefs.putFloat(RemoteConfigParam.TEST_FLOAT.rc_name, 3.14f)
+        assertEquals(3.14f, RemoteConfigUtils.getFloat(RemoteConfigParam.TEST_FLOAT)!!, 0.01f)
+        assertEquals("3.14", RemoteConfigUtils.getString(RemoteConfigParam.TEST_FLOAT))
+
+        localPrefs.putLong(RemoteConfigParam.TEST_LONG.rc_name, 101)
+        assertEquals(101L, RemoteConfigUtils.getLong(RemoteConfigParam.TEST_LONG))
+        assertEquals("101", RemoteConfigUtils.getString(RemoteConfigParam.TEST_LONG))
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `throws on use without initialization`() {
+        RemoteConfigUtils.getString(RemoteConfigParam.TEST_STRING)
+    }
+
+    @Test
+    fun `fail every time` () {
+        assertTrue(false)
+    }
+}

--- a/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/unit/RemoteConfigUtilsTest.kt
+++ b/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/unit/RemoteConfigUtilsTest.kt
@@ -142,9 +142,4 @@ class RemoteConfigUtilsTest : Assert() {
     fun `throws on use without initialization`() {
         RemoteConfigUtils.getString(RemoteConfigParam.TEST_STRING)
     }
-
-    @Test
-    fun `fail every time` () {
-        assertTrue(false)
-    }
 }


### PR DESCRIPTION
Initially, we're only doing this in the Student app.

We may want to do a few more things before charging into Remote Config usage:
- Decide on a naming scheme for remote config parameters.  Should we name specifically for app (e.g., "student_rubric_v2"), with the possibility of naming for all apps (e.g., "all_rubric_v2")?
- Add a "remote config settings" menu/activity in debug builds to allow us to locally override remote config parameter values.