### PR TITLE
Add generated changes for iOS

### DIFF
--- a/apps/flutter_parent/.gitignore
+++ b/apps/flutter_parent/.gitignore
@@ -12,6 +12,7 @@ google-services.json
 .buildlog/
 .history
 .svn/
+coverage/
 
 # IntelliJ related
 *.iml

--- a/apps/flutter_parent/ios/Flutter/Debug.xcconfig
+++ b/apps/flutter_parent/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/apps/flutter_parent/ios/Flutter/Release.xcconfig
+++ b/apps/flutter_parent/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/apps/flutter_parent/ios/Podfile
+++ b/apps/flutter_parent/ios/Podfile
@@ -1,0 +1,74 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '9.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def parse_KV_file(file, separator='=')
+  file_abs_path = File.expand_path(file)
+  if !File.exists? file_abs_path
+    return [];
+  end
+  pods_ary = []
+  skip_line_start_symbols = ["#", "/"]
+  File.foreach(file_abs_path) { |line|
+      next if skip_line_start_symbols.any? { |symbol| line =~ /^\s*#{symbol}/ }
+      plugin = line.split(pattern=separator)
+      if plugin.length == 2
+        podname = plugin[0].strip()
+        path = plugin[1].strip()
+        podpath = File.expand_path("#{path}", file_abs_path)
+        pods_ary.push({:name => podname, :path => podpath});
+      else
+        puts "Invalid plugin specification: #{line}"
+      end
+  }
+  return pods_ary
+end
+
+target 'Runner' do
+  use_frameworks!
+
+  # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
+  # referring to absolute paths on developers' machines.
+  system('rm -rf .symlinks')
+  system('mkdir -p .symlinks/plugins')
+
+  # Flutter Pods
+  generated_xcode_build_settings = parse_KV_file('./Flutter/Generated.xcconfig')
+  if generated_xcode_build_settings.empty?
+    puts "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first."
+  end
+  generated_xcode_build_settings.map { |p|
+    if p[:name] == 'FLUTTER_FRAMEWORK_DIR'
+      symlink = File.join('.symlinks', 'flutter')
+      File.symlink(File.dirname(p[:path]), symlink)
+      pod 'Flutter', :path => File.join(symlink, File.basename(p[:path]))
+    end
+  }
+
+  # Plugin Pods
+  plugin_pods = parse_KV_file('../.flutter-plugins')
+  plugin_pods.map { |p|
+    symlink = File.join('.symlinks', 'plugins', p[:name])
+    File.symlink(p[:path], symlink)
+    pod p[:name], :path => File.join(symlink, 'ios')
+  }
+end
+
+# Prevent Cocoapods from embedding a second Flutter framework and causing an error with the new Xcode build system.
+install! 'cocoapods', :disable_input_output_paths => true
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['ENABLE_BITCODE'] = 'NO'
+    end
+  end
+end


### PR DESCRIPTION
I don’t think we care about iOS, but every time I delete these files they just generate again. Seems like we just need to add them when they change. Also, adding `coverage/` as an ignored directory for git, so we don’t accidentally push coverage reports.