### PR TITLE
[Student][Teacher][MBL-13064] Use authenticated session to view HTML files to allow linking to other file resources

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/FileListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/FileListFragment.kt
@@ -46,7 +46,6 @@ import com.instructure.interactions.router.Route
 import com.instructure.interactions.router.RouterParams
 import com.instructure.pandautils.dialogs.FileExistsDialog
 import com.instructure.pandautils.dialogs.UploadFilesDialog
-import com.instructure.pandautils.dialogs.UploadFilesDialog.Companion.EVENT_ON_UPLOAD_BEGIN
 import com.instructure.pandautils.utils.*
 import com.instructure.student.R
 import com.instructure.student.adapter.FileFolderCallback
@@ -181,7 +180,19 @@ class FileListFragment : ParentFragment(), Bookmarkable {
                     RouteMatcher.route(requireContext(), FileListFragment.makeRoute(canvasContext, item))
                 } else {
                     recordFilePreviewEvent(item)
-                    openMedia(item.contentType, item.url, item.displayName, canvasContext)
+                    if (item.isHtmlFile) {
+                        /* An HTML file can reference other canvas files as resources (e.g. CSS files) and must be
+                        accessed as an authenticated preview to work correctly */
+                        RouteMatcher.route(requireContext(), InternalWebviewFragment.makeRoute(
+                            canvasContext = canvasContext,
+                            url = item.getFilePreviewUrl(ApiPrefs.fullDomain, canvasContext),
+                            authenticate = true,
+                            isUnsupportedFeature = false,
+                            allowUnsupportedRouting = false
+                        ))
+                    } else {
+                        openMedia(item.contentType, item.url, item.displayName, canvasContext)
+                    }
                 }
             }
 

