### PR TITLE
[Parent][MBL-13081] Fix 'No Submission' on non-submittable assignments

### DIFF
--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsPresenterTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsPresenterTest.kt
@@ -221,7 +221,7 @@ class AssignmentDetailsPresenterTest : Assert() {
         val calendar = Calendar.getInstance().apply { set(2000, 0, 31, 23, 59, 0) }
 
         val submission = baseSubmission.copy(attempt = 0, workflowState = "unsubmitted")
-        val assignment = baseAssignment.copy(submission = submission, dueAt = calendar.time.toApiString())
+        val assignment = baseAssignment.copy(submission = submission, dueAt = calendar.time.toApiString(), submissionTypesRaw = listOf(Assignment.SubmissionType.ONLINE_UPLOAD.apiString))
         val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
         val state = AssignmentDetailsPresenter.present(model, context) as AssignmentDetailsViewState.Loaded
         assertEquals("Missing", state.submittedStateLabel)
@@ -231,7 +231,7 @@ class AssignmentDetailsPresenterTest : Assert() {
     fun `Uses correct label text for submitted status when submission is past due and null`() {
         val calendar = Calendar.getInstance().apply { set(2000, 0, 31, 23, 59, 0) }
 
-        val assignment = baseAssignment.copy(submission = null, dueAt = calendar.time.toApiString())
+        val assignment = baseAssignment.copy(submission = null, dueAt = calendar.time.toApiString(), submissionTypesRaw = listOf(Assignment.SubmissionType.ONLINE_UPLOAD.apiString))
         val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
         val state = AssignmentDetailsPresenter.present(model, context) as AssignmentDetailsViewState.Loaded
         assertEquals("Missing", state.submittedStateLabel)

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/AssignmentUtils2.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/AssignmentUtils2.kt
@@ -43,7 +43,7 @@ object AssignmentUtils2 {
 
         // Case - Assignment does not take submissions, but is not 'on paper' (not graded, etc) and it has not been graded
         // Result - DUE
-        if (!assignment.isOnlineSubmissionType && !assignment.getSubmissionTypes().contains(Assignment.SubmissionType.ON_PAPER) && submission?.grade == null) {
+        if (assignment.turnInType == Assignment.TurnInType.NONE && submission?.grade == null) {
             return ASSIGNMENT_STATE_DUE
         }
 

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/AssignmentUtils2.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/AssignmentUtils2.kt
@@ -17,7 +17,6 @@
 
 package com.instructure.pandautils.utils
 
-import android.util.Log
 import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.Submission
 import java.util.*
@@ -40,6 +39,12 @@ object AssignmentUtils2 {
         // Case - Error
         if (assignment == null) {
             return ASSIGNMENT_STATE_UNKNOWN
+        }
+
+        // Case - Assignment does not take submissions, but is not 'on paper' (not graded, etc) and it has not been graded
+        // Result - DUE
+        if (!assignment.isOnlineSubmissionType && !assignment.getSubmissionTypes().contains(Assignment.SubmissionType.ON_PAPER) && submission?.grade == null) {
+            return ASSIGNMENT_STATE_DUE
         }
 
         // Case - We have an assignment with no submission

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/unit/AssignmentUtils2Test.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/unit/AssignmentUtils2Test.kt
@@ -35,7 +35,7 @@ class AssignmentUtils2Test : Assert() {
 
         val testValue = AssignmentUtils2.getAssignmentState(assignment, submission)
 
-        Assert.assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_UNKNOWN.toLong())
+        assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_UNKNOWN.toLong())
     }
 
     @Test
@@ -50,7 +50,7 @@ class AssignmentUtils2Test : Assert() {
 
         val testValue = AssignmentUtils2.getAssignmentState(assignment, submission)
 
-        Assert.assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_DUE.toLong())
+        assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_DUE.toLong())
     }
 
     @Test
@@ -68,18 +68,18 @@ class AssignmentUtils2Test : Assert() {
 
         val testValue = AssignmentUtils2.getAssignmentState(assignment, submission)
 
-        Assert.assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_IN_CLASS.toLong())
+        assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_IN_CLASS.toLong())
     }
 
     @Test
     @Throws(Exception::class)
     fun getAssignmentState_stateMissingNullDueDate() {
         val submission: Submission? = null
-        val assignment = Assignment(submission = submission)
+        val assignment = Assignment(submission = submission, submissionTypesRaw = listOf(Assignment.SubmissionType.ONLINE_UPLOAD.apiString))
 
         val testValue = AssignmentUtils2.getAssignmentState(assignment, submission)
 
-        Assert.assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_MISSING.toLong())
+        assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_MISSING.toLong())
     }
 
     @Test
