### PR TITLE
[Student][Automation][MBL-13158]: Abstracted most uses of RecyclerView scrolling logic to utility methods

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/AssignmentListPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/AssignmentListPage.kt
@@ -17,20 +17,23 @@
 package com.instructure.student.ui.pages
 
 import android.view.View
-import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withChild
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withParent
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.dataseeding.model.AssignmentApiModel
-import com.instructure.student.R
-import com.instructure.espresso.*
+import com.instructure.espresso.OnViewWithId
+import com.instructure.espresso.WaitForViewWithId
+import com.instructure.espresso.WaitForViewWithText
+import com.instructure.espresso.assertDisplayed
+import com.instructure.espresso.click
 import com.instructure.espresso.page.BasePage
 import com.instructure.espresso.page.waitForViewWithText
+import com.instructure.espresso.swipeDown
+import com.instructure.student.R
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.containsString
@@ -91,9 +94,8 @@ class AssignmentListPage : BasePage(pageResId = R.id.assignmentListPage) {
     }
 
     private fun scrollToAndAssertDisplayed(matcher: Matcher<View>) {
-        onView(allOf(withId(R.id.listView), ViewMatchers.isDisplayed()))
-                .perform(RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(ViewMatchers.hasDescendant(matcher)))
-                .assertDisplayed()
+        scrollRecyclerView(R.id.listView, matcher)
+        onView(matcher).assertDisplayed()
     }
 
     fun assertHasGradingPeriods() {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/CalendarPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/CalendarPage.kt
@@ -1,16 +1,16 @@
 package com.instructure.student.ui.pages
 
-import androidx.recyclerview.widget.RecyclerView
-import androidx.test.espresso.Espresso
-import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import com.instructure.canvas.espresso.scrollRecyclerView
+import com.instructure.canvas.espresso.withCustomConstraints
 import com.instructure.dataseeding.model.AssignmentApiModel
 import com.instructure.dataseeding.model.QuizApiModel
 import com.instructure.espresso.OnViewWithId
-import com.instructure.espresso.assertDisplayed
 import com.instructure.espresso.click
 import com.instructure.espresso.page.BasePage
 import com.instructure.espresso.page.onView
@@ -40,8 +40,10 @@ class CalendarPage: BasePage(R.id.calendarPage) {
         assertTextDisplayedInRecyclerView(quiz.title)
     }
 
+    // On low-res devices, the month text can get scrunched, and may not completely display.
+    // So we'll only ask that 50% of it be displayed.
     fun toggleCalendarVisibility() {
-        onView(withId(R.id.monthText)).click()
+        onView(withId(R.id.monthText)).perform(withCustomConstraints(click(), isDisplayingAtLeast(50)))
     }
 
     private fun assertTextDisplayedInRecyclerView(s: String) {
@@ -49,8 +51,7 @@ class CalendarPage: BasePage(R.id.calendarPage) {
         val matcher = ViewMatchers.withText(Matchers.containsString(s))
 
         // Scroll RecyclerView item into view, if necessary
-        onView(withId(R.id.calendarRecyclerView))
-                .perform(RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(ViewMatchers.hasDescendant(matcher)))
+        scrollRecyclerView(R.id.calendarRecyclerView, matcher)
 
         // Now make sure that it is displayed
         // Shouldn't be necessary given that the line above passed.  Also, this line can

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/CourseBrowserPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/CourseBrowserPage.kt
@@ -17,20 +17,18 @@
 package com.instructure.student.ui.pages
 
 import android.view.View
-import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.PerformException
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
-import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.canvas.espresso.withCustomConstraints
 import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.models.Tab
@@ -135,8 +133,7 @@ class CourseBrowserPage : BasePage(R.id.courseBrowserPage) {
     // minimizes the toolbar before scrolling.
     private fun recyclerViewScrollTo(matcher: Matcher<View>) {
         minimizeToolbar()
-        onView(allOf(withId(R.id.courseBrowserRecyclerView), isDisplayed()))
-                .perform(RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(hasDescendant(matcher)))
+        scrollRecyclerView(R.id.courseBrowserRecyclerView, matcher)
     }
 }
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DiscussionListPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DiscussionListPage.kt
@@ -16,39 +16,28 @@
  */
 package com.instructure.student.ui.pages
 
-import android.view.View
-import androidx.recyclerview.widget.RecyclerView
-import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.espresso.assertDisplayed
 import com.instructure.espresso.click
 import com.instructure.espresso.page.BasePage
 import com.instructure.student.R
-import org.hamcrest.Matcher
-import org.hamcrest.Matchers
 import org.hamcrest.Matchers.allOf
 
 class DiscussionListPage : BasePage(R.id.discussionListPage) {
 
     fun assertTopicDisplayed(topicTitle: String) {
         val matcher = allOf(withText(topicTitle), withId(R.id.discussionTitle))
-        scrollToItem(matcher)
+        scrollRecyclerView(R.id.discussionRecyclerView, matcher)
         onView(matcher).assertDisplayed()
     }
 
     fun selectTopic(topicTitle: String) {
         val matcher = allOf(withText(topicTitle), withId(R.id.discussionTitle))
-        scrollToItem(matcher)
+        scrollRecyclerView(R.id.discussionRecyclerView, matcher)
         onView(matcher).click()
-    }
-
-    private fun scrollToItem(matcher: Matcher<View>) {
-        Espresso.onView(Matchers.allOf(ViewMatchers.withId(R.id.discussionRecyclerView), ViewMatchers.isDisplayed()))
-                .perform(RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(ViewMatchers.hasDescendant(matcher)))
     }
 
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/FileListPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/FileListPage.kt
@@ -16,20 +16,14 @@
  */
 package com.instructure.student.ui.pages
 
-import android.view.View
-import androidx.recyclerview.widget.RecyclerView
-import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.espresso.assertDisplayed
 import com.instructure.espresso.click
 import com.instructure.espresso.page.BasePage
 import com.instructure.student.R
-import org.hamcrest.Matcher
-import org.hamcrest.Matchers
 import org.hamcrest.Matchers.allOf
 
 // Tests that files submitted for submissions, submission comments and discussions are
@@ -37,18 +31,13 @@ import org.hamcrest.Matchers.allOf
 class FileListPage : BasePage(R.id.fileListPage) {
     fun assertItemDisplayed(itemName: String) {
         val matcher = allOf(withId(R.id.fileName), withText(itemName))
-        scrollToItem(matcher)
+        scrollRecyclerView(R.id.listView, matcher)
         onView(matcher).assertDisplayed()
     }
 
     fun selectItem(itemName: String) {
         val matcher = allOf(withId(R.id.fileName), withText(itemName))
-        scrollToItem(matcher)
+        scrollRecyclerView(R.id.listView, matcher)
         onView(matcher).click()
-    }
-
-    private fun scrollToItem(matcher: Matcher<View>) {
-        Espresso.onView(Matchers.allOf(ViewMatchers.withId(R.id.listView), ViewMatchers.isDisplayed()))
-                .perform(RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(ViewMatchers.hasDescendant(matcher)))
     }
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
@@ -16,43 +16,21 @@
  */
 package com.instructure.student.ui.pages
 
-import android.view.View
-import androidx.recyclerview.widget.RecyclerView
-import androidx.test.espresso.Espresso
-import androidx.test.espresso.UiController
-import androidx.test.espresso.ViewAction
-import androidx.test.espresso.ViewInteraction
-import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
-import com.instructure.dataseeding.model.CanvasUserApiModel
+import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.dataseeding.model.ConversationApiModel
-import com.instructure.dataseeding.model.CourseApiModel
-import com.instructure.dataseeding.model.GroupApiModel
 import com.instructure.espresso.OnViewWithId
-import com.instructure.espresso.OnViewWithStringText
-import com.instructure.espresso.OnViewWithText
-import com.instructure.espresso.WaitForViewWithId
 import com.instructure.espresso.assertDisplayed
 import com.instructure.espresso.click
 import com.instructure.espresso.page.BasePage
 import com.instructure.espresso.page.onView
-import com.instructure.espresso.typeText
 import com.instructure.student.R
-import org.hamcrest.Matcher
-import org.hamcrest.core.AllOf
 
 class InboxPage : BasePage(R.id.inboxPage) {
 
     private val toolbar by OnViewWithId(R.id.toolbar)
     private val createMessageButton by OnViewWithId(R.id.addMessage)
-
-    private fun scrollToRecyclerViewItem(matcher: Matcher<View>) {
-        // Scroll RecyclerView item into view, if necessary
-        onView(ViewMatchers.withId(R.id.inboxRecyclerView))
-                .perform(RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(ViewMatchers.hasDescendant(matcher)))
-    }
 
     fun assertConversationDisplayed(conversation: ConversationApiModel) {
         assertConversationDisplayed(conversation.subject)
@@ -60,13 +38,13 @@ class InboxPage : BasePage(R.id.inboxPage) {
 
     fun assertConversationDisplayed(subject: String) {
         val matcher = withText(subject)
-        scrollToRecyclerViewItem(matcher)
+        scrollRecyclerView(R.id.inboxRecyclerView, matcher)
         onView(matcher).assertDisplayed()
     }
 
     fun selectConversation(conversation: ConversationApiModel) {
         val matcher = withText(conversation.subject)
-        scrollToRecyclerViewItem(matcher)
+        scrollRecyclerView(R.id.inboxRecyclerView, matcher)
         onView(matcher).click()
     }
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/ModulesPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/ModulesPage.kt
@@ -16,25 +16,20 @@
  */
 package com.instructure.student.ui.pages
 
-import androidx.recyclerview.widget.RecyclerView
-import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.dataseeding.model.ModuleApiModel
 import com.instructure.espresso.assertDisplayed
 import com.instructure.espresso.page.BasePage
 import com.instructure.espresso.page.withAncestor
 import com.instructure.student.R
-import org.hamcrest.Matchers
 import org.hamcrest.Matchers.allOf
 
 class ModulesPage : BasePage(R.id.modulesPage) {
     fun assertModuleDisplayed(module: ModuleApiModel) {
-        Espresso.onView(Matchers.allOf(ViewMatchers.withId(R.id.listView), ViewMatchers.isDisplayed()))
-                .perform(RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(ViewMatchers.hasDescendant(ViewMatchers.withText(module.name))))
-
+        scrollRecyclerView(R.id.listView, withText(module.name))
     }
 
     fun assertEmptyView() {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SubmissionDetailsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SubmissionDetailsPage.kt
@@ -16,15 +16,13 @@
  */
 package com.instructure.student.ui.pages
 
-import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.instructure.canvas.espresso.containsTextCaseInsensitive
+import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.dataseeding.model.CanvasUserApiModel
 import com.instructure.espresso.OnViewWithStringTextIgnoreCase
 import com.instructure.espresso.assertDisplayed
@@ -82,9 +80,8 @@ open class SubmissionDetailsPage : BasePage(R.id.submissionDetails) {
     fun assertFileDisplayed(fileName: String) {
         val matcher = allOf(withId(R.id.fileName),withText(fileName))
         openFiles() // Make sure that the files tab is open
-        onView(allOf(withId(R.id.recyclerView), isDisplayed()))
-                .perform(RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(ViewMatchers.hasDescendant(matcher)))
-                .assertDisplayed()
+        scrollRecyclerView(R.id.recyclerView, matcher)
+        onView(matcher).assertDisplayed()
     }
 
     fun addAndSendComment(comment: String) {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SyllabusPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SyllabusPage.kt
@@ -16,27 +16,20 @@
  */
 package com.instructure.student.ui.pages
 
-import androidx.recyclerview.widget.RecyclerView
-import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
-import com.instructure.dataseeding.model.ModuleApiModel
+import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.espresso.assertDisplayed
 import com.instructure.espresso.page.BasePage
 import com.instructure.espresso.page.withAncestor
 import com.instructure.espresso.swipeDown
 import com.instructure.student.R
-import org.hamcrest.Matchers
 import org.hamcrest.Matchers.allOf
 
 open class SyllabusPage : BasePage(R.id.syllabusPage) {
 
     fun assertItemDisplayed(itemText: String) {
-        onView(Matchers.allOf(ViewMatchers.withId(R.id.syllabusEventsRecycler), ViewMatchers.isDisplayed()))
-                .perform(RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(ViewMatchers.hasDescendant(ViewMatchers.withText(itemText))))
-
+        scrollRecyclerView(R.id.syllabusEventsRecycler, itemText)
     }
 
     fun assertEmptyView() {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/TodoPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/TodoPage.kt
@@ -1,19 +1,15 @@
 package com.instructure.student.ui.pages
 
-import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso
-import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.dataseeding.model.AssignmentApiModel
 import com.instructure.dataseeding.model.QuizApiModel
 import com.instructure.espresso.OnViewWithId
 import com.instructure.espresso.assertDisplayed
 import com.instructure.espresso.page.BasePage
-import com.instructure.espresso.page.onView
 import com.instructure.student.R
 import org.hamcrest.Matchers
-import org.hamcrest.core.AllOf.allOf
 
 class TodoPage: BasePage(R.id.todoPage) {
 
@@ -34,8 +30,7 @@ class TodoPage: BasePage(R.id.todoPage) {
         val matcher = ViewMatchers.withText(Matchers.containsString(s))
 
         // Scroll RecyclerView item into view, if necessary
-        onView(allOf(ViewMatchers.withId(R.id.listView), isDisplayed())) // The drawer (not displayed) also has a listView
-                .perform(RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(ViewMatchers.hasDescendant(matcher)))
+        scrollRecyclerView(R.id.listView, matcher)
 
         // Now make sure that it is displayed
         Espresso.onView(matcher).assertDisplayed()

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/renderPages/SubmissionCommentsRenderPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/renderPages/SubmissionCommentsRenderPage.kt
@@ -16,16 +16,13 @@
 package com.instructure.student.ui.pages.renderPages
 
 import android.view.View
-import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
-import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.espresso.OnViewWithId
 import com.instructure.espresso.assertDisplayed
 import com.instructure.espresso.click
@@ -76,8 +73,7 @@ class SubmissionCommentsRenderPage: BasePage(R.id.submissionCommentsPage) {
     }
 
     fun scrollAndAssertDisplayed(matcher: Matcher<View>) {
-        onView(allOf(withId(R.id.recyclerView), isDisplayed()))
-                .perform(RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(ViewMatchers.hasDescendant(matcher)))
+        scrollRecyclerView(R.id.recyclerView, matcher)
         onView(matcher).assertDisplayed()
     }
 

--- a/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasTest.kt
+++ b/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasTest.kt
@@ -195,4 +195,5 @@ abstract class CanvasTest : InstructureTest(BuildConfig.GLOBAL_DITTO_MODE) {
 
         return resourceName
     }
+
 }

--- a/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/CustomActions.kt
+++ b/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/CustomActions.kt
@@ -17,9 +17,14 @@
 package com.instructure.canvas.espresso
 
 import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.ViewMatchers
 import org.hamcrest.Matcher
+import org.hamcrest.Matchers
 
 //
 // This is a repo for generally useful Espresso actions
@@ -42,4 +47,21 @@ fun withCustomConstraints(action: ViewAction, constraints: Matcher<View>): ViewA
             action.perform(uiController, view)
         }
     }
+}
+
+/**
+ * Scroll a recycler view to the given string target
+ */
+fun scrollRecyclerView(recyclerViewId: Int, target: String) {
+    val matcher = ViewMatchers.withText(target)
+    scrollRecyclerView(recyclerViewId, matcher)
+}
+
+/**
+ * Scroll a recycler view to the given matcher target
+ */
+fun scrollRecyclerView(recyclerViewId: Int, target: Matcher<View>) {
+    Espresso.onView(Matchers.allOf(ViewMatchers.withId(recyclerViewId), ViewMatchers.isDisplayed()))
+            .perform(RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(ViewMatchers.hasDescendant(target)))
+
 }


### PR DESCRIPTION
There were a few corner cases, with additional constraints, that were not converted.  But most RecyclerView-scrolling logic now uses the centralized utility methods.