### PR TITLE
[Teacher][MBL-13199] Add post policy to toolbar in speed grader

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/adapters/SubmissionContentAdapter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/adapters/SubmissionContentAdapter.kt
@@ -28,7 +28,8 @@ import java.util.*
 class SubmissionContentAdapter(
         private val mAssignment: Assignment,
         private val mCourse: Course,
-        private val mStudentSubmissions: List<GradeableStudentSubmission>
+        private val mStudentSubmissions: List<GradeableStudentSubmission>,
+        private val newGradebookEnabled: Boolean
 ) : PagerAdapter() {
 
     var initialTabIdx = 0
@@ -36,7 +37,14 @@ class SubmissionContentAdapter(
     private val mContentMap = WeakHashMap<Int, SubmissionContentView>()
 
     override fun instantiateItem(container: ViewGroup, position: Int): Any {
-        return SubmissionContentView(container.context, mStudentSubmissions[position], mAssignment, mCourse, initialTabIdx).apply {
+        return SubmissionContentView(
+            context = container.context,
+            mStudentSubmission = mStudentSubmissions[position],
+            mAssignment = mAssignment,
+            mCourse = mCourse,
+            initialTabIndex = initialTabIdx,
+            newGradebookEnabled = newGradebookEnabled
+        ).apply {
             container.addView(this)
             mContentMap += position to this
         }
@@ -55,4 +63,7 @@ class SubmissionContentAdapter(
 
     fun hasUnsavedChanges(position: Int) = mContentMap[position]?.hasUnsavedChanges ?: false
 
+    fun invalidateSubmissionCache() {
+        mStudentSubmissions.onEach { it.isCached = false }
+    }
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/viewinterface/SpeedGraderView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/viewinterface/SpeedGraderView.kt
@@ -20,6 +20,6 @@ import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.GradeableStudentSubmission
 
 interface SpeedGraderView {
-    fun onDataSet(assignment: Assignment, submissions: List<GradeableStudentSubmission>)
+    fun onDataSet(assignment: Assignment, submissions: List<GradeableStudentSubmission>, newGradebookEnabled: Boolean)
     fun onErrorSettingData()
 }

--- a/apps/teacher/src/main/res/menu/menu_share_file.xml
+++ b/apps/teacher/src/main/res/menu/menu_share_file.xml
@@ -19,9 +19,16 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
+        android:id="@+id/menuPostPolicies"
+        android:title="@string/postPolicyTitle"
+        android:icon="@drawable/ic_eye_filled"
+        android:visible="false"
+        app:showAsAction="ifRoom" />
+
+    <item
         android:id="@+id/menu_share"
         android:title="@string/share"
-        android:visible="true"
+        android:visible="false"
         android:icon="@drawable/vd_share"
         app:showAsAction="always"/>
 


### PR DESCRIPTION
To test:
Navigate to speed grader for a course that is using the new gradebook.
Try to post/hide the grades.
Verify speed grader updates to reflect the new posted/hidden state (shows a crossed out eyeball if hidden, nothing otherwise).

- Also verify submission list updates for posted/hidden state
- Can also get to this screen from todo list
- Should also not display the post policy button in speed grader if the course is no the old gradebook.