### PR TITLE
[Teacher][MBL-13285] Allow teachers with only unpublished courses

### DIFF
--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/CoursesListPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/CoursesListPageTest.kt
@@ -52,4 +52,14 @@ class CoursesListPageTest : TeacherTest() {
 
         coursesListPage.assertHasCourses(data.favoriteCourses)
     }
+
+    @Test
+    @Ditto
+    fun displaysCourseListWithOnlyUnpublishedCourses() {
+        val data = seedData(teachers = 1, courses = 1, publishCourses = false)
+        val teacher = data.teachersList[0]
+        tokenLogin(teacher)
+
+        coursesListPage.assertHasCourses(data.coursesList)
+    }
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/utils/TeacherTestExtensions.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/utils/TeacherTestExtensions.kt
@@ -107,7 +107,8 @@ fun TeacherTest.seedData(
         announcements: Int = 0,
         discussions: Int = 0,
         gradingPeriods: Boolean = false,
-        pastCourses: Int = 0): SeedApi.SeededDataApiModel {
+        pastCourses: Int = 0,
+        publishCourses: Boolean = true): SeedApi.SeededDataApiModel {
 
     val request = SeedApi.SeedDataRequest(
             teachers = teachers,

--- a/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/api/CoursesApi.kt
+++ b/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/api/CoursesApi.kt
@@ -49,19 +49,20 @@ object CoursesApi {
     private fun coursesService(token: String): CoursesService
             = CanvasRestAdapter.retrofitWithToken(token).create(CoursesService::class.java)
 
-    fun createCourse(enrollmentTermId: Long? = null): CourseApiModel {
+    fun createCourse(enrollmentTermId: Long? = null, publish: Boolean = true): CourseApiModel {
         val randomCourseName = Randomizer.randomCourseName()
         val course = CreateCourseWrapper(
-                CreateCourse(
-                        name = randomCourseName,
-                        courseCode = randomCourseName.substring(0, 2),
-                        enrollmentTermId = enrollmentTermId
-                )
+            offer = publish,
+            course = CreateCourse(
+                name = randomCourseName,
+                courseCode = randomCourseName.substring(0, 2),
+                enrollmentTermId = enrollmentTermId
+            )
         )
         return adminCoursesService
-                .createCourse(course)
-                .execute()
-                .body()!!
+            .createCourse(course)
+            .execute()
+            .body()!!
     }
 
     fun concludeCourse(courseId: Long) {

--- a/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/api/SeedApi.kt
+++ b/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/api/SeedApi.kt
@@ -34,7 +34,8 @@ object SeedApi {
             val favoriteCourses: Int = 0,
             val gradingPeriods: Boolean = false,
             val discussions: Int = 0,
-            val announcements: Int = 0
+            val announcements: Int = 0,
+            val publishCourses: Boolean = true
     )
 
     // Seed data object/model, made to look very much like the old proto-generated SeededData class
@@ -92,7 +93,7 @@ object SeedApi {
         with(seededData) {
             for (c in 0 until maxOf(request.courses + request.pastCourses, request.favoriteCourses)) {
                 // Seed course
-                addCourses(createCourse(request.gradingPeriods))
+                addCourses(createCourse(request.gradingPeriods, request.publishCourses))
 
                 // Seed users
                 for (t in 0 until request.teachers) {
@@ -195,12 +196,12 @@ object SeedApi {
     }
 
     // Private course-creation method that does some special handling for grading periods
-    private fun createCourse(gradingPeriods: Boolean = false) : CourseApiModel {
+    private fun createCourse(gradingPeriods: Boolean = false, publishCourses: Boolean = true) : CourseApiModel {
         return if(gradingPeriods) {
             val enrollmentTerm = EnrollmentTermsApi.createEnrollmentTerm()
             val gradingPeriodSetWrapper = GradingPeriodsApi.createGradingPeriodSet(enrollmentTerm.id)
             val gradingPeriodSet = GradingPeriodsApi.createGradingPeriod(gradingPeriodSetWrapper.gradingPeriodSet.id)
-            val courseWithTerm = CoursesApi.createCourse(enrollmentTerm.id)
+            val courseWithTerm = CoursesApi.createCourse(enrollmentTerm.id, publishCourses)
             courseWithTerm
         }
         else {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CourseAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CourseAPI.kt
@@ -58,7 +58,7 @@ object CourseAPI {
         @GET
         fun next(@Url nextURL: String): Call<List<Course>>
 
-        @GET("courses?state[]=completed&state[]=available")
+        @GET("courses?state[]=completed&state[]=available&state[]=unpublished")
         fun getCoursesByEnrollmentType(@Query("enrollment_type") type: String): Call<List<Course>>
 
         // TODO: Set up pagination when API is fixed and remove per_page query parameterø


### PR DESCRIPTION
To test:

Create an unpublished course with a new teacher that is only for unpublished courses. Login to the app. The current version will take you the the "Not a teacher" page, this patch allows those teachers to login to the app again.