### PR TITLE
[Student][MBL-13013] Add rce images to text submission

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/text/TextSubmissionUploadEffectHandler.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/text/TextSubmissionUploadEffectHandler.kt
@@ -20,15 +20,29 @@ import com.instructure.canvasapi2.utils.exhaustive
 import com.instructure.student.mobius.assignmentDetails.submission.text.ui.TextSubmissionUploadView
 import com.instructure.student.mobius.common.ui.EffectHandler
 
-class TextSubmissionUploadEffectHandler : EffectHandler<TextSubmissionUploadView, TextSubmissionUploadEvent, TextSubmissionUploadEffect>() {
+class TextSubmissionUploadEffectHandler :
+    EffectHandler<TextSubmissionUploadView, TextSubmissionUploadEvent, TextSubmissionUploadEffect>() {
     override fun accept(effect: TextSubmissionUploadEffect) {
         when (effect) {
-            is TextSubmissionUploadEffect.SubmitText -> {
-                view?.onTextSubmitted(effect.text, effect.canvasContext, effect.assignmentId, effect.assignmentName)
-            }
-            is TextSubmissionUploadEffect.InitializeText -> {
-                view?.setInitialSubmissionText(effect.text)
-            }
+            is TextSubmissionUploadEffect.SubmitText -> view?.onTextSubmitted(
+                effect.text,
+                effect.canvasContext,
+                effect.assignmentId,
+                effect.assignmentName
+            )
+            is TextSubmissionUploadEffect.InitializeText -> view?.setInitialSubmissionText(effect.text)
+            is TextSubmissionUploadEffect.AddImage -> view?.addImageToSubmission(
+                effect.uri,
+                effect.canvasContext
+            )
+            TextSubmissionUploadEffect.ProcessCameraImage -> processCameraImage()
+            TextSubmissionUploadEffect.ShowFailedImageMessage -> view?.showFailedImageMessage()
         }.exhaustive
+    }
+
+    private fun processCameraImage() {
+        view?.retrieveCameraImage()?.let { uri ->
+            consumer.accept(TextSubmissionUploadEvent.ImageAdded(uri))
+        } ?: consumer.accept(TextSubmissionUploadEvent.ImageFailed)
     }
 }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/text/TextSubmissionUploadEventBusSource.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/text/TextSubmissionUploadEventBusSource.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2019 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.student.mobius.assignmentDetails.submission.text
+
+import android.app.Activity
+import android.net.Uri
+import com.instructure.canvasapi2.utils.Logger
+import com.instructure.pandautils.utils.FilePrefs
+import com.instructure.pandautils.utils.MediaUploadUtils
+import com.instructure.pandautils.utils.OnActivityResults
+import com.instructure.pandautils.utils.RequestCodes
+import com.instructure.student.mobius.assignmentDetails.ui.AssignmentDetailsFragment
+import com.instructure.student.mobius.common.EventBusSource
+import org.greenrobot.eventbus.Subscribe
+
+@Suppress("unused", "UNUSED_PARAMETER")
+class TextSubmissionUploadEventBusSource : EventBusSource<TextSubmissionUploadEvent>() {
+    private val subId = TextSubmissionUploadEventBusSource::class.java.name
+
+    @Subscribe(sticky = true)
+    fun onActivityResults(event: OnActivityResults) {
+        event.once(subId) {
+            if (it.resultCode == Activity.RESULT_OK) {
+                when (it.requestCode) {
+                    RequestCodes.PICK_IMAGE_GALLERY -> it.data?.data?.let { uri ->
+                        sendEvent(
+                            TextSubmissionUploadEvent.ImageAdded(uri)
+                        )
+                    } ?: sendEvent(TextSubmissionUploadEvent.ImageFailed)
+                    RequestCodes.CAMERA_PIC_REQUEST -> sendEvent(TextSubmissionUploadEvent.CameraImageTaken)
+                }
+            }
+        }
+    }
+}

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/text/TextSubmissionUploadModels.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/text/TextSubmissionUploadModels.kt
@@ -17,16 +17,23 @@
 
 package com.instructure.student.mobius.assignmentDetails.submission.text
 
+import android.net.Uri
 import com.instructure.canvasapi2.models.CanvasContext
 
 sealed class TextSubmissionUploadEvent {
     data class TextChanged(val text: String) : TextSubmissionUploadEvent()
     data class SubmitClicked(val text: String) : TextSubmissionUploadEvent()
+    data class ImageAdded(val uri: Uri) : TextSubmissionUploadEvent()
+    object CameraImageTaken : TextSubmissionUploadEvent()
+    object ImageFailed : TextSubmissionUploadEvent()
 }
 
 sealed class TextSubmissionUploadEffect {
     data class SubmitText(val text: String, val canvasContext: CanvasContext, val assignmentId: Long, val assignmentName: String?) : TextSubmissionUploadEffect()
     data class InitializeText(val text: String) : TextSubmissionUploadEffect()
+    data class AddImage(val uri: Uri, val canvasContext: CanvasContext) : TextSubmissionUploadEffect()
+    object ProcessCameraImage : TextSubmissionUploadEffect()
+    object ShowFailedImageMessage : TextSubmissionUploadEffect()
 }
 
 data class TextSubmissionUploadModel(

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/text/TextSubmissionUploadUpdate.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/text/TextSubmissionUploadUpdate.kt
@@ -23,20 +23,39 @@ import com.spotify.mobius.Next
 import java.io.UnsupportedEncodingException
 import java.net.URLEncoder
 
-class TextSubmissionUploadUpdate : UpdateInit<TextSubmissionUploadModel, TextSubmissionUploadEvent, TextSubmissionUploadEffect>() {
+class TextSubmissionUploadUpdate :
+    UpdateInit<TextSubmissionUploadModel, TextSubmissionUploadEvent, TextSubmissionUploadEffect>() {
     override fun performInit(model: TextSubmissionUploadModel): First<TextSubmissionUploadModel, TextSubmissionUploadEffect> {
-        return First.first(model, setOf<TextSubmissionUploadEffect>(TextSubmissionUploadEffect.InitializeText(model.initialText
-                ?: "")))
+        return First.first(model, setOf<TextSubmissionUploadEffect>(TextSubmissionUploadEffect.InitializeText(model.initialText ?: "")))
     }
 
-    override fun update(model: TextSubmissionUploadModel, event: TextSubmissionUploadEvent): Next<TextSubmissionUploadModel, TextSubmissionUploadEffect> {
+    override fun update(
+        model: TextSubmissionUploadModel,
+        event: TextSubmissionUploadEvent
+    ): Next<TextSubmissionUploadModel, TextSubmissionUploadEffect> {
         return when(event) {
-            is TextSubmissionUploadEvent.TextChanged -> {
-                Next.next(model.copy(isSubmittable = event.text.isNotEmpty()))
-            }
-            is TextSubmissionUploadEvent.SubmitClicked -> {
-                Next.dispatch(effects(TextSubmissionUploadEffect.SubmitText(event.text, model.canvasContext, model.assignmentId, model.assignmentName)))
-            }
+            is TextSubmissionUploadEvent.TextChanged -> Next.next(
+                model.copy(isSubmittable = event.text.isNotEmpty())
+            )
+            is TextSubmissionUploadEvent.SubmitClicked -> Next.dispatch(
+                effects(
+                    TextSubmissionUploadEffect.SubmitText(
+                        event.text,
+                        model.canvasContext,
+                        model.assignmentId,
+                        model.assignmentName
+                    )
+                )
+            )
+            is TextSubmissionUploadEvent.ImageAdded -> Next.dispatch(
+                effects(TextSubmissionUploadEffect.AddImage(event.uri, model.canvasContext))
+            )
+            TextSubmissionUploadEvent.CameraImageTaken -> Next.dispatch(
+                effects(TextSubmissionUploadEffect.ProcessCameraImage)
+            )
+            TextSubmissionUploadEvent.ImageFailed -> Next.dispatch(
+                effects(TextSubmissionUploadEffect.ShowFailedImageMessage)
+            )
         }
     }
 }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/text/ui/TextSubmissionUploadFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/text/ui/TextSubmissionUploadFragment.kt
@@ -23,6 +23,7 @@ import com.instructure.interactions.router.Route
 import com.instructure.pandautils.utils.*
 import com.instructure.student.mobius.assignmentDetails.submission.text.*
 import com.instructure.student.mobius.common.ui.MobiusFragment
+import com.spotify.mobius.EventSource
 
 class TextSubmissionUploadFragment : MobiusFragment<TextSubmissionUploadModel, TextSubmissionUploadEvent, TextSubmissionUploadEffect, TextSubmissionUploadView, TextSubmissionUploadViewState>() {
 
@@ -41,6 +42,8 @@ class TextSubmissionUploadFragment : MobiusFragment<TextSubmissionUploadModel, T
     override fun makePresenter() = TextSubmissionUploadPresenter
 
     override fun makeInitModel() = TextSubmissionUploadModel(course, assignmentId, assignmentName, initialText, isFailure)
+
+    override fun getExternalEventSources() = listOf(TextSubmissionUploadEventBusSource())
 
     companion object {
 

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/text/ui/TextSubmissionUploadView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/text/ui/TextSubmissionUploadView.kt
@@ -18,8 +18,10 @@ package com.instructure.student.mobius.assignmentDetails.submission.text.ui
 
 import android.app.Activity
 import android.graphics.Color
+import android.net.Uri
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.Toast
 import com.instructure.canvasapi2.models.CanvasContext
 import com.instructure.pandautils.utils.*
 import com.instructure.student.R
@@ -29,7 +31,12 @@ import com.instructure.student.mobius.common.ui.SubmissionService
 import com.spotify.mobius.functions.Consumer
 import kotlinx.android.synthetic.main.fragment_text_submission_upload.*
 
-class TextSubmissionUploadView(inflater: LayoutInflater, parent: ViewGroup) : MobiusView<TextSubmissionUploadViewState, TextSubmissionUploadEvent>(R.layout.fragment_text_submission_upload, inflater, parent) {
+class TextSubmissionUploadView(inflater: LayoutInflater, parent: ViewGroup) :
+    MobiusView<TextSubmissionUploadViewState, TextSubmissionUploadEvent>(
+        R.layout.fragment_text_submission_upload,
+        inflater,
+        parent
+    ) {
 
     init {
         toolbar.setupAsBackButton { (context as? Activity)?.onBackPressed() }
@@ -49,6 +56,9 @@ class TextSubmissionUploadView(inflater: LayoutInflater, parent: ViewGroup) : Mo
 
         rce.setOnTextChangeListener {
             output.accept(TextSubmissionUploadEvent.TextChanged(it))
+        }
+        rce.actionUploadImageCallback = {
+            MediaUploadUtils.showPickImageDialog(null, context as Activity)
         }
     }
 
@@ -73,5 +83,28 @@ class TextSubmissionUploadView(inflater: LayoutInflater, parent: ViewGroup) : Mo
         SubmissionService.startTextSubmission(context, canvasContext, assignmentId, assignmentName, text)
 
         (context as? Activity)?.onBackPressed()
+    }
+
+    fun retrieveCameraImage(): Uri? {
+        return (context as? Activity)?.let { activity ->
+            MediaUploadUtils.handleCameraPicResult(activity, null)
+        }
+    }
+
+    /**
+     * Add the image here, rather than in the loop, so that it is placed at the cursor position
+     */
+    fun addImageToSubmission(uri: Uri, canvasContext: CanvasContext) {
+        (context as? Activity)?.let { activity ->
+            MediaUploadUtils.uploadRceImageJob(uri, canvasContext, activity, ::insertImage)
+        }
+    }
+
+    private fun insertImage(text: String, alt: String) {
+        rce.insertImage(text, alt)
+    }
+
+    fun showFailedImageMessage() {
+        Toast.makeText(context, R.string.errorGettingPhoto, Toast.LENGTH_LONG).show()
     }
 }

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/TextSubmissionUploadEventBusSourceTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/TextSubmissionUploadEventBusSourceTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2019 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.student.test.assignment.details.submission
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import com.instructure.pandautils.utils.ActivityResult
+import com.instructure.pandautils.utils.OnActivityResults
+import com.instructure.pandautils.utils.RequestCodes
+import com.instructure.student.mobius.assignmentDetails.submission.text.TextSubmissionUploadEvent
+import com.instructure.student.mobius.assignmentDetails.submission.text.TextSubmissionUploadEventBusSource
+import com.spotify.mobius.functions.Consumer
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class TextSubmissionUploadEventBusSourceTest : Assert() {
+
+    lateinit var consumer: Consumer<TextSubmissionUploadEvent>
+    lateinit var source: TextSubmissionUploadEventBusSource
+
+    @Before
+    fun setup() {
+        consumer = mockk(relaxed = true)
+        source = TextSubmissionUploadEventBusSource().apply {
+            this.subscribe(consumer)
+        }
+    }
+
+    @Test
+    fun `onActivityResults with PICK_IMAGE_GALLERY code results in ImageAdded event`() {
+        val uri = mockk<Uri>()
+        val intent = mockk<Intent>()
+        val event = OnActivityResults(ActivityResult(RequestCodes.PICK_IMAGE_GALLERY, Activity.RESULT_OK, intent), null)
+
+        every { intent.data } returns uri
+
+        source.onActivityResults(event)
+
+        verify(timeout = 100) {
+            consumer.accept(TextSubmissionUploadEvent.ImageAdded(uri))
+        }
+
+        confirmVerified(consumer)
+    }
+
+    @Test
+    fun `onActivityResults with PICK_IMAGE_GALLERY code with no uri results in ImageFailed event`() {
+        val intent = mockk<Intent>()
+        val event = OnActivityResults(ActivityResult(RequestCodes.PICK_IMAGE_GALLERY, Activity.RESULT_OK, intent), null)
+
+        every { intent.data } returns null
+
+        source.onActivityResults(event)
+
+        verify(timeout = 100) {
+            consumer.accept(TextSubmissionUploadEvent.ImageFailed)
+        }
+
+        confirmVerified(consumer)
+    }
+
+    @Test
+    fun `onActivityResults with CAMERA_PIC_REQUEST code results in CameraImageTaken event`() {
+        val event = OnActivityResults(ActivityResult(RequestCodes.CAMERA_PIC_REQUEST, Activity.RESULT_OK, null), null)
+
+        source.onActivityResults(event)
+
+        verify(timeout = 100) {
+            consumer.accept(TextSubmissionUploadEvent.CameraImageTaken)
+        }
+
+        confirmVerified(consumer)
+    }
+}

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/TextSubmissionUploadPresenterTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/TextSubmissionUploadPresenterTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2019 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.student.test.assignment.details.submission
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.instructure.canvasapi2.models.CanvasContext
+import com.instructure.student.mobius.assignmentDetails.submission.text.TextSubmissionUploadModel
+import com.instructure.student.mobius.assignmentDetails.submission.text.TextSubmissionUploadPresenter
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TextSubmissionUploadPresenterTest : Assert() {
+    private lateinit var context: Context
+    private lateinit var canvasContext: CanvasContext
+    private lateinit var baseModel: TextSubmissionUploadModel
+
+    private val assignmentId = 123L
+    private val assignmentName = "Assignment"
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        canvasContext = CanvasContext.emptyCourseContext(0)
+        baseModel = TextSubmissionUploadModel(
+            canvasContext = canvasContext,
+            assignmentId = assignmentId,
+            assignmentName = assignmentName
+        )
+    }
+
+    @Test
+    fun `returns initial text when the model has it`() {
+        val initText = "test"
+        val model = baseModel.copy(initialText = initText)
+        val actualState = TextSubmissionUploadPresenter.present(model, context)
+        assertEquals(initText, actualState.text)
+    }
+
+    @Test
+    fun `returns null initial text when the model has none`() {
+        val initText = null
+        val model = baseModel.copy(initialText = initText)
+        val actualState = TextSubmissionUploadPresenter.present(model, context)
+        assertEquals(initText, actualState.text)
+    }
+
+    @Test
+    fun `returns submit enabled when the model is submittable`() {
+        val model = baseModel.copy(isSubmittable = true)
+        val actualState = TextSubmissionUploadPresenter.present(model, context)
+        assertTrue(actualState.submitEnabled)
+    }
+
+    @Test
+    fun `returns submit not enabled when the model is not submittable`() {
+        val model = baseModel.copy(isSubmittable = false)
+        val actualState = TextSubmissionUploadPresenter.present(model, context)
+        assertFalse(actualState.submitEnabled)
+    }
+
+    @Test
+    fun `returns is failure when the model is failure`() {
+        val model = baseModel.copy(isFailure = true)
+        val actualState = TextSubmissionUploadPresenter.present(model, context)
+        assertTrue(actualState.isFailure)
+    }
+
+    @Test
+    fun `returns is not failure when the model is not failure`() {
+        val model = baseModel.copy(isFailure = false)
+        val actualState = TextSubmissionUploadPresenter.present(model, context)
+        assertFalse(actualState.isFailure)
+    }
+}

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/TextSubmissionUploadUpdateTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/TextSubmissionUploadUpdateTest.kt
@@ -16,6 +16,7 @@
  */
 package com.instructure.student.test.assignment.details.submission
 
+import android.net.Uri
 import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.Course
 import com.instructure.student.mobius.assignmentDetails.submission.text.TextSubmissionUploadEffect
@@ -31,6 +32,7 @@ import com.spotify.mobius.test.NextMatchers
 import com.spotify.mobius.test.UpdateSpec
 import com.spotify.mobius.test.UpdateSpec.assertThatNext
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkStatic
 import org.junit.Assert
 import org.junit.Before
@@ -50,7 +52,11 @@ class TextSubmissionUploadUpdateTest : Assert() {
     fun setup() {
         course = Course()
         assignment = Assignment(id = 1234L, courseId = course.id, name = "name")
-        initModel = TextSubmissionUploadModel(assignmentId = assignment.id, canvasContext = course, assignmentName = assignment.name)
+        initModel = TextSubmissionUploadModel(
+            assignmentId = assignment.id,
+            canvasContext = course,
+            assignmentName = assignment.name
+        )
     }
 
     @Test
@@ -58,13 +64,15 @@ class TextSubmissionUploadUpdateTest : Assert() {
         val text = "Some text from a save"
         val startModel = initModel.copy(initialText = text)
         initSpec
-                .whenInit(startModel)
-                .then(
-                        assertThatFirst(
-                                FirstMatchers.hasModel(startModel),
-                                matchesFirstEffects<TextSubmissionUploadModel, TextSubmissionUploadEffect>(TextSubmissionUploadEffect.InitializeText(text))
-                        )
+            .whenInit(startModel)
+            .then(
+                assertThatFirst(
+                    FirstMatchers.hasModel(startModel),
+                    matchesFirstEffects<TextSubmissionUploadModel, TextSubmissionUploadEffect>(
+                        TextSubmissionUploadEffect.InitializeText(text)
+                    )
                 )
+            )
     }
 
     @Test
@@ -74,13 +82,13 @@ class TextSubmissionUploadUpdateTest : Assert() {
         val expectedModel = startModel.copy(isSubmittable = true)
 
         updateSpec
-                .given(startModel)
-                .whenEvent(TextSubmissionUploadEvent.TextChanged(text))
-                .then(
-                        assertThatNext(
-                                NextMatchers.hasModel(expectedModel)
-                        )
+            .given(startModel)
+            .whenEvent(TextSubmissionUploadEvent.TextChanged(text))
+            .then(
+                assertThatNext(
+                    NextMatchers.hasModel(expectedModel)
                 )
+            )
     }
 
     @Test
@@ -90,13 +98,13 @@ class TextSubmissionUploadUpdateTest : Assert() {
         val expectedModel = startModel.copy(isSubmittable = false)
 
         updateSpec
-                .given(startModel)
-                .whenEvent(TextSubmissionUploadEvent.TextChanged(text))
-                .then(
-                        assertThatNext(
-                                NextMatchers.hasModel(expectedModel)
-                        )
+            .given(startModel)
+            .whenEvent(TextSubmissionUploadEvent.TextChanged(text))
+            .then(
+                assertThatNext(
+                    NextMatchers.hasModel(expectedModel)
                 )
+            )
     }
 
     @Test
@@ -104,13 +112,20 @@ class TextSubmissionUploadUpdateTest : Assert() {
         val text = "Some text to submit"
 
         updateSpec
-                .given(initModel)
-                .whenEvent(TextSubmissionUploadEvent.SubmitClicked(text))
-                .then(
-                        assertThatNext(
-                                matchesEffects<TextSubmissionUploadModel, TextSubmissionUploadEffect>(TextSubmissionUploadEffect.SubmitText(text, course, assignment.id, assignment.name))
+            .given(initModel)
+            .whenEvent(TextSubmissionUploadEvent.SubmitClicked(text))
+            .then(
+                assertThatNext(
+                    matchesEffects<TextSubmissionUploadModel, TextSubmissionUploadEffect>(
+                        TextSubmissionUploadEffect.SubmitText(
+                            text,
+                            course,
+                            assignment.id,
+                            assignment.name
                         )
+                    )
                 )
+            )
     }
 
     @Test
@@ -118,27 +133,64 @@ class TextSubmissionUploadUpdateTest : Assert() {
         val text = "Some text to submit\nWith a new line"
 
         updateSpec
-                .given(initModel)
-                .whenEvent(TextSubmissionUploadEvent.SubmitClicked(text))
-                .then(
-                        assertThatNext(
-                                matchesEffects<TextSubmissionUploadModel, TextSubmissionUploadEffect>(TextSubmissionUploadEffect.SubmitText(text, course, assignment.id, assignment.name))
+            .given(initModel)
+            .whenEvent(TextSubmissionUploadEvent.SubmitClicked(text))
+            .then(
+                assertThatNext(
+                    matchesEffects<TextSubmissionUploadModel, TextSubmissionUploadEffect>(
+                        TextSubmissionUploadEffect.SubmitText(
+                            text,
+                            course,
+                            assignment.id,
+                            assignment.name
                         )
+                    )
                 )
+            )
     }
 
     @Test
-    fun `SubmitClicked event with unsupported encoding characters in text results in SubmitText effect`() {
-        val text = "Some text to submit"
+    fun `ImageAdded results in AddImage effect`() {
+        val uri = mockk<Uri>()
 
         updateSpec
-                .given(initModel)
-                .whenEvent(TextSubmissionUploadEvent.SubmitClicked(text))
-                .then(
-                        assertThatNext(
-                                matchesEffects<TextSubmissionUploadModel, TextSubmissionUploadEffect>(TextSubmissionUploadEffect.SubmitText(text, course, assignment.id, assignment.name))
-                        )
+            .given(initModel)
+            .whenEvent(TextSubmissionUploadEvent.ImageAdded(uri))
+            .then(
+                assertThatNext(
+                    matchesEffects<TextSubmissionUploadModel, TextSubmissionUploadEffect>(
+                        TextSubmissionUploadEffect.AddImage(uri, initModel.canvasContext)
+                    )
                 )
+            )
+    }
+
+    @Test
+    fun `CameraImageTaken results in ProcessCameraImage effect`() {
+        updateSpec
+            .given(initModel)
+            .whenEvent(TextSubmissionUploadEvent.CameraImageTaken)
+            .then(
+                assertThatNext(
+                    matchesEffects<TextSubmissionUploadModel, TextSubmissionUploadEffect>(
+                        TextSubmissionUploadEffect.ProcessCameraImage
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun `ImageFailed results in ShowFailedImageMessage effect`() {
+        updateSpec
+            .given(initModel)
+            .whenEvent(TextSubmissionUploadEvent.ImageFailed)
+            .then(
+                assertThatNext(
+                    matchesEffects<TextSubmissionUploadModel, TextSubmissionUploadEffect>(
+                        TextSubmissionUploadEffect.ShowFailedImageMessage
+                    )
+                )
+            )
     }
 
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/ProfileEditFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/ProfileEditFragment.kt
@@ -163,7 +163,7 @@ class ProfileEditFragment : BasePresenterFragment<
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
         if (requestCode == MediaUploadUtils.REQUEST_CODE_PERMISSIONS_TAKE_PHOTO) {
             if (PermissionUtils.allPermissionsGrantedResultSummary(grantResults)) {
-                takeNewPhotoBecausePermissionsAlreadyGranted(this)
+                takeNewPhotoBecausePermissionsAlreadyGranted(this, requireActivity())
             } else {
                 Toast.makeText(requireActivity(), R.string.permissionDenied, Toast.LENGTH_LONG).show()
             }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/dialogs/UploadFilesDialog.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/dialogs/UploadFilesDialog.kt
@@ -568,8 +568,8 @@ class UploadFilesDialog : AppCompatDialogFragment() {
 
     companion object {
         // Request codes, handled in Activity.onActivityResults(), activity required to implement EventBus in onActivityResults()
-        const val CAMERA_PIC_REQUEST = 4000
-        const val PICK_IMAGE_GALLERY = 4001
+        const val CAMERA_PIC_REQUEST = RequestCodes.CAMERA_PIC_REQUEST
+        const val PICK_IMAGE_GALLERY = RequestCodes.PICK_IMAGE_GALLERY
         const val PICK_FILE_FROM_DEVICE = 7000
 
         const val EVENT_DIALOG_CANCELED = 1


### PR DESCRIPTION
Altered the MediaUploadUtils to support a nullable fragment, falling back to the activity for requesting permission and dealing with activity results for images.