### PR TITLE
MBL-13216: Tagged some fragments for New Relic interaction tracing

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/ApplicationSettingsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/ApplicationSettingsFragment.kt
@@ -36,6 +36,7 @@ import com.instructure.student.activity.SettingsActivity
 import com.instructure.student.dialog.HelpDialogStyled
 import com.instructure.student.dialog.LegalDialogStyled
 import com.instructure.student.util.Analytics
+import com.newrelic.agent.android.NewRelic
 import kotlinx.android.synthetic.main.dialog_about.*
 import kotlinx.android.synthetic.main.fragment_application_settings.*
 
@@ -43,6 +44,11 @@ import kotlinx.android.synthetic.main.fragment_application_settings.*
 class ApplicationSettingsFragment : ParentFragment() {
 
     override fun title(): String = getString(R.string.settings)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        NewRelic.setInteractionName(this::class.java.simpleName)
+        super.onCreate(savedInstanceState)
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             inflater.inflate(R.layout.fragment_application_settings, container, false)

--- a/apps/student/src/main/java/com/instructure/student/fragment/AssignmentListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/AssignmentListFragment.kt
@@ -39,6 +39,7 @@ import com.instructure.student.adapter.TermSpinnerAdapter
 import com.instructure.student.interfaces.AdapterToAssignmentsCallback
 import com.instructure.student.mobius.assignmentDetails.ui.AssignmentDetailsFragment
 import com.instructure.student.router.RouteMatcher
+import com.newrelic.agent.android.NewRelic
 import kotlinx.android.synthetic.main.assignment_list_layout.*
 
 @PageView(url = "{canvasContext}/assignments")
@@ -83,6 +84,11 @@ class AssignmentListFragment : ParentFragment(), Bookmarkable {
     override fun title(): String = getString(R.string.assignments)
 
     override fun getSelectedParamName() = RouterParams.ASSIGNMENT_ID
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        NewRelic.setInteractionName(this::class.java.simpleName)
+        super.onCreate(savedInstanceState)
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             inflater.inflate(R.layout.assignment_list_layout, container, false)

--- a/apps/student/src/main/java/com/instructure/student/fragment/CalendarEventFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/CalendarEventFragment.kt
@@ -40,6 +40,7 @@ import com.instructure.student.R
 import com.instructure.student.events.CalendarEventDestroyed
 import com.instructure.student.events.post
 import com.instructure.student.router.RouteMatcher
+import com.newrelic.agent.android.NewRelic
 import kotlinx.android.synthetic.main.calendar_event_layout.*
 import kotlinx.android.synthetic.main.fragment_calendar_event.*
 import org.greenrobot.eventbus.EventBus
@@ -59,6 +60,11 @@ class CalendarEventFragment : ParentFragment() {
     private lateinit var deleteItemCallback: StatusCallback<ScheduleItem>
 
     //region Fragment Lifecycle Overrides
+    override fun onCreate(savedInstanceState: Bundle?) {
+        NewRelic.setInteractionName(this::class.java.simpleName)
+        super.onCreate(savedInstanceState)
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             inflater?.inflate(R.layout.fragment_calendar_event, container, false)
 

--- a/apps/student/src/main/java/com/instructure/student/fragment/CalendarListViewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/CalendarListViewFragment.kt
@@ -48,6 +48,7 @@ import com.instructure.student.util.Analytics
 import com.instructure.student.util.CanvasCalendarUtils
 import com.instructure.student.util.StudentPrefs
 import com.instructure.student.view.ViewUtils
+import com.newrelic.agent.android.NewRelic
 import com.roomorama.caldroid.CaldroidListener
 import hirondelle.date4j.DateTime
 import kotlinx.android.extensions.CacheImplementation
@@ -110,6 +111,7 @@ class CalendarListViewFragment : ParentFragment() {
     override fun title() = getString(R.string.calendar)
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        NewRelic.setInteractionName(this::class.java.simpleName)
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
         // Most of this will never get called since we are using

--- a/apps/student/src/main/java/com/instructure/student/fragment/CourseBrowserFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/CourseBrowserFragment.kt
@@ -48,6 +48,7 @@ import com.instructure.student.util.Const
 import com.instructure.student.util.DisableableAppBarLayoutBehavior
 import com.instructure.student.util.StudentPrefs
 import com.instructure.student.util.TabHelper
+import com.newrelic.agent.android.NewRelic
 import kotlinx.android.synthetic.main.fragment_course_browser.*
 import kotlinx.android.synthetic.main.view_course_browser_header.*
 import kotlinx.coroutines.Job
@@ -63,6 +64,11 @@ class CourseBrowserFragment : Fragment(), FragmentInteractions, AppBarLayout.OnO
 
     override val navigation: Navigation?
         get() = if (activity is Navigation) activity as Navigation else null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        NewRelic.setInteractionName(this::class.java.simpleName)
+        super.onCreate(savedInstanceState)
+    }
 
     //region Fragment Lifecycle Overrides
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =

--- a/apps/student/src/main/java/com/instructure/student/fragment/DashboardFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/DashboardFragment.kt
@@ -50,6 +50,7 @@ import com.instructure.student.events.CourseColorOverlayToggledEvent
 import com.instructure.student.events.ShowGradesToggledEvent
 import com.instructure.student.interfaces.CourseAdapterToFragmentCallback
 import com.instructure.student.router.RouteMatcher
+import com.newrelic.agent.android.NewRelic
 import kotlinx.android.synthetic.main.fragment_course_grid.*
 import kotlinx.android.synthetic.main.panda_recycler_refresh_layout.*
 import org.greenrobot.eventbus.EventBus
@@ -74,8 +75,14 @@ class DashboardFragment : ParentFragment() {
 
     override fun title(): String = if (isAdded) getString(R.string.dashboard) else ""
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        NewRelic.setInteractionName(this::class.java.simpleName)
+        super.onCreate(savedInstanceState)
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
-            layoutInflater.inflate(R.layout.fragment_course_grid, container, false)
+        layoutInflater.inflate(R.layout.fragment_course_grid, container, false)
+
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)

--- a/apps/student/src/main/java/com/instructure/student/fragment/DiscussionDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/DiscussionDetailsFragment.kt
@@ -56,6 +56,7 @@ import com.instructure.student.events.ModuleUpdatedEvent
 import com.instructure.student.events.post
 import com.instructure.student.router.RouteMatcher
 import com.instructure.student.util.Const
+import com.newrelic.agent.android.NewRelic
 import kotlinx.android.synthetic.main.fragment_discussions_details.*
 import kotlinx.coroutines.Job
 import org.greenrobot.eventbus.EventBus
@@ -97,6 +98,11 @@ class DiscussionDetailsFragment : ParentFragment(), Bookmarkable {
     //endregion
 
     //region Fragment Lifecycle Overrides
+    override fun onCreate(savedInstanceState: Bundle?) {
+        NewRelic.setInteractionName(this::class.java.simpleName)
+        super.onCreate(savedInstanceState)
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             layoutInflater.inflate(R.layout.fragment_discussions_details, container, false)
 

--- a/apps/student/src/main/java/com/instructure/student/fragment/DiscussionListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/DiscussionListFragment.kt
@@ -49,6 +49,7 @@ import com.instructure.student.events.DiscussionTopicHeaderDeletedEvent
 import com.instructure.student.events.DiscussionTopicHeaderEvent
 import com.instructure.student.events.DiscussionUpdatedEvent
 import com.instructure.student.router.RouteMatcher
+import com.newrelic.agent.android.NewRelic
 import kotlinx.android.synthetic.main.course_discussion_topic.*
 import kotlinx.coroutines.Job
 import org.greenrobot.eventbus.EventBus
@@ -73,6 +74,7 @@ open class DiscussionListFragment : ParentFragment(), Bookmarkable {
 
     //region Fragment Lifecycle Overrides
     override fun onCreate(savedInstanceState: Bundle?) {
+        NewRelic.setInteractionName(this::class.java.simpleName)
         super.onCreate(savedInstanceState)
         checkForPermission()
         retainInstance = true

--- a/apps/student/src/main/java/com/instructure/student/fragment/GradesListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/GradesListFragment.kt
@@ -46,6 +46,7 @@ import com.instructure.student.dialog.WhatIfDialogStyled
 import com.instructure.student.interfaces.AdapterToFragmentCallback
 import com.instructure.student.mobius.assignmentDetails.ui.AssignmentDetailsFragment
 import com.instructure.student.router.RouteMatcher
+import com.newrelic.agent.android.NewRelic
 import kotlinx.android.synthetic.main.fragment_course_grades.*
 import retrofit2.Response
 import java.math.BigDecimal
@@ -75,6 +76,7 @@ class GradesListFragment : ParentFragment(), Bookmarkable {
     override fun getSelectedParamName(): String = RouterParams.ASSIGNMENT_ID
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        NewRelic.setInteractionName(this::class.java.simpleName)
         super.onCreate(savedInstanceState)
         allTermsGradingPeriod = GradingPeriod()
         allTermsGradingPeriod.title = getString(R.string.allGradingPeriods)

--- a/apps/student/src/main/java/com/instructure/student/fragment/InboxComposeMessageFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/InboxComposeMessageFragment.kt
@@ -51,6 +51,7 @@ import com.instructure.student.events.ConversationUpdatedEvent
 import com.instructure.student.events.MessageAddedEvent
 import com.instructure.student.router.RouteMatcher
 import com.instructure.student.view.AttachmentView
+import com.newrelic.agent.android.NewRelic
 import kotlinx.android.synthetic.main.fragment_inbox_compose_message.*
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
@@ -129,6 +130,7 @@ class InboxComposeMessageFragment : ParentFragment() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        NewRelic.setInteractionName(this::class.java.simpleName)
         super.onCreate(savedInstanceState)
         selectedContext = nonNullArgs.getParcelable(Const.CANVAS_CONTEXT)
     }

--- a/apps/student/src/main/java/com/instructure/student/fragment/InboxFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/InboxFragment.kt
@@ -40,6 +40,7 @@ import com.instructure.student.dialog.CanvasContextListDialog
 import com.instructure.student.events.ConversationUpdatedEvent
 import com.instructure.student.interfaces.AdapterToFragmentCallback
 import com.instructure.student.router.RouteMatcher
+import com.newrelic.agent.android.NewRelic
 import kotlinx.android.synthetic.main.fragment_inbox.*
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
@@ -102,6 +103,12 @@ class InboxFragment : ParentFragment() {
         }
 
     }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        NewRelic.setInteractionName(this::class.java.simpleName)
+        super.onCreate(savedInstanceState)
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val rootView = layoutInflater.inflate(R.layout.fragment_inbox, container, false)
         adapter = InboxAdapter(requireContext(), adapterToFragmentCallback)

--- a/apps/student/src/main/java/com/instructure/student/fragment/ModuleListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/ModuleListFragment.kt
@@ -40,6 +40,7 @@ import com.instructure.student.interfaces.ModuleAdapterToFragmentCallback
 import com.instructure.student.router.RouteMatcher
 import com.instructure.student.util.ModuleProgressionUtility
 import com.instructure.student.util.ModuleUtility
+import com.newrelic.agent.android.NewRelic
 import kotlinx.android.synthetic.main.fragment_module_list.*
 import kotlinx.android.synthetic.main.panda_recycler_refresh_layout.*
 import org.greenrobot.eventbus.EventBus
@@ -69,6 +70,7 @@ class ModuleListFragment : ParentFragment(), Bookmarkable {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        NewRelic.setInteractionName(this::class.java.simpleName)
         super.onCreate(savedInstanceState)
         retainInstance = true
     }

--- a/apps/student/src/main/java/com/instructure/student/fragment/NotificationListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/NotificationListFragment.kt
@@ -39,6 +39,7 @@ import com.instructure.student.adapter.NotificationListRecyclerAdapter
 import com.instructure.student.interfaces.NotificationAdapterToFragmentCallback
 import com.instructure.student.mobius.assignmentDetails.ui.AssignmentDetailsFragment
 import com.instructure.student.router.RouteMatcher
+import com.newrelic.agent.android.NewRelic
 import kotlinx.android.synthetic.main.fragment_list_notification.*
 import kotlinx.android.synthetic.main.panda_recycler_refresh_layout.*
 
@@ -97,6 +98,11 @@ class NotificationListFragment : ParentFragment(), Bookmarkable {
 
 
     override fun title(): String = getString(if (canvasContext.isCourse || canvasContext.isGroup) R.string.homePageIdForNotifications else R.string.notifications)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        NewRelic.setInteractionName(this::class.java.simpleName)
+        super.onCreate(savedInstanceState)
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View?
             = layoutInflater.inflate(R.layout.fragment_list_notification, container, false)

--- a/apps/student/src/main/java/com/instructure/student/fragment/PeopleListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/PeopleListFragment.kt
@@ -32,6 +32,7 @@ import com.instructure.student.R
 import com.instructure.student.adapter.PeopleListRecyclerAdapter
 import com.instructure.student.interfaces.AdapterToFragmentCallback
 import com.instructure.student.router.RouteMatcher
+import com.newrelic.agent.android.NewRelic
 import kotlinx.android.synthetic.main.fragment_people_list.*
 
 @PageView(url = "{canvasContext}/users")
@@ -56,6 +57,11 @@ class PeopleListFragment : ParentFragment(), Bookmarkable {
     }
 
     override fun title(): String = getString(R.string.coursePeople)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        NewRelic.setInteractionName(this::class.java.simpleName)
+        super.onCreate(savedInstanceState)
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return layoutInflater.inflate(R.layout.fragment_people_list, container, false)

--- a/apps/student/src/main/java/com/instructure/student/fragment/QuizListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/QuizListFragment.kt
@@ -36,6 +36,7 @@ import com.instructure.student.R
 import com.instructure.student.adapter.QuizListRecyclerAdapter
 import com.instructure.student.interfaces.AdapterToFragmentCallback
 import com.instructure.student.router.RouteMatcher
+import com.newrelic.agent.android.NewRelic
 import kotlinx.android.synthetic.main.panda_recycler_refresh_layout.*
 import kotlinx.android.synthetic.main.quiz_list_layout.*
 
@@ -57,6 +58,11 @@ class QuizListFragment : ParentFragment(), Bookmarkable {
                 setEmptyView(emptyView, R.drawable.vd_panda_quizzes_rocket, R.string.noQuizzes, R.string.noQuizzesSubtext)
             }
         }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        NewRelic.setInteractionName(this::class.java.simpleName)
+        super.onCreate(savedInstanceState)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? = layoutInflater.inflate(R.layout.quiz_list_layout, container, false)

--- a/apps/student/src/main/java/com/instructure/student/fragment/ToDoListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/ToDoListFragment.kt
@@ -37,6 +37,7 @@ import com.instructure.student.adapter.TodoListRecyclerAdapter
 import com.instructure.student.interfaces.NotificationAdapterToFragmentCallback
 import com.instructure.student.mobius.assignmentDetails.ui.AssignmentDetailsFragment
 import com.instructure.student.router.RouteMatcher
+import com.newrelic.agent.android.NewRelic
 import kotlinx.android.synthetic.main.fragment_list_todo.*
 import kotlinx.android.synthetic.main.fragment_list_todo.view.*
 import kotlinx.android.synthetic.main.panda_recycler_refresh_layout.*
@@ -71,6 +72,11 @@ class ToDoListFragment : ParentFragment() {
     }
 
     override fun title(): String = getString(R.string.Todo)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        NewRelic.setInteractionName(this::class.java.simpleName)
+        super.onCreate(savedInstanceState)
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val rootView = layoutInflater.inflate(R.layout.fragment_list_todo, container, false)

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsFragment.kt
@@ -16,6 +16,7 @@
  */
 package com.instructure.student.mobius.assignmentDetails.ui
 
+import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.instructure.canvasapi2.CanvasRestAdapter
@@ -30,6 +31,7 @@ import com.instructure.interactions.router.RouterParams
 import com.instructure.pandautils.utils.*
 import com.instructure.student.mobius.assignmentDetails.*
 import com.instructure.student.mobius.common.ui.MobiusFragment
+import com.newrelic.agent.android.NewRelic
 
 @PageView(url = "{canvasContext}/assignments/{assignmentId}")
 class AssignmentDetailsFragment :
@@ -47,6 +49,11 @@ class AssignmentDetailsFragment :
         }
 
     val canvasContext by ParcelableArg<Course>(key = Const.CANVAS_CONTEXT)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        NewRelic.setInteractionName(this::class.java.simpleName)
+        super.onCreate(savedInstanceState)
+    }
 
     @get:PageViewUrlParam(name = "assignmentId")
     val assignmentId by LongArg(key = Const.ASSIGNMENT_ID)

--- a/apps/student/src/main/java/com/instructure/student/mobius/syllabus/ui/SyllabusFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/syllabus/ui/SyllabusFragment.kt
@@ -16,6 +16,7 @@
  */
 package com.instructure.student.mobius.syllabus.ui
 
+import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.instructure.canvasapi2.models.Course
@@ -24,11 +25,17 @@ import com.instructure.interactions.router.Route
 import com.instructure.pandautils.utils.*
 import com.instructure.student.mobius.common.ui.MobiusFragment
 import com.instructure.student.mobius.syllabus.*
+import com.newrelic.agent.android.NewRelic
 
 @PageView(url = "{canvasContext}/assignments/syllabus")
 class SyllabusFragment : MobiusFragment<SyllabusModel, SyllabusEvent, SyllabusEffect, SyllabusView, SyllabusViewState>() {
 
     val canvasContext by ParcelableArg<Course>(key = Const.CANVAS_CONTEXT)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        NewRelic.setInteractionName(this::class.java.simpleName)
+        super.onCreate(savedInstanceState)
+    }
 
     override fun makeEffectHandler() = SyllabusEffectHandler()
 


### PR DESCRIPTION
Absent these tags, New Relic will consider each fragment/activity/interaction to be called "Display ComponentActivity".  We add these tags to differentiate between fragments/activities for the purpose of interaction tracking in New Relic.

Please let me know if you can think of other fragments that should be tagged like this.