### PR TITLE
[Student][MBL-12952] Fix module name when linking to module item

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/CourseModuleProgressionFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/CourseModuleProgressionFragment.kt
@@ -718,8 +718,8 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
                 val current = moduleItemSequence.items!!.firstOrNull { it.current!!.id == moduleItemId.toLong() }?.current ?: moduleItemSequence.items!![0].current
                 val moduleItems = awaitApi<List<ModuleItem>> { ModuleManager.getAllModuleItems(canvasContext, current!!.moduleId, it, true) }
                 items = ArrayList<ArrayList<ModuleItem>>(1).apply { add(ArrayList(moduleItems)) }
-                modules = ArrayList<ModuleObject>(1).apply { add(moduleItemSequence.modules!![0]) }
-                val moduleHelper = ModuleProgressionUtility.prepareModulesForCourseProgression(this@CourseModuleProgressionFragment.context, current!!.id, modules, items)
+                modules = ArrayList<ModuleObject>(1).apply { moduleItemSequence.modules!!.firstOrNull { it.id == current?.moduleId }?.let { add(it) } }
+                val moduleHelper = ModuleProgressionUtility.prepareModulesForCourseProgression(requireContext(), current!!.id, modules, items)
                 groupPos = moduleHelper.newGroupPosition
                 childPos = moduleHelper.newChildPosition
             }


### PR DESCRIPTION
We are already supporting navigating in module progression for items in the same module. We will not support intermodule navigation at this time.

See ticket for test details.
There is also a page in mobiledev -> Android dev -> pages -> "A link to a module item" :: that has a link to "Page 3" and can be used to verify navigation buttons inside the course module progression.