### PR TITLE
[Teacher][MBL-13157] Add refresh to submissions list when post/hide grades

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/features/postpolicies/PostGradeEffectHandler.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/postpolicies/PostGradeEffectHandler.kt
@@ -49,23 +49,31 @@ class PostGradeEffectHandler : EffectHandler<PostGradeView, PostGradeEvent, Post
     }
 
     private suspend fun hideGrades(assignmentId: Long, sections: List<String>) {
-        val progressId = if (sections.isEmpty()) {
-            PostPolicyManager.hideGradesAsync(assignmentId).hideAssignmentGrades?.progress?._id
-        } else {
-            PostPolicyManager.hideGradesForSectionsAsync(assignmentId, sections).hideAssignmentGradesForSections?.progress?._id
-        }
+        try {
+            val progressId = if (sections.isEmpty()) {
+                PostPolicyManager.hideGradesAsync(assignmentId).hideAssignmentGrades?.progress?._id
+            } else {
+                PostPolicyManager.hideGradesForSectionsAsync(assignmentId, sections).hideAssignmentGradesForSections?.progress?._id
+            }
 
-        consumer.accept(PostGradeEvent.PostStarted(progressId))
+            consumer.accept(PostGradeEvent.PostStarted(progressId))
+        } catch (e: Throwable) {
+            consumer.accept(PostGradeEvent.PostFailed)
+        }
     }
 
     private suspend fun postGrades(assignmentId: Long, sections: List<String>, gradedOnly: Boolean) {
-        val progressId = if (sections.isEmpty()) {
-            PostPolicyManager.postGradesAsync(assignmentId, gradedOnly).postAssignmentGrades?.progress?._id
-        } else {
-            PostPolicyManager.postGradesForSectionsAsync(assignmentId, gradedOnly, sections).postAssignmentGradesForSections?.progress?._id
-        }
+        try {
+            val progressId = if (sections.isEmpty()) {
+                PostPolicyManager.postGradesAsync(assignmentId, gradedOnly).postAssignmentGrades?.progress?._id
+            } else {
+                PostPolicyManager.postGradesForSectionsAsync(assignmentId, gradedOnly, sections).postAssignmentGradesForSections?.progress?._id
+            }
 
-        consumer.accept(PostGradeEvent.PostStarted(progressId))
+            consumer.accept(PostGradeEvent.PostStarted(progressId))
+        } catch (e: Throwable) {
+            consumer.accept(PostGradeEvent.PostFailed)
+        }
     }
 
     private suspend fun watchProgress(progressId: String?) {

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/postpolicies/PostGradeEffectHandler.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/postpolicies/PostGradeEffectHandler.kt
@@ -23,6 +23,7 @@ import com.instructure.canvasapi2.managers.SectionManager
 import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.Progress
 import com.instructure.canvasapi2.utils.exhaustive
+import com.instructure.teacher.BuildConfig
 import com.instructure.teacher.features.postpolicies.ui.PostGradeView
 import com.instructure.teacher.mobius.common.ui.EffectHandler
 import kotlinx.coroutines.delay
@@ -85,7 +86,7 @@ class PostGradeEffectHandler : EffectHandler<PostGradeView, PostGradeEvent, Post
 
         lateinit var progress: Progress
         do {
-            delay(1000L) // Don't hit the API too hard while monitoring progress
+            delay(getProgressDelay()) // Don't hit the API too hard while monitoring progress
 
             progress = ProgressManager.getProgressAsync(progressId).await().dataOrNull ?: run {
                 consumer.accept(PostGradeEvent.PostFailed)
@@ -99,4 +100,7 @@ class PostGradeEffectHandler : EffectHandler<PostGradeView, PostGradeEvent, Post
             consumer.accept(PostGradeEvent.PostFailed)
         }
     }
+
+    // Don't inflate test times, only do a second delay if not testing
+    private fun getProgressDelay() = if (BuildConfig.IS_TESTING) 0L else 1000L
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/postpolicies/PostGradeEffectHandler.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/postpolicies/PostGradeEffectHandler.kt
@@ -25,6 +25,7 @@ import com.instructure.canvasapi2.models.Progress
 import com.instructure.canvasapi2.utils.exhaustive
 import com.instructure.teacher.features.postpolicies.ui.PostGradeView
 import com.instructure.teacher.mobius.common.ui.EffectHandler
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class PostGradeEffectHandler : EffectHandler<PostGradeView, PostGradeEvent, PostGradeEffect>() {
@@ -84,6 +85,8 @@ class PostGradeEffectHandler : EffectHandler<PostGradeView, PostGradeEvent, Post
 
         lateinit var progress: Progress
         do {
+            delay(1000L) // Don't hit the API too hard while monitoring progress
+
             progress = ProgressManager.getProgressAsync(progressId).await().dataOrNull ?: run {
                 consumer.accept(PostGradeEvent.PostFailed)
                 return

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/postpolicies/PostGradeModel.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/postpolicies/PostGradeModel.kt
@@ -22,8 +22,10 @@ import com.instructure.canvasapi2.models.Submission
 
 sealed class PostGradeEvent {
     object GradesPosted : PostGradeEvent()
+    object PostFailed : PostGradeEvent()
     object PostGradesClicked : PostGradeEvent()
     object SpecificSectionsToggled : PostGradeEvent()
+    data class PostStarted(val progressId: String?) : PostGradeEvent()
     data class GradedOnlySelected(val gradedOnly: Boolean) : PostGradeEvent()
     data class SectionToggled(val sectionId: Long) : PostGradeEvent()
     data class DataLoaded(val sections: List<Section>, val submissions: List<Submission>) : PostGradeEvent()
@@ -33,7 +35,9 @@ sealed class PostGradeEffect {
     data class LoadData(val assignment: Assignment) : PostGradeEffect()
     data class HideGrades(val assignmentId: Long, val sectionIds: List<String>) : PostGradeEffect()
     data class PostGrades(val assignmentId: Long, val sectionIds: List<String>, val gradedOnly: Boolean) : PostGradeEffect()
-    data class ShowGradesPosted(val isHidingGrades: Boolean) : PostGradeEffect()
+    data class WatchForProgress(val progressId: String?) : PostGradeEffect()
+    data class ShowGradesPosted(val isHidingGrades: Boolean, val assignmentId: Long) : PostGradeEffect()
+    data class ShowPostFailed(val isHidingGrades: Boolean) : PostGradeEffect()
 }
 
 data class PostGradeModel(

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/postpolicies/PostGradeUpdate.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/postpolicies/PostGradeUpdate.kt
@@ -27,7 +27,8 @@ class PostGradeUpdate : UpdateInit<PostGradeModel, PostGradeEvent, PostGradeEffe
 
     override fun update(model: PostGradeModel, event: PostGradeEvent): Next<PostGradeModel, PostGradeEffect> {
         return when (event) {
-            PostGradeEvent.GradesPosted -> Next.dispatch(setOf<PostGradeEffect>(PostGradeEffect.ShowGradesPosted(model.isHidingGrades)))
+            PostGradeEvent.GradesPosted -> Next.dispatch(setOf<PostGradeEffect>(PostGradeEffect.ShowGradesPosted(model.isHidingGrades, model.assignment.id)))
+            PostGradeEvent.PostFailed -> Next.next(model.copy(isProcessing = false), setOf<PostGradeEffect>(PostGradeEffect.ShowPostFailed(model.isHidingGrades)))
             PostGradeEvent.PostGradesClicked -> {
                 Next.next(
                     model.copy(isProcessing = true), setOf(
@@ -51,6 +52,7 @@ class PostGradeUpdate : UpdateInit<PostGradeModel, PostGradeEvent, PostGradeEffe
                     submissions = event.submissions
                 )
             )
+            is PostGradeEvent.PostStarted -> Next.dispatch(setOf<PostGradeEffect>(PostGradeEffect.WatchForProgress(event.progressId)))
         }
     }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/postpolicies/ui/PostGradeView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/postpolicies/ui/PostGradeView.kt
@@ -31,6 +31,8 @@ import kotlinx.android.synthetic.main.fragment_post_grade.*
 import com.instructure.pandautils.utils.applyTheme
 import android.app.AlertDialog
 import android.view.*
+import com.instructure.teacher.events.AssignmentGradedEvent
+import com.instructure.teacher.events.post
 import kotlinx.android.synthetic.main.dialog_post_graded_everyone.*
 
 class PostGradeView(inflater: LayoutInflater, parent: ViewGroup) : MobiusView<PostGradeViewState, PostGradeEvent>(R.layout.fragment_post_grade, inflater, parent) {
@@ -135,8 +137,13 @@ class PostGradeView(inflater: LayoutInflater, parent: ViewGroup) : MobiusView<Po
         adapter?.data = state.sections
     }
 
-    fun showGradesPosted(isHidingGrades: Boolean) {
+    fun showGradesPosted(isHidingGrades: Boolean, assignmentId: Long) {
         Toast.makeText(context, if (isHidingGrades) R.string.postPolicyHiddenToast else R.string.postPolicyPostedToast, Toast.LENGTH_SHORT).show()
         (context as Activity).onBackPressed()
+        AssignmentGradedEvent(assignmentId).post() //post bus event
+    }
+
+    fun showPostFailed(isHidingGrades: Boolean) {
+        Toast.makeText(context, if (isHidingGrades) R.string.postPolicyHideFailedToast else R.string.postPolicyPostFailedToast, Toast.LENGTH_LONG).show()
     }
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/postpolicies/ui/PostPolicyFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/postpolicies/ui/PostPolicyFragment.kt
@@ -14,7 +14,7 @@
  *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-package com.instructure.teacher.features.postpolicies
+package com.instructure.teacher.features.postpolicies.ui
 
 import android.graphics.Color
 import android.os.Bundle
@@ -30,7 +30,6 @@ import com.instructure.canvasapi2.models.Course
 import com.instructure.interactions.router.Route
 import com.instructure.pandautils.utils.*
 import com.instructure.teacher.R
-import com.instructure.teacher.features.postpolicies.ui.PostGradeFragment
 import com.instructure.teacher.utils.setupBackButtonAsBackPressedOnly
 import kotlinx.android.synthetic.main.fragment_post_policy_settings.*
 import kotlinx.android.synthetic.main.fragment_post_policy_settings.view.*

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/AssignmentSubmissionListFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/AssignmentSubmissionListFragment.kt
@@ -40,7 +40,7 @@ import com.instructure.teacher.events.AssignmentGradedEvent
 import com.instructure.teacher.events.SubmissionCommentsUpdated
 import com.instructure.teacher.events.SubmissionFilterChangedEvent
 import com.instructure.teacher.factory.AssignmentSubmissionListPresenterFactory
-import com.instructure.teacher.features.postpolicies.PostPolicyFragment
+import com.instructure.teacher.features.postpolicies.ui.PostPolicyFragment
 import com.instructure.teacher.holders.GradeableStudentSubmissionViewHolder
 import com.instructure.teacher.presenters.AssignmentSubmissionListPresenter
 import com.instructure.teacher.presenters.AssignmentSubmissionListPresenter.SubmissionListFilter

--- a/apps/teacher/src/main/java/com/instructure/teacher/router/RouteMatcher.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/router/RouteMatcher.kt
@@ -47,7 +47,7 @@ import com.instructure.teacher.PSPDFKit.AnnotationComments.AnnotationCommentList
 import com.instructure.teacher.R
 import com.instructure.teacher.activities.*
 import com.instructure.teacher.adapters.StudentContextFragment
-import com.instructure.teacher.features.postpolicies.PostPolicyFragment
+import com.instructure.teacher.features.postpolicies.ui.PostPolicyFragment
 import com.instructure.teacher.fragments.*
 import com.instructure.teacher.fragments.FileListFragment
 import instructure.rceditor.RCEFragment

--- a/apps/teacher/src/main/java/com/instructure/teacher/router/RouteResolver.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/router/RouteResolver.kt
@@ -11,7 +11,7 @@ import com.instructure.teacher.PSPDFKit.AnnotationComments.AnnotationCommentList
 import com.instructure.teacher.adapters.StudentContextFragment
 import com.instructure.teacher.features.files.search.FileSearchFragment
 import com.instructure.teacher.features.modules.list.ui.ModuleListFragment
-import com.instructure.teacher.features.postpolicies.PostPolicyFragment
+import com.instructure.teacher.features.postpolicies.ui.PostPolicyFragment
 import com.instructure.teacher.fragments.*
 import instructure.rceditor.RCEFragment
 

--- a/apps/teacher/src/test/java/com/instructure/teacher/unit/postpolicies/PostGradeEffectHandlerTest.kt
+++ b/apps/teacher/src/test/java/com/instructure/teacher/unit/postpolicies/PostGradeEffectHandlerTest.kt
@@ -21,8 +21,10 @@ import com.instructure.canvasapi2.PostAssignmentGradesForSectionsMutation
 import com.instructure.canvasapi2.PostAssignmentGradesMutation
 import com.instructure.canvasapi2.managers.AssignmentManager
 import com.instructure.canvasapi2.managers.PostPolicyManager
+import com.instructure.canvasapi2.managers.ProgressManager
 import com.instructure.canvasapi2.managers.SectionManager
 import com.instructure.canvasapi2.models.Assignment
+import com.instructure.canvasapi2.models.Progress
 import com.instructure.canvasapi2.models.Section
 import com.instructure.canvasapi2.models.Submission
 import com.instructure.canvasapi2.utils.DataResult
@@ -48,6 +50,8 @@ class PostGradeEffectHandlerTest : Assert() {
     private lateinit var effectHandler: PostGradeEffectHandler
     private lateinit var consumer: Consumer<PostGradeEvent>
     private lateinit var connection: Connection<PostGradeEffect>
+
+    private val progressId = "135"
 
     @ExperimentalCoroutinesApi
     @Before
@@ -118,7 +122,7 @@ class PostGradeEffectHandlerTest : Assert() {
     }
 
     @Test
-    fun `HideGrades calls the API to hide grades`() {
+    fun `HideGrades calls the API to hide grades with null response`() {
         val assignmentId = 123L
 
         val sections = emptyList<String>()
@@ -132,7 +136,32 @@ class PostGradeEffectHandlerTest : Assert() {
             PostPolicyManager.hideGradesAsync(assignmentId)
         }
         verify(timeout = 100) {
-            consumer.accept(PostGradeEvent.GradesPosted)
+            consumer.accept(PostGradeEvent.PostStarted(null))
+        }
+        confirmVerified(PostPolicyManager, consumer)
+    }
+
+    @Test
+    fun `HideGrades calls the API to hide grades`() {
+        val assignmentId = 123L
+
+        val sections = emptyList<String>()
+
+        mockkObject(PostPolicyManager)
+        coEvery { PostPolicyManager.hideGradesAsync(assignmentId) } returns HideAssignmentGradesMutation.Data(
+            HideAssignmentGradesMutation.HideAssignmentGrades(
+                "",
+                HideAssignmentGradesMutation.Progress("", progressId)
+            )
+        )
+
+        connection.accept(PostGradeEffect.HideGrades(assignmentId, sections))
+
+        coVerify(timeout = 100) {
+            PostPolicyManager.hideGradesAsync(assignmentId)
+        }
+        verify(timeout = 100) {
+            consumer.accept(PostGradeEvent.PostStarted(progressId))
         }
         confirmVerified(PostPolicyManager, consumer)
     }
@@ -144,7 +173,14 @@ class PostGradeEffectHandlerTest : Assert() {
         val sections = listOf("1", "2", "3")
 
         mockkObject(PostPolicyManager)
-        coEvery { PostPolicyManager.hideGradesForSectionsAsync(assignmentId, sections) } returns HideAssignmentGradesForSectionsMutation.Data(null)
+        coEvery {
+            PostPolicyManager.hideGradesForSectionsAsync(assignmentId, sections)
+        } returns HideAssignmentGradesForSectionsMutation.Data(
+            HideAssignmentGradesForSectionsMutation.HideAssignmentGradesForSections(
+                "",
+                HideAssignmentGradesForSectionsMutation.Progress("", progressId)
+            )
+        )
 
         connection.accept(PostGradeEffect.HideGrades(assignmentId, sections))
 
@@ -152,7 +188,7 @@ class PostGradeEffectHandlerTest : Assert() {
             PostPolicyManager.hideGradesForSectionsAsync(assignmentId, sections)
         }
         verify(timeout = 100) {
-            consumer.accept(PostGradeEvent.GradesPosted)
+            consumer.accept(PostGradeEvent.PostStarted(progressId))
         }
         confirmVerified(PostPolicyManager, consumer)
     }
@@ -165,7 +201,12 @@ class PostGradeEffectHandlerTest : Assert() {
         val sections = emptyList<String>()
 
         mockkObject(PostPolicyManager)
-        coEvery { PostPolicyManager.postGradesAsync(assignmentId, gradedOnly) } returns PostAssignmentGradesMutation.Data(null)
+        coEvery { PostPolicyManager.postGradesAsync(assignmentId, gradedOnly) } returns PostAssignmentGradesMutation.Data(
+            PostAssignmentGradesMutation.PostAssignmentGrades(
+                "",
+                PostAssignmentGradesMutation.Progress("", progressId)
+            )
+        )
 
         connection.accept(PostGradeEffect.PostGrades(assignmentId, sections, gradedOnly))
 
@@ -173,7 +214,7 @@ class PostGradeEffectHandlerTest : Assert() {
             PostPolicyManager.postGradesAsync(assignmentId, gradedOnly)
         }
         verify(timeout = 100) {
-            consumer.accept(PostGradeEvent.GradesPosted)
+            consumer.accept(PostGradeEvent.PostStarted(progressId))
         }
         confirmVerified(PostPolicyManager, consumer)
     }
@@ -186,7 +227,11 @@ class PostGradeEffectHandlerTest : Assert() {
         val sections = listOf("1", "2", "3")
 
         mockkObject(PostPolicyManager)
-        coEvery { PostPolicyManager.postGradesForSectionsAsync(assignmentId, gradedOnly, sections) } returns PostAssignmentGradesForSectionsMutation.Data(null)
+        coEvery {
+            PostPolicyManager.postGradesForSectionsAsync(assignmentId, gradedOnly, sections)
+        } returns PostAssignmentGradesForSectionsMutation.Data(
+            PostAssignmentGradesForSectionsMutation.PostAssignmentGradesForSections("", PostAssignmentGradesForSectionsMutation.Progress("", progressId))
+        )
 
         connection.accept(PostGradeEffect.PostGrades(assignmentId, sections, gradedOnly))
 
@@ -194,20 +239,94 @@ class PostGradeEffectHandlerTest : Assert() {
             PostPolicyManager.postGradesForSectionsAsync(assignmentId, gradedOnly, sections)
         }
         verify(timeout = 100) {
-            consumer.accept(PostGradeEvent.GradesPosted)
+            consumer.accept(PostGradeEvent.PostStarted(progressId))
         }
         confirmVerified(PostPolicyManager, consumer)
     }
 
     @Test
     fun `ShowGradesPosted calls showGradesPosted on the view`() {
+        val assignmentId = 123L
         val isHidingGrades = true
 
-        connection.accept(PostGradeEffect.ShowGradesPosted(isHidingGrades))
+        connection.accept(PostGradeEffect.ShowGradesPosted(isHidingGrades, assignmentId))
 
         verify(timeout = 100) {
-            view.showGradesPosted(isHidingGrades)
+            view.showGradesPosted(isHidingGrades, assignmentId)
         }
         confirmVerified(view)
+    }
+
+    @Test
+    fun `ShowPostFailed calls showGradesPosted on the view`() {
+        val isHidingGrades = true
+
+        connection.accept(PostGradeEffect.ShowPostFailed(isHidingGrades))
+
+        verify(timeout = 100) {
+            view.showPostFailed(isHidingGrades)
+        }
+        confirmVerified(view)
+    }
+
+    @Test
+    fun `WatchForProgress calls the consumer with PostFailed when given null id`() {
+        val progressId: String? = null
+
+        connection.accept(PostGradeEffect.WatchForProgress(progressId))
+
+        verify(timeout = 100) {
+            consumer.accept(PostGradeEvent.PostFailed)
+        }
+        confirmVerified(consumer)
+    }
+
+    @Test
+    fun `WatchForProgress calls the consumer with PostFailed when progress API result fails`() {
+        mockkObject(ProgressManager)
+        coEvery {
+            ProgressManager.getProgressAsync(progressId).await()
+        } returns DataResult.Fail(null)
+
+        connection.accept(PostGradeEffect.WatchForProgress(progressId))
+
+        verify(timeout = 100) {
+            consumer.accept(PostGradeEvent.PostFailed)
+        }
+        confirmVerified(consumer)
+    }
+
+    @Test
+    fun `WatchForProgress calls the consumer with PostFailed when progress is failed`() {
+        mockkObject(ProgressManager)
+        coEvery {
+            ProgressManager.getProgressAsync(progressId).await()
+        } returns DataResult.Success(Progress(workflowState = "failed"))
+
+        connection.accept(PostGradeEffect.WatchForProgress(progressId))
+
+        verify(timeout = 100) {
+            consumer.accept(PostGradeEvent.PostFailed)
+        }
+        confirmVerified(consumer)
+    }
+
+    @Test
+    fun `WatchForProgress calls the consumer with GradesPosted`() {
+        mockkObject(ProgressManager)
+        coEvery {
+            ProgressManager.getProgressAsync(progressId).await()
+        } returnsMany listOf(
+            DataResult.Success(Progress(workflowState = "queued")),
+            DataResult.Success(Progress(workflowState = "running")),
+            DataResult.Success(Progress(workflowState = "completed"))
+        )
+
+        connection.accept(PostGradeEffect.WatchForProgress(progressId))
+
+        verify(timeout = 100) {
+            consumer.accept(PostGradeEvent.GradesPosted)
+        }
+        confirmVerified(consumer)
     }
 }

--- a/apps/teacher/src/test/java/com/instructure/teacher/unit/postpolicies/PostGradeEffectHandlerTest.kt
+++ b/apps/teacher/src/test/java/com/instructure/teacher/unit/postpolicies/PostGradeEffectHandlerTest.kt
@@ -39,6 +39,7 @@ import io.mockk.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.setMain
 import org.junit.Assert
 import org.junit.Before
@@ -324,6 +325,9 @@ class PostGradeEffectHandlerTest : Assert() {
 
     @Test
     fun `WatchForProgress calls the consumer with PostFailed when progress API result fails`() {
+        mockkStatic("kotlinx.coroutines.DelayKt")
+        coEvery { delay(1000L) } returns Unit
+
         mockkObject(ProgressManager)
         coEvery {
             ProgressManager.getProgressAsync(progressId).await()
@@ -339,6 +343,9 @@ class PostGradeEffectHandlerTest : Assert() {
 
     @Test
     fun `WatchForProgress calls the consumer with PostFailed when progress is failed`() {
+        mockkStatic("kotlinx.coroutines.DelayKt")
+        coEvery { delay(1000L) } returns Unit
+
         mockkObject(ProgressManager)
         coEvery {
             ProgressManager.getProgressAsync(progressId).await()
@@ -354,6 +361,9 @@ class PostGradeEffectHandlerTest : Assert() {
 
     @Test
     fun `WatchForProgress calls the consumer with GradesPosted`() {
+        mockkStatic("kotlinx.coroutines.DelayKt")
+        coEvery { delay(1000L) } returns Unit
+
         mockkObject(ProgressManager)
         coEvery {
             ProgressManager.getProgressAsync(progressId).await()

--- a/apps/teacher/src/test/java/com/instructure/teacher/unit/postpolicies/PostGradeEffectHandlerTest.kt
+++ b/apps/teacher/src/test/java/com/instructure/teacher/unit/postpolicies/PostGradeEffectHandlerTest.kt
@@ -122,6 +122,26 @@ class PostGradeEffectHandlerTest : Assert() {
     }
 
     @Test
+    fun `HideGrades calls the API to hide grades with exception`() {
+        val assignmentId = 123L
+
+        val sections = emptyList<String>()
+
+        mockkObject(PostPolicyManager)
+        coEvery { PostPolicyManager.hideGradesAsync(assignmentId) } throws Exception()
+
+        connection.accept(PostGradeEffect.HideGrades(assignmentId, sections))
+
+        coVerify(timeout = 100) {
+            PostPolicyManager.hideGradesAsync(assignmentId)
+        }
+        verify(timeout = 100) {
+            consumer.accept(PostGradeEvent.PostFailed)
+        }
+        confirmVerified(PostPolicyManager, consumer)
+    }
+
+    @Test
     fun `HideGrades calls the API to hide grades with null response`() {
         val assignmentId = 123L
 
@@ -189,6 +209,27 @@ class PostGradeEffectHandlerTest : Assert() {
         }
         verify(timeout = 100) {
             consumer.accept(PostGradeEvent.PostStarted(progressId))
+        }
+        confirmVerified(PostPolicyManager, consumer)
+    }
+
+    @Test
+    fun `PostGrades calls the API to hide grades with exception`() {
+        val assignmentId = 123L
+        val gradedOnly = false
+
+        val sections = emptyList<String>()
+
+        mockkObject(PostPolicyManager)
+        coEvery { PostPolicyManager.postGradesAsync(assignmentId, gradedOnly) } throws Exception()
+
+        connection.accept(PostGradeEffect.PostGrades(assignmentId, sections, gradedOnly))
+
+        coVerify(timeout = 100) {
+            PostPolicyManager.postGradesAsync(assignmentId, gradedOnly)
+        }
+        verify(timeout = 100) {
+            consumer.accept(PostGradeEvent.PostFailed)
         }
         confirmVerified(PostPolicyManager, consumer)
     }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/ProgressAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/ProgressAPI.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2019 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+package com.instructure.canvasapi2.apis
+
+import com.instructure.canvasapi2.StatusCallback
+import com.instructure.canvasapi2.builders.RestBuilder
+import com.instructure.canvasapi2.builders.RestParams
+import com.instructure.canvasapi2.models.Progress
+import retrofit2.Call
+import retrofit2.http.*
+
+object ProgressAPI {
+
+    internal interface ProgressInterface {
+        @GET("progress/{progressId}")
+        fun getProgress(@Path("progressId") progressId: String): Call<Progress>
+    }
+
+    fun getProgress(adapter: RestBuilder, params: RestParams, progressId: String, callback: StatusCallback<Progress>) {
+        callback.addCall(adapter.build(ProgressInterface::class.java, params).getProgress(progressId)).enqueue(callback)
+    }
+}

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/ProgressManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/ProgressManager.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2019 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package com.instructure.canvasapi2.managers
+
+import com.instructure.canvasapi2.StatusCallback
+import com.instructure.canvasapi2.apis.PageAPI
+import com.instructure.canvasapi2.apis.ProgressAPI
+import com.instructure.canvasapi2.builders.RestBuilder
+import com.instructure.canvasapi2.builders.RestParams
+import com.instructure.canvasapi2.models.CanvasContext
+import com.instructure.canvasapi2.models.Page
+import com.instructure.canvasapi2.models.Progress
+import com.instructure.canvasapi2.models.postmodels.PagePostBody
+import com.instructure.canvasapi2.models.postmodels.PagePostBodyWrapper
+import com.instructure.canvasapi2.utils.ExhaustiveListCallback
+import com.instructure.canvasapi2.utils.weave.apiAsync
+
+object ProgressManager {
+
+    fun getProgress(progressId: String, callback: StatusCallback<Progress>) {
+        val adapter = RestBuilder(callback)
+        val params = RestParams(isForceReadFromNetwork = true)
+
+        ProgressAPI.getProgress(adapter, params, progressId, callback)
+    }
+
+    fun getProgressAsync(progressId: String) = apiAsync<Progress> { getProgress(progressId, it) }
+}

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Progress.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Progress.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2019 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.instructure.canvasapi2.models
+
+import com.google.gson.annotations.SerializedName
+import kotlinx.android.parcel.Parcelize
+
+@Suppress("unused", "MemberVisibilityCanBePrivate")
+@Parcelize
+data class Progress(
+        override var id: Long = 0,
+        @SerializedName("context_id")
+        val contextId: Long = 0,
+        @SerializedName("context_type")
+        val contextType: String = "", // The context owning the job
+        @SerializedName("user_id")
+        val userId: Long = 0, // The id of the user who started the job
+        @SerializedName("workflow_state")
+        private val workflowState: String = "", // One of 'queued', 'running', 'completed', 'failed'
+        val tag: String = "", // The type of operation
+        val completion: Long = 0, // Percent completed
+        val message: String? = null // Optional details about the job
+) : CanvasModel<Progress>() {
+    val isQueued: Boolean get() = workflowState == "queued"
+    val isRunning: Boolean get() = workflowState == "running"
+    val isCompleted: Boolean get() = workflowState == "completed"
+    val isFailed: Boolean get() = workflowState == "failed"
+
+    val hasRun: Boolean get() = isCompleted || isFailed
+}

--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -1049,6 +1049,8 @@
     <string name="postPolicyAllPostedMessage">All grades are currently posted.</string>
     <string name="postPolicyPostedToast">Grades Posted</string>
     <string name="postPolicyHiddenToast">Grades Hidden</string>
+    <string name="postPolicyPostFailedToast">Failed to post grades</string>
+    <string name="postPolicyHideFailedToast">Failed to hide grades</string>
     <string name="gradeBeforePosting">Grade before posting</string>
     <string name="gradeAfterPosting">Grade after posting</string>
     <string name="gradeOverride">Grade override</string>


### PR DESCRIPTION
To test:

Post or Hide grades on the new post policy screen in Teacher.
Wait for a few seconds while the delayed job on Canvas finishes.
Verify that the screen will go back and refresh the submission list automagically.