### PR TITLE
[Teacher][MBL-13429] A11y - Fix content descriptions for grades

### DIFF
--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/GradeCellStateTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/GradeCellStateTest.kt
@@ -129,6 +129,7 @@ class GradeCellStateTest : Assert() {
             score = "85",
             showPointsLabel = true,
             grade = "85%",
+            gradeContentDescription = "85%",
             gradeCellContentDescription = "85 Out of 100 points, 85%"
         )
         val actual = GradeCellViewState.fromSubmission(context, assignment, submission)
@@ -211,7 +212,31 @@ class GradeCellStateTest : Assert() {
             score = "85",
             showPointsLabel = true,
             grade = "B+",
+            gradeContentDescription = "B+",
             gradeCellContentDescription = "85 Out of 100 points, B+"
+        )
+        val actual = GradeCellViewState.fromSubmission(context, assignment, submission)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Returns correct state for 'Letter Grade' grading type with minus`() {
+        val assignment = baseAssignment.copy(
+            gradingType = Assignment.LETTER_GRADE_TYPE
+        )
+        val submission = baseSubmission.copy(
+            grade = "A-",
+            enteredGrade = "A-",
+            enteredScore = 91.0,
+            score = 91.0
+        )
+        val expected = baseGradedState.copy(
+            graphPercent = 0.91f,
+            score = "91",
+            showPointsLabel = true,
+            grade = "A-",
+            gradeContentDescription = "A. minus",
+            gradeCellContentDescription = "91 Out of 100 points, A. minus"
         )
         val actual = GradeCellViewState.fromSubmission(context, assignment, submission)
         assertEquals(expected, actual)
@@ -230,6 +255,7 @@ class GradeCellStateTest : Assert() {
             score = "85",
             showPointsLabel = true,
             grade = "3.8 GPA",
+            gradeContentDescription = "3.8 GPA",
             gradeCellContentDescription = "85 Out of 100 points, 3.8 GPA"
         )
         val actual = GradeCellViewState.fromSubmission(context, assignment, submission)
@@ -300,7 +326,7 @@ class GradeCellStateTest : Assert() {
                 score = "88",
                 showPointsLabel = true,
                 grade = "B",
-                gradeContentDescription = "", // We don't need one for regular letter grades
+                gradeContentDescription = "B",
                 gradeCellContentDescription = "88 Out of 100 points, B"
         )
         val actual = GradeCellViewState.fromSubmission(context, assignment, submission)

--- a/apps/teacher/src/main/java/com/instructure/teacher/adapters/StudentContextFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/adapters/StudentContextFragment.kt
@@ -179,17 +179,25 @@ class StudentContextFragment : PresenterFragment<StudentContextPresenter, Studen
 
             if (gradeBeforePostingText == gradeAfterPostingText) {
                 gradeBeforePosting.text = gradeBeforePostingText
+                gradeBeforePosting.contentDescription =
+                    getContentDescriptionForMinusGradeString(gradeBeforePostingText, requireContext())
                 gradeBeforePostingLabel.setText(R.string.currentGrade)
                 gradeAfterPostingContainer.setGone()
             } else {
                 gradeBeforePosting.text = gradeBeforePostingText
+                gradeBeforePosting.contentDescription =
+                    getContentDescriptionForMinusGradeString(gradeBeforePostingText, requireContext())
                 gradeAfterPosting.text = gradeAfterPostingText
+                gradeAfterPosting.contentDescription =
+                    getContentDescriptionForMinusGradeString(gradeAfterPostingText, requireContext())
             }
 
             // Override Grade
             val overrideText = enrollmentGrades?.let { it.overrideGrade ?: it.overrideScore?.toString() }
             if (overrideText.isValid()) {
                 gradeOverride.text = overrideText
+                gradeOverride.contentDescription =
+                    getContentDescriptionForMinusGradeString(overrideText, requireContext())
             } else {
                 gradeOverrideContainer.setGone()
             }

--- a/apps/teacher/src/main/java/com/instructure/teacher/holders/GradeableStudentSubmissionViewHolder.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/holders/GradeableStudentSubmissionViewHolder.kt
@@ -28,13 +28,7 @@ import com.instructure.canvasapi2.models.GroupAssignee
 import com.instructure.canvasapi2.models.StudentAssignee
 import com.instructure.canvasapi2.utils.NumberHelper
 import com.instructure.interactions.router.Route
-import com.instructure.pandautils.utils.ProfileUtils
-import com.instructure.pandautils.utils.ThemePrefs
-import com.instructure.pandautils.utils.ViewStyler
-import com.instructure.pandautils.utils.onClick
-import com.instructure.pandautils.utils.setGone
-import com.instructure.pandautils.utils.setVisible
-import com.instructure.pandautils.utils.setupAvatarA11y
+import com.instructure.pandautils.utils.*
 import com.instructure.teacher.R
 import com.instructure.teacher.adapters.StudentContextFragment
 import com.instructure.teacher.router.RouteMatcher
@@ -118,6 +112,8 @@ class GradeableStudentSubmissionViewHolder(view: View) : RecyclerView.ViewHolder
                             } catch(e: NumberFormatException) {
                                 // Grade is a letter or text grade
                                 submissionGrade.text = submission.grade
+                                submissionGrade.contentDescription =
+                                    getContentDescriptionForMinusGradeString(submission.grade.orEmpty(), context)
                             }
                         }
                     }

--- a/apps/teacher/src/main/java/com/instructure/teacher/holders/StudentContextSubmissionView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/holders/StudentContextSubmissionView.kt
@@ -29,7 +29,7 @@ import com.instructure.pandautils.utils.setVisible
 import com.instructure.teacher.R
 import com.instructure.teacher.utils.getAssignmentIcon
 import com.instructure.teacher.utils.getColorCompat
-import com.instructure.teacher.utils.getGradeText
+import com.instructure.teacher.utils.getDisplayGrade
 import com.instructure.teacher.utils.getResForSubmission
 import kotlinx.android.synthetic.main.adapter_student_context_submission.view.*
 
@@ -59,7 +59,7 @@ class StudentContextSubmissionView(context: Context, submission: StudentContextC
         // Submission grade
         if (submission.gradingStatus == "excused" || submission.gradingStatus == "graded") {
             val pointsPossible = submission.assignment?.pointsPossible ?: 0.0
-            val grade = getGradeText(
+            val displayGrade = getDisplayGrade(
                 context = context,
                 gradingStatus = submission.gradingStatus,
                 gradingType = submission.assignment?.gradingType?.name?.toLowerCase().orEmpty(),
@@ -71,7 +71,8 @@ class StudentContextSubmissionView(context: Context, submission: StudentContextC
                 includePointsPossible = false,
                 includeLatePenalty = false
             )
-            submissionGradeView.text = grade.takeUnless { it == "null" } ?: ""
+            submissionGradeView.text = displayGrade.text
+            submissionGradeView.contentDescription = displayGrade.contentDescription
             scoreBar.progress = ((submission.score ?: 0.0) / pointsPossible).toFloat()
         } else {
             submissionGradeContainer.setGone()

--- a/apps/teacher/src/main/java/com/instructure/teacher/utils/AssignmentExtensions.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/utils/AssignmentExtensions.kt
@@ -182,7 +182,7 @@ fun Assignment.getDisplayGrade(
             //edge case, NOT_GRADED type with grade, it COULD happen
             Assignment.GradingType.NOT_GRADED -> DisplayGrade(context.getString(R.string.not_graded))
             else ->{
-                var grade = submission.grade
+                var grade = submission.grade.takeUnless { it == "null" }.orEmpty()
                 if (this.gradingType == Assignment.PERCENT_TYPE) {
                     try {
                         val value: Double = if(includeLatePenalty) submission.enteredGrade?.removeSuffix("%")?.toDouble() as Double else submission.grade?.removeSuffix("%")?.toDouble() as Double
@@ -202,7 +202,7 @@ fun Assignment.getDisplayGrade(
                         getPointsFractionWithGrade(context, submission.score, this.pointsPossible, grade)
                     }
                 } else {
-                    DisplayGrade(grade.orEmpty())
+                    DisplayGrade(grade)
                 }
             }
 
@@ -248,7 +248,7 @@ fun getDisplayGrade(
         // Edge case, NOT_GRADED type with grade, it COULD happen
             Assignment.GradingType.NOT_GRADED -> DisplayGrade(context.getString(R.string.not_graded))
             else -> {
-                var formattedGrade = grade.orEmpty()
+                var formattedGrade = grade.takeUnless { it == "null" }.orEmpty()
                 if (gradingType == Assignment.PERCENT_TYPE) {
                     try {
                         val value: Double = if (includeLatePenalty) {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/A11yUtils.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/A11yUtils.kt
@@ -46,7 +46,7 @@ fun getContentDescriptionForMinusGradeString(grade: String, context: Context): S
         context.getString(
                 R.string.a11y_gradeLetterMinusContentDescription,
                 grade.substringBefore("-"))
-    } else ""
+    } else grade
 }
 
 

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/DisplayGrade.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/DisplayGrade.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2019 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package com.instructure.pandautils.utils
+
+data class DisplayGrade(
+    val text: String = "",
+    val contentDescription: String = text
+)


### PR DESCRIPTION
Originally this PR was attempting to consolidate grade formatting across all apps, but due to the scope of that task it has been moved to a [separate ticket](https://instructure.atlassian.net/browse/MBL-13435). This PR simply adds stronger typing to some existing logic (`Pair<String, String>` -> `DisplayGrade`) and ensures that grades in the Teacher app now use appropriate content descriptions.