### PR TITLE
[Teacher][MBL-12971] Honor module publish status nullability

### DIFF
--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/renderTests/ModuleListRenderTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/renderTests/ModuleListRenderTest.kt
@@ -171,6 +171,19 @@ class ModuleListRenderTest : TeacherRenderTest() {
     }
 
     @Test
+    fun doesNotDisplayModuleItemPublishStatusIcon() {
+        val moduleItem = moduleItemTemplate.copy(
+            isPublished = null
+        )
+        val state = ModuleListViewState(
+            items = listOf(moduleItem)
+        )
+        loadPageWithViewState(state)
+        page.moduleItemUnpublishedIcon.assertNotDisplayed()
+        page.moduleItemPublishedIcon.assertNotDisplayed()
+    }
+
+    @Test
     fun displaysSubHeaderModuleItem() {
         val moduleItem = moduleItemTemplate.copy(
             title = null,
@@ -244,6 +257,18 @@ class ModuleListRenderTest : TeacherRenderTest() {
         )
         loadPageWithViewState(state)
         page.moduleUnpublishedIcon.assertDisplayed()
+        page.modulePublishedIcon.assertNotDisplayed()
+    }
+
+    @Test
+    fun doesNotDisplayModulePublishStatusIcon() {
+        val state = ModuleListViewState(
+            items = listOf(
+                moduleTemplate.copy(isPublished = null)
+            )
+        )
+        loadPageWithViewState(state)
+        page.moduleUnpublishedIcon.assertNotDisplayed()
         page.modulePublishedIcon.assertNotDisplayed()
     }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ModuleListPresenter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ModuleListPresenter.kt
@@ -56,10 +56,10 @@ object ModuleListPresenter : Presenter<ModuleListModel, ModuleListViewState> {
                 }
             }
             ModuleListItemData.ModuleData(
-                module.id,
-                module.name.orEmpty(),
-                module.published,
-                moduleItems
+                id = module.id,
+                name = module.name.orEmpty(),
+                isPublished = module.published,
+                moduleItems = moduleItems
             )
         }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ui/ModuleListViewState.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ui/ModuleListViewState.kt
@@ -37,7 +37,7 @@ sealed class ModuleListItemData {
     data class ModuleData(
         val id: Long,
         val name: String,
-        val isPublished: Boolean,
+        val isPublished: Boolean?,
         val moduleItems: List<ModuleItemData>
     ): ModuleListItemData()
 
@@ -54,8 +54,8 @@ sealed class ModuleListItemData {
         /** The resource ID of the icon to show for this item. If null, the icon should be hidden. */
         val iconResId: Int?,
 
-        /** Whether this module item is published */
-        val isPublished: Boolean,
+        /** Whether this module item is published. Should not display any publish icon if null. */
+        val isPublished: Boolean?,
 
         /** The indent in pixels */
         val indent: Int,

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ui/binders/ModuleListItemBinder.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ui/binders/ModuleListItemBinder.kt
@@ -41,8 +41,8 @@ class ModuleListItemBinder : ListItemBinder<ModuleListItemData.ModuleItemData, M
             moduleItemIndent.layoutParams.width = item.indent
             moduleItemTitle.setTextForVisibility(item.title)
             moduleItemSubtitle.setTextForVisibility(item.subtitle)
-            moduleItemPublishedIcon.setVisible(item.isPublished)
-            moduleItemUnpublishedIcon.setVisible(!item.isPublished)
+            moduleItemPublishedIcon.setVisible(item.isPublished == true)
+            moduleItemUnpublishedIcon.setVisible(item.isPublished == false)
             moduleItemLoadingView.setVisible(item.isLoading)
             setOnClickListener { callback.moduleItemClicked(item.id) }
             isEnabled = item.enabled

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ui/binders/ModuleListModuleBinder.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ui/binders/ModuleListModuleBinder.kt
@@ -34,8 +34,8 @@ class ModuleListModuleBinder : ListItemBinder<ModuleListItemData.ModuleData, Mod
         onBind = { item, view, isCollapsed, _ ->
             with(view) {
                 moduleName.text = item.name
-                publishedIcon.setVisible(item.isPublished)
-                unpublishedIcon.setVisible(!item.isPublished)
+                publishedIcon.setVisible(item.isPublished == true)
+                unpublishedIcon.setVisible(item.isPublished == false)
                 collapseIcon.rotation = if (isCollapsed) 0f else 180f
             }
         }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/ModuleItem.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/ModuleItem.kt
@@ -37,7 +37,7 @@ data class ModuleItem(
     val completionRequirement: CompletionRequirement? = null,
     @SerializedName("content_details")
     val moduleDetails: ModuleContentDetails? = null,
-    val published: Boolean = false,
+    val published: Boolean? = null,
     @SerializedName("content_id")
     val contentId: Long = 0,
     @SerializedName("external_url")

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/ModuleObject.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/ModuleObject.kt
@@ -37,7 +37,7 @@ data class ModuleObject(
     val state: String? = null,
     @SerializedName("completed_at")
     val completedAt: String? = null,
-    val published: Boolean = false,
+    val published: Boolean? = null,
     @SerializedName("items_count")
     val itemCount: Int = 0,
     @SerializedName("items_url")


### PR DESCRIPTION
If a user is enrolled in a course with a custom teacher role that does not have permission to edit course content, the publish status for modules will be null for that user. This commit updates the teacher app to not show any publish status icon for modules when null. See ticket for repro steps.