### PR TITLE
[Student] Made adding/removing files from file picker better

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/ui/PickerSubmissionUploadView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/ui/PickerSubmissionUploadView.kt
@@ -225,6 +225,7 @@ interface PickerListCallback : BasicItemCallback {
 }
 
 class PickerListBinder : BasicItemBinder<PickerListItemViewState, PickerListCallback>() {
+    override fun getItemId(item: PickerListItemViewState) = item.position.toLong()
     override val layoutResId = R.layout.viewholder_file_upload
     override val bindBehavior = Item { state, pickerListCallback, _ ->
         fileIcon.setImageResource(state.iconRes)


### PR DESCRIPTION
Before, it was always adding/removing the first item in the list, which looked weird. Now it will animate less, but new items are added to the bottom, while removed items just render again.