### PR TITLE
[Teacher][MBL-13373] A11y - Fix hidden elements being traversed in the Attendance page

### DIFF
--- a/apps/teacher/src/main/res/layout/fragment_attendance_list.xml
+++ b/apps/teacher/src/main/res/layout/fragment_attendance_list.xml
@@ -22,6 +22,7 @@
 
     <WebView
         android:id="@+id/webView"
+        android:importantForAccessibility="no"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 


### PR DESCRIPTION
Because Attendance is an LTI, in order to create a native experience the Teacher app uses a hidden WebView for managing parts of the attendance-taking process that can't be accomplished via exposed APIs. However, this WebView was being picked up by the accessibility service and Talkback/switch controls had to traverse through the entire web page first before it could get to the native elements. This commit fixes that behavior by marking the WebView as not being important for accessibility, allowing it to be skipped by screen readers.