### PR TITLE
[Parent][MBL-13481] Support flutter localizations

### DIFF
--- a/apps/flutter_parent/README.md
+++ b/apps/flutter_parent/README.md
@@ -14,3 +14,57 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter, view our
 [online documentation](https://flutter.dev/docs), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Localization
+
+Localization is not built in to flutter like it is with native Android.
+Instead, we need to use the `intl` and `flutter_localizations` libraries.
+This will allow us to have different translations being used depending
+on the users locale.
+
+It's pretty easy to use, once set up. To add a new string, create a new
+getter in `lib/i10n/app_localizations.dart` that looks something like this:
+```
+  // The 'name' field must match the function name, and is optional unless arguments are part of the string resource
+
+  String get myCoolNewString {
+    return Intl.message('Cool string here', name: 'myCoolNewString', desc: 'A description to help translators');
+  }
+```
+
+Then, to use the newly created string, access it like so using a BuildContext:
+```
+final alertTabLabel = AppLocalizations.of(context).myCoolNewString;
+```
+
+That is the basics of using the `intl` library for localized strings!
+
+### Automating Imports
+Generated files are created through a dev dependency of `intl_translation`.
+
+The base strings are held in `lib/i10n/res/intl_messages.arb` and each
+translation is held in `lib/i10n/res/intl_*.arb` where * is the language
+identifier. e.g., `intl_en_unimelb_AU.arb` has the locale identifier
+`en_unimelb_AU`.
+
+Linking the translations back in will generate a
+`lib/i10n/generated/messages_*.dart` for each `intl_*.arb` that is
+provided. It will also generate a `messages_all.dart` to be able to
+actually perform the lookups. The `AppLocalization#load` function hooks
+into this by calling `initializeMessages` from the `messages_all.dart` file.
+
+Command Line Usage:
+
+Update the base intl_messages file for translators by running this
+command from the project root:
+```
+flutter pub run intl_translation:extract_to_arb --output-dir=lib/l10n/res lib/l10n/app_localizations.dart
+```
+
+Once intl_messages has been created, it can be sent to translators where
+they will create all the other `intl_*.arb` files. To link translations
+back into the project once translators finish the translations, run this
+command:
+```
+flutter pub run intl_translation:generate_from_arb --output-dir=lib/l10n/generated --no-use-deferred-loading lib/l10n/app_localizations.dart lib/l10n/res/intl_*.arb
+```

--- a/apps/flutter_parent/lib/l10n/app_localizations.dart
+++ b/apps/flutter_parent/lib/l10n/app_localizations.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_parent/l10n/generated/messages_all.dart';
+import 'package:intl/intl.dart';
+
+///
+/// Delegate for setting up locales.
+///
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  List<Locale> get supportedLocales {
+    return const <Locale>[
+      Locale("en", ""), // First so it's our fallback
+
+      // Supported languages
+      Locale("ar", ""),
+      Locale("cy", ""),
+      Locale("da", ""),
+      Locale("de", ""),
+      Locale("en", "AU"),
+      Locale("en", "CY"),
+      Locale("en", "GB"),
+      Locale("es", ""),
+      Locale("fi", ""),
+      Locale("fr", ""),
+      Locale("fr", "CA"),
+      Locale("ht", ""),
+      Locale("ja", ""),
+      Locale("mi", ""),
+      Locale("nb", ""),
+      Locale("nl", ""),
+      Locale("pl", ""),
+      Locale("pl", ""),
+      Locale("pl", "BR"),
+      Locale("pl", "PT"),
+      Locale("ru", ""),
+      Locale("sl", ""),
+      Locale("sv", ""),
+      Locale("zh", ""),
+      Locale("zh", "HK"),
+
+      // Custom language packs
+      Locale.fromSubtags(languageCode: "da", scriptCode: "instk12"),
+      Locale.fromSubtags(languageCode: "en", scriptCode: "unimelb", countryCode: "AU"),
+      Locale.fromSubtags(languageCode: "en", scriptCode: "instukhe", countryCode: "GB"),
+      Locale.fromSubtags(languageCode: "nb", scriptCode: "instk12"),
+      Locale.fromSubtags(languageCode: "sv", scriptCode: "instk12"),
+    ];
+  }
+
+  @override
+  bool isSupported(Locale locale) => _isSupported(locale, true);
+
+  @override
+  Future<AppLocalizations> load(Locale locale) => AppLocalizations._load(locale);
+
+  @override
+  bool shouldReload(LocalizationsDelegate<AppLocalizations> old) => false;
+
+  LocaleResolutionCallback resolution({Locale fallback, bool matchCountry = true}) {
+    return (Locale locale, Iterable<Locale> supported) {
+      return _resolve(locale, fallback, supported, matchCountry);
+    };
+  }
+
+  ///
+  /// Returns true if the specified locale is supported, false otherwise.
+  ///
+  bool _isSupported(Locale locale, bool matchCountry) {
+    if (locale == null) {
+      return false;
+    }
+
+    // Must match language code, must match country code if specified
+    return supportedLocales.any((Locale supportedLocale) =>
+        (supportedLocale.languageCode == locale.languageCode) &&
+        ((supportedLocale.countryCode == locale.countryCode) ||
+            (true != matchCountry && (supportedLocale.countryCode == null || supportedLocale.countryCode.isEmpty))));
+  }
+
+  ///
+  /// Internal method to resolve a locale from a list of locales.
+  ///
+  Locale _resolve(Locale locale, Locale fallback, Iterable<Locale> supported, bool matchCountry) {
+    if (locale == null || !_isSupported(locale, matchCountry)) {
+      return fallback ?? supported.first;
+    }
+
+    final languageLocale = Locale(locale.languageCode, "");
+    if (supported.contains(locale)) {
+      return locale;
+    } else if (supported.contains(languageLocale)) {
+      return languageLocale;
+    } else {
+      return fallback ?? supported.first;
+    }
+  }
+}
+
+///
+/// App Localization class.
+///
+/// This will hold all of the strings and reference the right resources depending on locale.
+/// View the README for detailed instructions on usage.
+///
+class AppLocalizations {
+  static Future<AppLocalizations> _load(Locale locale) {
+    final String localeName =
+        (locale.countryCode == null && locale.scriptCode == null) ? locale.languageCode : locale.toString();
+
+    return initializeMessages(localeName).then((_) {
+      Intl.defaultLocale = localeName;
+      return new AppLocalizations();
+    });
+  }
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations);
+  }
+
+  static const _AppLocalizationsDelegate delegate = _AppLocalizationsDelegate();
+
+  String get alertsLabel {
+    return Intl.message('Alerts', name: 'alertsLabel', desc: 'The label for the Alerts tab');
+  }
+
+  String get calendarLabel {
+    return Intl.message('Calendar', name: 'calendarLabel', desc: 'The label for the Calendar tab');
+  }
+
+  String get coursesLabel {
+    return Intl.message('Courses', name: 'coursesLabel', desc: 'The label for the Courses tab');
+  }
+}

