### PR TITLE
[Student][MBL-13200] Assignment details page: Fix submission status for graded-but-not-submitted assignments

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/AssignmentDetailsRenderTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/AssignmentDetailsRenderTest.kt
@@ -90,7 +90,7 @@ class AssignmentDetailsRenderTest : StudentRenderTest() {
     @Test
     @TestMetaData(Priority.P2, FeatureCategory.ASSIGNMENTS, TestCategory.RENDER)
     fun displaysTitleDataSubmitted() {
-        val submission = Submission(workflowState = "submitted")
+        val submission = Submission(workflowState = "submitted", submittedAt = Date())
         val assignment = Assignment(
             name = "Test Assignment",
             pointsPossible = 35.0,

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Assignment.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Assignment.kt
@@ -22,7 +22,7 @@ import com.google.gson.annotations.SerializedName
 import com.instructure.canvasapi2.R
 import com.instructure.canvasapi2.utils.toDate
 import kotlinx.android.parcel.Parcelize
-import java.util.*
+import java.util.Date
 
 @Parcelize
 data class Assignment(
@@ -105,7 +105,7 @@ data class Assignment(
 
     /**
      * Whether or not the user has submitted this assignment. If the user has not submitted anything, Canvas generates
-     * an empty submission with an "unsubmitted" workflow state. For very old assignments, canvas might not
+     * an empty submission with a null value for "submittedAt". For very old assignments, canvas might not
      * return a submission at all.
      */
     val isSubmitted: Boolean get() = submission?.submittedAt != null

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Assignment.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Assignment.kt
@@ -108,7 +108,7 @@ data class Assignment(
      * an empty submission with an "unsubmitted" workflow state. For very old assignments, canvas might not
      * return a submission at all.
      */
-    val isSubmitted: Boolean get() = submission != null && submission!!.workflowState != "unsubmitted"
+    val isSubmitted: Boolean get() = submission?.submittedAt != null
 
     val isAllowedToSubmit: Boolean
         get() {


### PR DESCRIPTION
If an assignment had been graded but was never submitted, the assignment detail page would show that status as "Submitted". This commit fixes the status for those cases and now shows either "Not Submitted" or "Missing".