### PR TITLE
[Student][InteractionTests][MBL-13451]: Hack for supporting mocked Webview calls

### DIFF
--- a/automation/canvas_espresso/build.gradle
+++ b/automation/canvas_espresso/build.gradle
@@ -77,4 +77,8 @@ dependencies {
     api('com.github.instructure:espresso:1.0.2') {
         exclude module: 'kotlin-stdlib'
     }
+    /* Mock web server */
+    //implementation("com.squareup.okhttp3:mockwebserver:4.2.1") // Later version causes build conflicts
+    implementation("com.squareup.okhttp3:mockwebserver:3.13.1")
+
 }


### PR DESCRIPTION
MockWebServer allows us to spin up a mock server that actually binds to an address/port (e.g.,  http://localhost:41634).  We can then intercept every request to that server and mock a response.

So how do we get Webviews to direct their calls to our mock server?  It seems that every time we show content in an internal webview, we issue a /login/session_token call to make sure that the session is properly set up.  That call has a "return_to" query parameter that contains the url that the webview would like to load.  Normally, we echo back that "return_to" parameter in the /login/session_token response.  But for this hack we return a url in which we substitute the MockWebServer host for the original host of the "return_to" parameter, and then catch and process the request in our MockWebServer dispatcher.

So this url:
https://mock-data.instructure.com/courses/1/files/2/preview
gets converted to this url:
http://localhost:41634/courses/1/files/2/preview

And we are able to detect and handle the mutated call in our MockWebServer dispatcher.

It works for the test that I was writing (CourseInteractionTest.testCourse_openFile).  Will it work for all future test scenarios?  Unknown, but it seems promising.  We may have to tweak as we go.