### PR TITLE
[Student][MBL-13042] Add retry/cancel to submissions

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/renderPages/UploadStatusSubmissionViewRenderPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/renderPages/UploadStatusSubmissionViewRenderPage.kt
@@ -31,7 +31,6 @@ class UploadStatusSubmissionViewRenderPage : BasePage(R.id.uploadStatusSubmissio
     val uploadStatusStateProgressSize by OnViewWithId(R.id.uploadStatusStateProgressSize)
 
     val uploadStatusStateRetry by OnViewWithId(R.id.uploadStatusStateRetry)
-    val uploadStatusStateCancelAll by OnViewWithId(R.id.uploadStatusStateCancelAll)
     val uploadStatusStateCancel by OnViewWithId(R.id.uploadStatusStateCancel)
     val uploadStatusStateDone by OnViewWithId(R.id.uploadStatusStateDone)
 
@@ -55,7 +54,7 @@ class UploadStatusSubmissionViewRenderPage : BasePage(R.id.uploadStatusSubmissio
         uploadStatusStateMessage.assertVisible()
         uploadStatusStateCancel.assertVisible()
         uploadStatusRecycler.assertVisible()
-//        uploadStatusStateRetry.assertVisible() // TODO: Comment out when retry is supported
+        uploadStatusStateRetry.assertVisible()
     }
 
     fun assertInProgressVisible() {
@@ -63,6 +62,6 @@ class UploadStatusSubmissionViewRenderPage : BasePage(R.id.uploadStatusSubmissio
         uploadStatusStateProgress.assertVisible()
         uploadStatusStateProgressPercent.assertVisible()
         uploadStatusStateProgressSize.assertVisible()
-        uploadStatusStateCancelAll.assertVisible()
+        uploadStatusStateCancel.assertVisible()
     }
 }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsEventBusSource.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsEventBusSource.kt
@@ -21,6 +21,7 @@ import android.net.Uri
 import com.instructure.canvasapi2.utils.Logger
 import com.instructure.pandautils.utils.FilePrefs
 import com.instructure.pandautils.utils.OnActivityResults
+import com.instructure.pandautils.utils.remove
 import com.instructure.student.mobius.assignmentDetails.ui.AssignmentDetailsFragment
 import com.instructure.student.mobius.common.EventBusSource
 import org.greenrobot.eventbus.Subscribe
@@ -34,6 +35,7 @@ class AssignmentDetailsEventBusSource : EventBusSource<AssignmentDetailsEvent>()
         event.once(subId) {
             when(it.requestCode) {
                 AssignmentDetailsFragment.VIDEO_REQUEST_CODE -> {
+                    event.remove()
                     if (it.resultCode == Activity.RESULT_OK) {
                         sendEvent(AssignmentDetailsEvent.SendVideoRecording)
                     } else {
@@ -41,6 +43,7 @@ class AssignmentDetailsEventBusSource : EventBusSource<AssignmentDetailsEvent>()
                     }
                 }
                 AssignmentDetailsFragment.CHOOSE_MEDIA_REQUEST_CODE -> {
+                    event.remove()
                     if (it.resultCode == Activity.RESULT_OK && it.data != null && it.data?.data != null) {
                         sendEvent(AssignmentDetailsEvent.SendMediaFile(it.data!!.data!!))
                     } else {

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/UploadStatusSubmissionEffectHandler.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/UploadStatusSubmissionEffectHandler.kt
@@ -104,6 +104,9 @@ class UploadStatusSubmissionEffectHandler(val context: Context, val submissionId
                     )
                 }
             }
+            is UploadStatusSubmissionEffect.ShowCancelDialog -> {
+                launch(Dispatchers.Main) { view?.showCancelSubmissionDialog() }
+            }
             is UploadStatusSubmissionEffect.OnDeleteSubmission -> {
                 launch { deleteSubmission(effect.submissionId) }
             }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/UploadStatusSubmissionEffectHandler.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/UploadStatusSubmissionEffectHandler.kt
@@ -107,9 +107,6 @@ class UploadStatusSubmissionEffectHandler(val context: Context, val submissionId
             is UploadStatusSubmissionEffect.OnDeleteSubmission -> {
                 launch { deleteSubmission(effect.submissionId) }
             }
-            is UploadStatusSubmissionEffect.OnCancelAllSubmissions -> {
-                launch { clearAllSubmissions() }
-            }
             is UploadStatusSubmissionEffect.RetrySubmission -> {
                 launch(Dispatchers.Main) { retrySubmission(effect.submissionId) }
             }
@@ -149,26 +146,12 @@ class UploadStatusSubmissionEffectHandler(val context: Context, val submissionId
     }
 
     /**
-     * TODO: Support this better
-     * This has to clear all submissions to stop any that are in progress. Once the file/submission
-     * services have been merged together, we can add support to cancel a submission for a specific
-     * assignment.
-     */
-    private fun clearAllSubmissions() {
-        // Cancel Submission/FileUpload services, this will also mark the submissions as errors
-        view?.getServiceIntents()?.forEach { context.stopService(it) }
-    }
-
-    /**
-     * TODO: Add support for retry
      * This doesn't work currently. The problem is that the FileUploadService will delete the temp
      * directory where the files are accessible when onDestroy is called. Any retry after the service
      * has "finished" will fail as it can no longer find the file on the device.
      */
     private fun retrySubmission(submissionId: Long) {
-        val canvasContext =
-            Db.getInstance(context).submissionQueries.getSubmissionById(submissionId).executeAsOne().canvasContext!!
-        SubmissionService.retryFileSubmission(context, canvasContext, submissionId)
+        SubmissionService.retryFileSubmission(context, submissionId)
 
         view?.submissionRetrying()
     }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/UploadStatusSubmissionModels.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/UploadStatusSubmissionModels.kt
@@ -21,7 +21,6 @@ import com.instructure.student.FileSubmission
 sealed class UploadStatusSubmissionEvent {
     object OnRetryClicked : UploadStatusSubmissionEvent()
     object OnCancelClicked : UploadStatusSubmissionEvent()
-    object OnCancelAllClicked : UploadStatusSubmissionEvent()
     data class OnFilesRefreshed(
         val failed: Boolean,
         val submissionId: Long,
@@ -41,7 +40,6 @@ sealed class UploadStatusSubmissionEvent {
 }
 
 sealed class UploadStatusSubmissionEffect {
-    object OnCancelAllSubmissions : UploadStatusSubmissionEffect()
     data class RetrySubmission(val submissionId: Long) : UploadStatusSubmissionEffect()
     data class LoadPersistedFiles(val submissionId: Long) : UploadStatusSubmissionEffect()
     data class OnDeleteSubmission(val submissionId: Long) : UploadStatusSubmissionEffect()

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/UploadStatusSubmissionModels.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/UploadStatusSubmissionModels.kt
@@ -21,6 +21,7 @@ import com.instructure.student.FileSubmission
 sealed class UploadStatusSubmissionEvent {
     object OnRetryClicked : UploadStatusSubmissionEvent()
     object OnCancelClicked : UploadStatusSubmissionEvent()
+    object OnRequestCancelClicked : UploadStatusSubmissionEvent()
     data class OnFilesRefreshed(
         val failed: Boolean,
         val submissionId: Long,
@@ -40,6 +41,7 @@ sealed class UploadStatusSubmissionEvent {
 }
 
 sealed class UploadStatusSubmissionEffect {
+    object ShowCancelDialog : UploadStatusSubmissionEffect()
     data class RetrySubmission(val submissionId: Long) : UploadStatusSubmissionEffect()
     data class LoadPersistedFiles(val submissionId: Long) : UploadStatusSubmissionEffect()
     data class OnDeleteSubmission(val submissionId: Long) : UploadStatusSubmissionEffect()

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/UploadStatusSubmissionUpdate.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/UploadStatusSubmissionUpdate.kt
@@ -57,9 +57,6 @@ class UploadStatusSubmissionUpdate :
         UploadStatusSubmissionEvent.OnCancelClicked -> {
             Next.dispatch(setOf(UploadStatusSubmissionEffect.OnDeleteSubmission(model.submissionId)))
         }
-        UploadStatusSubmissionEvent.OnCancelAllClicked -> {
-            Next.dispatch(setOf(UploadStatusSubmissionEffect.OnCancelAllSubmissions))
-        }
         UploadStatusSubmissionEvent.OnRetryClicked -> {
             Next.dispatch(setOf(UploadStatusSubmissionEffect.RetrySubmission(model.submissionId)))
         }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/UploadStatusSubmissionUpdate.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/UploadStatusSubmissionUpdate.kt
@@ -54,6 +54,9 @@ class UploadStatusSubmissionUpdate :
             }
             Next.next(model.copy(uploadedBytes = uploadedFileSize + event.uploaded))
         }
+        UploadStatusSubmissionEvent.OnRequestCancelClicked -> {
+            Next.dispatch(setOf(UploadStatusSubmissionEffect.ShowCancelDialog))
+        }
         UploadStatusSubmissionEvent.OnCancelClicked -> {
             Next.dispatch(setOf(UploadStatusSubmissionEffect.OnDeleteSubmission(model.submissionId)))
         }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/ui/UploadStatusSubmissionView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/ui/UploadStatusSubmissionView.kt
@@ -47,6 +47,8 @@ class UploadStatusSubmissionView(inflater: LayoutInflater, parent: ViewGroup) :
         parent
     ) {
 
+    private var dialog: AlertDialog? = null
+
     private val adapter = UploadRecyclerAdapter(object : UploadListCallback {
         override fun deleteClicked(position: Int) {
             consumer?.accept(UploadStatusSubmissionEvent.OnDeleteFile(position))
@@ -103,6 +105,9 @@ class UploadStatusSubmissionView(inflater: LayoutInflater, parent: ViewGroup) :
     private fun renderSucceeded(state: UploadStatusSubmissionViewState.Succeeded) {
         uploadStatusStateTitle.text = state.title
         uploadStatusStateMessage.text = state.message
+
+        dialog?.cancel()
+        dialog = null
     }
 
     private fun renderInProgress(state: UploadStatusSubmissionViewState.InProgress) {
@@ -137,7 +142,7 @@ class UploadStatusSubmissionView(inflater: LayoutInflater, parent: ViewGroup) :
     }
 
     fun showCancelSubmissionDialog() {
-        val dialog = AlertDialog.Builder(context)
+        dialog = AlertDialog.Builder(context)
             .setTitle(R.string.submissionDeleteTitle)
             .setMessage(R.string.submissionDeleteMessage)
             .setPositiveButton(R.string.yes) { _, _ ->
@@ -145,11 +150,14 @@ class UploadStatusSubmissionView(inflater: LayoutInflater, parent: ViewGroup) :
             }
             .setNegativeButton(R.string.no, null)
             .create()
-        dialog.setOnShowListener {
-            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(ContextCompat.getColor(context, R.color.destructive))
-            dialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(ContextCompat.getColor(context, R.color.gray))
+        dialog?.setOnShowListener {
+            dialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.setTextColor(ContextCompat.getColor(context, R.color.destructive))
+            dialog?.getButton(AlertDialog.BUTTON_NEGATIVE)?.setTextColor(ContextCompat.getColor(context, R.color.gray))
         }
-        dialog.show()
+        dialog?.setOnCancelListener {
+            dialog = null
+        }
+        dialog?.show()
     }
 }
 

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/ui/UploadStatusSubmissionView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/ui/UploadStatusSubmissionView.kt
@@ -140,13 +140,14 @@ class UploadStatusSubmissionView(inflater: LayoutInflater, parent: ViewGroup) :
         val dialog = AlertDialog.Builder(context)
             .setTitle(R.string.submissionDeleteTitle)
             .setMessage(R.string.submissionDeleteMessage)
-            .setPositiveButton(R.string.delete) { _, _ ->
+            .setPositiveButton(R.string.yes) { _, _ ->
                 consumer?.accept(UploadStatusSubmissionEvent.OnCancelClicked)
             }
-            .setNegativeButton(android.R.string.cancel, null)
+            .setNegativeButton(R.string.no, null)
             .create()
         dialog.setOnShowListener {
             dialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(ContextCompat.getColor(context, R.color.destructive))
+            dialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(ContextCompat.getColor(context, R.color.gray))
         }
         dialog.show()
     }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/ui/UploadStatusSubmissionView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/ui/UploadStatusSubmissionView.kt
@@ -70,7 +70,6 @@ class UploadStatusSubmissionView(inflater: LayoutInflater, parent: ViewGroup) :
 
         uploadStatusStateDone.setOnClickListener { backPress() }
         uploadStatusStateCancel.setOnClickListener { output.accept(UploadStatusSubmissionEvent.OnCancelClicked) }
-        uploadStatusStateCancelAll.setOnClickListener { output.accept(UploadStatusSubmissionEvent.OnCancelAllClicked) }
         uploadStatusStateRetry.setOnClickListener { output.accept(UploadStatusSubmissionEvent.OnRetryClicked) }
     }
 
@@ -94,7 +93,7 @@ class UploadStatusSubmissionView(inflater: LayoutInflater, parent: ViewGroup) :
         uploadStatusLoading.setVisible(visibilities.loading)
 
         // Set button visibilities
-//        uploadStatusStateRetry.setVisible(visibilities.failed) // TODO: Enable when retry is supported in the FileUploadService
+        uploadStatusStateRetry.setVisible(visibilities.failed)
         uploadStatusStateDone.setVisible(visibilities.succeeded)
         uploadStatusStateCancel.setVisible(visibilities.cancelable)
     }
@@ -134,14 +133,6 @@ class UploadStatusSubmissionView(inflater: LayoutInflater, parent: ViewGroup) :
         Toast.makeText(context, R.string.submittingAssignment, Toast.LENGTH_SHORT).show()
         backPress()
     }
-
-    /**
-     * Define intents here so we don't leak android resources into unit tests
-     */
-    fun getServiceIntents() = listOf(
-        Intent(context, FileUploadService::class.java),
-        Intent(context, SubmissionService::class.java)
-    )
 }
 
 interface UploadListCallback : BasicItemCallback {
@@ -168,13 +159,11 @@ class UploadListBinder : BasicItemBinder<UploadListItemViewState, UploadListCall
 //            fileError.setVisible().text = state.errorMessage
 //        }
 
-        // TODO: Not functionally useful right now since retry isn't enabled (no need to delete items yet)
-        deleteButton.setGone() // TODO: Remove this line
-//        if (state.canDelete) {
-//            deleteButton.setVisible().setOnClickListener { pickerListCallback.deleteClicked(state.position) }
-//        } else {
-//            deleteButton.setGone().setOnClickListener(null)
-//        }
+        if (state.canDelete) {
+            deleteButton.setVisible().setOnClickListener { pickerListCallback.deleteClicked(state.position) }
+        } else {
+            deleteButton.setGone().setOnClickListener(null)
+        }
     }
 }
 

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/ui/UploadStatusSubmissionView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/ui/UploadStatusSubmissionView.kt
@@ -17,12 +17,14 @@
 package com.instructure.student.mobius.assignmentDetails.submission.file.ui
 
 import android.app.Activity
+import android.app.AlertDialog
 import android.content.Intent
 import android.content.res.ColorStateList
 import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.instructure.pandautils.services.FileUploadService
 import com.instructure.pandautils.utils.*
@@ -69,7 +71,7 @@ class UploadStatusSubmissionView(inflater: LayoutInflater, parent: ViewGroup) :
         uploadStatusRecycler.adapter = adapter
 
         uploadStatusStateDone.setOnClickListener { backPress() }
-        uploadStatusStateCancel.setOnClickListener { output.accept(UploadStatusSubmissionEvent.OnCancelClicked) }
+        uploadStatusStateCancel.setOnClickListener { output.accept(UploadStatusSubmissionEvent.OnRequestCancelClicked) }
         uploadStatusStateRetry.setOnClickListener { output.accept(UploadStatusSubmissionEvent.OnRetryClicked) }
     }
 
@@ -125,13 +127,28 @@ class UploadStatusSubmissionView(inflater: LayoutInflater, parent: ViewGroup) :
 
     // Effect functions
     fun submissionDeleted() {
-        Toast.makeText(context, R.string.deleted, Toast.LENGTH_SHORT).show()
+        Toast.makeText(context, R.string.submissionDeleted, Toast.LENGTH_SHORT).show()
         backPress()
     }
 
     fun submissionRetrying() {
         Toast.makeText(context, R.string.submittingAssignment, Toast.LENGTH_SHORT).show()
         backPress()
+    }
+
+    fun showCancelSubmissionDialog() {
+        val dialog = AlertDialog.Builder(context)
+            .setTitle(R.string.submissionDeleteTitle)
+            .setMessage(R.string.submissionDeleteMessage)
+            .setPositiveButton(R.string.delete) { _, _ ->
+                consumer?.accept(UploadStatusSubmissionEvent.OnCancelClicked)
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .create()
+        dialog.setOnShowListener {
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(ContextCompat.getColor(context, R.color.destructive))
+        }
+        dialog.show()
     }
 }
 

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/ui/UploadStatusSubmissionViewState.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/ui/UploadStatusSubmissionViewState.kt
@@ -28,7 +28,7 @@ sealed class UploadStatusSubmissionViewState(val visibilities: UploadVisibilitie
         val percentageString: String = "",
         val percentage: Double = 0.0,
         val list: List<UploadListItemViewState>
-    ) : UploadStatusSubmissionViewState(UploadVisibilities(inProgress = true))
+    ) : UploadStatusSubmissionViewState(UploadVisibilities(inProgress = true, cancelable = true))
 
     data class Failed(
         val title: String = "",

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/PickerSubmissionUploadEffectHandler.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/PickerSubmissionUploadEffectHandler.kt
@@ -63,6 +63,8 @@ class PickerSubmissionUploadEffectHandler constructor(
         event.once(subId) {
             if (it.resultCode == Activity.RESULT_OK) {
                 if (it.requestCode == REQUEST_CAMERA_PIC) {
+                    event.remove() //Remove the event so it doesn't show up again somewhere else
+
                     // Attempt to restore URI in case were were booted from memory
                     val cameraImageUri = Uri.parse(FilePrefs.tempCaptureUri)
 
@@ -74,6 +76,8 @@ class PickerSubmissionUploadEffectHandler constructor(
 
                     consumer.accept(PickerSubmissionUploadEvent.OnFileSelected(cameraImageUri))
                 } else if (it.requestCode in listOf(REQUEST_PICK_IMAGE_GALLERY, REQUEST_PICK_FILE_FROM_DEVICE)) {
+                    event.remove() //Remove the event so it doesn't show up again somewhere else
+
                     if (it.data != null && it.data?.data != null) {
                         consumer.accept(PickerSubmissionUploadEvent.OnFileSelected(it.data!!.data!!))
                     } else {

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/text/TextSubmissionUploadEventBusSource.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/text/TextSubmissionUploadEventBusSource.kt
@@ -19,10 +19,7 @@ package com.instructure.student.mobius.assignmentDetails.submission.text
 import android.app.Activity
 import android.net.Uri
 import com.instructure.canvasapi2.utils.Logger
-import com.instructure.pandautils.utils.FilePrefs
-import com.instructure.pandautils.utils.MediaUploadUtils
-import com.instructure.pandautils.utils.OnActivityResults
-import com.instructure.pandautils.utils.RequestCodes
+import com.instructure.pandautils.utils.*
 import com.instructure.student.mobius.assignmentDetails.ui.AssignmentDetailsFragment
 import com.instructure.student.mobius.common.EventBusSource
 import org.greenrobot.eventbus.Subscribe
@@ -36,12 +33,16 @@ class TextSubmissionUploadEventBusSource : EventBusSource<TextSubmissionUploadEv
         event.once(subId) {
             if (it.resultCode == Activity.RESULT_OK) {
                 when (it.requestCode) {
-                    RequestCodes.PICK_IMAGE_GALLERY -> it.data?.data?.let { uri ->
-                        sendEvent(
-                            TextSubmissionUploadEvent.ImageAdded(uri)
-                        )
-                    } ?: sendEvent(TextSubmissionUploadEvent.ImageFailed)
-                    RequestCodes.CAMERA_PIC_REQUEST -> sendEvent(TextSubmissionUploadEvent.CameraImageTaken)
+                    RequestCodes.PICK_IMAGE_GALLERY -> {
+                        event.remove() //Remove the event so it doesn't show up again somewhere else
+                        it.data?.data?.let { uri ->
+                            sendEvent(TextSubmissionUploadEvent.ImageAdded(uri))
+                        } ?: sendEvent(TextSubmissionUploadEvent.ImageFailed)
+                    }
+                    RequestCodes.CAMERA_PIC_REQUEST -> {
+                        event.remove() //Remove the event so it doesn't show up again somewhere else
+                        sendEvent(TextSubmissionUploadEvent.CameraImageTaken)
+                    }
                 }
             }
         }

--- a/apps/student/src/main/java/com/instructure/student/mobius/common/ui/SubmissionService.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/common/ui/SubmissionService.kt
@@ -119,220 +119,125 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
         setIntentRedelivery(true)
     }
 
-    private fun getUserId() = ApiPrefs.user!!.id
-
     override fun onHandleIntent(intent: Intent) {
         Logger.d("Handling intent: $intent")
         val action = intent.action!!
 
+        var submission: com.instructure.student.Submission? = null
+        val db = Db.getInstance(this)
+
+        // Try to get the submission, won't have one for comment uploads
+        if (intent.hasExtra(Const.SUBMISSION_ID)) {
+            val dbSubmissionId = intent.getLongExtra(Const.SUBMISSION_ID, 0)
+            submission = db.submissionQueries.getSubmissionById(dbSubmissionId).executeAsOneOrNull() ?: return // Return early if deleted, means it was canceled
+        }
+
         when (Action.valueOf(action)) {
-            Action.TEXT_ENTRY -> uploadText(intent)
-            Action.FILE_ENTRY -> uploadFileSubmission(intent)
-            Action.MEDIA_ENTRY -> uploadMedia(intent)
-            Action.URL_ENTRY -> uploadUrl(intent, false)
-            Action.STUDIO_ENTRY -> uploadUrl(intent, true)
+            Action.TEXT_ENTRY -> uploadText(db, submission!!)
+            Action.FILE_ENTRY -> uploadFileSubmission(db, submission!!)
+            Action.MEDIA_ENTRY -> uploadMedia(db, submission!!, intent)
+            Action.URL_ENTRY -> uploadUrl(db, submission!!, false)
+            Action.STUDIO_ENTRY -> uploadUrl(db, submission!!, true)
             Action.COMMENT_ENTRY -> uploadComment(intent)
         }.exhaustive
     }
 
-    private fun uploadText(intent: Intent) {
-        val text = intent.getStringExtra(Const.MESSAGE)
-        val assignmentId = intent.getLongExtra(Const.ASSIGNMENT_ID, 0)
-        val assignmentName = intent.getStringExtra(Const.ASSIGNMENT_NAME)
-        val context = intent.getParcelableExtra<CanvasContext>(Const.CANVAS_CONTEXT)
-        val dbSubmissionId: Long
-        val db = Db.getInstance(this).submissionQueries
-
-        // Save to persistence
-        db.deleteSubmissionsForAssignmentId(assignmentId, getUserId())
-        db.insertOnlineTextSubmission(text, assignmentName, assignmentId, context, getUserId(), OffsetDateTime.now())
-        dbSubmissionId = db.getLastInsert().executeAsOne()
-
-        showProgressNotification(assignmentName, dbSubmissionId)
+    private fun uploadText(db: StudentDb, submission: com.instructure.student.Submission) {
+        showProgressNotification(submission.assignmentName, submission.id)
         val textToSubmit = try {
-            URLEncoder.encode(text, "UTF-8")
-        } catch (e: UnsupportedEncodingException) { text }
+            URLEncoder.encode(submission.submissionEntry, "UTF-8")
+        } catch (e: UnsupportedEncodingException) { submission.submissionEntry!! }
 
-        val result = apiAsync<Submission> { SubmissionManager.postTextSubmission(context, assignmentId, textToSubmit, it) }
-
-        GlobalScope.launch {
-            val uploadResult = result.await()
-            uploadResult.onSuccess {
-                db.deleteSubmissionById(dbSubmissionId)
-            }.onFailure {
-                db.setSubmissionError(true, dbSubmissionId)
-                showErrorNotification(this@SubmissionService, context, assignmentId, assignmentName, dbSubmissionId)
-            }
-        }
-    }
-
-    private fun uploadUrl(intent: Intent, isLti: Boolean) {
-        val url = intent.getStringExtra(Const.URL)
-        val assignmentId = intent.getLongExtra(Const.ASSIGNMENT_ID, 0)
-        val assignmentName = intent.getStringExtra(Const.ASSIGNMENT_NAME)
-        val context = intent.getParcelableExtra<CanvasContext>(Const.CANVAS_CONTEXT)
-        val dbSubmissionId: Long
-        val db = Db.getInstance(this).submissionQueries
-
-        // Save to persistence
-        db.deleteSubmissionsForAssignmentId(assignmentId, getUserId())
-        db.insertOnlineUrlSubmission(url, assignmentName, assignmentId, context, getUserId(), OffsetDateTime.now())
-        dbSubmissionId = db.getLastInsert().executeAsOne()
-
-        showProgressNotification(assignmentName, dbSubmissionId)
-        val result = apiAsync<Submission> { SubmissionManager.postUrlSubmission(context, assignmentId, url, isLti, it) }
+        val result = apiAsync<Submission> { SubmissionManager.postTextSubmission(submission.canvasContext, submission.assignmentId, textToSubmit, it) }
 
         GlobalScope.launch {
             val uploadResult = result.await()
             uploadResult.onSuccess {
-                db.deleteSubmissionById(dbSubmissionId)
+                db.submissionQueries.deleteSubmissionById(submission.id)
             }.onFailure {
-                db.setSubmissionError(true, dbSubmissionId)
-                showErrorNotification(this@SubmissionService, context, assignmentId, assignmentName, dbSubmissionId)
+                db.submissionQueries.setSubmissionError(true, submission.id)
+                showErrorNotification(this@SubmissionService, submission.canvasContext, submission.assignmentId, submission.assignmentName, submission.id)
             }
         }
     }
 
-    private fun uploadMedia(intent: Intent) {
-        val mediaFilePath = intent.getStringExtra(Const.MEDIA_FILE_PATH)
-        var assignment = intent.getParcelableExtra<Assignment>(Const.ASSIGNMENT)
-        val canvasContext = intent.getParcelableExtra<CanvasContext>(Const.CANVAS_CONTEXT)
+    private fun uploadUrl(db: StudentDb, submission: com.instructure.student.Submission, isLti: Boolean) {
+        showProgressNotification(submission.assignmentName, submission.id)
+        val result = apiAsync<Submission> { SubmissionManager.postUrlSubmission(submission.canvasContext, submission.assignmentId, submission.submissionEntry!!, isLti, it) }
+
+        GlobalScope.launch {
+            val uploadResult = result.await()
+            uploadResult.onSuccess {
+                db.submissionQueries.deleteSubmissionById(submission.id)
+            }.onFailure {
+                db.submissionQueries.setSubmissionError(true, submission.id)
+                showErrorNotification(this@SubmissionService, submission.canvasContext, submission.assignmentId, submission.assignmentName, submission.id)
+            }
+        }
+    }
+
+    private fun uploadMedia(db: StudentDb, submission: com.instructure.student.Submission, intent: Intent) {
         val action = intent.getSerializableExtra(Const.ACTION) as NotoriousUploadService.ACTION
 
-        val dbSubmissionId: Long
-        val filesDb = Db.getInstance(this).fileSubmissionQueries
-        val submissionsDb = Db.getInstance(this).submissionQueries
-
         // Check if we're retrying a submission or if it's a new one that needs to be persisted
-        if (intent.hasExtra(Const.SUBMISSION_ID)) {
-            // Get previously attempted submission information so we can retry
-            dbSubmissionId = intent.extras!!.getLong(Const.SUBMISSION_ID)
-            val submission = submissionsDb.getSubmissionById(dbSubmissionId).executeAsOne()
-
-            assignment = Assignment(
-                id = submission.assignmentId,
-                name = submission.assignmentName,
-                groupCategoryId = submission.assignmentGroupCategoryId ?: 0
-            )
-        } else {
-            // Delete all temp files for old file submissions
-            submissionsDb.getSubmissionsByAssignmentId(assignment.id, getUserId()).executeAsList().forEach { submission ->
-                filesDb.getFilesForSubmissionId(submission.id).executeAsList().forEach { file ->
-                    FileUploadUtils.deleteTempFile(file.fullPath)
-                }
-            }
-            submissionsDb.deleteSubmissionsForAssignmentId(assignment.id, getUserId())
-
-            // New submission - store submission details in the db
-            submissionsDb.insertOnlineUploadSubmission(
-                assignment.name,
-                assignment.id,
-                assignment.groupCategoryId,
-                canvasContext,
-                getUserId(),
-                OffsetDateTime.now()
-            )
-            dbSubmissionId = submissionsDb.getLastInsert().executeAsOne()
-
-            val file = File(mediaFilePath)
-            filesDb.insertFile(dbSubmissionId, file.name, file.length(), FileUtils.getMimeType(file.path), mediaFilePath)
-        }
+        // Get previously attempted submission information so we can retry
+        val assignment = Assignment(
+            id = submission.assignmentId,
+            name = submission.assignmentName,
+            groupCategoryId = submission.assignmentGroupCategoryId ?: 0
+        )
 
         // Don't show the notification in the foreground so it doesn't disappear when this service dies
-        showProgressNotification(assignment.name, dbSubmissionId, false)
+        showProgressNotification(submission.assignmentName, submission.id, false)
 
         // Handle broadcasts from file upload service
         // Register the receiver on the application context so this service can die and handle the next submission
-        val receiver = SubmissionFileUploadReceiver(dbSubmissionId)
+        val receiver = SubmissionFileUploadReceiver(submission.id)
 
         val filter = IntentFilter(FileUploadService.ALL_UPLOADS_COMPLETED)
         filter.addAction(FileUploadService.UPLOAD_ERROR)
         applicationContext.registerReceiver(receiver, filter)
 
+        val file = db.fileSubmissionQueries.getFilesForSubmissionId(submission.id).executeAsOneOrNull() ?: return // Nothing to upload, so return here
+
         val mediaFileUploadIntent = Intent(this, NotoriousUploadService::class.java).apply {
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            putExtra(Const.MEDIA_FILE_PATH, mediaFilePath)
+            putExtra(Const.MEDIA_FILE_PATH, file.fullPath)
             putExtra(Const.ACTION, action)
-            putExtra(Const.ASSIGNMENT, assignment.copy(courseId = canvasContext.id) as Parcelable)
-            putExtra(Const.SUBMISSION_ID, dbSubmissionId)
+            putExtra(Const.ASSIGNMENT, assignment.copy(courseId = submission.canvasContext.id) as Parcelable)
+            putExtra(Const.SUBMISSION_ID, submission.id)
         }
         startService(mediaFileUploadIntent)
     }
 
-    private fun uploadFileSubmission(intent: Intent) {
-        val dbSubmissionId: Long
-        val db = Db.getInstance(this)
-        val submissionsDb = db.submissionQueries
-        val filesDb = db.fileSubmissionQueries
-
-        var assignment = intent.getParcelableExtra<Assignment>(Const.ASSIGNMENT)
-        var context = intent.getParcelableExtra<CanvasContext>(Const.CANVAS_CONTEXT)
-
-        lateinit var attachments: List<FileSubmission>
-        var completedAttachments: List<FileSubmission> = emptyList()
-
-        // Check if we're retrying a submission or if it's a new one that needs to be persisted
-        if (intent.hasExtra(Const.SUBMISSION_ID)) {
-            dbSubmissionId = intent.extras!!.getLong(Const.SUBMISSION_ID)
-            val submission = submissionsDb.getSubmissionById(dbSubmissionId).executeAsOne()
-
-            val (completed, pending) = filesDb.getFilesForSubmissionId(dbSubmissionId).executeAsList().partition { it.attachmentId != null }
-            attachments = pending
-            completedAttachments = completed
-            context = submission.canvasContext
-            assignment = Assignment(
-                id = submission.assignmentId,
-                name = submission.assignmentName,
-                groupCategoryId = submission.assignmentGroupCategoryId ?: 0
-            )
-        } else {
-            val files = intent.getParcelableArrayListExtra<FileSubmitObject>(Const.FILES)
-
-            // Delete all temp files for old file submissions
-            submissionsDb.getSubmissionsByAssignmentId(assignment.id, getUserId()).executeAsList().forEach { submission ->
-                filesDb.getFilesForSubmissionId(submission.id).executeAsList().forEach { file ->
-                    FileUploadUtils.deleteTempFile(file.fullPath)
-                }
-            }
-            submissionsDb.deleteSubmissionsForAssignmentId(assignment.id, getUserId())
-
-            // Insert the new submission
-            submissionsDb.insertOnlineUploadSubmission(
-                assignment.name,
-                assignment.id,
-                assignment.groupCategoryId,
-                context,
-                getUserId(),
-                OffsetDateTime.now()
-            )
-            dbSubmissionId = submissionsDb.getLastInsert().executeAsOne()
-
-            files.forEach {
-                filesDb.insertFile(dbSubmissionId, it.name, it.size, it.contentType, it.fullPath)
-            }
-            attachments = filesDb.getFilesWithoutAttachmentsForSubmissionId(dbSubmissionId).executeAsList()
-        }
+    private fun uploadFileSubmission(db: StudentDb, submission: com.instructure.student.Submission) {
+        val assignment = Assignment(
+            id = submission.assignmentId,
+            name = submission.assignmentName,
+            groupCategoryId = submission.assignmentGroupCategoryId ?: 0
+        )
 
         // Don't show the notification in the foreground so it doesn't disappear when this service dies
-        showProgressNotification(assignment.name, dbSubmissionId)
+        showProgressNotification(assignment.name, submission.id)
 
-        val uploadedAttachmentIds = uploadFiles(dbSubmissionId, context, assignment, completedAttachments.size, attachments, db)
+        val (completed, pending) = db.fileSubmissionQueries.getFilesForSubmissionId(submission.id).executeAsList().partition { it.attachmentId != null }
+        val uploadedAttachmentIds = uploadFiles(submission.id, submission.canvasContext, assignment, completed.size, pending, db)
             ?: return // Cancel submitting if any of the files failed to upload
 
         // Update the notification to show that we're doing the actual submission now
-        showProgressNotification(assignment.name, dbSubmissionId)
+        showProgressNotification(assignment.name, submission.id)
 
-        val attachmentIds = completedAttachments.mapNotNull { it.attachmentId } + uploadedAttachmentIds
-        SubmissionManager.postSubmissionAttachmentsSynchronous(context.id, assignment.id, attachmentIds)?.let {
+        val attachmentIds = completed.mapNotNull { it.attachmentId } + uploadedAttachmentIds
+        SubmissionManager.postSubmissionAttachmentsSynchronous(submission.canvasContext.id, submission.assignmentId, attachmentIds)?.let {
             // Clear out the db for the successful submission
-            db.fileSubmissionQueries.deleteFilesForSubmissionId(dbSubmissionId)
-            db.submissionQueries.deleteSubmissionById(dbSubmissionId)
+            db.fileSubmissionQueries.deleteFilesForSubmissionId(submission.id)
+            db.submissionQueries.deleteSubmissionById(submission.id)
 
             detachForegroundNotification()
-            showCompleteNotification(this, context, assignment.id, assignment.name, dbSubmissionId)
+            showCompleteNotification(this, submission.canvasContext, submission.assignmentId, submission.assignmentName, submission.id)
         } ?: run {
             detachForegroundNotification()
-            showErrorNotification(this, context, assignment.id, assignment.name, dbSubmissionId)
+            showErrorNotification(this, submission.canvasContext, submission.assignmentId, submission.assignmentName, submission.id)
         }
     }
 
@@ -398,25 +303,8 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
             val commentDb = db.pendingSubmissionCommentQueries
             val fileDb = db.submissionCommentFileQueries
 
-            // Get existing pending comment from db, or create and insert a new one
-            val comment: PendingSubmissionComment = if (intent.hasExtra(Const.ID)) {
-                commentDb.getCommentById(intent.getLongExtra(Const.ID, 0)).executeAsOne()
-            } else {
-                commentDb.insertComment(
-                    accountDomain = ApiPrefs.domain,
-                    canvasContext = intent.getParcelableExtra(Const.CANVAS_CONTEXT),
-                    assignmentName = intent.getStringExtra(Const.ASSIGNMENT_NAME),
-                    assignmentId = intent.getLongExtra(Const.ASSIGNMENT_ID, 0L),
-                    lastActivityDate = Date.now(),
-                    isGroupMessage = intent.getBooleanExtra(Const.IS_GROUP, false),
-                    message = intent.getStringExtra(Const.MESSAGE),
-                    mediaPath = intent.getStringExtra(Const.MEDIA_FILE_PATH)
-                )
-                val id = commentDb.getLastInsert().executeAsOne()
-                val files = intent.getParcelableArrayListExtra<FileSubmitObject>(Const.FILES)
-                files?.forEach { fileDb.insertFile(id, it.name, it.size, it.contentType, it.fullPath) }
-                commentDb.getCommentById(id).executeAsOne()
-            }
+            // Get existing pending comment from db, or return if it was deleted
+            val comment = commentDb.getCommentById(intent.getLongExtra(Const.ID, 0)).executeAsOneOrNull() ?: return@runBlocking
 
             // Get attachments, partition by completed vs pending
             val (completed, pending) = fileDb
@@ -645,6 +533,30 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
         private const val CHANNEL_ID = "submissionChannel"
         const val COMMENT_CHANNEL_ID = "commentUploadChannel"
 
+        private fun getUserId() = ApiPrefs.user!!.id
+
+        private fun insertNewSubmission(assignmentId: Long, context: Context, files: List<FileSubmitObject> = emptyList(), insertBlock: (StudentDb) -> Unit): Long {
+            val db = Db.getInstance(context)
+            deleteSubmissionsForAssignment(assignmentId, db)
+            insertBlock.invoke(db)
+            val dbSubmissionId = db.submissionQueries.getLastInsert().executeAsOne()
+
+            files.forEach {
+                db.fileSubmissionQueries.insertFile(dbSubmissionId, it.name, it.size, it.contentType, it.fullPath)
+            }
+
+            return dbSubmissionId
+        }
+
+        private fun deleteSubmissionsForAssignment(id: Long, db: StudentDb) {
+            db.submissionQueries.getSubmissionsByAssignmentId(id, getUserId()).executeAsList().forEach { submission ->
+                db.fileSubmissionQueries.getFilesForSubmissionId(submission.id).executeAsList().forEach { file ->
+                    FileUploadUtils.deleteTempFile(file.fullPath)
+                }
+            }
+            db.submissionQueries.deleteSubmissionsForAssignmentId(id, getUserId())
+        }
+
         fun createNotificationChannel(notificationManager: NotificationManager, channelId: String = CHANNEL_ID) {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
 
@@ -740,11 +652,12 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
             assignmentName: String?,
             text: String
         ) {
+            val dbSubmissionId = insertNewSubmission(assignmentId, context) {
+                it.submissionQueries.insertOnlineTextSubmission(text, assignmentName, assignmentId, canvasContext, getUserId(), OffsetDateTime.now())
+            }
+
             val bundle = Bundle().apply {
-                putParcelable(Const.CANVAS_CONTEXT, canvasContext)
-                putLong(Const.ASSIGNMENT_ID, assignmentId)
-                putString(Const.ASSIGNMENT_NAME, assignmentName)
-                putString(Const.MESSAGE, text)
+                putLong(Const.SUBMISSION_ID, dbSubmissionId)
             }
 
             startService(context, Action.TEXT_ENTRY, bundle)
@@ -757,11 +670,12 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
             assignmentName: String?,
             url: String
         ) {
+            val dbSubmissionId = insertNewSubmission(assignmentId, context) {
+                it.submissionQueries.insertOnlineUrlSubmission(url, assignmentName, assignmentId, canvasContext, getUserId(), OffsetDateTime.now())
+            }
+
             val bundle = Bundle().apply {
-                putParcelable(Const.CANVAS_CONTEXT, canvasContext)
-                putLong(Const.ASSIGNMENT_ID, assignmentId)
-                putString(Const.ASSIGNMENT_NAME, assignmentName)
-                putString(Const.URL, url)
+                putLong(Const.SUBMISSION_ID, dbSubmissionId)
             }
 
             startService(context, Action.URL_ENTRY, bundle)
@@ -777,18 +691,19 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
         ) {
             files.ifEmpty { return } // No need to upload files if we aren't given any
 
+            val dbSubmissionId = insertNewSubmission(assignmentId, context, files) {
+                it.submissionQueries.insertOnlineUploadSubmission(assignmentName, assignmentId, assignmentGroupCategoryId, canvasContext, getUserId(), OffsetDateTime.now())
+            }
+
             val bundle = Bundle().apply {
-                putParcelable(Const.CANVAS_CONTEXT, canvasContext)
-                putParcelable(Const.ASSIGNMENT, Assignment(id = assignmentId, name = assignmentName, groupCategoryId = assignmentGroupCategoryId))
-                putParcelableArrayList(Const.FILES, files)
+                putLong(Const.SUBMISSION_ID, dbSubmissionId)
             }
 
             startService(context, Action.FILE_ENTRY, bundle)
         }
 
-        fun retryFileSubmission(context: Context, canvasContext: CanvasContext, dbSubmissionId: Long) {
+        fun retryFileSubmission(context: Context, dbSubmissionId: Long) {
             val bundle = Bundle().apply {
-                putParcelable(Const.CANVAS_CONTEXT, canvasContext)
                 putLong(Const.SUBMISSION_ID, dbSubmissionId)
             }
 
@@ -801,13 +716,16 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
             assignmentId: Long,
             assignmentName: String?,
             assignmentGroupCategoryId: Long,
-            mediaFilePath: String?,
+            mediaFilePath: String,
             notoriousAction: NotoriousUploadService.ACTION
         ) {
+            val file = File(mediaFilePath).let { FileSubmitObject(it.name, it.length(), FileUtils.getMimeType(it.path), mediaFilePath) }
+            val dbSubmissionId = insertNewSubmission(assignmentId, context, listOf(file)) {
+                it.submissionQueries.insertOnlineUploadSubmission(assignmentName, assignmentId, assignmentGroupCategoryId, canvasContext, getUserId(), OffsetDateTime.now())
+            }
+
             val bundle = Bundle().apply {
-                putParcelable(Const.CANVAS_CONTEXT, canvasContext)
-                putParcelable(Const.ASSIGNMENT, Assignment(id = assignmentId, name = assignmentName, groupCategoryId = assignmentGroupCategoryId))
-                putString(Const.MEDIA_FILE_PATH, mediaFilePath)
+                putLong(Const.SUBMISSION_ID, dbSubmissionId)
                 putSerializable(Const.ACTION, notoriousAction)
             }
 
@@ -821,11 +739,12 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
             assignmentName: String?,
             url: String
         ) {
+            val dbSubmissionId = insertNewSubmission(assignmentId, context) {
+                it.submissionQueries.insertOnlineUrlSubmission(url, assignmentName, assignmentId, canvasContext, getUserId(), OffsetDateTime.now())
+            }
+
             val bundle = Bundle().apply {
-                putParcelable(Const.CANVAS_CONTEXT, canvasContext)
-                putLong(Const.ASSIGNMENT_ID, assignmentId)
-                putString(Const.ASSIGNMENT_NAME, assignmentName)
-                putString(Const.URL, url)
+                putLong(Const.SUBMISSION_ID, dbSubmissionId)
             }
 
             startService(context, Action.STUDIO_ENTRY, bundle)
@@ -847,13 +766,22 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
             isGroupMessage: Boolean
         ) {
             require(message.isValid() || attachments?.isNotEmpty() == true)
+            val db = Db.getInstance(context)
+            db.pendingSubmissionCommentQueries.insertComment(
+                accountDomain = ApiPrefs.domain,
+                canvasContext = canvasContext,
+                assignmentName = assignmentName,
+                assignmentId = assignmentId,
+                lastActivityDate = Date.now(),
+                isGroupMessage = isGroupMessage,
+                message = message,
+                mediaPath = null
+            )
+            val commentId = db.pendingSubmissionCommentQueries.getLastInsert().executeAsOne()
+            attachments?.forEach { db.submissionCommentFileQueries.insertFile(commentId, it.name, it.size, it.contentType, it.fullPath) }
+
             val bundle = Bundle().apply {
-                putParcelable(Const.CANVAS_CONTEXT, canvasContext)
-                putLong(Const.ASSIGNMENT_ID, assignmentId)
-                putString(Const.ASSIGNMENT_NAME, assignmentName)
-                putString(Const.MESSAGE, message)
-                putBoolean(Const.IS_GROUP, isGroupMessage)
-                attachments?.let { putParcelableArrayList(Const.FILES, ArrayList(it)) }
+                putLong(Const.ID, commentId)
             }
             startService(context, Action.COMMENT_ENTRY, bundle)
         }
@@ -870,12 +798,21 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
             mediaFile: File,
             isGroupMessage: Boolean
         ) {
+            val db = Db.getInstance(context)
+            db.pendingSubmissionCommentQueries.insertComment(
+                accountDomain = ApiPrefs.domain,
+                canvasContext = canvasContext,
+                assignmentName = assignmentName,
+                assignmentId = assignmentId,
+                lastActivityDate = Date.now(),
+                isGroupMessage = isGroupMessage,
+                message = null,
+                mediaPath = mediaFile.absolutePath
+            )
+            val commentId = db.pendingSubmissionCommentQueries.getLastInsert().executeAsOne()
+
             val bundle = Bundle().apply {
-                putParcelable(Const.CANVAS_CONTEXT, canvasContext)
-                putLong(Const.ASSIGNMENT_ID, assignmentId)
-                putString(Const.ASSIGNMENT_NAME, assignmentName)
-                putString(Const.MEDIA_FILE_PATH, mediaFile.absolutePath)
-                putBoolean(Const.IS_GROUP, isGroupMessage)
+                putLong(Const.ID, commentId)
             }
             startService(context, Action.COMMENT_ENTRY, bundle)
         }

--- a/apps/student/src/main/res/layout/fragment_upload_status_submission.xml
+++ b/apps/student/src/main/res/layout/fragment_upload_status_submission.xml
@@ -122,16 +122,6 @@
         app:layout_constraintTop_toBottomOf="@id/uploadStatusStateButtonBarrier" />
 
     <TextView
-        android:id="@+id/uploadStatusStateCancelAll"
-        style="@style/FlatButton"
-        android:layout_marginEnd="8dp"
-        android:layout_marginBottom="8dp"
-        android:text="@string/cancelAllSubmissions"
-        android:visibility="gone"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/uploadStatusStateButtonBarrier" />
-
-    <TextView
         android:id="@+id/uploadStatusStateCancel"
         style="@style/FlatButton"
         android:layout_marginEnd="8dp"
@@ -156,7 +146,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:visibility="visible"
-        app:constraint_referenced_ids="uploadStatusStateProgressLabel, uploadStatusStateProgress, uploadStatusStateProgressPercent, uploadStatusStateProgressSize, uploadStatusStateCancelAll" />
+        app:constraint_referenced_ids="uploadStatusStateProgressLabel, uploadStatusStateProgress, uploadStatusStateProgressPercent, uploadStatusStateProgressSize" />
 
     <androidx.constraintlayout.widget.Group
         android:id="@+id/statusGroup"
@@ -170,7 +160,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:barrierDirection="bottom"
-        app:constraint_referenced_ids="uploadStatusStateDone, uploadStatusStateCancel, uploadStatusStateRetry, uploadStatusStateCancelAll" />
+        app:constraint_referenced_ids="uploadStatusStateDone, uploadStatusStateCancel, uploadStatusStateRetry" />
 
     <FrameLayout
         android:id="@+id/divider"

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/UploadStatusSubmissionEffectHandlerTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/UploadStatusSubmissionEffectHandlerTest.kt
@@ -313,4 +313,13 @@ class UploadStatusSubmissionEffectHandlerTest : Assert() {
 
         confirmVerified(db)
     }
+
+    @Test
+    fun `ShowCancelDialog calls showCancelSubmissionDialog`() {
+        effectHandler.accept(UploadStatusSubmissionEffect.ShowCancelDialog)
+        verify(timeout = 100) {
+            view.showCancelSubmissionDialog()
+        }
+        confirmVerified(view)
+    }
 }

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/UploadStatusSubmissionEffectHandlerTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/UploadStatusSubmissionEffectHandlerTest.kt
@@ -264,34 +264,12 @@ class UploadStatusSubmissionEffectHandlerTest : Assert() {
     }
 
     @Test
-    fun `OnCancelAllSubmissions results in stopping services`() {
-        val count = 2
-        every { view.getServiceIntents() } returns List(count) { mockk<Intent>(relaxed = true) }
-
-        effectHandler.accept(UploadStatusSubmissionEffect.OnCancelAllSubmissions)
-
-        excludeRecords {
-            context.registerReceiver(any(), any())
-        }
-
-        verify (timeout = 100) {
-            view.getServiceIntents()
-        }
-
-        verify (timeout = 100, exactly = count) {
-            context.stopService(any())
-        }
-
-        confirmVerified(view, context)
-    }
-
-    @Test
     fun `RetrySubmission results in view call for submissionDeleted`() {
         val course = Course()
 
         mockkObject(SubmissionService.Companion)
         every {
-            SubmissionService.retryFileSubmission(any(), any(), any())
+            SubmissionService.retryFileSubmission(any(), any())
         } returns Unit
 
         mockkStatic("com.instructure.student.db.ExtensionsKt")
@@ -307,7 +285,7 @@ class UploadStatusSubmissionEffectHandlerTest : Assert() {
         effectHandler.accept(UploadStatusSubmissionEffect.RetrySubmission(submissionId))
 
         verify (timeout = 100) {
-            SubmissionService.retryFileSubmission(context, course, submissionId)
+            SubmissionService.retryFileSubmission(context, submissionId)
             view.submissionRetrying()
         }
 

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/UploadStatusSubmissionUpdateTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/UploadStatusSubmissionUpdateTest.kt
@@ -325,4 +325,22 @@ class UploadStatusSubmissionUpdateTest : Assert() {
                 )
             )
     }
+
+    @Test
+    fun `OnRequestCancelClicked results in ShowCancelDialog effect`() {
+        val startModel = initModel.copy(files = listOf(initFile))
+        updateSpec
+            .given(startModel)
+            .whenEvent(
+                UploadStatusSubmissionEvent.OnRequestCancelClicked
+            )
+            .then(
+                assertThatNext(
+                    NextMatchers.hasNoModel(),
+                    NextMatchers.hasEffects<UploadStatusSubmissionModel, UploadStatusSubmissionEffect>(
+                        UploadStatusSubmissionEffect.ShowCancelDialog
+                    )
+                )
+            )
+    }
 }

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/UploadStatusSubmissionUpdateTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/UploadStatusSubmissionUpdateTest.kt
@@ -272,23 +272,6 @@ class UploadStatusSubmissionUpdateTest : Assert() {
     }
 
     @Test
-    fun `OnCancelAllClicked results in an OnCancelAllSubmissions effect`() {
-        updateSpec
-            .given(initModel)
-            .whenEvent(
-                UploadStatusSubmissionEvent.OnCancelAllClicked
-            )
-            .then(
-                assertThatNext(
-                    NextMatchers.hasNoModel(),
-                    NextMatchers.hasEffects<UploadStatusSubmissionModel, UploadStatusSubmissionEffect>(
-                        UploadStatusSubmissionEffect.OnCancelAllSubmissions
-                    )
-                )
-            )
-    }
-
-    @Test
     fun `OnRetryClicked results in a RetrySubmission effect`() {
         updateSpec
             .given(initModel)

--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -57,8 +57,8 @@
     <string name="submissionUploadByteProgress">%1$s of %2$s</string>
     <string name="submissionSuccessTitle">Submission Success!</string>
     <string name="submissionSuccessMessage">Your assignment was successfully submitted. Enjoy your day!</string>
-    <string name="submissionDeleteTitle">Delete Submission?</string>
-    <string name="submissionDeleteMessage">Are you sure you want to delete this submission?</string>
+    <string name="submissionDeleteTitle">Cancel Submission</string>
+    <string name="submissionDeleteMessage">This will cancel and delete your submission.</string>
     <string name="submissionDeleted">Submission Deleted</string>
     <string name="missingSubmissionLabel">Missing</string>
     <string name="gradedSubmissionLabel">Graded</string>

--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -57,7 +57,9 @@
     <string name="submissionUploadByteProgress">%1$s of %2$s</string>
     <string name="submissionSuccessTitle">Submission Success!</string>
     <string name="submissionSuccessMessage">Your assignment was successfully submitted. Enjoy your day!</string>
-    <string name="cancelAllSubmissions">Cancel All Assignment Submissions</string>
+    <string name="submissionDeleteTitle">Delete Submission?</string>
+    <string name="submissionDeleteMessage">Are you sure you want to delete this submission?</string>
+    <string name="submissionDeleted">Submission Deleted</string>
     <string name="missingSubmissionLabel">Missing</string>
     <string name="gradedSubmissionLabel">Graded</string>
 


### PR DESCRIPTION
Two extra things in this PR:
1. Fix a bug with onActivityResult event bus messages. Not removing the event was causing the event to leak to other things listening to that event.
2. Moved inserting into the database into the start service call. This will allow multiple submissions to be in progress WITH meaningful messages to users. Before, no ‘in progress’ messages would be visible to users and the submission service wouldn’t update to in progress until it was handling that submission. Now it will update everything to in progress right away, updating the actual progress of uploads as it happens. (This wasn’t an issue before as we were quickly moving through file uploads to the file upload service, meaning our submission service could quickly handle all the incoming intents. This doesn’t work as nice now that file uploads are synchronous in the submission service)