### PR TITLE
[Student][MBL-13267] Graded non-gradeable assignment push notification work around

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsModels.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsModels.kt
@@ -91,5 +91,6 @@ data class AssignmentDetailsModel(
     val quizResult: DataResult<Quiz>? = null,
     val ltiTool: DataResult<LTITool>? = null,
     val databaseSubmission: Submission? = null,
-    val videoFileUri: Uri? = null
+    val videoFileUri: Uri? = null,
+    var shouldRouteToSubmissionDetails: Boolean = false
 )

--- a/apps/student/src/main/java/com/instructure/student/router/RouteMatcher.kt
+++ b/apps/student/src/main/java/com/instructure/student/router/RouteMatcher.kt
@@ -159,7 +159,8 @@ object RouteMatcher : BaseRouteMatcher() {
         // Submissions
         // :sliding_tab_type can be /rubric or /submissions (used to navigate to the nested fragment)
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/assignments/:${RouterParams.ASSIGNMENT_ID}/:${RouterParams.SLIDING_TAB_TYPE}"), AssignmentDetailsFragment::class.java, SubmissionDetailsFragment::class.java))
-        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/assignments/:${RouterParams.ASSIGNMENT_ID}/:${RouterParams.SLIDING_TAB_TYPE}/:${RouterParams.SUBMISSION_ID}"), AssignmentDetailsFragment::class.java, SubmissionDetailsFragment::class.java))
+        // Route to Assignment Details first - no submission/on paper assignments won't have grades on the Submission Details page, but we also need to account for routing to submission comments (Assignment Details will check for that)
+        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/assignments/:${RouterParams.ASSIGNMENT_ID}/:${RouterParams.SLIDING_TAB_TYPE}/:${RouterParams.SUBMISSION_ID}"), AssignmentDetailsFragment::class.java))
 
         // Settings
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/settings"), CourseSettingsFragment::class.java))

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsUpdateTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsUpdateTest.kt
@@ -489,6 +489,39 @@ class AssignmentDetailsUpdateTest : Assert() {
     }
 
     @Test
+    fun `DataLoaded event with shouldRouteToSubmissionDetails = true, updates model and sends ShowSubmissionView effect`() {
+        val assignment = Assignment(id = assignmentId)
+        val submission = mockkSubmission()
+        val startModel = initModel.copy(shouldRouteToSubmissionDetails = true)
+        val expectedModel = initModel.copy(
+            isLoading = false,
+            assignmentResult = DataResult.Success(assignment),
+            isStudioEnabled = true,
+            ltiTool = DataResult.Fail(null),
+            databaseSubmission = submission,
+            shouldRouteToSubmissionDetails = false
+        )
+        updateSpec
+            .given(startModel)
+            .whenEvent(
+                AssignmentDetailsEvent.DataLoaded(
+                    assignmentResult = expectedModel.assignmentResult,
+                    isStudioEnabled = true,
+                    studioLTIToolResult = null,
+                    ltiToolResult = expectedModel.ltiTool,
+                    submission = submission,
+                    quizResult = null
+                )
+            )
+            .then(
+                assertThatNext(
+                    NextMatchers.hasModel(expectedModel),
+                    matchesEffects<AssignmentDetailsModel, AssignmentDetailsEffect>(AssignmentDetailsEffect.ShowSubmissionView(expectedModel.assignmentId, expectedModel.course))
+                )
+            )
+    }
+
+    @Test
     fun `SubmissionStatusUpdated event updates the model`() {
         val submission = mockkSubmission()
         val startModel = initModel

--- a/apps/student/src/test/java/com/instructure/student/test/util/RouterUtilsTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/util/RouterUtilsTest.kt
@@ -41,36 +41,36 @@ class RouterUtilsTest : TestCase() {
     @Test
     fun testCanRouteInternally_misc() {
         // Home
-        TestCase.assertTrue(callCanRouteInternally("http://mobiledev.instructure.com"))
+        assertTrue(callCanRouteInternally("http://mobiledev.instructure.com"))
 
         //  Login
-        TestCase.assertFalse(callCanRouteInternally("http://mobiledev.instructure.com/login"))
+        assertFalse(callCanRouteInternally("http://mobiledev.instructure.com/login"))
     }
 
     @Test
     fun testCanRouteInternally_notSupported() {
-        TestCase.assertTrue(callCanRouteInternally("https://mobiledev.instructure.com/courses/833052/media_download?"))
+        assertTrue(callCanRouteInternally("https://mobiledev.instructure.com/courses/833052/media_download?"))
     }
 
     @Test
     fun testCanRouteInternally_courseIdParseCorrect() {
-        TestCase.assertEquals(833052L, BaseRouterActivity.parseCourseId("833052"))
+        assertEquals(833052L, BaseRouterActivity.parseCourseId("833052"))
     }
 
     @Test
     fun testCanRouteInternally_courseIdParseWrong() {
         // Written due to a crash found by Crashlytics
         // See: https://fabric.io/instructure/android/apps/com.instructure.candroid/issues/5a69f6858cb3c2fa63977be1?time=1509408000000%3A1517270399999
-        TestCase.assertNull(BaseRouterActivity.parseCourseId("sis_course_id:833"))
+        assertNull(BaseRouterActivity.parseCourseId("sis_course_id:833"))
     }
 
     @Test
     fun testCanRouteInternally() {
         // Since there is a catch all, anything with the correct domain returns true.
-        TestCase.assertTrue(callCanRouteInternally("https://mobiledev.instructure.com/calendar2?include_contexts=course_833052#view_name=month&view_start=2015-03-19T06%3A00%3A00.000Z"))
-        TestCase.assertTrue(callCanRouteInternally("https://mobiledev.instructure.com/courses/833052/calendar_events/921098"))
+        assertTrue(callCanRouteInternally("https://mobiledev.instructure.com/calendar2?include_contexts=course_833052#view_name=month&view_start=2015-03-19T06%3A00%3A00.000Z"))
+        assertTrue(callCanRouteInternally("https://mobiledev.instructure.com/courses/833052/calendar_events/921098"))
 
-        TestCase.assertFalse(callCanRouteInternally("http://google.com/courses/54564/"))
+        assertFalse(callCanRouteInternally("http://google.com/courses/54564/"))
 
     }
 
@@ -86,45 +86,45 @@ class RouterUtilsTest : TestCase() {
     @Test
     fun testGetInternalRoute_supportedDomain() {
         var route = callGetInternalRoute("https://instructure.com")
-        TestCase.assertNull(route)
+        assertNull(route)
 
         route = callGetInternalRoute("https://mobiledev.instructure.com")
-        TestCase.assertNotNull(route)
+        assertNotNull(route)
 
         route = callGetInternalRoute("https://canvas.net")
-        TestCase.assertNull(route)
+        assertNull(route)
 
         route = callGetInternalRoute("https://canvas.net/courses/12344")
-        TestCase.assertNull(route)
+        assertNull(route)
     }
 
     @Test
     fun testGetInternalRoute_nonSupportedDomain() {
         var route = callGetInternalRoute("https://google.com")
-        TestCase.assertNull(route)
+        assertNull(route)
 
         route = callGetInternalRoute("https://youtube.com")
-        TestCase.assertNull(route)
+        assertNull(route)
 
         route = callGetInternalRoute("https://aFakeWebsite.com/courses/12344")
-        TestCase.assertNull(route)
+        assertNull(route)
     }
 
     @Test
     fun testGetInternalRoute_calendar() {
         var route = callGetInternalRoute("https://mobiledev.instructure.com/calendar2?include_contexts=course_833052#view_name=month&view_start=2015-03-19T06%3A00%3A00.000Z")
-        TestCase.assertNotNull(route)
+        assertNotNull(route)
         // TODO add test for calendar
         //assertEquals(CalendarEventFragment.class, route.getMasterCls());
 
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/833052/calendar_events/921098")
-        TestCase.assertNotNull(route)
+        assertNotNull(route)
     }
 
     @Test
     fun testGetInternalRoute_externalTools() {
         val route = callGetInternalRoute("https://mobiledev.instructure.com/courses/833052/external_tools/131971")
-        TestCase.assertNotNull(route)
+        assertNotNull(route)
 
     }
 
@@ -133,314 +133,314 @@ class RouterUtilsTest : TestCase() {
 
         // Courses
         var route = callGetInternalRoute("https://mobiledev.instructure.com/courses/833052/files/63383591/download?wrap=1")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(RouteContext.FILE, route!!.routeContext)
+        assertNotNull(route)
+        assertEquals(RouteContext.FILE, route!!.routeContext)
 
         var expectedParams = HashMap<String, String>()
         expectedParams[RouterParams.COURSE_ID] = "833052"
         expectedParams[RouterParams.FILE_ID] = "63383591"
-        TestCase.assertEquals(expectedParams, route.paramsHash)
+        assertEquals(expectedParams, route.paramsHash)
 
         val expectedQueryParams = HashMap<String, String>()
         expectedQueryParams["wrap"] = "1"
-        TestCase.assertEquals(expectedQueryParams, route.queryParamsHash)
+        assertEquals(expectedQueryParams, route.queryParamsHash)
 
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/833052/files/63383591")
-        TestCase.assertNotNull(route) // route is not supported
-        TestCase.assertEquals(null, route!!.primaryClass)
+        assertNotNull(route) // route is not supported
+        assertEquals(null, route!!.primaryClass)
 
 
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/833052/files/63383591/download?verifier=12344556")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(RouteContext.FILE, route!!.routeContext)
+        assertNotNull(route)
+        assertEquals(RouteContext.FILE, route!!.routeContext)
 
         // Files
         route = callGetInternalRoute("https://mobiledev.instructure.com/files/63383591/download?wrap=1")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(RouteContext.FILE, route!!.routeContext)
+        assertNotNull(route)
+        assertEquals(RouteContext.FILE, route!!.routeContext)
 
         expectedParams = HashMap()
         expectedParams[RouterParams.FILE_ID] = "63383591"
-        TestCase.assertEquals(expectedParams, route.paramsHash)
+        assertEquals(expectedParams, route.paramsHash)
 
-        TestCase.assertEquals(expectedQueryParams, route.queryParamsHash)
+        assertEquals(expectedQueryParams, route.queryParamsHash)
 
         route = callGetInternalRoute("https://mobiledev.instructure.com/files/63383591")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(FileListFragment::class.java, route!!.primaryClass)
+        assertNotNull(route)
+        assertEquals(FileListFragment::class.java, route!!.primaryClass)
 
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/833052/files/63383591/download?verifier=12344556")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(RouteContext.FILE, route!!.routeContext)
+        assertNotNull(route)
+        assertEquals(RouteContext.FILE, route!!.routeContext)
     }
 
     @Test
     fun testGetInternalRoute_conversation() {
         var route = callGetInternalRoute("https://mobiledev.instructure.com/conversations/")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(InboxFragment::class.java, route!!.primaryClass)
+        assertNotNull(route)
+        assertEquals(InboxFragment::class.java, route!!.primaryClass)
 
         // Detailed Conversation
         route = callGetInternalRoute("https://mobiledev.instructure.com/conversations/1078680")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(InboxConversationFragment::class.java, route!!.primaryClass)
+        assertNotNull(route)
+        assertEquals(InboxConversationFragment::class.java, route!!.primaryClass)
 
         val expectedParams = HashMap<String, String>()
         expectedParams[RouterParams.CONVERSATION_ID] = "1078680"
-        TestCase.assertEquals(expectedParams, route.paramsHash)
+        assertEquals(expectedParams, route.paramsHash)
     }
 
     @Test
     fun testGetInternalRoute_modules() {
         var route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/modules")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(ModuleListFragment::class.java, route!!.primaryClass)
+        assertNotNull(route)
+        assertEquals(ModuleListFragment::class.java, route!!.primaryClass)
 
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/modules/48753")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(ModuleListFragment::class.java, route!!.primaryClass)
+        assertNotNull(route)
+        assertEquals(ModuleListFragment::class.java, route!!.primaryClass)
 
         // Discussion
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/24219/discussion_topics/1129998?module_item_id=12345")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(ModuleListFragment::class.java, route!!.primaryClass)
-        TestCase.assertEquals(CourseModuleProgressionFragment::class.java, route.secondaryClass)
+        assertNotNull(route)
+        assertEquals(ModuleListFragment::class.java, route!!.primaryClass)
+        assertEquals(CourseModuleProgressionFragment::class.java, route.secondaryClass)
 
         val expectedQueryParams = HashMap<String, String>()
         expectedQueryParams[RouterParams.MODULE_ITEM_ID] = "12345"
-        TestCase.assertEquals(expectedQueryParams, route.queryParamsHash)
+        assertEquals(expectedQueryParams, route.queryParamsHash)
 
         // Pages
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/24219/pages/1129998?module_item_id=12345")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(ModuleListFragment::class.java, route!!.primaryClass)
-        TestCase.assertEquals(CourseModuleProgressionFragment::class.java, route.secondaryClass)
-        TestCase.assertEquals(expectedQueryParams, route.queryParamsHash)
+        assertNotNull(route)
+        assertEquals(ModuleListFragment::class.java, route!!.primaryClass)
+        assertEquals(CourseModuleProgressionFragment::class.java, route.secondaryClass)
+        assertEquals(expectedQueryParams, route.queryParamsHash)
 
         // Quizzes
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/24219/quizzes/1129998?module_item_id=12345")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(ModuleListFragment::class.java, route!!.primaryClass)
-        TestCase.assertEquals(CourseModuleProgressionFragment::class.java, route.secondaryClass)
-        TestCase.assertEquals(expectedQueryParams, route.queryParamsHash)
+        assertNotNull(route)
+        assertEquals(ModuleListFragment::class.java, route!!.primaryClass)
+        assertEquals(CourseModuleProgressionFragment::class.java, route.secondaryClass)
+        assertEquals(expectedQueryParams, route.queryParamsHash)
 
         // Assignments
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/24219/assignments/1129998?module_item_id=12345")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(ModuleListFragment::class.java, route!!.primaryClass)
-        TestCase.assertEquals(CourseModuleProgressionFragment::class.java, route.secondaryClass)
-        TestCase.assertEquals(expectedQueryParams, route.queryParamsHash)
+        assertNotNull(route)
+        assertEquals(ModuleListFragment::class.java, route!!.primaryClass)
+        assertEquals(CourseModuleProgressionFragment::class.java, route.secondaryClass)
+        assertEquals(expectedQueryParams, route.queryParamsHash)
 
         // Files
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/24219/files/1129998?module_item_id=12345")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(ModuleListFragment::class.java, route!!.primaryClass)
-        TestCase.assertEquals(CourseModuleProgressionFragment::class.java, route.secondaryClass)
-        TestCase.assertEquals(expectedQueryParams, route.queryParamsHash)
+        assertNotNull(route)
+        assertEquals(ModuleListFragment::class.java, route!!.primaryClass)
+        assertEquals(CourseModuleProgressionFragment::class.java, route.secondaryClass)
+        assertEquals(expectedQueryParams, route.queryParamsHash)
     }
 
     @Test
     fun testGetInternalRoute_notifications() {
         val route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/notifications")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(NotificationListFragment::class.java, route!!.primaryClass)
+        assertNotNull(route)
+        assertEquals(NotificationListFragment::class.java, route!!.primaryClass)
 
         val expectedParams = HashMap<String, String>()
         expectedParams[RouterParams.COURSE_ID] = "836357"
-        TestCase.assertEquals(expectedParams, route.paramsHash)
+        assertEquals(expectedParams, route.paramsHash)
     }
 
     @Test
     fun testGetInternalRoute_grades() {
         val route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/grades")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(GradesListFragment::class.java, route!!.primaryClass)
+        assertNotNull(route)
+        assertEquals(GradesListFragment::class.java, route!!.primaryClass)
 
         val expectedParams = HashMap<String, String>()
         expectedParams[RouterParams.COURSE_ID] = "836357"
-        TestCase.assertEquals(expectedParams, route.paramsHash)
+        assertEquals(expectedParams, route.paramsHash)
     }
 
     @Test
     fun testGetInternalRoute_users() {
         var route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/users")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(PeopleListFragment::class.java, route!!.primaryClass)
+        assertNotNull(route)
+        assertEquals(PeopleListFragment::class.java, route!!.primaryClass)
 
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/users/1234")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(PeopleListFragment::class.java, route!!.primaryClass)
-        TestCase.assertEquals(PeopleDetailsFragment::class.java, route.secondaryClass)
+        assertNotNull(route)
+        assertEquals(PeopleListFragment::class.java, route!!.primaryClass)
+        assertEquals(PeopleDetailsFragment::class.java, route.secondaryClass)
 
         val expectedParams = HashMap<String, String>()
         expectedParams[RouterParams.COURSE_ID] = "836357"
         expectedParams[RouterParams.USER_ID] = "1234"
-        TestCase.assertEquals(expectedParams, route.paramsHash)
+        assertEquals(expectedParams, route.paramsHash)
     }
 
     @Test
     fun testGetInternalRoute_discussion() {
         var route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/discussion_topics")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(DiscussionListFragment::class.java, route!!.primaryClass)
+        assertNotNull(route)
+        assertEquals(DiscussionListFragment::class.java, route!!.primaryClass)
 
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/discussion_topics/1234")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(DiscussionListFragment::class.java, route!!.primaryClass)
-        TestCase.assertEquals(DiscussionDetailsFragment::class.java, route.secondaryClass)
+        assertNotNull(route)
+        assertEquals(DiscussionListFragment::class.java, route!!.primaryClass)
+        assertEquals(DiscussionDetailsFragment::class.java, route.secondaryClass)
 
         val expectedParams = HashMap<String, String>()
         expectedParams[RouterParams.COURSE_ID] = "836357"
         expectedParams[RouterParams.MESSAGE_ID] = "1234"
-        TestCase.assertEquals(expectedParams, route.paramsHash)
+        assertEquals(expectedParams, route.paramsHash)
 
     }
 
     @Test
     fun testGetInternalRoute_pages() {
         var route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/pages")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(PageListFragment::class.java, route!!.primaryClass)
+        assertNotNull(route)
+        assertEquals(PageListFragment::class.java, route!!.primaryClass)
 
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/pages/hello")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(PageListFragment::class.java, route!!.primaryClass)
-        TestCase.assertEquals(PageDetailsFragment::class.java, route.secondaryClass)
+        assertNotNull(route)
+        assertEquals(PageListFragment::class.java, route!!.primaryClass)
+        assertEquals(PageDetailsFragment::class.java, route.secondaryClass)
 
         val expectedParams = HashMap<String, String>()
         expectedParams[RouterParams.COURSE_ID] = "836357"
         expectedParams[RouterParams.PAGE_ID] = "hello"
-        TestCase.assertEquals(expectedParams, route.paramsHash)
+        assertEquals(expectedParams, route.paramsHash)
     }
 
     @Test
     fun testGetInternalRoute_announcements() {
         var route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/announcements")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(AnnouncementListFragment::class.java, route!!.primaryClass)
+        assertNotNull(route)
+        assertEquals(AnnouncementListFragment::class.java, route!!.primaryClass)
 
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/announcements/12345")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(AnnouncementListFragment::class.java, route!!.primaryClass)
-        TestCase.assertEquals(DiscussionDetailsFragment::class.java, route.secondaryClass)
+        assertNotNull(route)
+        assertEquals(AnnouncementListFragment::class.java, route!!.primaryClass)
+        assertEquals(DiscussionDetailsFragment::class.java, route.secondaryClass)
 
         val expectedParams = HashMap<String, String>()
         expectedParams[RouterParams.COURSE_ID] = "836357"
         expectedParams[RouterParams.MESSAGE_ID] = "12345"
-        TestCase.assertEquals(expectedParams, route.paramsHash)
+        assertEquals(expectedParams, route.paramsHash)
     }
 
     @Test
     fun testGetInternalRoute_quiz() {
         var route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/quizzes")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(QuizListFragment::class.java, route!!.primaryClass)
+        assertNotNull(route)
+        assertEquals(QuizListFragment::class.java, route!!.primaryClass)
 
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/quizzes/12345")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(QuizListFragment::class.java, route!!.primaryClass)
-        TestCase.assertEquals(BasicQuizViewFragment::class.java, route.secondaryClass)
+        assertNotNull(route)
+        assertEquals(QuizListFragment::class.java, route!!.primaryClass)
+        assertEquals(BasicQuizViewFragment::class.java, route.secondaryClass)
 
         val expectedParams = HashMap<String, String>()
         expectedParams[RouterParams.COURSE_ID] = "836357"
         expectedParams[RouterParams.QUIZ_ID] = "12345"
-        TestCase.assertEquals(expectedParams, route.paramsHash)
+        assertEquals(expectedParams, route.paramsHash)
     }
 
     @Test
     fun testGetInternalRoute_syllabus() {
         val route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/assignments/syllabus")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(SyllabusFragment::class.java, route!!.primaryClass)
+        assertNotNull(route)
+        assertEquals(SyllabusFragment::class.java, route!!.primaryClass)
 
         val expectedParams = HashMap<String, String>()
         expectedParams[RouterParams.COURSE_ID] = "836357"
-        TestCase.assertEquals(expectedParams, route.paramsHash)
+        assertEquals(expectedParams, route.paramsHash)
     }
 
     @Test
     fun testGetInternalRoute_assignments() {
         var route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/assignments/")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(AssignmentListFragment::class.java, route!!.primaryClass)
+        assertNotNull(route)
+        assertEquals(AssignmentListFragment::class.java, route!!.primaryClass)
 
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/assignments/213445213445213445213445213445213445213445213445213445213445213445213445")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(AssignmentListFragment::class.java, route!!.primaryClass)
-        TestCase.assertEquals(AssignmentDetailsFragment::class.java, route.secondaryClass)
+        assertNotNull(route)
+        assertEquals(AssignmentListFragment::class.java, route!!.primaryClass)
+        assertEquals(AssignmentDetailsFragment::class.java, route.secondaryClass)
 
         val expectedParams = HashMap<String, String>()
         expectedParams[RouterParams.COURSE_ID] = "836357"
         expectedParams[RouterParams.ASSIGNMENT_ID] = "213445213445213445213445213445213445213445213445213445213445213445213445"
-        TestCase.assertEquals(expectedParams, route.paramsHash)
+        assertEquals(expectedParams, route.paramsHash)
     }
 
     @Test
     fun testGetInternalRoute_submissions_rubric() {
         // TODO: This test needs to change when we remove the assignment feature flag
         var route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/assignments/12345/rubric")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(AssignmentDetailsFragment::class.java, route!!.primaryClass)
-        TestCase.assertEquals(SubmissionDetailsFragment::class.java, route.secondaryClass)
+        assertNotNull(route)
+        assertEquals(AssignmentDetailsFragment::class.java, route!!.primaryClass)
+        assertEquals(SubmissionDetailsFragment::class.java, route.secondaryClass)
 
         var expectedParams = HashMap<String, String>()
         expectedParams[RouterParams.COURSE_ID] = "836357"
         expectedParams[RouterParams.ASSIGNMENT_ID] = "12345"
         expectedParams[RouterParams.SLIDING_TAB_TYPE] = "rubric"
-        TestCase.assertEquals(expectedParams, route.paramsHash)
+        assertEquals(expectedParams, route.paramsHash)
 
 
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/assignments/213445213445213445213445213445213445213445213445213445213445213445213445/submissions/1234")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(AssignmentDetailsFragment::class.java, route!!.primaryClass)
-        TestCase.assertEquals(SubmissionDetailsFragment::class.java, route.secondaryClass)
+        assertNotNull(route)
+        assertEquals(AssignmentDetailsFragment::class.java, route!!.primaryClass)
+        assertEquals(null, route.secondaryClass)
 
         expectedParams = HashMap()
         expectedParams[RouterParams.COURSE_ID] = "836357"
         expectedParams[RouterParams.ASSIGNMENT_ID] = "213445213445213445213445213445213445213445213445213445213445213445213445"
         expectedParams[RouterParams.SLIDING_TAB_TYPE] = "submissions"
         expectedParams[RouterParams.SUBMISSION_ID] = "1234"
-        TestCase.assertEquals(expectedParams, route.paramsHash)
+        assertEquals(expectedParams, route.paramsHash)
     }
 
     @Test
     fun testGetInternalRoute_settings() {
         val route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/settings/")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(CourseSettingsFragment::class.java, route!!.primaryClass)
+        assertNotNull(route)
+        assertEquals(CourseSettingsFragment::class.java, route!!.primaryClass)
 
         val expectedParams = HashMap<String, String>()
         expectedParams[RouterParams.COURSE_ID] = "836357"
-        TestCase.assertEquals(expectedParams, route.paramsHash)
+        assertEquals(expectedParams, route.paramsHash)
     }
 
     @Test
     fun testGetInternalRoute_unsupported() {
         var route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/collaborations/")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(UnsupportedTabFragment::class.java, route!!.primaryClass)
+        assertNotNull(route)
+        assertEquals(UnsupportedTabFragment::class.java, route!!.primaryClass)
         //        assertEquals(Tab.COLLABORATIONS_ID, route.getTabId());
         val expectedParams = HashMap<String, String>()
         expectedParams[RouterParams.COURSE_ID] = "836357"
-        TestCase.assertEquals(expectedParams, route.paramsHash)
+        assertEquals(expectedParams, route.paramsHash)
 
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/collaborations/234") // not an actual url
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(UnsupportedTabFragment::class.java, route!!.primaryClass)
+        assertNotNull(route)
+        assertEquals(UnsupportedTabFragment::class.java, route!!.primaryClass)
         //        assertEquals(Tab.COLLABORATIONS_ID, route.getTabId());
-        TestCase.assertEquals(expectedParams, route.paramsHash)
+        assertEquals(expectedParams, route.paramsHash)
 
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/outcomes/")
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(UnsupportedTabFragment::class.java, route!!.primaryClass)
+        assertNotNull(route)
+        assertEquals(UnsupportedTabFragment::class.java, route!!.primaryClass)
         //        assertEquals(Tab.OUTCOMES_ID, route.getTabId());
-        TestCase.assertEquals(expectedParams, route.paramsHash)
+        assertEquals(expectedParams, route.paramsHash)
 
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/outcomes/234") // not an actual url
-        TestCase.assertNotNull(route)
-        TestCase.assertEquals(UnsupportedTabFragment::class.java, route!!.primaryClass)
+        assertNotNull(route)
+        assertEquals(UnsupportedTabFragment::class.java, route!!.primaryClass)
         //        assertEquals(Tab.OUTCOMES_ID, route.getTabId());
-        TestCase.assertEquals(expectedParams, route.paramsHash)
+        assertEquals(expectedParams, route.paramsHash)
     }
 
     @Test
@@ -471,7 +471,7 @@ class RouterUtilsTest : TestCase() {
 
 
         val url = RouteMatcher.generateUrl(canvasContext.type, QuizListFragment::class.java, BasicQuizViewFragment::class.java, replacementParams, queryParams)
-        TestCase.assertEquals("https://mobiledev.instructure.com/courses/123/quizzes/456", url)
+        assertEquals("https://mobiledev.instructure.com/courses/123/quizzes/456", url)
     }
 
     @Test
@@ -485,6 +485,6 @@ class RouterUtilsTest : TestCase() {
         val queryParams = HashMap<String, String>()
 
         val url = RouteMatcher.generateUrl(canvasContext.type, QuizListFragment::class.java, BasicQuizViewFragment::class.java, replacementParams, queryParams)
-        TestCase.assertEquals("https://mobiledev.instructure.com/groups/123/quizzes/456", url)
+        assertEquals("https://mobiledev.instructure.com/groups/123/quizzes/456", url)
     }
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/models/PushNotification.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/models/PushNotification.kt
@@ -16,7 +16,6 @@
 
 package com.instructure.pandautils.models
 
-import android.content.Context
 import android.text.TextUtils
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken


### PR DESCRIPTION
This will also cause the app to go to the submission details page if the app is opened fresh from a push notification, then the user backs out completely and opens the app again. I don't think it's too big of an issue, but to make it stay on the assignment details page if the user opens the app again requires a bit more work (somehow modifying the fragment arguments between when it gets released from the Fragment Manager and when it gets loaded up again). I think the behavior of the app when it opens and we don't have a backstack setup is already wonky, so I didn't think this issue would be much of a problem.