### PR TITLE
[Student][MBL-12861] Replace submission file picker FAB with bottom bar

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/renderPages/PickerSubmissionUploadRenderPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/renderPages/PickerSubmissionUploadRenderPage.kt
@@ -30,10 +30,11 @@ class PickerSubmissionUploadRenderPage : BasePage(R.id.pickerSubmissionUploadPag
     val submitButton by OnViewWithId(R.id.menuSubmit)
     val loading by OnViewWithId(R.id.fileLoading)
 
-    val fabPick by OnViewWithId(R.id.pickFab)
-    val fabFile by OnViewWithId(R.id.pickFabFile)
-    val fabCamera by OnViewWithId(R.id.pickFabCamera)
-    val fabGallery by OnViewWithId(R.id.pickFabGallery)
+    val sourcesContainer by OnViewWithId(R.id.sourcesContainer)
+    val sourcesDivider by OnViewWithId(R.id.sourcesDivider)
+    val deviceButton by OnViewWithId(R.id.sourceDevice)
+    val cameraButton by OnViewWithId(R.id.sourceCamera)
+    val galleryButton by OnViewWithId(R.id.sourceGallery)
 
     val emptyMessage by OnViewWithId(R.id.message)
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/PickerSubmissionUploadRenderTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/PickerSubmissionUploadRenderTest.kt
@@ -21,7 +21,10 @@ import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.Course
-import com.instructure.espresso.*
+import com.instructure.espresso.assertDisplayed
+import com.instructure.espresso.assertHasText
+import com.instructure.espresso.assertNotDisplayed
+import com.instructure.espresso.assertVisible
 import com.instructure.panda_annotations.FeatureCategory
 import com.instructure.panda_annotations.Priority
 import com.instructure.panda_annotations.TestCategory
@@ -42,18 +45,18 @@ import org.junit.runner.RunWith
 class PickerSubmissionUploadRenderTest : StudentRenderTest() {
 
     private val page = PickerSubmissionUploadRenderPage()
-    private val baseVisibilities = PickerVisibilities(fab = true)
+    private val baseVisibilities = PickerVisibilities(sources = true)
 
     @Test
     @TestMetaData(Priority.P3, FeatureCategory.SUBMISSIONS, TestCategory.RENDER)
     fun displaysEmptyState() {
         loadPageWithViewState(PickerSubmissionUploadViewState.Empty(baseVisibilities))
         page.emptyView.assertVisible()
-        page.fabPick.assertVisible()
+        page.sourcesContainer.assertVisible()
 
         page.recycler.assertNotDisplayed()
         page.submitButton.check(doesNotExist())
-        assertExtraFabsNotDisplayed()
+        assertSourceButtonsNotDisplayed()
     }
 
     @Test
@@ -67,12 +70,12 @@ class PickerSubmissionUploadRenderTest : StudentRenderTest() {
 
         loadPageWithViewState(PickerSubmissionUploadViewState.Empty(baseVisibilities.copy(loading = true)))
         page.emptyView.assertVisible()
-        page.fabPick.assertVisible()
+        page.sourcesContainer.assertVisible()
         page.loading.assertVisible()
 
         page.recycler.assertNotDisplayed()
         page.submitButton.check(doesNotExist())
-        assertExtraFabsNotDisplayed()
+        assertSourceButtonsNotDisplayed()
     }
 
     @Test
@@ -88,11 +91,11 @@ class PickerSubmissionUploadRenderTest : StudentRenderTest() {
             )
         )
         page.recycler.assertVisible()
-        page.fabPick.assertVisible()
+        page.sourcesContainer.assertVisible()
         page.submitButton.assertVisible()
 
         page.emptyView.assertNotDisplayed()
-        assertExtraFabsNotDisplayed()
+        assertSourceButtonsNotDisplayed()
     }
 
     @Test
@@ -114,122 +117,95 @@ class PickerSubmissionUploadRenderTest : StudentRenderTest() {
             )
         )
         page.recycler.assertVisible()
-        page.fabPick.assertVisible()
+        page.sourcesContainer.assertVisible()
         page.submitButton.assertVisible()
         page.loading.assertVisible()
 
         page.emptyView.assertNotDisplayed()
-        assertExtraFabsNotDisplayed()
+        assertSourceButtonsNotDisplayed()
     }
 
     @Test
     @TestMetaData(Priority.P3, FeatureCategory.SUBMISSIONS, TestCategory.RENDER)
