### PR TITLE
[Student][MBL-13151] Fix crash when opening peer review in browser

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/NotificationListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/NotificationListFragment.kt
@@ -240,7 +240,7 @@ class NotificationListFragment : ParentFragment(), Bookmarkable {
                 }
                 COLLABORATION -> UnsupportedTabFragment.makeRoute(canvasContext, Tab.COLLABORATIONS_ID)
                 CONFERENCE -> ConferencesFragment.makeRoute(canvasContext)
-                else -> UnsupportedFeatureFragment.makeRoute(canvasContext, streamItem.type, streamItem.url)
+                else -> UnsupportedFeatureFragment.makeRoute(canvasContext, streamItem.type, streamItem.url ?: streamItem.htmlUrl)
             }
 
             if (route != null) RouteMatcher.route(context, route)


### PR DESCRIPTION
When accessing a peer review from the notifications list, clicking on "Open in Browser" would crash the app.

Repro: My sandbox -> Notification list -> "Peer Review for Peer Review Assignment" -> Open in Browser