### PR TITLE
[Student][MBL-12828] Fix passing 'Null' auth provider back to Canvas

### DIFF
--- a/libs/login-api-2/src/main/java/com/instructure/loginapi/login/activities/BaseLoginSignInActivity.java
+++ b/libs/login-api-2/src/main/java/com/instructure/loginapi/login/activities/BaseLoginSignInActivity.java
@@ -477,7 +477,7 @@ public abstract class BaseLoginSignInActivity extends AppCompatActivity implemen
 
         //If an authentication provider is supplied we need to pass that along. This should only be appended if one exists.
         String authenticationProvider = accountDomain.getAuthenticationProvider();
-        if(authenticationProvider != null && authenticationProvider.length() > 0) {
+        if(authenticationProvider != null && authenticationProvider.length() > 0 && !authenticationProvider.equalsIgnoreCase("null")) {
             Logger.d("authentication_provider=" + authenticationProvider);
             builder.appendQueryParameter("authentication_provider", authenticationProvider);
         }


### PR DESCRIPTION
To test: 
	Search for 'scoe' in the school finder. Two results will pop up, one will work normally, the other won't... _until now._