### PR TITLE
[Student][MBL-12704] Combine file uploads into submission service

### DIFF
--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/FileUploadAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/FileUploadAPI.kt
@@ -25,6 +25,7 @@ import com.instructure.canvasapi2.models.StorageQuotaExceededError
 import com.instructure.canvasapi2.utils.DataResult
 import com.instructure.canvasapi2.utils.Failure
 import com.instructure.canvasapi2.utils.ProgressRequestBody
+import com.instructure.canvasapi2.utils.ProgressRequestUpdateListener
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import org.greenrobot.eventbus.EventBus
@@ -91,7 +92,7 @@ internal object FileUploadAPI {
         file: File,
         adapter: RestBuilder,
         params: RestParams,
-        onProgress: ((Float, Long) -> Unit)? = null
+        onProgress: ProgressRequestUpdateListener? = null
     ): Attachment? {
         val requestFile = ProgressRequestBody(file, "application/octet-stream", onProgress = onProgress)
         val requestFilePart = MultipartBody.Part.createFormData("file", file.name, requestFile)

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/FileUploadManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/FileUploadManager.kt
@@ -25,6 +25,7 @@ import com.instructure.canvasapi2.models.AvatarWrapper
 import com.instructure.canvasapi2.models.FileUploadParams
 import com.instructure.canvasapi2.models.postmodels.FileSubmitObject
 import com.instructure.canvasapi2.utils.DataResult
+import com.instructure.canvasapi2.utils.ProgressRequestUpdateListener
 import java.io.File
 
 object FileUploadManager {
@@ -32,7 +33,7 @@ object FileUploadManager {
     private fun performUpload(
         file: File,
         uploadParams: FileUploadParams,
-        onProgress: ((Float, Long) -> Unit)? = null
+        onProgress: ProgressRequestUpdateListener? = null
     ): DataResult<Attachment> {
         val adapter = RestBuilder()
         val params = RestParams(shouldIgnoreToken = true)
@@ -40,7 +41,7 @@ object FileUploadManager {
         return if (attachment != null) DataResult.Success(attachment) else DataResult.Fail()
     }
 
-    fun uploadFile(config: FileUploadConfig, onProgress: ((Float, Long) -> Unit)? = null): DataResult<Attachment> {
+    fun uploadFile(config: FileUploadConfig, onProgress: ProgressRequestUpdateListener? = null): DataResult<Attachment> {
         return FileUploadAPI.getUploadParams(config)
             .then { performUpload(File(config.filePath), it, onProgress) }
     }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/NotoriousManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/NotoriousManager.kt
@@ -25,6 +25,7 @@ import com.instructure.canvasapi2.models.NotoriousSession
 import com.instructure.canvasapi2.models.notorious.NotoriousResultWrapper
 import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.canvasapi2.utils.ProgressRequestBody
+import com.instructure.canvasapi2.utils.ProgressRequestUpdateListener
 import okhttp3.MultipartBody
 import retrofit2.Response
 import java.io.File
@@ -56,7 +57,7 @@ object NotoriousManager {
         uploadToken: String,
         file: File,
         contentType: String,
-        onProgress: ((Float, Long) -> Unit)? = null
+        onProgress: ProgressRequestUpdateListener? = null
     ): Response<Void>? {
         val requestBody = ProgressRequestBody(file, contentType, onProgress = onProgress)
         val filePart = MultipartBody.Part.createFormData("fileData", file.name, requestBody)

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/DataResult.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/DataResult.kt
@@ -70,8 +70,8 @@ sealed class DataResult<out A> {
 }
 
 // Simple abstraction for repository layer errors, add to as needed
-sealed class Failure {
-    data class Network(val message: String? = null) : Failure() // Covers 404/500, no internet, etc. Generic case for failed request
-    data class Authorization(val message: String? = null) : Failure() // Covers 401, or permission errors.
-    data class Exception(val exception: Throwable, val message: String? = null) : Failure()
+sealed class Failure(open val message: String?) {
+    data class Network(override val message: String? = null) : Failure(message) // Covers 404/500, no internet, etc. Generic case for failed request
+    data class Authorization(override val message: String? = null) : Failure(message) // Covers 401, or permission errors.
+    data class Exception(val exception: Throwable, override val message: String? = null) : Failure(message)
 }

--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -104,8 +104,8 @@
     <string name="rubricViewLongDescription">View long description</string>
 
     <!-- Student Submission Comments -->
+    <string name="assignmentSubmissionUploadingFile">Uploading file %1$d of %2$d</string>
     <string name="assignmentSubmissionCommentUpload">Uploading comment for %s</string>
-    <string name="assignmentSubmissionCommentUploadingFile">Uploading file %1$d of %2$d</string>
     <string name="assignmentSubmissionCommentUploadingMedia">Uploading media file</string>
     <string name="assignmentSubmissionCommentError">Comment upload failed for %s</string>
     <string name="chooseFileForCommentSubtext">Attach files to your comment by tapping an option below</string>

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/services/FileUploadService.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/services/FileUploadService.kt
@@ -124,16 +124,7 @@ class FileUploadService @JvmOverloads constructor(name: String = FileUploadServi
                     ACTION_SUBMISSION_COMMENT -> FileUploadConfig.forSubmissionComment(fso, courseId, assignment!!.id)
                     else -> throw IllegalArgumentException("Unknown file upload action: $action")
                 }
-                attachments += FileUploadManager.uploadFile(config){ progress, length ->
-                    /*
-                     * TEMPORARY: Post progress events for UploadStatusSubmissionEffectHandler from here until submission
-                     * file uploads are directly handled in SubmissionService
-                     */
-                    if (submissionId != null) {
-                        val event = ProgressEvent(idx, submissionId, (progress * length).toLong(), length)
-                        EventBus.getDefault().postSticky(event)
-                    }
-                }.dataOrThrow
+                attachments += FileUploadManager.uploadFile(config).dataOrThrow
             }
             // Submit fileIds to the assignment
             val attachmentsIds = attachments.map { it.id }.plus(bundle.getLongArray(Const.ATTACHMENTS)?.toList() ?: emptyList())

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/FileUploadUtils.java
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/FileUploadUtils.java
@@ -403,6 +403,11 @@ public class FileUploadUtils {
         return canvasFolder;
     }
 
+    public static boolean deleteTempFile(String filename) {
+        File file = new File(filename);
+        return file.delete();
+    }
+
     public static boolean deleteTempDirectory(Context context){
         return deleteDirectory(getCacheDir(context)) && deleteDirectory(getExternalCacheDir(context));
     }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/NotoriousUploader.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/NotoriousUploader.kt
@@ -28,10 +28,10 @@ import java.io.File
 
 object NotoriousUploader {
 
-    suspend fun performUpload(mediaPath: String, onProgress: ((Float, Long) -> Unit)? = null) : DataResult<NotoriousResult> {
+    suspend fun performUpload(mediaPath: String, onProgress: ProgressRequestUpdateListener? = null) : DataResult<NotoriousResult> {
         try{
             // Set initial progress
-            onProgress?.invoke(0f, 0)
+            onProgress?.onProgressUpdated(0f, 0)
 
             // Get NotoriousConfig
             val config = awaitApi<NotoriousConfig> { NotoriousManager.getConfiguration(it) }


### PR DESCRIPTION
Do all of the file uploading inline in the submission service rather than splitting out the tasks between services requiring gross extra communication. 

Media uploads still need to be addressed, and comments still could be cleaned up.