### PR TITLE
[Student] Log mobius exceptions to Crashlytics

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/common/MobiusExceptionLogger.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/common/MobiusExceptionLogger.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2019 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.student.mobius.common
+
+import com.crashlytics.android.Crashlytics
+import com.instructure.student.BuildConfig
+import com.spotify.mobius.First
+import com.spotify.mobius.Next
+import com.spotify.mobius.android.AndroidLogger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+
+/**
+ * Intercepts exceptions in the mobius loop's update and init operations and logs them to Crashlytics.
+ * For debug builds the exception will be logged locally and then thrown.
+ */
+class MobiusExceptionLogger<MODEL, EVENT, EFFECT> : AndroidLogger<MODEL, EVENT, EFFECT>("Mobius") {
+    override fun afterUpdate(model: MODEL, event: EVENT, result: Next<MODEL, EFFECT>) {
+        if (BuildConfig.DEBUG) super.afterUpdate(model, event, result)
+    }
+
+    override fun afterInit(model: MODEL, result: First<MODEL, EFFECT>) {
+        if (BuildConfig.DEBUG) super.afterInit(model, result)
+    }
+
+    override fun beforeInit(model: MODEL) {
+        if (BuildConfig.DEBUG) super.beforeInit(model)
+    }
+
+    override fun beforeUpdate(model: MODEL, event: EVENT) {
+        if (BuildConfig.DEBUG) super.beforeUpdate(model, event)
+    }
+
+    override fun exceptionDuringInit(model: MODEL, exception: Throwable) {
+        if (BuildConfig.DEBUG) {
+            super.exceptionDuringInit(model, exception)
+            // Must throw as a separate message, otherwise Mobius might consume the exception
+            GlobalScope.launch(Dispatchers.Main) { throw exception }
+        } else {
+            Crashlytics.logException(exception)
+        }
+    }
+
+    override fun exceptionDuringUpdate(model: MODEL, event: EVENT, exception: Throwable) {
+        if (BuildConfig.DEBUG) {
+            super.exceptionDuringUpdate(model, event, exception)
+            // Must throw as a separate message, otherwise Mobius might consume the exception
+            GlobalScope.launch(Dispatchers.Main) { throw exception }
+        } else {
+            Crashlytics.logException(exception)
+        }
+    }
+}


### PR DESCRIPTION
In release builds, any exceptions caught in the update or init operations, or in EffectHandler.accept, will be logged to Crashlytics.
In debug builds, logging for all loop operations is enabled; exceptions are not logged to crashlytics, instead they are logged locally and then thrown.