--- a/apps/flutter_parent/lib/l10n/app_localizations.dart
+++ b/apps/flutter_parent/lib/l10n/app_localizations.dart
@@ -1,3 +1,17 @@
+/// Copyright (C) 2019 - present Instructure, Inc.
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, version 3 of the License.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import 'package:flutter/material.dart';
 import 'package:flutter_parent/l10n/generated/messages_all.dart';
 import 'package:intl/intl.dart';

--- a/apps/flutter_parent/lib/l10n/generated/messages_all.dart
+++ b/apps/flutter_parent/lib/l10n/generated/messages_all.dart
@@ -1,0 +1,75 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that looks up messages for specific locales by
+// delegating to the appropriate library.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:implementation_imports, file_names, unnecessary_new
+// ignore_for_file:unnecessary_brace_in_string_interps, directives_ordering
+// ignore_for_file:argument_type_not_assignable, invalid_assignment
+// ignore_for_file:prefer_single_quotes, prefer_generic_function_type_aliases
+// ignore_for_file:comment_references
+
+import 'dart:async';
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+import 'package:intl/src/intl_helpers.dart';
+
+import 'messages_ar.dart' as messages_ar;
+import 'messages_en.dart' as messages_en;
+import 'messages_en_unimelb_AU.dart' as messages_en_unimelb_au;
+import 'messages_messages.dart' as messages_messages;
+
+typedef Future<dynamic> LibraryLoader();
+Map<String, LibraryLoader> _deferredLibraries = {
+  'ar': () => new Future.value(null),
+  'en': () => new Future.value(null),
+  'en_unimelb_AU': () => new Future.value(null),
+  'messages': () => new Future.value(null),
+};
+
+MessageLookupByLibrary _findExact(String localeName) {
+  switch (localeName) {
+    case 'ar':
+      return messages_ar.messages;
+    case 'en':
+      return messages_en.messages;
+    case 'en_unimelb_AU':
+      return messages_en_unimelb_au.messages;
+    case 'messages':
+      return messages_messages.messages;
+    default:
+      return null;
+  }
+}
+
+/// User programs should call this before using [localeName] for messages.
+Future<bool> initializeMessages(String localeName) async {
+  var availableLocale = Intl.verifiedLocale(
+    localeName,
+    (locale) => _deferredLibraries[locale] != null,
+    onFailure: (_) => null);
+  if (availableLocale == null) {
+    return new Future.value(false);
+  }
+  var lib = _deferredLibraries[availableLocale];
+  await (lib == null ? new Future.value(false) : lib());
+  initializeInternalMessageLookup(() => new CompositeMessageLookup());
+  messageLookup.addLocale(availableLocale, _findGeneratedMessagesFor);
+  return new Future.value(true);
+}
+
+bool _messagesExistFor(String locale) {
+  try {
+    return _findExact(locale) != null;
+  } catch (e) {
+    return false;
+  }
+}
+
+MessageLookupByLibrary _findGeneratedMessagesFor(String locale) {
+  var actualLocale = Intl.verifiedLocale(locale, _messagesExistFor,
+      onFailure: (_) => null);
+  if (actualLocale == null) return null;
+  return _findExact(actualLocale);
+}

