### PR TITLE
[Student][MBL-12985] Fix url encoded text submissions in database

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/text/TextSubmissionUploadUpdate.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/text/TextSubmissionUploadUpdate.kt
@@ -35,12 +35,7 @@ class TextSubmissionUploadUpdate : UpdateInit<TextSubmissionUploadModel, TextSub
                 Next.next(model.copy(isSubmittable = event.text.isNotEmpty()))
             }
             is TextSubmissionUploadEvent.SubmitClicked -> {
-                var textToSubmit = event.text
-                try {
-                    textToSubmit = URLEncoder.encode(textToSubmit, "UTF-8")
-                } catch (e: UnsupportedEncodingException) {}
-
-                Next.dispatch(effects(TextSubmissionUploadEffect.SubmitText(textToSubmit, model.canvasContext, model.assignmentId, model.assignmentName)))
+                Next.dispatch(effects(TextSubmissionUploadEffect.SubmitText(event.text, model.canvasContext, model.assignmentId, model.assignmentName)))
             }
         }
     }

--- a/apps/student/src/main/java/com/instructure/student/mobius/common/ui/SubmissionService.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/common/ui/SubmissionService.kt
@@ -60,6 +60,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.threeten.bp.OffsetDateTime
 import java.io.File
+import java.io.UnsupportedEncodingException
+import java.net.URLEncoder
 
 
 class SubmissionFileUploadReceiver(private val dbSubmissionId: Long) : BroadcastReceiver() {
@@ -148,7 +150,11 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
         dbSubmissionId = db.getLastInsert().executeAsOne()
 
         showProgressNotification(assignmentName, dbSubmissionId)
-        val result = apiAsync<Submission> { SubmissionManager.postTextSubmission(context, assignmentId, text, it) }
+        val textToSubmit = try {
+            URLEncoder.encode(text, "UTF-8")
+        } catch (e: UnsupportedEncodingException) { text }
+
+        val result = apiAsync<Submission> { SubmissionManager.postTextSubmission(context, assignmentId, textToSubmit, it) }
 
         GlobalScope.launch {
             val uploadResult = result.await()

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/TextSubmissionUploadUpdateTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/TextSubmissionUploadUpdateTest.kt
@@ -103,9 +103,6 @@ class TextSubmissionUploadUpdateTest : Assert() {
     fun `SubmitClicked event results in SubmitText effect`() {
         val text = "Some text to submit"
 
-        mockkStatic(URLEncoder::class)
-        every { URLEncoder.encode(any(), any()) } returns text
-
         updateSpec
                 .given(initModel)
                 .whenEvent(TextSubmissionUploadEvent.SubmitClicked(text))
@@ -119,17 +116,13 @@ class TextSubmissionUploadUpdateTest : Assert() {
     @Test
     fun `SubmitClicked event with new lines in text results in SubmitText effect`() {
         val text = "Some text to submit\nWith a new line"
-        val expected = "Some text to submit<br/>With a new line"
-
-        mockkStatic(URLEncoder::class)
-        every { URLEncoder.encode(any(), any()) } returns expected
 
         updateSpec
                 .given(initModel)
                 .whenEvent(TextSubmissionUploadEvent.SubmitClicked(text))
                 .then(
                         assertThatNext(
-                                matchesEffects<TextSubmissionUploadModel, TextSubmissionUploadEffect>(TextSubmissionUploadEffect.SubmitText(expected, course, assignment.id, assignment.name))
+                                matchesEffects<TextSubmissionUploadModel, TextSubmissionUploadEffect>(TextSubmissionUploadEffect.SubmitText(text, course, assignment.id, assignment.name))
                         )
                 )
     }
@@ -137,9 +130,6 @@ class TextSubmissionUploadUpdateTest : Assert() {
     @Test
     fun `SubmitClicked event with unsupported encoding characters in text results in SubmitText effect`() {
         val text = "Some text to submit"
-
-        mockkStatic(URLEncoder::class)
-        every { URLEncoder.encode(any(), any()) } throws UnsupportedEncodingException()
 
         updateSpec
                 .given(initModel)


### PR DESCRIPTION
Instead, only encode when we're actually submitting the text to the API.