### PR TITLE
[Student][MBL-13027] Remove assignment.muted from grades and assignment list

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/binders/AssignmentBinder.kt
+++ b/apps/student/src/main/java/com/instructure/student/binders/AssignmentBinder.kt
@@ -47,13 +47,9 @@ class AssignmentBinder : BaseBinder() {
 
             val submission = assignment.submission
 
-            if (assignment.muted) {
-                // Mute that score
-                holder.points.visibility = View.GONE
-            } else {
-                holder.points.visibility = View.VISIBLE
-                BaseBinder.setupGradeText(context, holder.points, assignment, submission, courseColor)
-            }
+            // Don't care about assignment.muted, the API should restrict our grade if we shouldn't see it
+            holder.points.visibility = View.VISIBLE
+            BaseBinder.setupGradeText(context, holder.points, assignment, submission, courseColor)
 
 
             val drawable = BaseBinder.getAssignmentIcon(assignment)

--- a/apps/student/src/main/java/com/instructure/student/binders/GradeBinder.kt
+++ b/apps/student/src/main/java/com/instructure/student/binders/GradeBinder.kt
@@ -54,25 +54,21 @@ object GradeBinder : BaseBinder() {
 
         holder.points.setTextColor(ThemePrefs.brandColor)
 
-        if (assignment.muted && !isEdit) {
-            // Mute that score
+        // Don't care about assignment.muted, the API should restrict our grade if we shouldn't see it
+        val submission = assignment.submission
+        if (submission != null && Const.PENDING_REVIEW == submission.workflowState) {
             holder.points.setGone()
+            holder.icon.setNestedIcon(R.drawable.vd_published, courseColor)
         } else {
-            val submission = assignment.submission
-            if (submission != null && Const.PENDING_REVIEW == submission.workflowState) {
-                holder.points.setGone()
-                holder.icon.setNestedIcon(R.drawable.vd_published, courseColor)
+            holder.points.setVisible()
+            val grade = getGrade(submission, assignment.pointsPossible, context)
+            holder.points.text = grade
+            val accessibleGrade = getContentDescriptionForMinusGradeString(grade ?: "", context)
+            val outOf = context.resources.getString(R.string.outOf)
+            holder.points.contentDescription = if (accessibleGrade.isNotEmpty()) {
+                accessibleGrade
             } else {
-                holder.points.setVisible()
-                val grade = getGrade(submission, assignment.pointsPossible, context)
-                holder.points.text = grade
-                val accessibleGrade = getContentDescriptionForMinusGradeString(grade ?: "", context)
-                val outOf = context.resources.getString(R.string.outOf)
-                holder.points.contentDescription = if (accessibleGrade.isNotEmpty()) {
-                    accessibleGrade
-                } else {
-                    context.getString(R.string.a11y_letterGrade, grade?.replace("/", " $outOf "))
-                }
+                context.getString(R.string.a11y_letterGrade, grade?.replace("/", " $outOf "))
             }
         }
 


### PR DESCRIPTION


We shouldn't be using assignment.muted to determine if we are showing grades to the user. Instead, if needed, the API should restrict our access to grades if we aren't allowed to see them.