### PR TITLE
[Student][MBL-12923] Refresh assignment deets on successful submission

### DIFF
--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsUpdateTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsUpdateTest.kt
@@ -499,6 +499,23 @@ class AssignmentDetailsUpdateTest : Assert() {
     }
 
     @Test
+    fun `SubmissionStatusUpdated event updates the model and loads data when given a null submission`() {
+        val submission = mockkSubmission()
+        val startModel = initModel.copy(databaseSubmission = submission)
+        val expectedModel = startModel.copy(
+            databaseSubmission = null
+        )
+
+        updateSpec
+            .given(startModel)
+            .whenEvent(AssignmentDetailsEvent.SubmissionStatusUpdated(submission = null))
+            .then(assertThatNext(
+                NextMatchers.hasModel(expectedModel),
+                matchesEffects<AssignmentDetailsModel, AssignmentDetailsEffect>(AssignmentDetailsEffect.LoadData(startModel.assignmentId, startModel.course.id, true))
+            ))
+    }
+
+    @Test
     fun `SubmissionTypeClicked event results in ShowCreateSubmissionView effect`() {
         val submissionType = Assignment.SubmissionType.ONLINE_UPLOAD
         val submissionTypes = listOf("online_upload")


### PR DESCRIPTION
This was mainly an issue on first submission, where a user submitting for the first time would see the status (in progress/failed) for their pending submission, but once it succeeds and the submission is deleted from the database, we would then not show any status or success for the submission on the assignment deets until pull to refresh.