--- a/apps/flutter_parent/lib/l10n/generated/messages_ar.dart
+++ b/apps/flutter_parent/lib/l10n/generated/messages_ar.dart
@@ -1,0 +1,28 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a ar locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  String get localeName => 'ar';
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static _notInlinedMessages(_) => <String, Function> {
+    "alertsLabel" : MessageLookupByLibrary.simpleMessage("التنبيهات"),
+    "calendarLabel" : MessageLookupByLibrary.simpleMessage("التقويم"),
+    "coursesLabel" : MessageLookupByLibrary.simpleMessage("المساقات")
+  };
+}

--- a/apps/flutter_parent/lib/l10n/generated/messages_en.dart
+++ b/apps/flutter_parent/lib/l10n/generated/messages_en.dart
@@ -1,0 +1,28 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a en locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  String get localeName => 'en';
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static _notInlinedMessages(_) => <String, Function> {
+    "alertsLabel" : MessageLookupByLibrary.simpleMessage("Alerts"),
+    "calendarLabel" : MessageLookupByLibrary.simpleMessage("Calendar"),
+    "coursesLabel" : MessageLookupByLibrary.simpleMessage("Courses")
+  };
+}

--- a/apps/flutter_parent/lib/l10n/generated/messages_en_unimelb_AU.dart
+++ b/apps/flutter_parent/lib/l10n/generated/messages_en_unimelb_AU.dart
@@ -1,0 +1,28 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a en_unimelb_AU locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  String get localeName => 'en_unimelb_AU';
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static _notInlinedMessages(_) => <String, Function> {
+    "alertsLabel" : MessageLookupByLibrary.simpleMessage("AlertsMelb"),
+    "calendarLabel" : MessageLookupByLibrary.simpleMessage("CalendarMelb"),
+    "coursesLabel" : MessageLookupByLibrary.simpleMessage("CoursesMelb")
+  };
+}

