### PR TITLE
[Student] Fix progress notifications always peeking

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/services/FileUploadService.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/services/FileUploadService.kt
@@ -297,7 +297,9 @@ class FileUploadService @JvmOverloads constructor(name: String = FileUploadServi
     @Suppress("unused", "UNUSED_PARAMETER")
     @Subscribe
     fun onUploadProgress(event: ProgressEvent) {
-        notificationBuilder.setProgress(100, (event.uploaded * 100f / event.contentLength).toInt(), false)
+        notificationBuilder
+            .setProgress(100, (event.uploaded * 100f / event.contentLength).toInt(), false)
+            .setOnlyAlertOnce(true)
         notificationManager.notify(event.submissionId.toInt(), notificationBuilder.build())
     }
 


### PR DESCRIPTION
Now, they'll only peek the first time.

This was especially annoying when uploading a large file or multiple large files. Every time you swiped the notification up to let it keep going in the background, the next progress update would make it peek again.