### PR TITLE
[Student][MBL-13405] Fix flakey drawer test

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/SubmissionDetailsRenderTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/SubmissionDetailsRenderTest.kt
@@ -19,7 +19,6 @@ import android.content.pm.ActivityInfo
 import android.os.SystemClock.sleep
 import androidx.test.espresso.action.GeneralLocation
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.instructure.canvas.espresso.Stub
 import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.models.Submission
@@ -228,8 +227,6 @@ class SubmissionDetailsRenderTest : StudentRenderTest() {
         submissionDetailsRenderPage.assertDisplaysDrawerContent()
     }
 
-    // MBL-13405: Stubbing out this test until we fix the underlying bug
-    @Stub
     @Test
     fun updatesDrawerHeightOnOrientationChangeToLandscape() {
         loadPageWithModel(
@@ -243,17 +240,12 @@ class SubmissionDetailsRenderTest : StudentRenderTest() {
         )
         submissionDetailsRenderPage.swipeDrawerTo(GeneralLocation.CENTER)
         submissionDetailsRenderPage.assertDisplaysDrawerContent()
+
         // SENSOR_LANDSCAPE guarantees that your screen won't flip if you were already in landscape
         activityRule.activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
-        // Speculative fix for intermittent failures.  The orientation-changing operation above
-        // seems to be asynchronous in nature, so it may be at any stage of completion before the
-        // next line is executed.  Add a delay to ensure that the orientation-change completed.
-        sleep(3000)
         submissionDetailsRenderPage.assertDisplaysDrawerContent()
     }
 
-    // MBL-13405: Stubbing out this test until we fix the underlying bug
-    @Stub
     @Test
     fun updatesDrawerHeightOnOrientationChangeToPortrait() {
         loadPageWithModel(
@@ -267,9 +259,9 @@ class SubmissionDetailsRenderTest : StudentRenderTest() {
         )
         submissionDetailsRenderPage.swipeDrawerTo(GeneralLocation.TOP_CENTER)
         submissionDetailsRenderPage.assertDisplaysDrawerContent()
+
         // SENSOR_PORTRAIT guarantees that your screen won't flip if you were already in portrait
         activityRule.activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
-        sleep(3000) // See explanation in Landscape version of this test
         submissionDetailsRenderPage.assertDisplaysDrawerContent()
     }
 
@@ -285,7 +277,7 @@ class SubmissionDetailsRenderTest : StudentRenderTest() {
         }
         activityRule.activity.loadFragment(fragment)
 
-        if( (model.assignmentResult?.isSuccess ?: false) && (model.rootSubmissionResult?.isSuccess ?: false) ) {
+        if ((model.assignmentResult?.isSuccess ?: false) && (model.rootSubmissionResult?.isSuccess ?: false)) {
             submissionDetailsRenderPage.waitForDrawerRender()
         }
     }


### PR DESCRIPTION
This was caused by the SlidingUpPanelLayout not using the correct type of animators, meaning that espresso couldn’t tell when it was “idle”. We were changing orientation while the layout was still “dragging”, and then fell back to it’s default state when showing in the new orientation (which is “collapsed”).