### PR TITLE
Allow HTTP urls

### DIFF
--- a/apps/student/src/main/AndroidManifest.xml
+++ b/apps/student/src/main/AndroidManifest.xml
@@ -72,7 +72,8 @@
             android:clearTaskOnLaunch="true"
             android:launchMode="singleTop"
             android:configChanges="keyboardHidden|orientation|screenSize"
-            android:theme="@style/LoginFlowTheme.Splash_Student">
+            android:theme="@style/LoginFlowTheme.Splash_Student"
+            android:usesCleartextTraffic="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>


### PR DESCRIPTION
Should fix the bug where the WebView can't open HTTP URLs and only gives the error: net::ERR_CLEARTEXT_NOT_PERMITTED

Haven't actually tested it though.