### PR TITLE
[Student] Fix string for empty files in submission

### DIFF
--- a/libs/pandautils/src/main/res/values/strings.xml
+++ b/libs/pandautils/src/main/res/values/strings.xml
@@ -165,7 +165,7 @@
     <string name="noAssignmentsSubtext">It looks like assignments haven\'t been created in this space. Time to go out and explore.</string>
     <string name="noAssignmentsTeacher">It looks like no assignments have been published yet.</string>
     <string name="noFiles">No Files</string>
-    <string name="noFilesForAssignment">There are no files for this assignment</string>
+    <string name="noFilesForAssignment">There are no files for this submission</string>
     <string name="noFilesSubtext">There are no files associated with this account.</string>
     <string name="notSupported">Not Supported</string>
     <string name="noEvents">No Events Today!</string>


### PR DESCRIPTION
This tab shows the different file attachments for only one submission at a time, not just files for the assignment.