@@ -92,12 +92,13 @@ class AssignmentUtils2Test : Assert() {
 
         val assignment = Assignment(
             submission = submission,
-            dueAt = date.toApiString()
+            dueAt = date.toApiString(),
+            submissionTypesRaw = listOf(Assignment.SubmissionType.ONLINE_UPLOAD.apiString)
         )
 
         val testValue = AssignmentUtils2.getAssignmentState(assignment, submission)
 
-        Assert.assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_SUBMITTED.toLong())
+        assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_SUBMITTED.toLong())
     }
 
     @Test
@@ -118,7 +119,7 @@ class AssignmentUtils2Test : Assert() {
 
         val testValue = AssignmentUtils2.getAssignmentState(assignment, submission)
 
-        Assert.assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_GRADED.toLong())
+        assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_GRADED.toLong())
     }
 
     @Test
@@ -134,12 +135,13 @@ class AssignmentUtils2Test : Assert() {
 
         val assignment = Assignment(
             submission = submission,
-            dueAt = date.toApiString()
+            dueAt = date.toApiString(),
+            submissionTypesRaw = listOf(Assignment.SubmissionType.ONLINE_UPLOAD.apiString)
         )
 
         val testValue = AssignmentUtils2.getAssignmentState(assignment, submission)
 
-        Assert.assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_SUBMITTED_LATE.toLong())
+        assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_SUBMITTED_LATE.toLong())
     }
 
     @Test
@@ -162,18 +164,18 @@ class AssignmentUtils2Test : Assert() {
 
         val testValue = AssignmentUtils2.getAssignmentState(assignment, submission)
 
-        Assert.assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_GRADED_LATE.toLong())
+        assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_GRADED_LATE.toLong())
     }
 
     @Test
     @Throws(Exception::class)
     fun getAssignmentState_stateExcused() {
         val submission = Submission(excused = true)
-        val assignment = Assignment(submission = submission)
+        val assignment = Assignment(submission = submission, submissionTypesRaw = listOf(Assignment.SubmissionType.ONLINE_UPLOAD.apiString))
 
         val testValue = AssignmentUtils2.getAssignmentState(assignment, submission)
 
-        Assert.assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_EXCUSED.toLong())
+        assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_EXCUSED.toLong())
     }
 
     @Test
@@ -194,7 +196,7 @@ class AssignmentUtils2Test : Assert() {
 
         val testValue = AssignmentUtils2.getAssignmentState(assignment, submission, true)
 
-        Assert.assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_GRADED.toLong())
+        assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_GRADED.toLong())
     }
 
     @Test
@@ -215,7 +217,7 @@ class AssignmentUtils2Test : Assert() {
 
         val testValue = AssignmentUtils2.getAssignmentState(assignment, submission)
 
-        Assert.assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_SUBMITTED.toLong())
+        assertEquals("", testValue.toLong(), AssignmentUtils2.ASSIGNMENT_STATE_SUBMITTED.toLong())
     }
 
 }


### PR DESCRIPTION
On paper assignments will still show "In Class", but all other non-online submissions will not show anything. They will also show 'Submitted' if there is a grade for the assignment.

Before, they would show a big red 'Missing' label if they were past due.