### PR TITLE
[Student][MBL-13260] Fix non native quizzes from assignments

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsView.kt
@@ -265,7 +265,11 @@ class AssignmentDetailsView(
 
     fun showQuizStartView(canvasContext: CanvasContext, quiz: Quiz) {
         logEvent(AnalyticsEventConstants.ASSIGNMENT_DETAIL_QUIZLAUNCH)
-        RouteMatcher.route(context, QuizStartFragment.makeRoute(canvasContext, quiz))
+        if (QuizListFragment.isNativeQuiz(canvasContext, quiz)) {
+            RouteMatcher.route(context, QuizStartFragment.makeRoute(canvasContext, quiz))
+        } else {
+            RouteMatcher.route(context, BasicQuizViewFragment.makeRoute(canvasContext, quiz, quiz.url!!))
+        }
     }
 
     fun showDiscussionDetailView(canvasContext: CanvasContext, discussionTopicHeaderId: Long) {


### PR DESCRIPTION
To test:
See ticket details, but basically any non native quiz was routing to the QuizStartFragment, which should only be navigated to if we have a native quiz. Otherwise, our BasicQuizViewFragment handles displaying quiz content that has web content.