--- a/apps/flutter_parent/lib/l10n/generated/messages_messages.dart
+++ b/apps/flutter_parent/lib/l10n/generated/messages_messages.dart
@@ -1,0 +1,28 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a messages locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  String get localeName => 'messages';
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static _notInlinedMessages(_) => <String, Function> {
+    "alertsLabel" : MessageLookupByLibrary.simpleMessage("Alerts"),
+    "calendarLabel" : MessageLookupByLibrary.simpleMessage("Calendar"),
+    "coursesLabel" : MessageLookupByLibrary.simpleMessage("Courses")
+  };
+}

--- a/apps/flutter_parent/lib/l10n/res/intl_ar.arb
+++ b/apps/flutter_parent/lib/l10n/res/intl_ar.arb
@@ -1,0 +1,21 @@
+{
+  "@@last_modified": "2019-10-30T13:15:17.774455",
+  "alertsLabel": "التنبيهات",
+  "@alertsLabel": {
+    "description": "The label for the Alerts tab",
+    "type": "text",
+    "placeholders": {}
+  },
+  "calendarLabel": "التقويم",
+  "@calendarLabel": {
+    "description": "The label for the Calendar tab",
+    "type": "text",
+    "placeholders": {}
+  },
+  "coursesLabel": "المساقات",
+  "@coursesLabel": {
+    "description": "The label for the Courses tab",
+    "type": "text",
+    "placeholders": {}
+  }
+}

--- a/apps/flutter_parent/lib/l10n/res/intl_en.arb
+++ b/apps/flutter_parent/lib/l10n/res/intl_en.arb
@@ -1,0 +1,21 @@
+{
+  "@@last_modified": "2019-10-30T13:15:17.774455",
+  "alertsLabel": "Alerts",
+  "@alertsLabel": {
+    "description": "The label for the Alerts tab",
+    "type": "text",
+    "placeholders": {}
+  },
+  "calendarLabel": "Calendar",
+  "@calendarLabel": {
+    "description": "The label for the Calendar tab",
+    "type": "text",
+    "placeholders": {}
+  },
+  "coursesLabel": "Courses",
+  "@coursesLabel": {
+    "description": "The label for the Courses tab",
+    "type": "text",
+    "placeholders": {}
+  }
+}

--- a/apps/flutter_parent/lib/l10n/res/intl_en_unimelb_AU.arb
+++ b/apps/flutter_parent/lib/l10n/res/intl_en_unimelb_AU.arb
@@ -1,0 +1,21 @@
+{
+  "@@last_modified": "2019-10-30T13:15:17.774455",
+  "alertsLabel": "AlertsMelb",
+  "@alertsLabel": {
+    "description": "The label for the Alerts tab",
+    "type": "text",
+    "placeholders": {}
+  },
+  "calendarLabel": "CalendarMelb",
+  "@calendarLabel": {
+    "description": "The label for the Calendar tab",
+    "type": "text",
+    "placeholders": {}
+  },
+  "coursesLabel": "CoursesMelb",
+  "@coursesLabel": {
+    "description": "The label for the Courses tab",
+    "type": "text",
+    "placeholders": {}
+  }
+}

--- a/apps/flutter_parent/lib/l10n/res/intl_messages.arb
+++ b/apps/flutter_parent/lib/l10n/res/intl_messages.arb
@@ -1,0 +1,21 @@
+{
+  "@@last_modified": "2019-10-30T13:15:17.774455",
+  "alertsLabel": "Alerts",
+  "@alertsLabel": {
+    "description": "The label for the Alerts tab",
+    "type": "text",
+    "placeholders": {}
+  },
+  "calendarLabel": "Calendar",
+  "@calendarLabel": {
+    "description": "The label for the Calendar tab",
+    "type": "text",
+    "placeholders": {}
+  },
+  "coursesLabel": "Courses",
+  "@coursesLabel": {
+    "description": "The label for the Courses tab",
+    "type": "text",
+    "placeholders": {}
+  }
+}

