### PR TITLE
[Student][MBL-13079] Fix submission status for submission NONE

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/renderPages/AssignmentDetailsRenderPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/renderPages/AssignmentDetailsRenderPage.kt
@@ -33,6 +33,7 @@ class AssignmentDetailsRenderPage : AssignmentDetailsPage() {
     val assignmentName by OnViewWithId(R.id.assignmentName)
     val points by OnViewWithId(R.id.points)
     val submissionStatus by OnViewWithId(R.id.submissionStatus)
+    val submissionStatusIcon by OnViewWithId(R.id.submissionStatusIcon)
     val date by OnViewWithId(R.id.dueDateTextView)
     val submissionTypes by OnViewWithId(R.id.submissionTypesTextView)
     val fileTypes by OnViewWithId(R.id.fileTypesTextView)
@@ -155,5 +156,16 @@ class AssignmentDetailsRenderPage : AssignmentDetailsPage() {
     fun assertSubmitButton(submitButtonText: Int) {
         submitButton.assertVisible()
         submitButton.assertHasText(submitButtonText)
+    }
+
+    fun assertSubmissionStatusVisibility(visible: Boolean) {
+        if(visible) {
+            submissionStatus.assertVisible()
+            submissionStatusIcon.assertVisible()
+        } else {
+            submissionStatus.assertGone()
+            submissionStatusIcon.assertGone()
+        }
+
     }
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/AssignmentDetailsRenderTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/AssignmentDetailsRenderTest.kt
@@ -471,6 +471,112 @@ class AssignmentDetailsRenderTest : StudentRenderTest() {
         assignmentDetailsRenderPage.assertPointsContentDescription("35 points")
     }
 
+    @Test
+    @TestMetaData(Priority.P2, FeatureCategory.ASSIGNMENTS, TestCategory.RENDER, false, FeatureCategory.SUBMISSIONS)
+    fun hideSubmissionStatusSubmissionTypeNone() {
+        val allTypes = listOf(Assignment.SubmissionType.NONE)
+        val assignment = Assignment(
+            id = 123,
+            name = "Assignment Name",
+            description = "This is a description",
+            pointsPossible = 35.0,
+            submissionTypesRaw = allTypes.map { it.apiString }
+        )
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
+        loadPageWithModel(model)
+        assignmentDetailsRenderPage.assertSubmissionStatusVisibility(false)
+    }
+
+    @Test
+    @TestMetaData(Priority.P2, FeatureCategory.ASSIGNMENTS, TestCategory.RENDER, false, FeatureCategory.SUBMISSIONS)
+    fun hideSubmissionStatusSubmissionTypeOnPaper() {
+        val allTypes = listOf(Assignment.SubmissionType.ON_PAPER)
+        val assignment = Assignment(
+                id = 123,
+                name = "Assignment Name",
+                description = "This is a description",
+                pointsPossible = 35.0,
+                submissionTypesRaw = allTypes.map { it.apiString }
+        )
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
+        loadPageWithModel(model)
+        assignmentDetailsRenderPage.assertSubmissionStatusVisibility(false)
+    }
+
+    @Test
+    @TestMetaData(Priority.P2, FeatureCategory.ASSIGNMENTS, TestCategory.RENDER, false, FeatureCategory.SUBMISSIONS)
+    fun showSubmissionStatusSubmissionTypeOnline() {
+        val allTypes = listOf(
+                Assignment.SubmissionType.ONLINE_UPLOAD,
+                Assignment.SubmissionType.ONLINE_TEXT_ENTRY,
+                Assignment.SubmissionType.ONLINE_URL,
+                Assignment.SubmissionType.BASIC_LTI_LAUNCH,
+                Assignment.SubmissionType.EXTERNAL_TOOL,
+                Assignment.SubmissionType.ATTENDANCE,
+                Assignment.SubmissionType.MEDIA_RECORDING
+        )
+        val assignment = Assignment(
+                id = 123,
+                name = "Assignment Name",
+                description = "This is a description",
+                pointsPossible = 35.0,
+                submissionTypesRaw = allTypes.map { it.apiString }
+        )
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
+        loadPageWithModel(model)
+        assignmentDetailsRenderPage.assertSubmissionStatusVisibility(true)
+    }
+
+    @Test
+    @TestMetaData(Priority.P2, FeatureCategory.ASSIGNMENTS, TestCategory.RENDER, false, FeatureCategory.SUBMISSIONS)
+    fun showSubmissionStatusSubmissionTypeQuiz() {
+        val allTypes = listOf(
+                Assignment.SubmissionType.ONLINE_QUIZ
+        )
+        val quiz = Quiz(
+                id = 123L
+        )
+        val assignment = Assignment(
+                id = 123,
+                name = "Assignment Name",
+                description = "This is a description",
+                pointsPossible = 35.0,
+                submissionTypesRaw = allTypes.map { it.apiString },
+                quizId = quiz.id
+        )
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment), quizResult = DataResult.Success(quiz))
+        loadPageWithModel(model)
+        assignmentDetailsRenderPage.assertSubmissionStatusVisibility(true)
+    }
+
+    @Test
+    @TestMetaData(Priority.P2, FeatureCategory.ASSIGNMENTS, TestCategory.RENDER, false, FeatureCategory.SUBMISSIONS)
+    fun showSubmissionStatusSubmissionTypeDiscussion() {
+        val allTypes = listOf(
+                Assignment.SubmissionType.DISCUSSION_TOPIC
+        )
+        val discussion = DiscussionTopicHeader(
+                id = 123L,
+                message = "discussion message",
+                author = DiscussionParticipant(
+                        displayName = "Hodor",
+                        avatarImageUrl = "pretty-hodor.com"
+                ),
+                postedDate = Date()
+        )
+        val assignment = Assignment(
+                id = 123,
+                name = "Assignment Name",
+                description = "This is a description",
+                pointsPossible = 35.0,
+                submissionTypesRaw = allTypes.map { it.apiString },
+                discussionTopicHeader = discussion
+        )
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
+        loadPageWithModel(model)
+        assignmentDetailsRenderPage.assertSubmissionStatusVisibility(true)
+    }
+
     private fun mockkSubmission(failed: Boolean = false) = com.instructure.student.Submission.Impl(
         123L,
         null,

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/AssignmentDetailsRenderTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/AssignmentDetailsRenderTest.kt
@@ -505,6 +505,23 @@ class AssignmentDetailsRenderTest : StudentRenderTest() {
 
     @Test
     @TestMetaData(Priority.P2, FeatureCategory.ASSIGNMENTS, TestCategory.RENDER, false, FeatureCategory.SUBMISSIONS)
+    fun showsSubmissionStatusSubmissionTypeOnPaperWithGrade() {
+        val allTypes = listOf(Assignment.SubmissionType.ON_PAPER)
+        val assignment = Assignment(
+                id = 123,
+                name = "Assignment Name",
+                description = "This is a description",
+                pointsPossible = 35.0,
+                submission = Submission(id = 1, grade = "A", score = 35.0, late = false, attempt = 1, missing = false),
+                submissionTypesRaw = allTypes.map { it.apiString }
+        )
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
+        loadPageWithModel(model)
+        assignmentDetailsRenderPage.assertSubmissionStatusVisibility(true)
+    }
+
+    @Test
+    @TestMetaData(Priority.P2, FeatureCategory.ASSIGNMENTS, TestCategory.RENDER, false, FeatureCategory.SUBMISSIONS)
     fun showSubmissionStatusSubmissionTypeOnline() {
         val allTypes = listOf(
                 Assignment.SubmissionType.ONLINE_UPLOAD,
@@ -520,6 +537,32 @@ class AssignmentDetailsRenderTest : StudentRenderTest() {
                 name = "Assignment Name",
                 description = "This is a description",
                 pointsPossible = 35.0,
+                submission = Submission(id = 1, grade = "A", score = 35.0, late = false, attempt = 1, missing = false),
+                submissionTypesRaw = allTypes.map { it.apiString }
+        )
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
+        loadPageWithModel(model)
+        assignmentDetailsRenderPage.assertSubmissionStatusVisibility(true)
+    }
+
+    @Test
+    @TestMetaData(Priority.P2, FeatureCategory.ASSIGNMENTS, TestCategory.RENDER, false, FeatureCategory.SUBMISSIONS)
+    fun showSubmissionStatusSubmissionTypeOnlineWithGrade() {
+        val allTypes = listOf(
+                Assignment.SubmissionType.ONLINE_UPLOAD,
+                Assignment.SubmissionType.ONLINE_TEXT_ENTRY,
+                Assignment.SubmissionType.ONLINE_URL,
+                Assignment.SubmissionType.BASIC_LTI_LAUNCH,
+                Assignment.SubmissionType.EXTERNAL_TOOL,
+                Assignment.SubmissionType.ATTENDANCE,
+                Assignment.SubmissionType.MEDIA_RECORDING
+        )
+        val assignment = Assignment(
+                id = 123,
+                name = "Assignment Name",
+                description = "This is a description",
+                pointsPossible = 35.0,
+
                 submissionTypesRaw = allTypes.map { it.apiString }
         )
         val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsPresenter.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsPresenter.kt
@@ -84,10 +84,6 @@ object AssignmentDetailsPresenter : Presenter<AssignmentDetailsModel, Assignment
             NumberHelper.formatDecimal(assignment.pointsPossible, 1, true)
         )
 
-        // Submission Status under title
-        visibilities.submissionStatus = assignment.turnInType != Assignment.TurnInType.ON_PAPER
-                && assignment.turnInType != Assignment.TurnInType.NONE
-
         // Submission state - Some of this may be hidden by the visibility above
         val assignmentState = AssignmentUtils2.getAssignmentState(assignment, assignment.submission, false)
         val (submittedLabelRes, submittedColorRes, submittedIconRes) = if (assignment.isSubmitted) {
@@ -108,6 +104,13 @@ object AssignmentDetailsPresenter : Presenter<AssignmentDetailsModel, Assignment
             } else {
                 Triple(R.string.notSubmitted, R.color.defaultTextGray, R.drawable.vd_unsubmitted)
             }
+        }
+
+        // Submission Status under title - We only show Graded or nothing at all for PAPER/NONE
+        visibilities.submissionStatus = if (assignmentState == AssignmentUtils2.ASSIGNMENT_STATE_GRADED) {
+            true
+        } else {
+            assignment.turnInType != Assignment.TurnInType.ON_PAPER && assignment.turnInType != Assignment.TurnInType.NONE
         }
 
         val submittedLabel = context.getString(submittedLabelRes)

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsPresenter.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsPresenter.kt
@@ -84,7 +84,11 @@ object AssignmentDetailsPresenter : Presenter<AssignmentDetailsModel, Assignment
             NumberHelper.formatDecimal(assignment.pointsPossible, 1, true)
         )
 
-        // Submission state
+        // Submission Status under title
+        visibilities.submissionStatus = assignment.turnInType != Assignment.TurnInType.ON_PAPER
+                && assignment.turnInType != Assignment.TurnInType.NONE
+
+        // Submission state - Some of this may be hidden by the visibility above
         val assignmentState = AssignmentUtils2.getAssignmentState(assignment, assignment.submission, false)
         val (submittedLabelRes, submittedColorRes, submittedIconRes) = if (assignment.isSubmitted) {
             Triple(

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsView.kt
@@ -122,6 +122,8 @@ class AssignmentDetailsView(
             swipeRefreshLayout.isRefreshing = visibilities.loading
             errorContainer.setVisible(visibilities.errorMessage)
             titleContainer.setVisible(visibilities.title)
+            submissionStatusIcon.setVisible(visibilities.submissionStatus)
+            submissionStatus.setVisible(visibilities.submissionStatus)
             dueDateContainer.setVisible(visibilities.dueDate)
             submissionTypesContainer.setVisible(visibilities.submissionTypes)
             fileTypesContainer.setVisible(visibilities.fileTypes)

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsViewState.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsViewState.kt
@@ -50,6 +50,7 @@ sealed class AssignmentDetailsViewState(val visibilities: AssignmentDetailsVisib
 data class AssignmentDetailsVisibilities (
     var loading: Boolean = false,
     var errorMessage: Boolean = false,
+    var submissionStatus: Boolean = false,
     var title: Boolean = false,
     var dueDate: Boolean = false,
     var submissionTypes: Boolean = false,

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsPresenterTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsPresenterTest.kt
@@ -67,6 +67,7 @@ class AssignmentDetailsPresenterTest : Assert() {
             title = true,
             dueDate = true,
             submissionTypes = true,
+            submissionStatus = true,
             description = true,
             submissionAndRubricButton = true
         )
@@ -176,7 +177,7 @@ class AssignmentDetailsPresenterTest : Assert() {
             allowedExtensions = listOf("pdf", "JPG", "PNG", "zip")
         )
         val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
-        val expected = baseVisibilities.copy(fileTypes = false, submissionTypes = false)
+        val expected = baseVisibilities.copy(fileTypes = false, submissionTypes = false, submissionStatus = false)
         val actual = AssignmentDetailsPresenter.present(model, context).visibilities
         assertEquals(expected, actual)
     }
@@ -890,6 +891,70 @@ class AssignmentDetailsPresenterTest : Assert() {
 
         unmockkObject(CanvasRestAdapter.Companion)
     }
+
+    @Test
+    fun `Hides submission status when on paper submission type`() {
+        val allTypes = listOf(Assignment.SubmissionType.ON_PAPER)
+        val assignment = baseAssignment.copy(submissionTypesRaw = allTypes.map { it.apiString })
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
+        val state = AssignmentDetailsPresenter.present(model, context) as AssignmentDetailsViewState.Loaded
+        assertFalse(state.visibilities.submissionStatus)
+    }
+
+    @Test
+    fun `Hides submission status when no submission type`() {
+        val allTypes = listOf(Assignment.SubmissionType.NONE)
+        val assignment = baseAssignment.copy(submissionTypesRaw = allTypes.map { it.apiString })
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
+        val state = AssignmentDetailsPresenter.present(model, context) as AssignmentDetailsViewState.Loaded
+        assertFalse(state.visibilities.submissionStatus)
+    }
+
+    @Test
+    fun `Shows submission status when online submission type`() {
+        val allTypes = listOf(
+            Assignment.SubmissionType.ONLINE_UPLOAD,
+            Assignment.SubmissionType.ONLINE_TEXT_ENTRY,
+            Assignment.SubmissionType.ONLINE_URL,
+            Assignment.SubmissionType.BASIC_LTI_LAUNCH,
+            Assignment.SubmissionType.EXTERNAL_TOOL,
+            Assignment.SubmissionType.ATTENDANCE,
+            Assignment.SubmissionType.MEDIA_RECORDING
+        )
+
+        val assignment = baseAssignment.copy(
+                submissionTypesRaw = allTypes.map { it.apiString }
+        )
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
+        val state = AssignmentDetailsPresenter.present(model, context) as AssignmentDetailsViewState.Loaded
+        assertTrue(state.visibilities.submissionStatus)
+    }
+
+    @Test
+    fun `Shows submission status when discussion submission type`() {
+        val allTypes = listOf(Assignment.SubmissionType.DISCUSSION_TOPIC)
+        val assignment = baseAssignment.copy(
+                submissionTypesRaw = allTypes.map { it.apiString },
+                discussionTopicHeader = baseDiscussion
+        )
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
+        val state = AssignmentDetailsPresenter.present(model, context) as AssignmentDetailsViewState.Loaded
+        assertTrue(state.visibilities.submissionStatus)
+    }
+
+    @Test
+    fun `Shows submission status when quiz submission type`() {
+        val allTypes = listOf(Assignment.SubmissionType.ONLINE_QUIZ)
+        val assignment = baseAssignment.copy(
+                submissionTypesRaw = allTypes.map { it.apiString },
+                quizId = baseQuiz.id
+        )
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment), quizResult = DataResult.Success(baseQuiz))
+        val state = AssignmentDetailsPresenter.present(model, context) as AssignmentDetailsViewState.Loaded
+        assertTrue(state.visibilities.submissionStatus)
+    }
+
+
 
     private val discussionHtml = "<!DOCTYPE html>\n" +
             "<html>\n" +

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsPresenterTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsPresenterTest.kt
@@ -902,6 +902,16 @@ class AssignmentDetailsPresenterTest : Assert() {
     }
 
     @Test
+    fun `Shows submission status when on paper submission type with Grade`() {
+        val allTypes = listOf(Assignment.SubmissionType.ON_PAPER)
+        val submission = Submission(id = 1, grade = "A", score = 35.0, late = false, attempt = 1, missing = false)
+        val assignment = baseAssignment.copy(submissionTypesRaw = allTypes.map { it.apiString }, submission = submission)
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
+        val state = AssignmentDetailsPresenter.present(model, context) as AssignmentDetailsViewState.Loaded
+        assertTrue(state.visibilities.submissionStatus)
+    }
+
+    @Test
     fun `Hides submission status when no submission type`() {
         val allTypes = listOf(Assignment.SubmissionType.NONE)
         val assignment = baseAssignment.copy(submissionTypesRaw = allTypes.map { it.apiString })
@@ -931,11 +941,33 @@ class AssignmentDetailsPresenterTest : Assert() {
     }
 
     @Test
+    fun `Shows submission status when online submission type with Grade`() {
+        val allTypes = listOf(
+            Assignment.SubmissionType.ONLINE_UPLOAD,
+            Assignment.SubmissionType.ONLINE_TEXT_ENTRY,
+            Assignment.SubmissionType.ONLINE_URL,
+            Assignment.SubmissionType.BASIC_LTI_LAUNCH,
+            Assignment.SubmissionType.EXTERNAL_TOOL,
+            Assignment.SubmissionType.ATTENDANCE,
+            Assignment.SubmissionType.MEDIA_RECORDING
+        )
+
+        val submission = Submission(id = 1, grade = "A", score = 35.0, late = false, attempt = 1, missing = false)
+        val assignment = baseAssignment.copy(
+            submissionTypesRaw = allTypes.map { it.apiString },
+            submission = submission
+        )
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
+        val state = AssignmentDetailsPresenter.present(model, context) as AssignmentDetailsViewState.Loaded
+        assertTrue(state.visibilities.submissionStatus)
+    }
+
+    @Test
     fun `Shows submission status when discussion submission type`() {
         val allTypes = listOf(Assignment.SubmissionType.DISCUSSION_TOPIC)
         val assignment = baseAssignment.copy(
-                submissionTypesRaw = allTypes.map { it.apiString },
-                discussionTopicHeader = baseDiscussion
+            submissionTypesRaw = allTypes.map { it.apiString },
+            discussionTopicHeader = baseDiscussion
         )
         val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
         val state = AssignmentDetailsPresenter.present(model, context) as AssignmentDetailsViewState.Loaded
@@ -946,8 +978,8 @@ class AssignmentDetailsPresenterTest : Assert() {
     fun `Shows submission status when quiz submission type`() {
         val allTypes = listOf(Assignment.SubmissionType.ONLINE_QUIZ)
         val assignment = baseAssignment.copy(
-                submissionTypesRaw = allTypes.map { it.apiString },
-                quizId = baseQuiz.id
+            submissionTypesRaw = allTypes.map { it.apiString },
+            quizId = baseQuiz.id
         )
         val model = baseModel.copy(assignmentResult = DataResult.Success(assignment), quizResult = DataResult.Success(baseQuiz))
         val state = AssignmentDetailsPresenter.present(model, context) as AssignmentDetailsViewState.Loaded


### PR DESCRIPTION
See the ticket for more details. The gist is simple tho, we now hide the submission status indicator (Not Submitted, Mising, etc) for on paper/none submission types. We still show the Graded submission status regardless of submission type.