### PR TITLE
[Student][MBL-12921]: Fixed problem with assignment details scrolling at startup

### DIFF
--- a/apps/student/src/main/res/layout/fragment_assignment_details.xml
+++ b/apps/student/src/main/res/layout/fragment_assignment_details.xml
@@ -620,7 +620,9 @@
                             android:layout_marginStart="8dp"
                             android:layout_marginEnd="8dp"
                             android:minHeight="24dp"
-                            android:scrollbars="none"/>
+                            android:scrollbars="none"
+                            android:focusable="false"
+                            android:focusableInTouchMode="false"/>
 
                     </LinearLayout>
 


### PR DESCRIPTION
So, the problem only occurs when there is a description for the assignment, which means that the description webview needs to be rendered.  It seems that, when the webview is rendered, it demands focus and therefore causes a scroll event to occur.

This is a pretty simple fix, but let me know if you see any potential problems with it.