--- a/apps/flutter_parent/lib/main.dart
+++ b/apps/flutter_parent/lib/main.dart
@@ -1,3 +1,17 @@
+/// Copyright (C) 2019 - present Instructure, Inc.
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, version 3 of the License.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import 'package:flutter/material.dart';
 
 void main() => runApp(MyApp());

--- a/apps/flutter_parent/lib/parent_app.dart
+++ b/apps/flutter_parent/lib/parent_app.dart
@@ -1,3 +1,17 @@
+/// Copyright (C) 2019 - present Instructure, Inc.
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, version 3 of the License.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import 'dart:ui';
 
 import 'package:flutter/material.dart';

--- a/apps/flutter_parent/lib/parent_app.dart
+++ b/apps/flutter_parent/lib/parent_app.dart
@@ -1,0 +1,62 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_parent/l10n/app_localizations.dart';
+
+class ParentApp extends StatefulWidget {
+  @override
+  _ParentAppState createState() => _ParentAppState();
+}
+
+class _ParentAppState extends State<ParentApp> {
+  Locale _locale;
+
+  rebuild(locale) {
+    setState(() => _locale = locale);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    // TODO: Set locale from stored user
+//    _locale = AuthService.effectiveLocale();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Canvas Parent',
+      locale: _locale,
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        // Material components use these delegate to provide default localization
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ],
+      supportedLocales: AppLocalizations.delegate.supportedLocales,
+      localeResolutionCallback: _localeCallback(),
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+//      home: AuthService.isLoggedIn() ? DashboardPage() : LoginLandingPage(),
+    );
+  }
+
+  // Get notified when there's a new system locale so we can rebuild the app with the new language
+  LocaleResolutionCallback _localeCallback() => (locale, supportedLocales) {
+        const fallback = Locale("en", "");
+        Locale resolvedLocale =
+            AppLocalizations.delegate.resolution(fallback: fallback, matchCountry: false)(locale, supportedLocales);
+
+        // Update the state if the locale changed
+        if (_locale != resolvedLocale) {
+          SchedulerBinding.instance.addPostFrameCallback((_) {
+            setState(() => _locale = resolvedLocale);
+          });
+        }
+
+        return resolvedLocale;
+      };
+}

--- a/apps/flutter_parent/pubspec.lock
+++ b/apps/flutter_parent/pubspec.lock
@@ -8,13 +8,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.36.4"
-  archive:
-    dependency: transitive
-    description:
-      name: archive
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.10"
   args:
     dependency: transitive
     description:
@@ -63,7 +56,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.1+1"
   csslib:
     dependency: transitive
     description:
@@ -91,7 +84,7 @@ packages:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.10"
+    version: "5.0.8+1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -159,20 +152,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.3"
-  image:
-    dependency: transitive
-    description:
-      name: image
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.4"
   intl:
     dependency: "direct main"
     description:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.0"
+    version: "0.15.8"
   intl_translation:
     dependency: "direct dev"
     description:
@@ -312,7 +298,7 @@ packages:
       name: process
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.12"
+    version: "3.0.11"
   pub_semver:
     dependency: transitive
     description:
@@ -465,13 +451,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.15"
-  xml:
-    dependency: transitive
-    description:
-      name: xml
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.5.0"
   yaml:
     dependency: transitive
     description:

--- a/apps/flutter_parent/pubspec.lock
+++ b/apps/flutter_parent/pubspec.lock
@@ -8,6 +8,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.36.4"
+  archive:
+    dependency: transitive
+    description:
+      name: archive
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.10"
   args:
     dependency: transitive
     description:
@@ -56,7 +63,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1+1"
+    version: "2.1.3"
   csslib:
     dependency: transitive
     description:
