### PR TITLE
[Student][RemoteConfig][MBL-12852]: Added simple Remote Config override capability

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/ApplicationSettingsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/ApplicationSettingsFragment.kt
@@ -27,6 +27,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.canvasapi2.utils.pageview.PageView
+import com.instructure.pandautils.fragments.RemoteConfigParamsFragment
 import com.instructure.pandautils.utils.*
 import com.instructure.student.BuildConfig
 import com.instructure.student.R
@@ -87,6 +88,11 @@ class ApplicationSettingsFragment : ParentFragment() {
             featureFlags.setVisible()
             featureFlags.onClick {
                 addFragment(FeatureFlagsFragment())
+            }
+
+            remoteConfigParams.setVisible()
+            remoteConfigParams.onClick {
+                addFragment(RemoteConfigParamsFragment())
             }
         }
     }

--- a/apps/student/src/main/res/layout/fragment_application_settings.xml
+++ b/apps/student/src/main/res/layout/fragment_application_settings.xml
@@ -146,6 +146,20 @@
                 android:visibility="gone"
                 tools:visibility="visible"/>
 
+            <TextView
+                android:id="@+id/remoteConfigParams"
+                style="@style/TextFont.Medium"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/listPreferredItemHeight"
+                android:background="?attr/selectableItemBackground"
+                android:gravity="center_vertical"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:text="@string/remoteConfigParamsTitle"
+                android:textSize="16sp"
+                android:visibility="gone"
+                tools:visibility="visible"/>
+
         </LinearLayout>
 
     </ScrollView>

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/fragments/RemoteConfigParamsFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/fragments/RemoteConfigParamsFragment.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2019 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.pandautils.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.RecyclerView
+import com.instructure.canvasapi2.utils.RemoteConfigParam
+import com.instructure.canvasapi2.utils.RemoteConfigPrefs
+import com.instructure.pandautils.R
+import com.instructure.pandautils.utils.onTextChanged
+import com.instructure.pandautils.utils.setupAsBackButton
+import kotlinx.android.synthetic.main.fragment_remote_config_params.*
+
+class RemoteConfigParamsFragment : Fragment() {
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.fragment_remote_config_params, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        recyclerView.adapter = RemoteConfigParamAdapter()
+        toolbar.setupAsBackButton(this)
+    }
+}
+
+private class RemoteConfigParamAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+    val params = RemoteConfigParam.values()
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val layout = LayoutInflater.from(parent.context).inflate(R.layout.adapter_remote_config_param, parent, false)
+        return object : RecyclerView.ViewHolder(layout) {}
+    }
+
+    override fun getItemCount(): Int = params.size
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        val param = params[position]
+        with (holder.itemView) {
+            val nameLabel = findViewById<TextView>(R.id.param_name)
+            val valueEditText = findViewById<EditText>(R.id.param_value)
+            nameLabel.text = param.rc_name + ": "
+            valueEditText.text.insert(0, RemoteConfigPrefs.getString(param.rc_name, param.safeValueAsString))
+            valueEditText.onTextChanged { newText ->
+                RemoteConfigPrefs.putString(param.rc_name, newText)
+            }
+        }
+    }
+
+}

--- a/libs/pandautils/src/main/res/layout/adapter_remote_config_param.xml
+++ b/libs/pandautils/src/main/res/layout/adapter_remote_config_param.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2019 - present Instructure, Inc.
+  ~
+  ~     This program is free software: you can redistribute it and/or modify
+  ~     it under the terms of the GNU General Public License as published by
+  ~     the Free Software Foundation, version 3 of the License.
+  ~
+  ~     This program is distributed in the hope that it will be useful,
+  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~     GNU General Public License for more details.
+  ~
+  ~     You should have received a copy of the GNU General Public License
+  ~     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/param_name"/>
+
+    <EditText
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:id="@+id/param_value"/>
+
+</LinearLayout>

--- a/libs/pandautils/src/main/res/layout/fragment_remote_config_params.xml
+++ b/libs/pandautils/src/main/res/layout/fragment_remote_config_params.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2019 - present Instructure, Inc.
+  ~
+  ~     This program is free software: you can redistribute it and/or modify
+  ~     it under the terms of the GNU General Public License as published by
+  ~     the Free Software Foundation, version 3 of the License.
+  ~
+  ~     This program is distributed in the hope that it will be useful,
+  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~     GNU General Public License for more details.
+  ~
+  ~     You should have received a copy of the GNU General Public License
+  ~     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/white"
+        android:elevation="6dp"
+        app:title="@string/remoteConfigParamsTitle"
+        app:titleTextColor="@color/defaultTextDark"/>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        tools:listitem="@layout/adapter_remote_config_param"
+        android:padding="16dp"/>
+
+</LinearLayout>

--- a/libs/pandautils/src/main/res/values/strings_no_translate.xml
+++ b/libs/pandautils/src/main/res/values/strings_no_translate.xml
@@ -22,5 +22,5 @@
     <string name="utils_mobileSupportEmailAddress" translatable="false">mobilesupport@instructure.com</string>
     <string name="utils_supportEmailAddress" translatable="false">support@instructure.com</string>
     <string name="utils_dotWithSpaces" translatable="false">\u0020\u0020\u2022\u0020\u0020</string>
-
+    <string name="remoteConfigParamsTitle" translatable="false">Remote Config Params</string>
 </resources>


### PR DESCRIPTION
I added a UI for applying local overrides to Remote Config parameters, found in the settings menu next to Feature Flag functionality.  This allows developers to mess with the local settings of Remote Config parameters w/o messing with our global settings.

Some notes:
--The UI is drop-dead simple (and possibly ugly and inefficient).  But it only shows up in debug builds, and it gets the job done.
--I believe that parameter override(s) will persist until the next time that the app re-reads the Remote Config params from firebase.  That's about once per hour according to our current settings.
--I put as much of the logic as I could in the pandautils lib, so it shouldn't be too hard to duplicate this functionality in teacher and parent.