### PR TITLE
[Student] Fix spinner staying up for failed files in file picker

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/PickerSubmissionUploadEffectHandler.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/PickerSubmissionUploadEffectHandler.kt
@@ -149,15 +149,17 @@ class PickerSubmissionUploadEffectHandler constructor(
             val submitObject = FileUploadUtils.getFile(context, uri)
 
             submitObject?.let {
+                var fileToSubmit: FileSubmitObject? = null
                 if (it.errorMessage.isNullOrBlank()) {
                     if (isExtensionAllowed(it, allowedExtensions)) {
-                        consumer.accept(PickerSubmissionUploadEvent.OnFileAdded(it))
+                        fileToSubmit = it
                     } else {
                         view?.showBadExtensionDialog(allowedExtensions)
                     }
                 } else {
                     view?.showFileErrorMessage(it.errorMessage.orEmpty())
                 }
+                consumer.accept(PickerSubmissionUploadEvent.OnFileAdded(fileToSubmit))
             }
         }
     }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/PickerSubmissionUploadModels.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/PickerSubmissionUploadModels.kt
@@ -27,7 +27,7 @@ sealed class PickerSubmissionUploadEvent {
     object SelectFileClicked : PickerSubmissionUploadEvent()
     data class OnFileSelected(val uri: Uri) : PickerSubmissionUploadEvent()
     data class OnFileRemoved(val fileIndex: Int) : PickerSubmissionUploadEvent()
-    data class OnFileAdded(val file: FileSubmitObject) : PickerSubmissionUploadEvent()
+    data class OnFileAdded(val file: FileSubmitObject?) : PickerSubmissionUploadEvent()
 }
 
 sealed class PickerSubmissionUploadEffect {

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/PickerSubmissionUploadUpdate.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/PickerSubmissionUploadUpdate.kt
@@ -50,7 +50,7 @@ class PickerSubmissionUploadUpdate :
         }
         is PickerSubmissionUploadEvent.OnFileAdded -> {
             val files = model.files.toMutableList()
-            files.add(event.file)
+            if (event.file != null) files.add(event.file)
             Next.next(model.copy(isLoadingFile = false, files = files.toList()))
         }
     }

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/PickerSubmissionUploadEffectHandlerTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/PickerSubmissionUploadEffectHandlerTest.kt
@@ -269,9 +269,10 @@ class PickerSubmissionUploadEffectHandlerTest : Assert() {
 
         verify(timeout = 1000) {
             view.showBadExtensionDialog(allowedExtensions)
+            eventConsumer.accept(PickerSubmissionUploadEvent.OnFileAdded(null))
         }
 
-        confirmVerified(view)
+        confirmVerified(view, eventConsumer)
     }
 
     @Test
@@ -298,9 +299,10 @@ class PickerSubmissionUploadEffectHandlerTest : Assert() {
 
         verify(timeout = 1000) {
             view.showFileErrorMessage(errorMessage)
+            eventConsumer.accept(PickerSubmissionUploadEvent.OnFileAdded(null))
         }
 
-        confirmVerified(view)
+        confirmVerified(view, eventConsumer)
     }
 
     @Test

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/PickerSubmissionUploadUpdateTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/PickerSubmissionUploadUpdateTest.kt
@@ -181,6 +181,22 @@ class PickerSubmissionUploadUpdateTest : Assert() {
     }
 
     @Test
+    fun `OnFileAdded event with null file results in model change to loading`() {
+        val startModel = initModel.copy(files = listOf(initFile), isLoadingFile = true)
+        val expectedModel = startModel.copy(isLoadingFile = false)
+
+        updateSpec
+            .given(startModel)
+            .whenEvent(PickerSubmissionUploadEvent.OnFileAdded(null))
+            .then(
+                assertThatNext(
+                    NextMatchers.hasModel(expectedModel),
+                    NextMatchers.hasNoEffects()
+                )
+            )
+    }
+
+    @Test
     fun `OnFileRemoved event results in model change to files and no effects`() {
         val startModel = initModel.copy(files = listOf(initFile))
         val expectedModel = startModel.copy(files = emptyList())


### PR DESCRIPTION
If a file failed or if a file was the wrong type, the loading spinner wouldn't go away.