### PR TITLE
[Student][MBL-13364] Fix LTI viewable when assignment is locked

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsModels.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsModels.kt
@@ -86,4 +86,5 @@ sealed class SubmissionDetailsContentType {
     data class ImageContent(val title: String, val url: String, val contentType: String) : SubmissionDetailsContentType()
     data class UrlContent(val url: String, val previewUrl: String?) : SubmissionDetailsContentType()
     data class DiscussionContent(val previewUrl: String?) : SubmissionDetailsContentType()
+    object LockedContent : SubmissionDetailsContentType()
 }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsUpdate.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsUpdate.kt
@@ -154,7 +154,11 @@ class SubmissionDetailsUpdate : UpdateInit<SubmissionDetailsModel, SubmissionDet
         return when {
             Assignment.SubmissionType.NONE.apiString in assignment?.submissionTypesRaw ?: emptyList() -> SubmissionDetailsContentType.NoneContent
             Assignment.SubmissionType.ON_PAPER.apiString in assignment?.submissionTypesRaw ?: emptyList() -> SubmissionDetailsContentType.OnPaperContent
-            Assignment.SubmissionType.EXTERNAL_TOOL.apiString in assignment?.submissionTypesRaw ?: emptyList() -> SubmissionDetailsContentType.ExternalToolContent(canvasContext, ltiUrl?.url ?: "")
+            Assignment.SubmissionType.EXTERNAL_TOOL.apiString in assignment?.submissionTypesRaw ?: emptyList() -> {
+                if (assignment?.isAllowedToSubmit == true)
+                    SubmissionDetailsContentType.ExternalToolContent(canvasContext, ltiUrl?.url ?: "")
+                else SubmissionDetailsContentType.LockedContent
+            }
             submission?.submissionType == null -> SubmissionDetailsContentType.NoSubmissionContent(canvasContext, assignment!!, isStudioEnabled!!, quiz, studioLTITool)
             submission.workflowState != "submitted" && AssignmentUtils2.getAssignmentState(assignment, submission) in listOf(AssignmentUtils2.ASSIGNMENT_STATE_MISSING, AssignmentUtils2.ASSIGNMENT_STATE_GRADED_MISSING) -> SubmissionDetailsContentType.NoSubmissionContent(canvasContext, assignment!!, isStudioEnabled!!, quiz)
             else -> when (Assignment.getSubmissionTypeFromAPIString(submission.submissionType)) {

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/ui/SubmissionDetailsView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/ui/SubmissionDetailsView.kt
@@ -32,7 +32,6 @@ import androidx.fragment.app.FragmentManager
 import com.google.android.material.tabs.TabLayout
 import com.instructure.canvasapi2.models.CanvasContext
 import com.instructure.canvasapi2.models.Course
-import com.instructure.canvasapi2.utils.Analytics
 import com.instructure.canvasapi2.utils.AnalyticsEventConstants
 import com.instructure.canvasapi2.utils.AnalyticsParamConstants
 import com.instructure.canvasapi2.utils.ApiPrefs
@@ -276,6 +275,7 @@ class SubmissionDetailsView(
             is SubmissionDetailsContentType.ImageContent -> ViewImageFragment.newInstance(type.title, Uri.parse(type.url), type.contentType, false)
             SubmissionDetailsContentType.NoneContent -> SubmissionMessageFragment.newInstance(title = R.string.noOnlineSubmissions,  subtitle = R.string.noneContentMessage)
             SubmissionDetailsContentType.OnPaperContent -> SubmissionMessageFragment.newInstance(title = R.string.noOnlineSubmissions, subtitle = R.string.onPaperContentMessage)
+            SubmissionDetailsContentType.LockedContent -> SubmissionMessageFragment.newInstance(title = R.string.submissionDetailsAssignmentLocked, subtitle = R.string.could_not_route_locked)
             is SubmissionDetailsContentType.UnsupportedContent -> {
                 // Users shouldn't get here, but we'll handle the case and send up some analytics if they do
                 val bundle = Bundle().apply {

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/submissionDetails/SubmissionDetailsUpdateTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/submissionDetails/SubmissionDetailsUpdateTest.kt
@@ -21,6 +21,7 @@ import com.instructure.canvasapi2.models.*
 import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.canvasapi2.utils.DataResult
 import com.instructure.canvasapi2.utils.Failure
+import com.instructure.canvasapi2.utils.toApiString
 import com.instructure.student.mobius.assignmentDetails.submissionDetails.*
 import com.instructure.student.test.util.matchesEffects
 import com.instructure.student.test.util.matchesFirstEffects
@@ -41,6 +42,8 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import java.io.File
+import java.util.*
+import java.util.concurrent.TimeUnit
 
 class SubmissionDetailsUpdateTest : Assert() {
 
@@ -288,6 +291,18 @@ class SubmissionDetailsUpdateTest : Assert() {
             assignment.copy(submissionTypesRaw = listOf(Assignment.SubmissionType.EXTERNAL_TOOL.apiString)),
             submission,
             SubmissionDetailsContentType.ExternalToolContent(course, ltiTool.url!!),
+            ltiTool
+        )
+    }
+
+    @Test
+    fun `EXTERNAL_TOOL with locked assignment results in SubmissionDetailsContentType of LockedContent`() {
+        verifyGetSubmissionContentType(
+            assignment.copy(
+                submissionTypesRaw = listOf(Assignment.SubmissionType.EXTERNAL_TOOL.apiString),
+                lockedForUser = true),
+            submission,
+            SubmissionDetailsContentType.LockedContent,
             ltiTool
         )
     }


### PR DESCRIPTION
LTIs are viewable from the submission details page even if the assignment is locked. This just adds in a page that will show if the assignment is locked.