@@ -71,13 +78,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.2"
+  dart_style:
+    dependency: transitive
+    description:
+      name: dart_style
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.9"
   file:
     dependency: transitive
     description:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.8+1"
+    version: "5.0.10"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -85,6 +99,11 @@ packages:
     version: "0.0.0"
   flutter_driver:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_localizations:
+    dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -140,13 +159,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.3"
-  intl:
+  image:
     dependency: transitive
+    description:
+      name: image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.4"
+  intl:
+    dependency: "direct main"
     description:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.8"
+    version: "0.16.0"
+  intl_translation:
+    dependency: "direct dev"
+    description:
+      name: intl_translation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.7"
   io:
     dependency: transitive
     description:
@@ -252,6 +285,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0+1"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.4.0"
   platform:
     dependency: transitive
     description:
@@ -272,7 +312,7 @@ packages:
       name: process
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.11"
+    version: "3.0.12"
   pub_semver:
     dependency: transitive
     description:
@@ -425,6 +465,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.15"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.5.0"
   yaml:
     dependency: transitive
     description:
@@ -433,4 +480,4 @@ packages:
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=2.3.0 <3.0.0"
+  dart: ">=2.4.0 <3.0.0"

--- a/apps/flutter_parent/pubspec.yaml
+++ b/apps/flutter_parent/pubspec.yaml
@@ -19,6 +19,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+  intl: ^0.16.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -30,6 +33,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   test: any
+  intl_translation: ^0.17.7
 
 
 # For information on the generic Dart part of this file, see the

--- a/apps/flutter_parent/pubspec.yaml
+++ b/apps/flutter_parent/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  intl: ^0.16.0
+  intl: ^0.15.8
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/apps/flutter_parent/test/l10n/app_localizations_delegate_test.dart
+++ b/apps/flutter_parent/test/l10n/app_localizations_delegate_test.dart
@@ -1,0 +1,116 @@
+import 'dart:ui';
+
+import 'package:flutter_parent/l10n/app_localizations.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('shouldReload returns false', () {
+    expect(AppLocalizations.delegate.shouldReload(AppLocalizations.delegate), false);
+  });
+
+  /// isSupported tests
+
+  test('isSupported returns true for supported language', () {
+    final locale = Locale("en", "");
+    expect(AppLocalizations.delegate.isSupported(locale), true);
+  });
+
+  test('isSupported returns true for supported custom language pack', () {
+    final locale = Locale.fromSubtags(languageCode: "en", scriptCode: "unimelb", countryCode: "AU");
+    expect(AppLocalizations.delegate.isSupported(locale), true);
+  });
+
+  test('isSupported returns true for supported custom language pack without a country code', () {
+    final locale = Locale.fromSubtags(languageCode: "sv", scriptCode: "instk12");
+    expect(AppLocalizations.delegate.isSupported(locale), true);
+  });
+
+  test('isSupported returns false for unsupported language', () {
+    final locale = Locale("aa", "");
+    expect(AppLocalizations.delegate.isSupported(locale), false);
+  });
+
+  test('isSupported returns false for unsupported custom language pack', () {
+    final locale = Locale.fromSubtags(languageCode: "en", scriptCode: "bleminu", countryCode: "AU");
+    expect(AppLocalizations.delegate.isSupported(locale), true);
+  });
+
+  test('isSupported returns false for unsupported country', () {
+    final locale = Locale("en", "AA");
+    expect(AppLocalizations.delegate.isSupported(locale), false);
+  });
+
+  /// resolution tests
+
+  test('resolution callback returns locale when supported', () {
+    final fallback = Locale("en", "");
+    final locale = Locale("es", "");
+
+    _testLocaleResolution(fallback, locale, locale);
+  });
+
+  test('resolution callback returns locale without country code when language with a country code is unsupported', () {
+    final fallback = Locale("en", "");
+    final locale = Locale("pl", "AA");
+    final expected = Locale("pl", "");
+
+    _testLocaleResolution(fallback, locale, expected, matchCountry: false);
+  });
+
+  test('resolution callback returns fallback when language with a country code is unsupported', () {
+    final fallback = Locale("en", "");
+    final locale = Locale("pl", "AA");
+
+    _testLocaleResolution(fallback, locale, fallback);
+  });
+
+  test('resolution callback returns custom language locale when supported', () {
+    final fallback = Locale("en", "");
+    final locale = Locale.fromSubtags(languageCode: "en", scriptCode: "unimelb", countryCode: "AU");
+
+    _testLocaleResolution(fallback, locale, locale);
+  });
+
+  test('resolution callback returns custom language locale without a country code when supported', () {
+    final fallback = Locale("en", "");
+    final locale = Locale.fromSubtags(languageCode: "sv", scriptCode: "instk12");
+
+    _testLocaleResolution(fallback, locale, locale);
+  });
+
+  test('resolution callback returns fallback locale when unsupported', () {
+    final fallback = Locale("en", "");
+    final locale = Locale("aa", "");
+
+    _testLocaleResolution(fallback, locale, fallback);
+  });
+
+  test('resolution callback returns fallback locale when custom language locale is unsupported', () {
+    final fallback = Locale("en", "");
+    final locale = Locale.fromSubtags(languageCode: "en", scriptCode: "bleminu", countryCode: "AU");
+
+    _testLocaleResolution(fallback, locale, fallback);
+  });
+
+  test('resolution callback returns locale when custom language without a country code is unsupported', () {
+    final fallback = Locale("en", "");
+    final locale = Locale.fromSubtags(languageCode: "sv", scriptCode: "12inst");
+    final expected = Locale("sv", "");
+
+    _testLocaleResolution(fallback, locale, expected);
+  });
+
+  test('resolution callback returns en locale when no fallback and locale is unsupported', () {
+    final locale = Locale("aa", '');
+    final expected = Locale("en", "");
+
+    _testLocaleResolution(null, locale, expected);
+  });
+}
+
+_testLocaleResolution(Locale fallback, Locale resolving, Locale expected, {bool matchCountry = true}) {
+  final callback = AppLocalizations.delegate.resolution(fallback: fallback, matchCountry: matchCountry);
+  final actual = callback(resolving, AppLocalizations.delegate.supportedLocales);
+
+  expect(actual, expected);
+}

