### PR TITLE
[Student][R-6.6.1] Fix duplicate file error in submission

### DIFF
--- a/apps/student/src/main/db/com/instructure/student/FileSubmission.sq
+++ b/apps/student/src/main/db/com/instructure/student/FileSubmission.sq
@@ -53,6 +53,11 @@ SELECT *
 FROM fileSubmission
 WHERE dbSubmissionId = ?;
 
+getFilesForPath:
+SELECT *
+FROM fileSubmission
+WHERE id != ? AND fullPath = ?;
+
 getFilesWithoutAttachmentsForSubmissionId:
 SELECT *
 FROM fileSubmission

--- a/apps/student/src/main/java/com/instructure/student/mobius/common/ui/SubmissionService.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/common/ui/SubmissionService.kt
@@ -190,8 +190,7 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
         val attachmentIds = completed.mapNotNull { it.attachmentId } + uploadedAttachmentIds
         SubmissionManager.postSubmissionAttachmentsSynchronous(submission.canvasContext.id, submission.assignmentId, attachmentIds)?.let {
             // Clear out the db for the successful submission
-            db.fileSubmissionQueries.deleteFilesForSubmissionId(submission.id)
-            db.submissionQueries.deleteSubmissionById(submission.id)
+            deleteSubmissionsForAssignment(submission.id, db)
 
             detachForegroundNotification()
             showCompleteNotification(this, submission)
@@ -235,7 +234,6 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
                 db.fileSubmissionQueries.setFileAttachmentIdAndError(attachment.id, false, null, pendingAttachment.id)
 
                 attachmentIds.add(attachment.id)
-                FileUploadUtils.deleteTempFile(pendingAttachment.fullPath)
             }.onFailure {
                 handleFileError(db, submission, index, attachments, it?.message)
                 return null
@@ -569,7 +567,7 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
 
         private fun insertNewSubmission(assignmentId: Long, context: Context, files: List<FileSubmitObject> = emptyList(), insertBlock: (StudentDb) -> Unit): Long {
             val db = Db.getInstance(context)
-            deleteSubmissionsForAssignment(assignmentId, db)
+            deleteSubmissionsForAssignment(assignmentId, db, files)
             insertBlock(db)
             val dbSubmissionId = db.submissionQueries.getLastInsert().executeAsOne()
 
@@ -580,13 +578,17 @@ class SubmissionService : IntentService(SubmissionService::class.java.simpleName
             return dbSubmissionId
         }
 
-        private fun deleteSubmissionsForAssignment(id: Long, db: StudentDb) {
+        private fun deleteSubmissionsForAssignment(id: Long, db: StudentDb, files: List<FileSubmitObject> = emptyList()) {
             db.submissionQueries.getSubmissionsByAssignmentId(id, getUserId()).executeAsList().forEach { submission ->
                 db.fileSubmissionQueries.getFilesForSubmissionId(submission.id).executeAsList().forEach { file ->
-                    FileUploadUtils.deleteTempFile(file.fullPath)
+                    // Delete the file for the old submission unless a new file or another database file depends on it (duplicate file being uploaded)
+                    if (!files.any { it.fullPath == file.fullPath } && db.fileSubmissionQueries.getFilesForPath(file.id, file.fullPath).executeAsList().isEmpty()) {
+                        FileUploadUtils.deleteTempFile(file.fullPath)
+                    }
                 }
             }
             db.submissionQueries.deleteSubmissionsForAssignmentId(id, getUserId())
+            db.fileSubmissionQueries.deleteFilesForSubmissionId(id)
         }
 
         // region start helpers


### PR DESCRIPTION
Instead of naming files something unique and altering the users filename, only delete files if no other file for a submission depends on it. This will also include newly created submissions that haven't been put into the database yet.