### PR TITLE
[Student][MBL-13261] Fix Google Apps LTI Auth

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
@@ -94,6 +94,7 @@ open class InternalWebviewFragment : ParentFragment() {
         with(rootView) {
             canvasWebView.settings.loadWithOverviewMode = true
             canvasWebView.setInitialScale(100)
+            canvasWebView.settings.userAgentString = ApiPrefs.userAgent
 
             canvasWebView.canvasWebChromeClientCallback = CanvasWebView.CanvasWebChromeClientCallback { _, newProgress ->
                 if (newProgress == 100) {

--- a/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
@@ -93,8 +93,8 @@ open class InternalWebviewFragment : ParentFragment() {
 
         with(rootView) {
             canvasWebView.settings.loadWithOverviewMode = true
-            canvasWebView.setInitialScale(100)
             canvasWebView.settings.userAgentString = ApiPrefs.userAgent
+            canvasWebView.setInitialScale(100)
 
             canvasWebView.canvasWebChromeClientCallback = CanvasWebView.CanvasWebChromeClientCallback { _, newProgress ->
                 if (newProgress == 100) {

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/InternalWebViewFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/InternalWebViewFragment.kt
@@ -120,6 +120,7 @@ open class InternalWebViewFragment : BaseFragment() {
         canvasWebView.settings.loadWithOverviewMode = true
         canvasWebView.settings.displayZoomControls = false
         canvasWebView.settings.setSupportZoom(true)
+        canvasWebView.settings.userAgentString = ApiPrefs.userAgent
         canvasWebView.addVideoClient(requireActivity())
         canvasWebView.setInitialScale(100)
 


### PR DESCRIPTION
Since 2017, Google has blocked WebViews from accessing their auth stuff. What they didn't count on was devs changing their user agent string...

(See ticket for repro creds)