--- a/apps/flutter_parent/test/l10n/app_localizations_delegate_test.dart
+++ b/apps/flutter_parent/test/l10n/app_localizations_delegate_test.dart
@@ -1,3 +1,17 @@
+/// Copyright (C) 2019 - present Instructure, Inc.
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, version 3 of the License.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import 'dart:ui';
 
 import 'package:flutter_parent/l10n/app_localizations.dart';

--- a/apps/flutter_parent/test/utils/accessibility_utils.dart
+++ b/apps/flutter_parent/test/utils/accessibility_utils.dart
@@ -1,3 +1,17 @@
+/// Copyright (C) 2019 - present Instructure, Inc.
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, version 3 of the License.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 // Accessibility-related utilities for our widget tests.
 
 import 'dart:async';

--- a/apps/flutter_parent/test/widget_test.dart
+++ b/apps/flutter_parent/test/widget_test.dart
@@ -1,3 +1,17 @@
+/// Copyright (C) 2019 - present Instructure, Inc.
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, version 3 of the License.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 // This is a basic Flutter widget test.
 //
 // To perform an interaction with a widget in your test, use the WidgetTester


### PR DESCRIPTION
This uses intl to handle localization. Currently there is nothing to test, as there are no pages created to navigate to yet.

All the files in the `generated` folder can be ignored during PR's. They are generated code from the `intl_translation` tool and cannot be edited. They are necessary pieces for hooking up the strings resources (in the `res` folder) to the AppLocalization class.

Also, created a new app that's hooked up to all the localization stuff, but there's no screens to load yet so it's not being used by anything. We should be good to use this new ParentApp widget going forward.