--- a/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
@@ -64,6 +64,13 @@ open class InternalWebviewFragment : ParentFragment() {
     var title: String? by NullableStringArg(key = Const.ACTION_BAR_TITLE)
     var url: String? by NullableStringArg(key = Const.INTERNAL_URL)
 
+    /*
+     * Our router has some catch-all routes which open the UnsupportedFeatureFragment for urls that match the user's
+     * domain but don't match any other internal routes. In some cases, such as viewing an HTML file preview, we need to
+     * disable this behavior to ensure that content loads in the WebView instead of the app.
+     */
+    val allowUnsupportedRouting by BooleanArg(key = Const.ALLOW_UNSUPPORTED_ROUTING, default = true)
+
     var downloadUrl: String? = null
     var downloadFilename: String? = null
 
@@ -111,12 +118,12 @@ open class InternalWebviewFragment : ParentFragment() {
 
                 override fun canRouteInternallyDelegate(url: String): Boolean {
                     if (activity == null) return false
-                    return shouldRouteInternally && !isUnsupportedFeature && RouteMatcher.canRouteInternally(requireActivity(), url, ApiPrefs.domain, false)
+                    return shouldRouteInternally && !isUnsupportedFeature && RouteMatcher.canRouteInternally(requireActivity(), url, ApiPrefs.domain, false, allowUnsupportedRouting)
                 }
 
                 override fun routeInternallyCallback(url: String) {
                     if (activity == null) return
-                    RouteMatcher.canRouteInternally(requireActivity(), url, ApiPrefs.domain, true)
+                    RouteMatcher.canRouteInternally(requireActivity(), url, ApiPrefs.domain, true, allowUnsupportedRouting)
                 }
             }
             canvasWebView.setMediaDownloadCallback { _, url, filename ->
@@ -411,13 +418,21 @@ open class InternalWebviewFragment : ParentFragment() {
                             putBoolean(Const.AUTHENTICATE, authenticate)
                         })
 
-        fun makeRoute(canvasContext: CanvasContext, url: String, authenticate: Boolean, isUnsupportedFeature: Boolean, shouldRouteInternally: Boolean = true): Route =
+        fun makeRoute(
+            canvasContext: CanvasContext,
+            url: String,
+            authenticate: Boolean,
+            isUnsupportedFeature: Boolean,
+            shouldRouteInternally: Boolean = true,
+            allowUnsupportedRouting: Boolean = true
+        ): Route =
                 Route(InternalWebviewFragment::class.java, canvasContext,
                         canvasContext.makeBundle().apply {
                             putString(Const.INTERNAL_URL, url)
                             putBoolean(Const.AUTHENTICATE, authenticate)
                             putBoolean(Const.IS_UNSUPPORTED_FEATURE, isUnsupportedFeature)
                             putBoolean(SHOULD_ROUTE_INTERNALLY, shouldRouteInternally)
+                            putBoolean(Const.ALLOW_UNSUPPORTED_ROUTING, allowUnsupportedRouting)
                         })
 
         fun makeRoute(bundle: Bundle) = Route(InternalWebviewFragment::class.java, null, bundle)

--- a/apps/student/src/main/java/com/instructure/student/router/RouteMatcher.kt
+++ b/apps/student/src/main/java/com/instructure/student/router/RouteMatcher.kt
@@ -398,11 +398,22 @@ object RouteMatcher : BaseRouteMatcher() {
      * Returns true if url can be routed to a fragment, false otherwise
      * @param url
      * @param routeIfPossible
+     * @param allowUnsupported If true (default), this function will return true for unsupported urls - i.e. urls that
+     *                         match the provided domain but do not match any existing routes. If [routeIfPossible] is
+     *                         also true, the user will be routed to UnsupportedFeatureFragment for such urls.
      * @return
      */
     @JvmStatic
-    fun canRouteInternally(context: Context, url: String, domain: String, routeIfPossible: Boolean): Boolean {
-        val canRoute = getInternalRoute(url, domain) != null
+    @JvmOverloads
+    fun canRouteInternally(
+        context: Context,
+        url: String,
+        domain: String,
+        routeIfPossible: Boolean,
+        allowUnsupported: Boolean = true
+    ): Boolean {
+        val route = getInternalRoute(url, domain)
+        val canRoute = route != null && (allowUnsupported || route.primaryClass != UnsupportedFeatureFragment::class.java)
         if (canRoute && routeIfPossible) routeUrl(context, url)
         return canRoute
     }

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/FileListFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/FileListFragment.kt
@@ -178,7 +178,14 @@ class FileListFragment : BaseSyncFragment<
                 if (it.displayName.isValid()) {
                     // This is a file
                     val editableFile = EditableFile(it, presenter.usageRights, presenter.licenses, courseColor, presenter.mCanvasContext, R.drawable.vd_document)
-                    viewMedia(requireContext(), it.displayName.orEmpty(), it.contentType.orEmpty(), it.url, it.thumbnailUrl, it.displayName, R.drawable.vd_document, courseColor, editableFile)
+                    if (it.isHtmlFile) {
+                        /* An HTML file can reference other canvas files as resources (e.g. CSS files) and must be
+                        accessed as an authenticated preview to work correctly */
+                        val bundle = ViewHtmlFragment.makeAuthSessionBundle(mCanvasContext, it, it.displayName.orEmpty(), courseColor, editableFile)
+                        RouteMatcher.route(requireActivity(), Route(ViewHtmlFragment::class.java, null, bundle))
+                    } else {
+                        viewMedia(requireContext(), it.displayName.orEmpty(), it.contentType.orEmpty(), it.url, it.thumbnailUrl, it.displayName, R.drawable.vd_document, courseColor, editableFile)
+                    }
                 } else {
                     // This is a folder
                     val args = FileListFragment.makeBundle(presenter.mCanvasContext, it)

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/InternalWebViewFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/InternalWebViewFragment.kt
@@ -37,7 +37,6 @@ import com.instructure.pandautils.utils.*
 import com.instructure.pandautils.views.CanvasWebView
 import com.instructure.teacher.R
 import com.instructure.teacher.router.RouteMatcher
-import com.instructure.teacher.services.FileDownloadService
 import com.instructure.teacher.utils.setupCloseButton
 import com.instructure.teacher.utils.setupMenu
 import kotlinx.android.synthetic.main.fragment_internal_webview.*
@@ -51,7 +50,7 @@ open class InternalWebViewFragment : BaseFragment() {
     var html: String by StringArg()
     var title: String by StringArg()
     var darkToolbar: Boolean by BooleanArg()
-    private var shouldAuthenticate: Boolean by BooleanArg()
+    private var shouldAuthenticate: Boolean by BooleanArg(key = AUTHENTICATE)
 
     private var shouldRouteInternally = true
     private var shouldLoadUrl = true
@@ -197,8 +196,8 @@ open class InternalWebViewFragment : BaseFragment() {
                     } catch (e: StatusCallbackError) {
                     }
                 }
+                canvasWebView.loadUrl(url, getReferer())
             }
-            canvasWebView.loadUrl(url, getReferer())
         }
     }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/ViewHtmlFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/ViewHtmlFragment.kt
@@ -20,36 +20,41 @@ import android.graphics.Color
 import android.os.Bundle
 import com.instructure.annotations.FileCaching.FileCache
 import com.instructure.annotations.awaitFileDownload
+import com.instructure.canvasapi2.models.CanvasContext
+import com.instructure.canvasapi2.models.FileFolder
+import com.instructure.canvasapi2.utils.ApiPrefs
+import com.instructure.canvasapi2.utils.isValid
 import com.instructure.canvasapi2.utils.weave.WeaveJob
 import com.instructure.canvasapi2.utils.weave.weave
+import com.instructure.interactions.router.Route
+import com.instructure.pandautils.models.EditableFile
 import com.instructure.pandautils.utils.*
+import com.instructure.pandautils.utils.Utils.copyToClipboard
 import com.instructure.teacher.R
 import com.instructure.teacher.events.FileFolderDeletedEvent
 import com.instructure.teacher.events.FileFolderUpdatedEvent
-import com.instructure.interactions.router.Route
-import com.instructure.pandautils.models.EditableFile
-import com.instructure.pandautils.utils.Utils.copyToClipboard
 import com.instructure.teacher.router.RouteMatcher
-import com.instructure.teacher.utils.*
+import com.instructure.teacher.utils.setupMenu
 import kotlinx.android.synthetic.main.fragment_internal_webview.*
 import org.greenrobot.eventbus.EventBus
 import java.io.File
 
 class ViewHtmlFragment : InternalWebViewFragment() {
 
-    private var mHtmlUrl by StringArg()
-    private var mJob: WeaveJob? = null
-    private var mToolbarColor by IntArg()
-    private var mEditableFile: EditableFile? by NullableParcelableArg()
+    private val downloadUrl by NullableStringArg(key = DOWNLOAD_URL)
+    private val toolbarColor by IntArg(key = TOOLBAR_COLOR)
+    private val editableFile: EditableFile? by NullableParcelableArg(key = EDITABLE_FILE)
+
+    private var job: WeaveJob? = null
 
     @Suppress("EXPERIMENTAL_FEATURE_WARNING")
     override fun onActivityCreated(savedInstanceState: Bundle?) {
-        setShouldLoadUrl(false)
+        setShouldLoadUrl(!downloadUrl.isValid())
         super.onActivityCreated(savedInstanceState)
-        mJob = weave {
+        if (downloadUrl.isValid()) job = weave {
             loading.setVisible()
             loading.announceForAccessibility(getString(R.string.loading))
-            val tempFile: File? = FileCache.awaitFileDownload(mHtmlUrl)
+            val tempFile: File? = FileCache.awaitFileDownload(downloadUrl!!)
             if (tempFile == null) {
                 toast(R.string.errorLoadingFiles)
                 activity?.onBackPressed()
@@ -67,13 +72,13 @@ class ViewHtmlFragment : InternalWebViewFragment() {
         if (fileFolderDeletedEvent != null)
             requireActivity().finish()
 
-        mEditableFile?.let {
-            setupToolbar(mToolbarColor)
+        editableFile?.let {
+            setupToolbar(toolbarColor)
         }
     }
 
     override fun setupToolbar(courseColor: Int) {
-        mEditableFile?.let {
+        editableFile?.let {
             // Check if we need to update the file name
             val fileFolderUpdatedEvent = EventBus.getDefault().getStickyEvent(FileFolderUpdatedEvent::class.java)
             fileFolderUpdatedEvent?.let { event ->
@@ -96,8 +101,8 @@ class ViewHtmlFragment : InternalWebViewFragment() {
             }
         }
 
-        if(isTablet && mToolbarColor != 0) {
-            ViewStyler.themeToolbar(requireActivity(), toolbar!!, mToolbarColor, Color.WHITE)
+        if(isTablet && toolbarColor != 0) {
+            ViewStyler.themeToolbar(requireActivity(), toolbar!!, toolbarColor, Color.WHITE)
         } else {
             super.setupToolbar(courseColor)
         }
@@ -105,16 +110,45 @@ class ViewHtmlFragment : InternalWebViewFragment() {
 
     override fun onDestroy() {
         super.onDestroy()
-        mJob?.cancel()
+        job?.cancel()
     }
 
     companion object {
-        @JvmStatic @JvmOverloads fun newInstance(htmlUrl: String, title: String, toolbarColor: Int = 0, editableFile: EditableFile? = null) = ViewHtmlFragment().apply {
-            mHtmlUrl = htmlUrl
-            this.title = title
-            mToolbarColor = toolbarColor
-            mEditableFile = editableFile
+        private const val DOWNLOAD_URL = "downloadUrl"
+        private const val TOOLBAR_COLOR = "toolbarColor"
+        private const val EDITABLE_FILE = "editableFile"
+
+        fun makeAuthSessionBundle(
+            canvasContext: CanvasContext,
+            file: FileFolder,
+            title: String,
+            toolbarColor: Int = 0,
+            editableFile: EditableFile? = null
+        ): Bundle {
+            return makeBundle(
+                url = file.getFilePreviewUrl(ApiPrefs.fullDomain, canvasContext),
+                title = title,
+                shouldAuthenticate = true
+            ).apply {
+                putInt(TOOLBAR_COLOR, toolbarColor)
+                putParcelable(EDITABLE_FILE, editableFile)
+            }
         }
+
+        @JvmStatic
+        @JvmOverloads
+        fun makeDownloadBundle(
+            downloadUrl: String,
+            title: String,
+            toolbarColor: Int = 0,
+            editableFile: EditableFile? = null
+        ) = Bundle().apply {
+            putString(DOWNLOAD_URL, downloadUrl)
+            putString(Const.TITLE, title)
+            putInt(TOOLBAR_COLOR, toolbarColor)
+            putParcelable(EDITABLE_FILE, editableFile)
+        }
+
         @JvmStatic fun newInstance(bundle: Bundle) = ViewHtmlFragment().apply { arguments = bundle }
     }
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/router/RouteMatcher.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/router/RouteMatcher.kt
@@ -472,7 +472,7 @@ object RouteMatcher : BaseRouteMatcher() {
                                 Toast.makeText(activity, activity.resources.getString(loadedMedia.errorMessage), Toast.LENGTH_LONG).show()
                             }
                         } else if (loadedMedia.isHtmlFile) {
-                            val args = ViewHtmlFragment.newInstance(loadedMedia.bundle.getString(Const.INTERNAL_URL)!!, loadedMedia.bundle.getString(Const.ACTION_BAR_TITLE)!!).nonNullArgs
+                            val args = ViewHtmlFragment.makeDownloadBundle(loadedMedia.bundle.getString(Const.INTERNAL_URL)!!, loadedMedia.bundle.getString(Const.ACTION_BAR_TITLE)!!)
                             RouteMatcher.route(activity, Route(ViewHtmlFragment::class.java, null, args))
                         } else if (loadedMedia.intent != null) {
                             if (loadedMedia.intent.type!!.contains("pdf") && !loadedMedia.isUseOutsideApps) {

--- a/apps/teacher/src/main/java/com/instructure/teacher/utils/ModelExtensions.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/utils/ModelExtensions.kt
@@ -91,7 +91,7 @@ fun viewMedia(context: Context, filename: String, contentType: String, url: Stri
         }
     // HTML
         contentType == "text/html" || extension == "htm" || extension == "html" -> {
-            val bundle = ViewHtmlFragment.newInstance(url ?: "", filename, toolbarColor, editableFile).nonNullArgs
+            val bundle = ViewHtmlFragment.makeDownloadBundle(url ?: "", filename, toolbarColor, editableFile)
             RouteMatcher.route(context, Route(null, ViewHtmlFragment::class.java, null, bundle))
         }
     // Multipart (Unknown)

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/FileFolder.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/FileFolder.kt
@@ -20,7 +20,7 @@ package com.instructure.canvasapi2.models
 import com.google.gson.annotations.SerializedName
 import com.instructure.canvasapi2.utils.NaturalOrderComparator
 import kotlinx.android.parcel.Parcelize
-import java.util.*
+import java.util.Date
 
 @Parcelize
 data class FileFolder(
@@ -84,6 +84,15 @@ data class FileFolder(
 ) : CanvasModel<FileFolder>() {
     val isRoot: Boolean get() = parentFolderId == 0L
     val isFile: Boolean get() = !displayName.isNullOrBlank()
+
+    val isHtmlFile: Boolean
+        get() = contentType?.contains("html") == true
+                || name?.endsWith(".htm") == true
+                || name?.endsWith(".html") == true
+
+    fun getFilePreviewUrl(fullDomain: String, canvasContext: CanvasContext): String {
+        return "$fullDomain${canvasContext.toAPIString()}/files/$id/preview"
+    }
 
     /* We override compareTo instead of using Canvas Comparable methods */
     override fun compareTo(other: FileFolder) = compareFiles(this, other)

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/Const.java
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/Const.java
@@ -17,8 +17,6 @@
 
 package com.instructure.pandautils.utils;
 
-import org.jetbrains.annotations.Nullable;
-
 public class Const {
     public static final String PANDA_UTILS = "panda_utils";
     public static final String PANDA_UTILS_FILE_UPLOAD_UTILS_LOG = "file_upload_utils";
@@ -105,6 +103,7 @@ public class Const {
     public static final String IS_STARRED = "isStarred";
     public static final String IS_GROUP = "isGroup";
     public static final String IS_UNSUPPORTED_FEATURE ="isUnsupportedFeature";
+    public static final String ALLOW_UNSUPPORTED_ROUTING ="allowUnsupportedRouting";
     public static final String LAYOUT_ID = "layout_id";
     public static final String MASTERY_PATH = "mastery_path";
     public static final String MEDIA_UPLOAD_ALLOWED = "isMediaUploadAllowed";


### PR DESCRIPTION
Repro steps on my sandbox (ask me for creds if needed, or see ticket for additional creds):

Student App
- Login as a student -> Change user (this clears cached cookies) -> Select previous login -> The Blue Course -> Files -> htmlpage.html
- There should be three lines of text. The first two lines should be large, italicized, and magenta. 
- The second line is styled by an external CSS file and prior to this commit was not being styled.
- The third line is a link to an assignment and should work as expected.
- Go to user files -> html -> htmlpage2.html. This should look and behave identical to the other HTML file.

Teacher
- Same as student, but log in as a teacher