### PR TITLE
[Student][MBL-12991] Pull assignment details from network when routing from a URL

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsFragment.kt
@@ -18,6 +18,7 @@ package com.instructure.student.mobius.assignmentDetails.ui
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import com.instructure.canvasapi2.CanvasRestAdapter
 import com.instructure.canvasapi2.models.CanvasContext
 import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.utils.pageview.PageView
@@ -27,7 +28,6 @@ import com.instructure.interactions.router.RouterParams
 import com.instructure.pandautils.utils.*
 import com.instructure.student.mobius.assignmentDetails.*
 import com.instructure.student.mobius.common.ui.MobiusFragment
-import com.spotify.mobius.EventSource
 
 @PageView(url = "{canvasContext}/assignments/{assignmentId}")
 class AssignmentDetailsFragment :
@@ -77,6 +77,8 @@ class AssignmentDetailsFragment :
             if (route.paramsHash.containsKey(RouterParams.ASSIGNMENT_ID)) {
                 val assignmentId = route.paramsHash[RouterParams.ASSIGNMENT_ID]?.toLong() ?: -1
                 route.arguments.putLong(Const.ASSIGNMENT_ID, assignmentId)
+                // Clear API cache when routing from a URL so we fetch fresh data from the network
+                CanvasRestAdapter.clearCacheUrls("assignments/$assignmentId")
             }
 
             return AssignmentDetailsFragment().withArgs(route.arguments)

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsPresenterTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsPresenterTest.kt
@@ -19,19 +19,21 @@ package com.instructure.student.test.assignment.details
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.instructure.canvasapi2.CanvasRestAdapter
 import com.instructure.canvasapi2.models.*
 import com.instructure.canvasapi2.utils.DataResult
+import com.instructure.canvasapi2.utils.isRtl
 import com.instructure.canvasapi2.utils.toApiString
+import com.instructure.interactions.router.Route
+import com.instructure.interactions.router.RouterParams
 import com.instructure.student.R
 import com.instructure.student.mobius.assignmentDetails.AssignmentDetailsModel
 import com.instructure.student.mobius.assignmentDetails.AssignmentDetailsPresenter
+import com.instructure.student.mobius.assignmentDetails.ui.AssignmentDetailsFragment
 import com.instructure.student.mobius.assignmentDetails.ui.AssignmentDetailsViewState
 import com.instructure.student.mobius.assignmentDetails.ui.AssignmentDetailsVisibilities
-import com.instructure.canvasapi2.utils.isRtl
 import com.instructure.student.mobius.assignmentDetails.ui.DiscussionHeaderViewState
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkStatic
+import io.mockk.*
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -732,6 +734,22 @@ class AssignmentDetailsPresenterTest : Assert() {
         val actualState = AssignmentDetailsPresenter.present(model, context) as AssignmentDetailsViewState.Error
 
         assertEquals(expectedState, actualState)
+    }
+
+    @Test
+    fun `Clears URL cache when routing from a URL`() {
+        mockkObject(CanvasRestAdapter.Companion)
+        every { CanvasRestAdapter.clearCacheUrls(any()) } returns Unit
+
+        val route = Route(AssignmentDetailsFragment::class.java, Course())
+        route.paramsHash[RouterParams.ASSIGNMENT_ID] = "123"
+
+        AssignmentDetailsFragment.newInstance(route)
+
+        verify { CanvasRestAdapter.clearCacheUrls("assignments/123") }
+        confirmVerified(CanvasRestAdapter)
+
+        unmockkObject(CanvasRestAdapter.Companion)
     }
 
     private val discussionHtml = "<!DOCTYPE html>\n" +

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/CanvasRestAdapter.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/CanvasRestAdapter.kt
@@ -319,7 +319,7 @@ protected constructor(var statusCallback: StatusCallback<*>?, private val authUs
         }
 
         /**
-         * Removes cached responses for the urls in which the provided [regex] contains a match
+         * Removes cached responses for all urls containing the provided regex [pattern]
          */
         fun clearCacheUrls(pattern: String) {
             synchronized(okHttpClient) {


### PR DESCRIPTION
In order to avoid excessive network calls, the assignment details page does not force load from the network unless the user has pulled to refresh. This can lead to an issue where routing to the page from a notification (e.g. a notification pushed because the student's submission has been graded or the assignment has otherwise been updated) before the cache has expired could result in the user seeing stale, misleading data. This commit works around the issue by clearing the network cache for the associated assignment when routing from a URL, causing the assignment details page to pull fresh data from the network.