### PR TITLE
[Student][MBL-12847] Hooked in database submissions to status on assignment details

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/renderPages/AssignmentDetailsRenderPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/renderPages/AssignmentDetailsRenderPage.kt
@@ -23,6 +23,8 @@ import androidx.test.espresso.web.webdriver.DriverAtoms.getText
 import androidx.test.espresso.web.webdriver.Locator
 import com.instructure.espresso.*
 import com.instructure.espresso.page.onViewWithText
+import com.instructure.espresso.page.withId
+import com.instructure.espresso.page.withText
 import com.instructure.student.R
 import com.instructure.student.ui.pages.AssignmentDetailsPage
 import org.hamcrest.Matchers
@@ -39,6 +41,9 @@ class AssignmentDetailsRenderPage : AssignmentDetailsPage() {
     val noDescription by OnViewWithId(R.id.noDescriptionContainer)
     val descriptionWebView by OnViewWithId(R.id.descriptionWebView)
     val gradeContainer by OnViewWithId(R.id.gradeContainer)
+    val submissionSuceeded by OnViewWithText(R.string.submissionStatusSuccessTitle)
+    val submissionStatusUploading by OnViewWithId(R.id.submissionStatusUploading)
+    val submissionStatusFailed by OnViewWithId(R.id.submissionStatusFailed)
 
     fun assertDisplaysToolbarTitle(text: String) {
         onViewWithText(text).assertDisplayed()
@@ -79,6 +84,19 @@ class AssignmentDetailsRenderPage : AssignmentDetailsPage() {
 
     fun assertDisplaysGrade() {
         gradeContainer.assertVisible()
+    }
+
+    fun assertDisplaysSuccessfulSubmit() {
+        assertDisplaysGrade()
+        submissionSuceeded.assertVisible()
+    }
+
+    fun assertDisplaysUploadingSubmission() {
+        submissionStatusUploading.assertVisible()
+    }
+
+    fun assertDisplaysFailedSubmission() {
+        submissionStatusFailed.assertVisible()
     }
 
     fun assertDisplaysDescription(text: String) {

--- a/apps/student/src/main/db/com/instructure/student/FileSubmission.sq
+++ b/apps/student/src/main/db/com/instructure/student/FileSubmission.sq
@@ -27,7 +27,8 @@ CREATE TABLE fileSubmission (
     contentType TEXT,
     fullPath TEXT,
     error TEXT,
-    errorFlag INTEGER as Boolean NOT NULL DEFAULT 0
+    errorFlag INTEGER as Boolean NOT NULL DEFAULT 0,
+    FOREIGN KEY (dbSubmissionId) REFERENCES submission(id) ON DELETE CASCADE
 );
 
 CREATE INDEX fileSubmission_dbSubmissionId ON fileSubmission(dbSubmissionId);

--- a/apps/student/src/main/db/com/instructure/student/Submission.sq
+++ b/apps/student/src/main/db/com/instructure/student/Submission.sq
@@ -65,6 +65,12 @@ DELETE
 FROM submission
 WHERE id = ?;
 
+deleteSubmissionsForAssignmentId:
+DELETE
+FROM submission
+WHERE assignmentId = ?
+AND userId = ?;
+
 setSubmissionError:
 UPDATE submission
 SET errorFlag = ?

--- a/apps/student/src/main/java/com/instructure/student/db/Extensions.kt
+++ b/apps/student/src/main/java/com/instructure/student/db/Extensions.kt
@@ -17,6 +17,7 @@
 package com.instructure.student.db
 
 import android.content.Context
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.squareup.sqldelight.android.AndroidSqliteDriver
 
 const val DB_NAME = "student.db"
@@ -24,7 +25,12 @@ const val DB_NAME = "student.db"
 fun Db.getInstance(context: Context): StudentDb {
     if (!ready)
         // Note: To use an in-memory database (for testing purposes), pass in 'null' for the name argument or don't pass anything at all (null by default)
-        dbSetup(AndroidSqliteDriver(Schema, context, DB_NAME))
+        dbSetup(AndroidSqliteDriver(Schema, context, DB_NAME, callback = object : AndroidSqliteDriver.Callback(Schema) {
+            override fun onOpen(db: SupportSQLiteDatabase?) {
+                super.onOpen(db)
+                db?.execSQL("PRAGMA foreign_keys=ON;")
+            }
+        }))
 
     return instance
 }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsModels.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsModels.kt
@@ -20,6 +20,7 @@ import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.models.LTITool
 import com.instructure.canvasapi2.utils.DataResult
+import com.instructure.student.Submission
 
 sealed class AssignmentDetailsEvent {
     object SubmitAssignmentClicked : AssignmentDetailsEvent()
@@ -27,18 +28,22 @@ sealed class AssignmentDetailsEvent {
     object ViewUploadStatusClicked : AssignmentDetailsEvent()
     object PullToRefresh : AssignmentDetailsEvent()
     data class SubmissionTypeClicked(val submissionType: Assignment.SubmissionType) : AssignmentDetailsEvent()
-    data class DataLoaded(val assignmentResult: DataResult<Assignment>?, val isArcEnabled: Boolean, val ltiTool: DataResult<LTITool>?, val submissionId: Long?) : AssignmentDetailsEvent()
-    data class SubmissionStatusUpdated(val status: SubmissionUploadStatus) : AssignmentDetailsEvent()
+    data class DataLoaded(
+        val assignmentResult: DataResult<Assignment>?,
+        val isArcEnabled: Boolean,
+        val ltiTool: DataResult<LTITool>?,
+        val submission: Submission?
+    ) : AssignmentDetailsEvent()
+    data class SubmissionStatusUpdated(val submission: Submission?) : AssignmentDetailsEvent()
     data class InternalRouteRequested(val url: String) : AssignmentDetailsEvent()
 }
 
 sealed class AssignmentDetailsEffect {
     data class ShowSubmitDialogView(val assignment: Assignment, val course: Course, val isArcEnabled: Boolean) : AssignmentDetailsEffect()
     data class ShowSubmissionView(val assignmentId: Long, val course: Course) : AssignmentDetailsEffect()
-    data class ShowUploadStatusView(val submissionId: Long) : AssignmentDetailsEffect()
+    data class ShowUploadStatusView(val submission: Submission) : AssignmentDetailsEffect()
     data class ShowCreateSubmissionView(val submissionType: Assignment.SubmissionType, val course: Course, val assignment: Assignment, val ltiUrl: String? = null) : AssignmentDetailsEffect()
     data class LoadData(val assignmentId: Long, val courseId: Long, val forceNetwork: Boolean) : AssignmentDetailsEffect()
-    data class ObserveSubmissionStatus(val assignmentId: Long) : AssignmentDetailsEffect()
     data class RouteInternally(
         val url: String,
         val course: Course,
@@ -52,14 +57,6 @@ data class AssignmentDetailsModel(
     val isLoading: Boolean = false,
     val assignmentResult: DataResult<Assignment>? = null,
     val isArcEnabled: Boolean = false,
-    val status: SubmissionUploadStatus = SubmissionUploadStatus.Empty,
     val ltiTool: DataResult<LTITool>? = null,
-    val databaseSubmissionId: Long? = null
+    val databaseSubmission: Submission? = null
 )
-
-sealed class SubmissionUploadStatus {
-    object Uploading : SubmissionUploadStatus()
-    object Failure : SubmissionUploadStatus()
-    object Finished : SubmissionUploadStatus()
-    object Empty : SubmissionUploadStatus()
-}

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsPresenter.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsPresenter.kt
@@ -24,6 +24,7 @@ import com.instructure.canvasapi2.utils.NumberHelper
 import com.instructure.canvasapi2.utils.isRtl
 import com.instructure.canvasapi2.utils.isValid
 import com.instructure.student.R
+import com.instructure.student.Submission
 import com.instructure.student.mobius.assignmentDetails.ui.AssignmentDetailsViewState
 import com.instructure.student.mobius.assignmentDetails.ui.AssignmentDetailsVisibilities
 import com.instructure.student.mobius.assignmentDetails.ui.gradeCell.GradeCellViewState
@@ -45,11 +46,12 @@ object AssignmentDetailsPresenter : Presenter<AssignmentDetailsModel, Assignment
         assignment.isArcEnabled = model.isArcEnabled
 
         // Loaded state
-        return presentLoadedState(assignment, context)
+        return presentLoadedState(assignment, model.databaseSubmission, context)
     }
 
     private fun presentLoadedState(
         assignment: Assignment,
+        databaseSubmission: Submission?,
         context: Context
     ): AssignmentDetailsViewState.Loaded {
         val visibilities = AssignmentDetailsVisibilities()
@@ -143,8 +145,14 @@ object AssignmentDetailsPresenter : Presenter<AssignmentDetailsModel, Assignment
             }
         )
 
+        // Show the grade cell if there's not a database submission and the grade state isn't empty
         val gradeState = GradeCellViewState.fromSubmission(context, assignment, assignment.submission)
-        visibilities.grade = gradeState != GradeCellViewState.Empty
+        if (databaseSubmission == null) {
+            visibilities.grade = gradeState != GradeCellViewState.Empty
+        } else {
+            visibilities.submissionUploadStatusInProgress = !databaseSubmission.errorFlag
+            visibilities.submissionUploadStatusFailed = databaseSubmission.errorFlag
+        }
 
         return AssignmentDetailsViewState.Loaded(
             assignmentName = assignment.name.orEmpty(),

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsFragment.kt
@@ -37,7 +37,7 @@ class AssignmentDetailsFragment :
     @get:PageViewUrlParam(name = "assignmentId")
     val assignmentId by LongArg(key = Const.ASSIGNMENT_ID)
 
-    override fun makeEffectHandler() = AssignmentDetailsEffectHandler(requireContext())
+    override fun makeEffectHandler() = AssignmentDetailsEffectHandler(requireContext(), assignmentId)
 
     override fun makeUpdate() = AssignmentDetailsUpdate()
 

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsView.kt
@@ -26,6 +26,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebView
+import android.widget.Toast
 import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.CanvasContext
 import com.instructure.canvasapi2.models.Course
@@ -125,7 +126,9 @@ class AssignmentDetailsView(
             noDescriptionContainer.setVisible(visibilities.noDescriptionLabel)
             descriptionWebView.setVisible(visibilities.description)
             submitButton.setVisible(visibilities.submitButton)
-            submissionUploadStatusContainer.setVisible(visibilities.submissionUploadStatus)
+            submissionUploadStatusContainer.setVisible(visibilities.submissionUploadStatusInProgress || visibilities.submissionUploadStatusFailed)
+            submissionStatusUploading.setVisible(visibilities.submissionUploadStatusInProgress)
+            submissionStatusFailed.setVisible(visibilities.submissionUploadStatusFailed)
             descriptionContainer.setVisible(visibilities.description || visibilities.noDescriptionLabel)
         }
 
@@ -152,11 +155,6 @@ class AssignmentDetailsView(
         if (state.visibilities.description) {
             descriptionWebView.formatHTML(state.description, state.assignmentName)
         }
-        renderSubmissionStatus(state)
-    }
-
-    private fun renderSubmissionStatus(state: AssignmentDetailsViewState.Loaded) {
-        // TODO
     }
 
     override fun onDispose() {
@@ -207,6 +205,7 @@ class AssignmentDetailsView(
     }
 
     fun showUploadStatusView(submissionId: Long) {
+        Toast.makeText(context, "Route to upload status", Toast.LENGTH_SHORT).show()
     }
 
     fun showOnlineTextEntryView(assignmentId: Long, assignmentName: String?, submittedText: String? = null) {

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsViewState.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsViewState.kt
@@ -18,7 +18,6 @@ package com.instructure.student.mobius.assignmentDetails.ui
 
 import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
-import com.instructure.student.mobius.assignmentDetails.SubmissionUploadStatus
 import com.instructure.student.mobius.assignmentDetails.ui.gradeCell.GradeCellViewState
 
 sealed class AssignmentDetailsViewState(val visibilities: AssignmentDetailsVisibilities) {
@@ -33,7 +32,6 @@ sealed class AssignmentDetailsViewState(val visibilities: AssignmentDetailsVisib
         val submittedStateLabel: String,
         @ColorInt val submittedStateColor: Int,
         @DrawableRes val submittedStateIcon: Int,
-        val submissionUploadStatus: SubmissionUploadStatus = SubmissionUploadStatus.Empty,
         val dueDate: String = "",
         val lockMessage: String = "",
         val submissionTypes: String = "",
@@ -60,7 +58,8 @@ data class AssignmentDetailsVisibilities (
     var noDescriptionLabel: Boolean = false,
     var description: Boolean = false,
     var submitButton: Boolean = false,
-    var submissionUploadStatus: Boolean = false
+    var submissionUploadStatusInProgress: Boolean = false,
+    var submissionUploadStatusFailed: Boolean = false
 )
 
 data class SubmissionTypesVisibilities(

--- a/apps/student/src/main/java/com/instructure/student/mobius/common/ui/SubmissionService.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/common/ui/SubmissionService.kt
@@ -43,6 +43,7 @@ import com.instructure.pandautils.utils.Const
 import com.instructure.student.R
 import com.instructure.student.activity.NavigationActivity
 import com.instructure.student.db.Db
+import com.instructure.student.db.StudentDb
 import com.instructure.student.db.getInstance
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -130,6 +131,7 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
         val db = Db.getInstance(this).submissionQueries
 
         // Save to persistence
+        db.deleteSubmissionsForAssignmentId(assignmentId, getUserId())
         db.insertOnlineTextSubmission(text, assignmentName, assignmentId, context, getUserId(), OffsetDateTime.now())
         dbSubmissionId = db.getLastInsert().executeAsOne()
 
@@ -156,6 +158,7 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
         val db = Db.getInstance(this).submissionQueries
 
         // Save to persistence
+        db.deleteSubmissionsForAssignmentId(assignmentId, getUserId())
         db.insertOnlineUrlSubmission(url, assignmentName, assignmentId, context, getUserId(), OffsetDateTime.now())
         dbSubmissionId = db.getLastInsert().executeAsOne()
 
@@ -196,6 +199,7 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
             )
         } else {
             // New submission - store submission details in the db
+            submissionsDb.deleteSubmissionsForAssignmentId(assignment.id, getUserId())
             submissionsDb.insertOnlineUploadSubmission(
                 assignment.name,
                 assignment.id,
@@ -257,6 +261,7 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
                 groupCategoryId = submission.assignmentGroupCategoryId ?: 0
             )
         } else {
+            submissionsDb.deleteSubmissionsForAssignmentId(assignment.id, getUserId())
             submissionsDb.insertOnlineUploadSubmission(
                 assignment.name,
                 assignment.id,

--- a/apps/student/src/main/res/layout/fragment_assignment_details.xml
+++ b/apps/student/src/main/res/layout/fragment_assignment_details.xml
@@ -146,36 +146,6 @@
                     tools:visibility="visible">
 
                     <LinearLayout
-                        android:id="@+id/submissionStatusSuccess"
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:gravity="center"
-                        android:orientation="vertical"
-                        android:padding="16dp"
-                        android:visibility="gone"
-                        tools:visibility="visible">
-
-                        <TextView
-                            style="@style/TextFont.Medium"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:gravity="center"
-                            android:text="@string/submissionStatusSuccessTitle"
-                            android:textColor="@color/alertGreen"
-                            android:textSize="20sp"/>
-
-                        <TextView
-                            style="@style/TextFont.Regular"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="6dp"
-                            android:gravity="center"
-                            android:text="@string/submissionStatusSuccessSubtitle"
-                            android:textColor="@color/defaultTextDark"/>
-
-                    </LinearLayout>
-
-                    <LinearLayout
                         android:id="@+id/submissionStatusUploading"
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
@@ -184,7 +154,9 @@
                         android:gravity="center"
                         android:orientation="vertical"
                         android:padding="16dp"
-                        android:visibility="gone">
+                        android:background="?attr/selectableItemBackground"
+                        android:visibility="gone"
+                        tools:visibility="visible">
 
                         <TextView
                             style="@style/TextFont.Medium"
@@ -216,6 +188,7 @@
                         android:gravity="center"
                         android:orientation="vertical"
                         android:padding="16dp"
+                        android:background="?attr/selectableItemBackground"
                         android:visibility="gone">
 
                         <TextView

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsPresenterTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsPresenterTest.kt
@@ -383,7 +383,10 @@ class AssignmentDetailsPresenterTest : Assert() {
             null,
             null
         )
-        val model = baseModel.copy(databaseSubmission = submission)
+        val model = baseModel.copy(
+            assignmentResult = DataResult.Success(baseAssignment),
+            databaseSubmission = submission
+        )
         val actual = AssignmentDetailsPresenter.present(model, context).visibilities.submissionUploadStatusInProgress
         assertTrue(actual)
     }
@@ -402,7 +405,10 @@ class AssignmentDetailsPresenterTest : Assert() {
             null,
             null
         )
-        val model = baseModel.copy(databaseSubmission = submission)
+        val model = baseModel.copy(
+            assignmentResult = DataResult.Success(baseAssignment),
+            databaseSubmission = submission
+        )
         val actual = AssignmentDetailsPresenter.present(model, context).visibilities.submissionUploadStatusFailed
         assertTrue(actual)
     }

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsPresenterTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsPresenterTest.kt
@@ -35,6 +35,7 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.threeten.bp.OffsetDateTime
 import java.util.*
 import java.util.concurrent.TimeUnit
 
@@ -365,6 +366,44 @@ class AssignmentDetailsPresenterTest : Assert() {
         )
         val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
         val actual = AssignmentDetailsPresenter.present(model, context).visibilities.grade
+        assertTrue(actual)
+    }
+
+    @Test
+    fun `Displays upload in progress when database submission is not failed`() {
+        val submission = com.instructure.student.Submission.Impl(
+            123L,
+            null,
+            OffsetDateTime.now(),
+            null,
+            baseAssignment.id,
+            null,
+            null,
+            false,
+            null,
+            null
+        )
+        val model = baseModel.copy(databaseSubmission = submission)
+        val actual = AssignmentDetailsPresenter.present(model, context).visibilities.submissionUploadStatusInProgress
+        assertTrue(actual)
+    }
+
+    @Test
+    fun `Displays failed submission when database submission is failed`() {
+        val submission = com.instructure.student.Submission.Impl(
+            123L,
+            null,
+            OffsetDateTime.now(),
+            null,
+            baseAssignment.id,
+            null,
+            null,
+            true,
+            null,
+            null
+        )
+        val model = baseModel.copy(databaseSubmission = submission)
+        val actual = AssignmentDetailsPresenter.present(model, context).visibilities.submissionUploadStatusFailed
         assertTrue(actual)
     }
 


### PR DESCRIPTION
To test:
Make a file submission, notice that when you come back to assignment details the page should update for "uploading in progress". When it succeeds, you'll see a succeeded message. When it fails (file quota limit for a group upload assignment), you'll see a failure message.

Should also update status for url/text submissions.