### PR TITLE
Removed a few unused strings

### DIFF
--- a/libs/login-api-2/src/main/res/values/strings.xml
+++ b/libs/login-api-2/src/main/res/values/strings.xml
@@ -68,7 +68,6 @@
     <string name="loginNearYou">Near You</string>
     <string name="loginCanvasNetwork">Canvas Network</string>
     <string name="loginRightBehindYou">Right behind you</string>
-    <string name="loginMiles">%1$s miles away</string>
     <string name="loginCanvasHelp">Don\'t see your school? Enter the school URL or tap here for help.</string>
     <string name="loginCanvasHelpWithUser">Enter the school URL or tap here for help.</string>
     <string name="loginHint">Find your school or district</string>

--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -858,9 +858,6 @@
     <string name="like">like</string>
     <string name="likes">likes</string>
 
-    <string name="wear_reminder">Schedule Due Date Reminders</string>
-    <string name="wear_notifications">Turn on Wear Notifications</string>
-
     <string name="color_1">Red</string>
     <string name="color_2">Hot Pink</string>
     <string name="color_3">Lavender</string>


### PR DESCRIPTION
Apparently the translation folks were a bit confused by these strings and wanted clarity. I figured we'd remove them since they are not in use, they have been informed of this. Removing from the base file and letting the next import take care of the translations seems like the best way to handle this.