-    fun displaysFabsAndHandlesClicks() {
+    fun displaysSourceButtons() {
         loadPageWithViewState(
             PickerSubmissionUploadViewState.Empty(
                 baseVisibilities.copy(
-                    fabCamera = true,
-                    fabGallery = true,
-                    fabFile = true
+                    sourceCamera = true,
+                    sourceGallery = true,
+                    sourceFile = true
                 )
             )
         )
-        page.fabPick.assertVisible()
-        assertExtraFabsNotDisplayed()
-
-        // Perform click and assert displayed
-        page.fabPick.click()
-        assertExtraFabsDisplayed()
-
-        // Test file click closes fab
-        page.fabFile.click()
-        assertExtraFabsNotDisplayed()
-
-        // Perform click and assert displayed
-        page.fabPick.click()
-        assertExtraFabsDisplayed()
-
-        // Test gallery click closes fab
-        page.fabGallery.click()
-        assertExtraFabsNotDisplayed()
-
-        // Perform click and assert displayed
-        page.fabPick.click()
-        assertExtraFabsDisplayed()
-
-        // Test camera click closes fab
-        page.fabCamera.click()
-        assertExtraFabsNotDisplayed()
+        page.sourcesContainer.assertVisible()
+        page.sourcesDivider.assertDisplayed()
+        page.cameraButton.assertDisplayed()
+        page.deviceButton.assertDisplayed()
+        page.galleryButton.assertDisplayed()
     }
 
     @Test
     @TestMetaData(Priority.P3, FeatureCategory.SUBMISSIONS, TestCategory.RENDER)
-    fun showsOnlyFabCamera() {
+    fun showsOnlyCameraSource() {
         loadPageWithViewState(
             PickerSubmissionUploadViewState.Empty(
                 baseVisibilities.copy(
-                    fabCamera = true,
-                    fabGallery = false,
-                    fabFile = false
+                    sourceCamera = true,
+                    sourceGallery = false,
+                    sourceFile = false
                 )
             )
         )
-        page.fabPick.assertVisible()
-        assertExtraFabsNotDisplayed()
+        page.sourcesContainer.assertVisible()
 
-        // Perform click and assert displayed
-        page.fabPick.click()
-        page.fabCamera.assertDisplayed()
+        // Assert displayed
+        page.cameraButton.assertDisplayed()
 
-        page.fabFile.assertNotDisplayed()
-        page.fabGallery.assertNotDisplayed()
+        page.deviceButton.assertNotDisplayed()
+        page.galleryButton.assertNotDisplayed()
     }
 
     @Test
     @TestMetaData(Priority.P3, FeatureCategory.SUBMISSIONS, TestCategory.RENDER)
-    fun showsOnlyFabGallery() {
+    fun showsOnlyGallerySource() {
         loadPageWithViewState(
             PickerSubmissionUploadViewState.Empty(
                 baseVisibilities.copy(
-                    fabCamera = false,
-                    fabGallery = true,
-                    fabFile = false
+                    sourceCamera = false,
+                    sourceGallery = true,
+                    sourceFile = false
                 )
             )
         )
-        page.fabPick.assertVisible()
-        assertExtraFabsNotDisplayed()
+        page.sourcesContainer.assertVisible()
 
-        // Perform click and assert displayed
-        page.fabPick.click()
-        page.fabGallery.assertDisplayed()
+        // PAssert displayed
+        page.galleryButton.assertDisplayed()
 
-        page.fabFile.assertNotDisplayed()
-        page.fabCamera.assertNotDisplayed()
+        page.deviceButton.assertNotDisplayed()
+        page.cameraButton.assertNotDisplayed()
 
     }
 
     @Test
     @TestMetaData(Priority.P3, FeatureCategory.SUBMISSIONS, TestCategory.RENDER)
-    fun showsOnlyFabFile() {
+    fun showsOnlyFileSource() {
         loadPageWithViewState(
             PickerSubmissionUploadViewState.Empty(
                 baseVisibilities.copy(
-                    fabCamera = false,
-                    fabGallery = false,
-                    fabFile = true
+                    sourceCamera = false,
+                    sourceGallery = false,
+                    sourceFile = true
                 )
             )
         )
-        page.fabPick.assertVisible()
-        assertExtraFabsNotDisplayed()
+        page.sourcesContainer.assertVisible()
 
-        // Perform click and assert displayed
-        page.fabPick.click()
-        page.fabFile.assertDisplayed()
+        // Assert displayed
+        page.deviceButton.assertDisplayed()
 
-        page.fabCamera.assertNotDisplayed()
-        page.fabGallery.assertNotDisplayed()
+        page.cameraButton.assertNotDisplayed()
+        page.galleryButton.assertNotDisplayed()
     }
 
     @Test
@@ -253,16 +229,25 @@ class PickerSubmissionUploadRenderTest : StudentRenderTest() {
         page.emptyMessage.assertHasText(R.string.chooseFileForCommentSubtext)
     }
 
-    private fun assertExtraFabsDisplayed() {
-        page.fabFile.assertDisplayed()
-        page.fabCamera.assertDisplayed()
-        page.fabGallery.assertDisplayed()
+    @Test
+    @TestMetaData(Priority.P3, FeatureCategory.SUBMISSIONS, TestCategory.RENDER)
+    fun hidesSourceButtons() {
+        loadPageWithViewState(
+            PickerSubmissionUploadViewState.Empty(
+                baseVisibilities.copy(sources = false)
+            )
+        )
+        page.sourcesContainer.assertNotDisplayed()
+        page.sourcesDivider.assertNotDisplayed()
+        page.cameraButton.assertNotDisplayed()
+        page.deviceButton.assertNotDisplayed()
+        page.galleryButton.assertNotDisplayed()
     }
 
-    private fun assertExtraFabsNotDisplayed() {
-        page.fabFile.assertNotDisplayed()
-        page.fabCamera.assertNotDisplayed()
-        page.fabGallery.assertNotDisplayed()
+    private fun assertSourceButtonsNotDisplayed() {
+        page.deviceButton.assertNotDisplayed()
+        page.cameraButton.assertNotDisplayed()
+        page.galleryButton.assertNotDisplayed()
     }
 
     private fun loadPageWithViewState(

--- a/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
@@ -100,7 +100,14 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
     private var mDrawerToggle: ActionBarDrawerToggle? = null
     private var colorOverlayJob: Job? = null
 
-    //endregion
+    /** 'Root' fragments that should include the bottom nav bar */
+    private val bottomNavBarFragments = listOf(
+        DashboardFragment::class.java,
+        CalendarListViewFragment::class.java,
+        ToDoListFragment::class.java,
+        NotificationListFragment::class.java,
+        InboxFragment::class.java
+    )
 
     override fun contentResId(): Int = R.layout.activity_navigation
 
@@ -151,6 +158,11 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
             // Sends a broadcast event to notify the backstack has changed and which fragment class is on top.
             OnBackStackChangedEvent(it::class.java).post()
             applyCurrentFragmentTheme()
+
+            /* Update nav bar visibility to show for specific 'root' fragment. Also show the nav bar when there is
+             only one fragment on the backstack, which commonly occurs when with non-root fragments when routing
+             from external sources. */
+            bottomBar.setVisible(it::class.java in bottomNavBarFragments || supportFragmentManager.backStackEntryCount <= 1)
         }
     }
 

--- a/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
@@ -159,8 +159,8 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
             OnBackStackChangedEvent(it::class.java).post()
             applyCurrentFragmentTheme()
 
-            /* Update nav bar visibility to show for specific 'root' fragment. Also show the nav bar when there is
-             only one fragment on the backstack, which commonly occurs when with non-root fragments when routing
+            /* Update nav bar visibility to show for specific 'root' fragments. Also show the nav bar when there is
+             only one fragment on the backstack, which commonly occurs with non-root fragments when routing
              from external sources. */
             bottomBar.setVisible(it::class.java in bottomNavBarFragments || supportFragmentManager.backStackEntryCount <= 1)
         }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/PickerSubmissionUploadPresenter.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/PickerSubmissionUploadPresenter.kt
@@ -17,9 +17,7 @@
 package com.instructure.student.mobius.assignmentDetails.submission.picker
 
 import android.content.Context
-import androidx.annotation.IntegerRes
 import com.instructure.canvasapi2.utils.NumberHelper
-import com.instructure.student.R
 import com.instructure.student.mobius.assignmentDetails.submission.picker.ui.PickerListItemViewState
 import com.instructure.student.mobius.assignmentDetails.submission.picker.ui.PickerSubmissionUploadViewState
 import com.instructure.student.mobius.assignmentDetails.submission.picker.ui.PickerVisibilities
@@ -60,11 +58,11 @@ object PickerSubmissionUploadPresenter : Presenter<PickerSubmissionUploadModel, 
 
     private fun getVisibilities(model: PickerSubmissionUploadModel) = PickerVisibilities(
         loading = model.isLoadingFile,
-        fab = !model.mode.isMediaSubmission,
+        sources = !model.mode.isMediaSubmission,
         submit = model.files.isNotEmpty(),
-        fabFile = !model.mode.isMediaSubmission,
-        fabCamera = !model.mode.isMediaSubmission && allowsCameraImages(model.allowedExtensions),
-        fabGallery = !model.mode.isMediaSubmission && allowsGalleryImages(model.allowedExtensions)
+        sourceFile = !model.mode.isMediaSubmission,
+        sourceCamera = !model.mode.isMediaSubmission && allowsCameraImages(model.allowedExtensions),
+        sourceGallery = !model.mode.isMediaSubmission && allowsGalleryImages(model.allowedExtensions)
     )
 
     private fun allowsCameraImages(allowedExtensions: List<String>): Boolean {

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/ui/PickerSubmissionUploadViewState.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/ui/PickerSubmissionUploadViewState.kt
@@ -23,10 +23,10 @@ sealed class PickerSubmissionUploadViewState(open val visibilities: PickerVisibi
 
 data class PickerVisibilities(
     val loading: Boolean = false,
-    val fab: Boolean = false,
-    val fabCamera: Boolean = false,
-    val fabGallery: Boolean = false,
-    val fabFile: Boolean = false,
+    val sources: Boolean = false,
+    val sourceCamera: Boolean = false,
+    val sourceGallery: Boolean = false,
+    val sourceFile: Boolean = false,
     val submit: Boolean = false
 )
 

--- a/apps/student/src/main/res/layout/activity_navigation.xml
+++ b/apps/student/src/main/res/layout/activity_navigation.xml
@@ -18,47 +18,50 @@
 
 <androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/drawerLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/canvasBackgroundWhite">
 
-    <RelativeLayout
+    <LinearLayout
         android:id="@+id/fullscreenWrapper"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:clipChildren="false"
         android:clipToPadding="false"
-        android:animateLayoutChanges="true">
+        android:orientation="vertical">
 
         <FrameLayout
-            android:id="@+id/fullscreen"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_above="@+id/bottomBarDivider" />
+            android:layout_height="0dp"
+            android:layout_weight="1">
+
+            <FrameLayout
+                android:id="@+id/fullscreen"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"/>
+
+            <include layout="@layout/loading_canvas_view"/>
+
+        </FrameLayout>
 
         <View
             android:id="@+id/bottomBarDivider"
             android:layout_width="match_parent"
             android:layout_height="0.5dp"
-            android:layout_above="@+id/bottomBar"
             android:background="@color/bottomBarNavigationColor"
-            android:importantForAccessibility="no" />
+            android:importantForAccessibility="no"/>
 
         <com.google.android.material.bottomnavigation.BottomNavigationView
             android:id="@+id/bottomBar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
             android:background="@color/white"
             app:elevation="0dp"
-            app:menu="@menu/bottom_bar_menu" />
+            app:menu="@menu/bottom_bar_menu"/>
 
-        <include layout="@layout/loading_canvas_view"/>
+    </LinearLayout>
 
-    </RelativeLayout>
-
-    <include layout="@layout/navigation_drawer" />
+    <include layout="@layout/navigation_drawer"/>
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/apps/student/src/main/res/layout/fragment_picker_submission_upload.xml
+++ b/apps/student/src/main/res/layout/fragment_picker_submission_upload.xml
@@ -14,7 +14,8 @@
   ~     You should have received a copy of the GNU General Public License
   ~     along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/pickerSubmissionUploadPage"
@@ -30,91 +31,135 @@
         tools:background="#fff"
         tools:navigationIcon="@drawable/vd_back_arrow"
         tools:title="@string/submission"
-        tools:titleTextColor="@color/defaultTextDark" />
+        tools:titleTextColor="@color/defaultTextDark"/>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/filePickerRecycler"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/sourcesContainer"
         app:layout_constraintTop_toBottomOf="@id/toolbar"
-        tools:listitem="@layout/viewholder_file_upload" />
+        tools:listitem="@layout/viewholder_file_upload"/>
 
     <com.instructure.student.view.EmptyView
         android:id="@+id/pickerEmptyView"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
+        tools:visibility="visible"
+        app:layout_constraintBottom_toTopOf="@id/sourcesContainer"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/toolbar" />
+        app:layout_constraintTop_toBottomOf="@id/toolbar"/>
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/pickFabFile"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="16dp"
-        android:backgroundTint="@color/white"
-        android:contentDescription="@string/addFile"
-        android:tint="@color/defaultActionColor"
-        android:visibility="gone"
-        app:borderWidth="0dp"
-        app:elevation="4dp"
-        app:fabCustomSize="48dp"
-        app:layout_constraintBottom_toTopOf="@id/pickFabGallery"
-        app:layout_constraintEnd_toEndOf="@id/pickFab"
-        app:layout_constraintStart_toStartOf="@id/pickFab"
-        app:srcCompat="@drawable/vd_document" />
+    <View
+        android:id="@+id/sourcesDivider"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:background="@color/dividerColor"
+        app:layout_constraintBottom_toTopOf="@id/sourcesContainer"/>
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/pickFabGallery"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:id="@+id/sourcesContainer"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="16dp"
-        android:backgroundTint="@color/white"
-        android:contentDescription="@string/chooseFromGallery"
-        android:tint="@color/defaultActionColor"
-        android:visibility="gone"
-        app:borderWidth="0dp"
-        app:elevation="4dp"
-        app:fabCustomSize="48dp"
-        app:layout_constraintBottom_toTopOf="@id/pickFabCamera"
-        app:layout_constraintEnd_toEndOf="@id/pickFab"
-        app:layout_constraintStart_toStartOf="@id/pickFab"
-        app:srcCompat="@drawable/vd_image" />
+        android:layout_marginTop="16dp"
+        android:baselineAligned="false"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toBottomOf="parent">
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/pickFabCamera"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="16dp"
-        android:backgroundTint="@color/white"
-        android:contentDescription="@string/takePhoto"
-        android:tint="@color/defaultActionColor"
-        android:visibility="gone"
-        app:borderWidth="0dp"
-        app:elevation="4dp"
-        app:fabCustomSize="48dp"
-        app:layout_constraintBottom_toTopOf="@id/pickFab"
-        app:layout_constraintEnd_toEndOf="@id/pickFab"
-        app:layout_constraintStart_toStartOf="@id/pickFab"
-        app:srcCompat="@drawable/vd_camera" />
+        <LinearLayout
+            android:id="@+id/sourceCamera"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:gravity="center_horizontal"
+            android:orientation="vertical"
+            android:paddingTop="8dp"
+            android:paddingBottom="8dp">
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/pickFab"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="16dp"
-        android:backgroundTint="@color/defaultActionColor"
-        android:contentDescription="@string/addFileFabContentDesc"
-        android:tint="@color/white"
-        app:borderWidth="0dp"
-        app:elevation="4dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:srcCompat="@drawable/vd_add" />
+            <ImageView
+                android:id="@+id/sourceCameraIcon"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:importantForAccessibility="no"
+                android:tint="@color/defaultActionColor"
+                app:srcCompat="@drawable/vd_add_from_camera"/>
+
+            <TextView
+                android:id="@+id/sourceCameraLabel"
+                style="@style/TextFont.Regular"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/fromCamera"
+                android:textColor="@color/defaultActionColor"
+                android:textSize="12sp"/>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/sourceGallery"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:gravity="center_horizontal"
+            android:orientation="vertical"
+            android:paddingTop="8dp"
+            android:paddingBottom="8dp">
+
+            <ImageView
+                android:id="@+id/sourceGalleryIcon"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:importantForAccessibility="no"
+                android:tint="@color/defaultActionColor"
+                app:srcCompat="@drawable/vd_add_from_gallery"/>
+
+            <TextView
+                android:id="@+id/sourceGalleryLabel"
+                style="@style/TextFont.Regular"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/fromGallery"
+                android:textColor="@color/defaultActionColor"
+                android:textSize="12sp"/>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/sourceDevice"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:gravity="center_horizontal"
+            android:orientation="vertical"
+            android:paddingTop="8dp"
+            android:paddingBottom="8dp">
+
+            <ImageView
+                android:id="@+id/sourceDeviceIcon"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:importantForAccessibility="no"
+                android:tint="@color/defaultActionColor"
+                app:srcCompat="@drawable/vd_add_from_device"/>
+
+            <TextView
+                android:id="@+id/sourceDeviceLabel"
+                style="@style/TextFont.Regular"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/fromDevice"
+                android:textColor="@color/defaultActionColor"
+                android:textSize="12sp"/>
+
+        </LinearLayout>
+
+    </LinearLayout>
 
     <ProgressBar
         android:id="@+id/fileLoading"
@@ -124,6 +169,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/PickerSubmissionUploadPresenterTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/PickerSubmissionUploadPresenterTest.kt
@@ -54,10 +54,10 @@ class PickerSubmissionUploadPresenterTest : Assert() {
             mode = PickerSubmissionMode.FileSubmission
         )
         baseVisibilities = PickerVisibilities(
-            fab = true,
-            fabGallery = true,
-            fabCamera = true,
-            fabFile = true,
+            sources = true,
+            sourceGallery = true,
+            sourceCamera = true,
+            sourceFile = true,
             loading = false
         )
     }
@@ -83,8 +83,8 @@ class PickerSubmissionUploadPresenterTest : Assert() {
         val model = baseModel.copy(allowedExtensions = listOf("broken"))
         val expectedState = PickerSubmissionUploadViewState.Empty(
             baseVisibilities.copy(
-                fabCamera = false,
-                fabGallery = false
+                sourceCamera = false,
+                sourceGallery = false
             )
         )
         val actualState = PickerSubmissionUploadPresenter.present(model, context)
@@ -174,10 +174,10 @@ class PickerSubmissionUploadPresenterTest : Assert() {
         val expectedState = PickerSubmissionUploadViewState.FileList(
             baseVisibilities.copy(
                 submit = true,
-                fab = false,
-                fabCamera = false,
-                fabGallery = false,
-                fabFile = false
+                sources = false,
+                sourceCamera = false,
+                sourceGallery = false,
+                sourceFile = false
             ), fileViewStates
         )
         val actualState = PickerSubmissionUploadPresenter.present(model, context)

--- a/libs/pandares/src/main/res/drawable/vd_add_from_camera.xml
+++ b/libs/pandares/src/main/res/drawable/vd_add_from_camera.xml
@@ -1,0 +1,35 @@
+<!--
+  ~ Copyright (C) 2019 - present Instructure, Inc.
+  ~
+  ~     Licensed under the Apache License, Version 2.0 (the "License");
+  ~     you may not use this file except in compliance with the License.
+  ~     You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~     Unless required by applicable law or agreed to in writing, software
+  ~     distributed under the License is distributed on an "AS IS" BASIS,
+  ~     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~     See the License for the specific language governing permissions and
+  ~     limitations under the License.
+  ~
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#888"
+        android:pathData="M11.1736,7.1117L9.159,7.1111C8.7381,7.1111 8.3534,7.3489 8.1652,7.7253L7.1651,9.7255L3.2222,9.7255C2.6086,9.7255 2.1111,10.223 2.1111,10.8366L2.1111,19.8562C2.1111,20.4699 2.6086,20.9673 3.2222,20.9673L18.7778,20.9673C19.3914,20.9673 19.8889,20.4699 19.8889,19.8562L19.8883,12.8718C20.2703,12.8003 20.642,12.6998 21.0011,12.5728L21,19.8562C21,21.0835 20.0051,22.0784 18.7778,22.0784L3.2222,22.0784C1.9949,22.0784 1,21.0835 1,19.8562L1,10.8366C1,9.6093 1.9949,8.6144 3.2222,8.6144L6.4784,8.6144L7.1714,7.2284C7.5478,6.4756 8.3173,6 9.159,6L11.0164,5.9997C11.0413,6.3787 11.0944,6.7501 11.1736,7.1117ZM11,10.4742C13.3299,10.4742 15.2187,12.3629 15.2187,14.6928C15.2187,17.0227 13.3299,18.9115 11,18.9115C8.6701,18.9115 6.7813,17.0227 6.7813,14.6928C6.7813,12.3629 8.6701,10.4742 11,10.4742ZM11,11.5853C9.2837,11.5853 7.8925,12.9766 7.8925,14.6928C7.8925,16.4091 9.2837,17.8004 11,17.8004C12.7163,17.8004 14.1075,16.4091 14.1075,14.6928C14.1075,12.9766 12.7163,11.5853 11,11.5853ZM4.3333,10.4444C4.947,10.4444 5.4444,10.9419 5.4444,11.5556C5.4444,12.1692 4.947,12.6667 4.3333,12.6667C3.7197,12.6667 3.2222,12.1692 3.2222,11.5556C3.2222,10.9419 3.7197,10.4444 4.3333,10.4444Z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000"/>
+
+    <path
+        android:fillColor="#888"
+        android:pathData="M18.5,0C21.5376,0 24,2.4624 24,5.5C24,8.5376 21.5376,11 18.5,11C15.4624,11 13,8.5376 13,5.5C13,2.4624 15.4624,0 18.5,0ZM19.25,2.5L17.75,2.5L17.75,4.75L15.5,4.75L15.5,6.25L17.75,6.25L17.75,8.5L19.25,8.5L19.25,6.25L21.5,6.25L21.5,4.75L19.25,4.75L19.25,2.5Z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000"/>
+
+</vector>

--- a/libs/pandares/src/main/res/drawable/vd_add_from_device.xml
+++ b/libs/pandares/src/main/res/drawable/vd_add_from_device.xml
@@ -1,0 +1,35 @@
+<!--
+  ~ Copyright (C) 2019 - present Instructure, Inc.
+  ~
+  ~     Licensed under the Apache License, Version 2.0 (the "License");
+  ~     you may not use this file except in compliance with the License.
+  ~     You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~     Unless required by applicable law or agreed to in writing, software
+  ~     distributed under the License is distributed on an "AS IS" BASIS,
+  ~     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~     See the License for the specific language governing permissions and
+  ~     limitations under the License.
+  ~
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#888"
+        android:pathData="M11.1164,4.1765L4.2876,4.1765L4.2876,21.8235L18.4052,21.8235L18.4055,12.9994C18.437,12.9998 18.4685,13 18.5,13C18.8674,13 19.2286,12.9736 19.5818,12.9226L19.5811,13.588L19.5811,14.764L19.5811,15.941L19.5811,17.117L19.5811,18.294L19.5811,21.823L19.5817,23L3.1111,23L3.1111,21.823L3.1111,18.294L3.1111,17.117L3.1111,15.941L3.1111,14.764L3.1111,13.588L3.1111,12.5L3.1111,12.499L3.1111,12.49L3.1111,12.462L3.1111,12.416L3.1111,12.411L3.1111,11.235L3.1111,10.058L3.1111,8.882L3.1111,7.705L3.1111,4.176L3.1111,3.874L3.1111,3.577L3.1111,3.285L3.1111,3L11.4271,2.9991C11.2929,3.3785 11.1884,3.7719 11.1164,4.1765ZM11.3464,17.1176L11.3464,18.2941L6.6405,18.2941L6.6405,17.1176L11.3464,17.1176ZM14.8758,14.7647L14.8758,15.9412L6.6405,15.9412L6.6405,14.7647L14.8758,14.7647ZM13.6993,12.4118L13.6993,13.5882L6.6405,13.5882L6.6405,12.4118L13.6993,12.4118ZM13.6672,11.2355L6.6405,11.2353L6.6405,10.0588L12.5437,10.0584C12.8747,10.4902 13.2517,10.885 13.6672,11.2355ZM11.3462,7.7589L11.3464,8.8824L6.6405,8.8824L6.6405,7.7059L11.3297,7.7059C11.3351,7.7236 11.3406,7.7413 11.3462,7.7589Z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000"/>
+
+    <path
+        android:fillColor="#888"
+        android:pathData="M18.5,0C21.5376,0 24,2.4624 24,5.5C24,8.5376 21.5376,11 18.5,11C15.4624,11 13,8.5376 13,5.5C13,2.4624 15.4624,0 18.5,0ZM19.25,2.5L17.75,2.5L17.75,4.75L15.5,4.75L15.5,6.25L17.75,6.25L17.75,8.5L19.25,8.5L19.25,6.25L21.5,6.25L21.5,4.75L19.25,4.75L19.25,2.5Z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000"/>
+
+</vector>

--- a/libs/pandares/src/main/res/drawable/vd_add_from_gallery.xml
+++ b/libs/pandares/src/main/res/drawable/vd_add_from_gallery.xml
@@ -1,0 +1,35 @@
+<!--
+  ~ Copyright (C) 2019 - present Instructure, Inc.
+  ~
+  ~     Licensed under the Apache License, Version 2.0 (the "License");
+  ~     you may not use this file except in compliance with the License.
+  ~     You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~     Unless required by applicable law or agreed to in writing, software
+  ~     distributed under the License is distributed on an "AS IS" BASIS,
+  ~     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~     See the License for the specific language governing permissions and
+  ~     limitations under the License.
+  ~
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#888"
+        android:pathData="M11.003,5.2873L2.1765,5.2876L2.1765,20.5829L19.8235,20.5829L19.8235,12.8836C20.2282,12.8115 20.6217,12.707 21.0011,12.5728L21,21.7582L1,21.7582L1,4.1111L11.1284,4.1108C11.0567,4.4935 11.0141,4.8865 11.003,5.2873ZM17.2005,12.8878C17.8353,13.9646 18.315,15.5182 18.64,17.5476L18.64,17.5476L18.7494,18.2288L3.1659,18.2288L3.3753,17.4817C4.2647,14.2935 5.1765,12.7205 6.3271,12.3805C7.3953,12.0664 8.2576,12.837 9.0235,13.517C9.4776,13.9182 9.9694,14.3617 10.3,14.3382C10.4659,14.3193 10.6353,14.1241 10.7494,13.9629C11.8903,12.3505 12.9071,11.5976 13.75,11.3023C14.725,12.1034 15.9057,12.6616 17.2005,12.8878ZM14.9282,12.3499C14.0635,12.1488 12.8859,12.9829 11.7106,14.6417C11.3435,15.1605 10.9153,15.4523 10.4365,15.5076C9.5918,15.6076 8.9153,14.9899 8.2447,14.3982C7.68,13.897 7.0918,13.3876 6.6612,13.5088C6.3024,13.6146 5.5953,14.2288 4.7259,17.0523L4.7259,17.0523L17.3588,17.0523C16.8329,14.2899 15.9588,12.5899 14.9282,12.3499ZM8.0588,6.4641C9.3565,6.4641 10.4118,7.5193 10.4118,8.817C10.4118,10.1146 9.3565,11.1699 8.0588,11.1699C6.7612,11.1699 5.7059,10.1146 5.7059,8.817C5.7059,7.5193 6.7612,6.4641 8.0588,6.4641ZM8.0588,7.6405C7.4094,7.6405 6.8824,8.1688 6.8824,8.817C6.8824,9.4652 7.4094,9.9935 8.0588,9.9935C8.7082,9.9935 9.2353,9.4652 9.2353,8.817C9.2353,8.1688 8.7082,7.6405 8.0588,7.6405Z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000"/>
+
+    <path
+        android:fillColor="#888"
+        android:pathData="M18.5,0C21.5376,0 24,2.4624 24,5.5C24,8.5376 21.5376,11 18.5,11C15.4624,11 13,8.5376 13,5.5C13,2.4624 15.4624,0 18.5,0ZM19.25,2.5L17.75,2.5L17.75,4.75L15.5,4.75L15.5,6.25L17.75,6.25L17.75,8.5L19.25,8.5L19.25,6.25L21.5,6.25L21.5,4.75L19.25,4.75L19.25,2.5Z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000"/>
+
+</vector>

--- a/libs/pandautils/src/main/res/layout/dialog_files_upload.xml
+++ b/libs/pandautils/src/main/res/layout/dialog_files_upload.xml
@@ -59,7 +59,7 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:text="@string/chooseFileSubtext"
+            android:text="@string/chooseFileForUploadSubtext"
             android:textAlignment="center"
             style="@style/TextFont.Regular"
             android:textSize="14sp"

--- a/libs/pandautils/src/main/res/values/strings.xml
+++ b/libs/pandautils/src/main/res/values/strings.xml
@@ -175,6 +175,7 @@
     <string name="lockedSubtext">This assignment is locked until %1$s at %2$s.</string>
     <string name="chooseFile">Choose a File</string>
     <string name="chooseFileSubtext">Attach a file to your submission by tapping an option below.</string>
+    <string name="chooseFileForUploadSubtext">Select a file to upload by tapping an option below</string>
     <string name="noNotifications">No Notifications</string>
     <string name="noNotificationsSubtext">There\'s nothing to be notified of yet.</string>
     <string name="noTodos">Well Done!</string>


### PR DESCRIPTION
Also updates the empty state subtext in the non-submisison file upload dialog, and updates NavigationActivity to only show the bottom nav bar for 'root' fragments or if there is only one fragment on the backstack.