### PR TITLE
[Student] Fix crash in compose message fragment

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/InboxComposeMessageFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/InboxComposeMessageFragment.kt
@@ -56,7 +56,7 @@ import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import java.net.URLEncoder
-import java.util.*
+import java.util.ArrayList
 
 class InboxComposeMessageFragment : ParentFragment() {
 
@@ -304,7 +304,8 @@ class InboxComposeMessageFragment : ParentFragment() {
         // Check to see if the user has made any changes
         if (editSubject.text.isNotBlank() || message.text.isNotBlank() || attachments.isNotEmpty()) {
             shouldAllowExit = false
-            UnsavedChangesExitDialog.show(requireActivity().supportFragmentManager) {
+            // Use childFragmentManager so that exiting the compose fragment also dismisses the dialog
+            UnsavedChangesExitDialog.show(childFragmentManager) {
                 shouldAllowExit = true
                 requireActivity().onBackPressed()
             }


### PR DESCRIPTION
Repro: Compose/reply to a message, tap the send button, and then quickly tap the back button to show the exit confirmation dialog. Previously this dialog would remain open after the message had successfully sent and the compose fragment had been removed, and tapping 'Exit' would then cause a crash. This change causes the confirmation dialog to be dismissed along with the compose fragment.