### PR TITLE
[Flutter-Parent][MBL-13573] Add course details holder

### DIFF
--- a/apps/flutter_parent/lib/api/assignment_api.dart
+++ b/apps/flutter_parent/lib/api/assignment_api.dart
@@ -58,7 +58,6 @@ class AssignmentApi {
           'as_user_id': studentId,
           'include': ['assignments', 'discussion_topic', 'submission', 'all_dates', 'overrides'], // rubric_assessment?
           'override_assignment_dates': 'true',
-          'order_by': 'due_at', // No order_by?
         },
         options: Options(headers: ApiPrefs.getHeaderMap()));
 

--- a/apps/flutter_parent/lib/api/assignment_api.dart
+++ b/apps/flutter_parent/lib/api/assignment_api.dart
@@ -20,7 +20,7 @@ import 'package:flutter_parent/models/serializers.dart';
 
 class AssignmentApi {
 
-  static Future<List<Assignment>> getAssignmentsWithSubmissionsDepaginated(int courseId, int studentId) async {
+  Future<List<Assignment>> getAssignmentsWithSubmissionsDepaginated(int courseId, int studentId) async {
     var assignmentResponse = await Dio().get(ApiPrefs.getApiUrl() + 'courses/$courseId/assignments',
         queryParameters: {
           'as_user_id': studentId,
@@ -39,7 +39,7 @@ class AssignmentApi {
     }
   }
 
-  static Future<List<Assignment>> _getAssignmentsWithSubmissionsDepaginated(PagedList<Assignment> prevResponse) async {
+  Future<List<Assignment>> _getAssignmentsWithSubmissionsDepaginated(PagedList<Assignment> prevResponse) async {
     // Query params already specified in url
     var assignmentResponse = await Dio().get(prevResponse.nextUrl, options: Options(headers: ApiPrefs.getHeaderMap()));
 
@@ -51,7 +51,7 @@ class AssignmentApi {
     }
   }
 
-  static Future<PagedList<Assignment>> getAssignmentsWithSubmissionsPaged(int courseId, int studentId) async {
+  Future<PagedList<Assignment>> getAssignmentsWithSubmissionsPaged(int courseId, int studentId) async {
     var assignmentResponse = await Dio().get(ApiPrefs.getApiUrl() + 'courses/$courseId/assignments',
         queryParameters: {
           'as_user_id': studentId,
@@ -69,7 +69,7 @@ class AssignmentApi {
     }
   }
 
-  static Future<PagedList<Assignment>> getAssignmentsWithSubmissionsPagedNext(String nextUrl) async {
+  Future<PagedList<Assignment>> getAssignmentsWithSubmissionsPagedNext(String nextUrl) async {
     // Query params already specified in url
     var assignmentResponse = await Dio().get(nextUrl, options: Options(headers: ApiPrefs.getHeaderMap()));
 
@@ -80,7 +80,7 @@ class AssignmentApi {
     }
   }
 
-  static Future<Assignment> getAssignment(int courseId, int assignmentId) async {
+  Future<Assignment> getAssignment(int courseId, int assignmentId) async {
     var assignmentResponse = await Dio().get(ApiPrefs.getApiUrl() + 'courses/$courseId/assignments/$assignmentId',
         queryParameters: {
           'include': ['overrides', 'rubric_assessment', 'submission'],

--- a/apps/flutter_parent/lib/api/course_api.dart
+++ b/apps/flutter_parent/lib/api/course_api.dart
@@ -69,20 +69,22 @@ class CourseApi {
     }
   }
 
-  static Future<Course> getCourse(int courseId) async {
-    var response = await Dio().get('${ApiPrefs.getApiUrl()}courses/${courseId}', queryParameters: {
-      'include': [
-        'syllabus_body',
-        'term',
-        'permissions',
-        'license',
-        'is_public',
-        'needs_grading_count',
-        'total_scores',
-        'current_grading_period_scores',
-        'course_image'
-      ]
-    });
+  Future<Course> getCourse(int courseId) async {
+    var response = await Dio().get('${ApiPrefs.getApiUrl()}courses/${courseId}',
+        options: Options(headers: ApiPrefs.getHeaderMap()),
+        queryParameters: {
+          'include': [
+            'syllabus_body',
+            'term',
+            'permissions',
+            'license',
+            'is_public',
+            'needs_grading_count',
+            'total_scores',
+            'current_grading_period_scores',
+            'course_image',
+          ],
+        });
 
     if (response.statusCode == 200 || response.statusCode == 201) {
       return deserialize<Course>(response.data);

--- a/apps/flutter_parent/lib/l10n/app_localizations.dart
+++ b/apps/flutter_parent/lib/l10n/app_localizations.dart
@@ -206,6 +206,28 @@ class AppLocalizations {
         desc: 'Message shown when there is currently no grade available for a course',
       );
 
+  /// Course Details Screen
+
+  String get courseGradesLabel => Intl.message(
+        'Grades',
+        desc: 'Label for the "Grades" tab in course details',
+      );
+
+  String get courseSyllabusLabel => Intl.message(
+        'Syllabus',
+        desc: 'Label for the "Syllabus" tab in course details',
+      );
+
+  String get courseSummaryLabel => Intl.message(
+        'Summary',
+        desc: 'Label for the "Summary" tab in course details',
+      );
+
+  String get courseMessageHint => Intl.message(
+        'Send a message about this course',
+        desc: 'Accessibility hint for the course messaage floating action button',
+      );
+
   /// Web Login Screen
 
   String get domainVerificationErrorGeneral => Intl.message(

--- a/apps/flutter_parent/lib/models/assignment_group.dart
+++ b/apps/flutter_parent/lib/models/assignment_group.dart
@@ -1,3 +1,17 @@
+/// Copyright (C) 2019 - present Instructure, Inc.
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, version 3 of the License.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';

--- a/apps/flutter_parent/lib/models/assignment_group.dart
+++ b/apps/flutter_parent/lib/models/assignment_group.dart
@@ -33,10 +33,10 @@ abstract class AssignmentGroup implements Built<AssignmentGroup, AssignmentGroup
 
   String get name;
 
-  int get position; // the position of the Assignment Group
+  int get position;
 
   @BuiltValueField(wireName: 'group_weight')
-  double get groupWeight; // the weight of the Assignment Group
+  double get groupWeight;
 
   BuiltList<Assignment> get assignments;
 }

--- a/apps/flutter_parent/lib/models/assignment_group.dart
+++ b/apps/flutter_parent/lib/models/assignment_group.dart
@@ -1,0 +1,28 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:flutter_parent/models/assignment.dart';
+
+part 'assignment_group.g.dart';
+
+/// To have this built_value be generated, run this command from the project root:
+/// flutter packages pub run build_runner build --delete-conflicting-outputs
+abstract class AssignmentGroup implements Built<AssignmentGroup, AssignmentGroupBuilder> {
+  @BuiltValueSerializer(serializeNulls: true)
+  static Serializer<AssignmentGroup> get serializer => _$assignmentGroupSerializer;
+
+  AssignmentGroup._();
+
+  factory AssignmentGroup([void Function(AssignmentGroupBuilder) updates]) = _$AssignmentGroup;
+
+  int get id;
+
+  String get name;
+
+  int get position; // the position of the Assignment Group
+
+  @BuiltValueField(wireName: 'group_weight')
+  double get groupWeight; // the weight of the Assignment Group
+
+  BuiltList<Assignment> get assignments;
+}

--- a/apps/flutter_parent/lib/models/assignment_group.g.dart
+++ b/apps/flutter_parent/lib/models/assignment_group.g.dart
@@ -1,0 +1,238 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'assignment_group.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<AssignmentGroup> _$assignmentGroupSerializer =
+    new _$AssignmentGroupSerializer();
+
+class _$AssignmentGroupSerializer
+    implements StructuredSerializer<AssignmentGroup> {
+  @override
+  final Iterable<Type> types = const [AssignmentGroup, _$AssignmentGroup];
+  @override
+  final String wireName = 'AssignmentGroup';
+
+  @override
+  Iterable<Object> serialize(Serializers serializers, AssignmentGroup object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object>[
+      'id',
+      serializers.serialize(object.id, specifiedType: const FullType(int)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+      'position',
+      serializers.serialize(object.position,
+          specifiedType: const FullType(int)),
+      'group_weight',
+      serializers.serialize(object.groupWeight,
+          specifiedType: const FullType(double)),
+      'assignments',
+      serializers.serialize(object.assignments,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(Assignment)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  AssignmentGroup deserialize(
+      Serializers serializers, Iterable<Object> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new AssignmentGroupBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final dynamic value = iterator.current;
+      if (value == null) continue;
+      switch (key) {
+        case 'id':
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'position':
+          result.position = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int;
+          break;
+        case 'group_weight':
+          result.groupWeight = serializers.deserialize(value,
+              specifiedType: const FullType(double)) as double;
+          break;
+        case 'assignments':
+          result.assignments.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(Assignment)]))
+              as BuiltList<dynamic>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$AssignmentGroup extends AssignmentGroup {
+  @override
+  final int id;
+  @override
+  final String name;
+  @override
+  final int position;
+  @override
+  final double groupWeight;
+  @override
+  final BuiltList<Assignment> assignments;
+
+  factory _$AssignmentGroup([void Function(AssignmentGroupBuilder) updates]) =>
+      (new AssignmentGroupBuilder()..update(updates)).build();
+
+  _$AssignmentGroup._(
+      {this.id, this.name, this.position, this.groupWeight, this.assignments})
+      : super._() {
+    if (id == null) {
+      throw new BuiltValueNullFieldError('AssignmentGroup', 'id');
+    }
+    if (name == null) {
+      throw new BuiltValueNullFieldError('AssignmentGroup', 'name');
+    }
+    if (position == null) {
+      throw new BuiltValueNullFieldError('AssignmentGroup', 'position');
+    }
+    if (groupWeight == null) {
+      throw new BuiltValueNullFieldError('AssignmentGroup', 'groupWeight');
+    }
+    if (assignments == null) {
+      throw new BuiltValueNullFieldError('AssignmentGroup', 'assignments');
+    }
+  }
+
+  @override
+  AssignmentGroup rebuild(void Function(AssignmentGroupBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  AssignmentGroupBuilder toBuilder() =>
+      new AssignmentGroupBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is AssignmentGroup &&
+        id == other.id &&
+        name == other.name &&
+        position == other.position &&
+        groupWeight == other.groupWeight &&
+        assignments == other.assignments;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(
+        $jc($jc($jc($jc(0, id.hashCode), name.hashCode), position.hashCode),
+            groupWeight.hashCode),
+        assignments.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('AssignmentGroup')
+          ..add('id', id)
+          ..add('name', name)
+          ..add('position', position)
+          ..add('groupWeight', groupWeight)
+          ..add('assignments', assignments))
+        .toString();
+  }
+}
+
+class AssignmentGroupBuilder
+    implements Builder<AssignmentGroup, AssignmentGroupBuilder> {
+  _$AssignmentGroup _$v;
+
+  int _id;
+  int get id => _$this._id;
+  set id(int id) => _$this._id = id;
+
+  String _name;
+  String get name => _$this._name;
+  set name(String name) => _$this._name = name;
+
+  int _position;
+  int get position => _$this._position;
+  set position(int position) => _$this._position = position;
+
+  double _groupWeight;
+  double get groupWeight => _$this._groupWeight;
+  set groupWeight(double groupWeight) => _$this._groupWeight = groupWeight;
+
+  ListBuilder<Assignment> _assignments;
+  ListBuilder<Assignment> get assignments =>
+      _$this._assignments ??= new ListBuilder<Assignment>();
+  set assignments(ListBuilder<Assignment> assignments) =>
+      _$this._assignments = assignments;
+
+  AssignmentGroupBuilder();
+
+  AssignmentGroupBuilder get _$this {
+    if (_$v != null) {
+      _id = _$v.id;
+      _name = _$v.name;
+      _position = _$v.position;
+      _groupWeight = _$v.groupWeight;
+      _assignments = _$v.assignments?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(AssignmentGroup other) {
+    if (other == null) {
+      throw new ArgumentError.notNull('other');
+    }
+    _$v = other as _$AssignmentGroup;
+  }
+
+  @override
+  void update(void Function(AssignmentGroupBuilder) updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$AssignmentGroup build() {
+    _$AssignmentGroup _$result;
+    try {
+      _$result = _$v ??
+          new _$AssignmentGroup._(
+              id: id,
+              name: name,
+              position: position,
+              groupWeight: groupWeight,
+              assignments: assignments.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'assignments';
+        assignments.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'AssignmentGroup', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new

--- a/apps/flutter_parent/lib/models/course.dart
+++ b/apps/flutter_parent/lib/models/course.dart
@@ -90,6 +90,7 @@ abstract class Course implements Built<Course, CourseBuilder> {
   @BuiltValueField(wireName: 'access_restricted_by_date')
   bool get accessRestrictedByDate;
 
+  @nullable
   @BuiltValueField(wireName: 'image_download_url')
   String get imageDownloadUrl;
 

--- a/apps/flutter_parent/lib/models/course.g.dart
+++ b/apps/flutter_parent/lib/models/course.g.dart
@@ -44,9 +44,6 @@ class _$CourseSerializer implements StructuredSerializer<Course> {
       'access_restricted_by_date',
       serializers.serialize(object.accessRestrictedByDate,
           specifiedType: const FullType(bool)),
-      'image_download_url',
-      serializers.serialize(object.imageDownloadUrl,
-          specifiedType: const FullType(String)),
       'has_weighted_grading_periods',
       serializers.serialize(object.hasWeightedGradingPeriods,
           specifiedType: const FullType(bool)),
@@ -90,6 +87,13 @@ class _$CourseSerializer implements StructuredSerializer<Course> {
       result.add(null);
     } else {
       result.add(serializers.serialize(object.syllabusBody,
+          specifiedType: const FullType(String)));
+    }
+    result.add('image_download_url');
+    if (object.imageDownloadUrl == null) {
+      result.add(null);
+    } else {
+      result.add(serializers.serialize(object.imageDownloadUrl,
           specifiedType: const FullType(String)));
     }
     result.add('workflow_state');
@@ -302,9 +306,6 @@ class _$Course extends Course {
     }
     if (accessRestrictedByDate == null) {
       throw new BuiltValueNullFieldError('Course', 'accessRestrictedByDate');
-    }
-    if (imageDownloadUrl == null) {
-      throw new BuiltValueNullFieldError('Course', 'imageDownloadUrl');
     }
     if (hasWeightedGradingPeriods == null) {
       throw new BuiltValueNullFieldError('Course', 'hasWeightedGradingPeriods');

--- a/apps/flutter_parent/lib/models/enrollment.dart
+++ b/apps/flutter_parent/lib/models/enrollment.dart
@@ -42,9 +42,11 @@ abstract class Enrollment implements Built<Enrollment, EnrollmentBuilder> {
   int get id;
 
   // Only included when we get enrollments using the user's url: /users/self/enrollments
+  @nullable
   @BuiltValueField(wireName: 'course_id')
   int get courseId;
 
+  @nullable
   @BuiltValueField(wireName: 'course_section_id')
   int get courseSectionId;
 

--- a/apps/flutter_parent/lib/models/enrollment.g.dart
+++ b/apps/flutter_parent/lib/models/enrollment.g.dart
@@ -20,12 +20,6 @@ class _$EnrollmentSerializer implements StructuredSerializer<Enrollment> {
     final result = <Object>[
       'id',
       serializers.serialize(object.id, specifiedType: const FullType(int)),
-      'course_id',
-      serializers.serialize(object.courseId,
-          specifiedType: const FullType(int)),
-      'course_section_id',
-      serializers.serialize(object.courseSectionId,
-          specifiedType: const FullType(int)),
       'enrollment_state',
       serializers.serialize(object.enrollmentState,
           specifiedType: const FullType(String)),
@@ -60,6 +54,20 @@ class _$EnrollmentSerializer implements StructuredSerializer<Enrollment> {
     } else {
       result.add(serializers.serialize(object.type,
           specifiedType: const FullType(String)));
+    }
+    result.add('course_id');
+    if (object.courseId == null) {
+      result.add(null);
+    } else {
+      result.add(serializers.serialize(object.courseId,
+          specifiedType: const FullType(int)));
+    }
+    result.add('course_section_id');
+    if (object.courseSectionId == null) {
+      result.add(null);
+    } else {
+      result.add(serializers.serialize(object.courseSectionId,
+          specifiedType: const FullType(int)));
     }
     result.add('grades');
     if (object.grades == null) {
@@ -362,12 +370,6 @@ class _$Enrollment extends Enrollment {
       : super._() {
     if (id == null) {
       throw new BuiltValueNullFieldError('Enrollment', 'id');
-    }
-    if (courseId == null) {
-      throw new BuiltValueNullFieldError('Enrollment', 'courseId');
-    }
-    if (courseSectionId == null) {
-      throw new BuiltValueNullFieldError('Enrollment', 'courseSectionId');
     }
     if (enrollmentState == null) {
       throw new BuiltValueNullFieldError('Enrollment', 'enrollmentState');

--- a/apps/flutter_parent/lib/models/serializers.dart
+++ b/apps/flutter_parent/lib/models/serializers.dart
@@ -20,6 +20,7 @@ import 'package:built_value/serializer.dart';
 import 'package:built_value/standard_json_plugin.dart';
 import 'package:flutter_parent/models/alert.dart';
 import 'package:flutter_parent/models/assignment.dart';
+import 'package:flutter_parent/models/assignment_group.dart';
 import 'package:flutter_parent/models/canvas_token.dart';
 import 'package:flutter_parent/models/course.dart';
 import 'package:flutter_parent/models/enrollment.dart';
@@ -36,6 +37,7 @@ part 'serializers.g.dart';
 @SerializersFor([
   Alert,
   Assignment,
+  AssignmentGroup,
   CanvasToken,
   Course,
   Enrollment,

--- a/apps/flutter_parent/lib/models/serializers.g.dart
+++ b/apps/flutter_parent/lib/models/serializers.g.dart
@@ -11,6 +11,7 @@ Serializers _$_serializers = (new Serializers().toBuilder()
       ..add(AlertType.serializer)
       ..add(AlertWorkflowState.serializer)
       ..add(Assignment.serializer)
+      ..add(AssignmentGroup.serializer)
       ..add(CanvasToken.serializer)
       ..add(Course.serializer)
       ..add(Enrollment.serializer)
@@ -19,6 +20,9 @@ Serializers _$_serializers = (new Serializers().toBuilder()
       ..add(SchoolDomain.serializer)
       ..add(Submission.serializer)
       ..add(User.serializer)
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(Assignment)]),
+          () => new ListBuilder<Assignment>())
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(Enrollment)]),
           () => new ListBuilder<Enrollment>())

--- a/apps/flutter_parent/lib/screens/courses/courses_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/courses_screen.dart
@@ -17,11 +17,12 @@ import 'package:flutter_parent/l10n/app_localizations.dart';
 import 'package:flutter_parent/models/course.dart';
 import 'package:flutter_parent/models/course_grade.dart';
 import 'package:flutter_parent/models/user.dart';
+import 'package:flutter_parent/screens/courses/details/course_details_screen.dart';
+import 'package:flutter_parent/utils/quick_nav.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
 import 'package:intl/intl.dart';
 
 import 'courses_interactor.dart';
-
 
 class CoursesScreen extends StatefulWidget {
   final User _student;
@@ -146,10 +147,6 @@ class _CoursesScreenState extends State<CoursesScreen> {
   }
 
   void _courseTapped(context, Course course) {
-    Navigator.of(context).push(MaterialPageRoute(builder: (context) {
-      // TODO: Route to course page
-//      return CoursePage(widget._student, course);
-        return null;
-    }));
+    QuickNav.push(context, CourseDetailsScreen.withCourse(widget._student.id, course));
   }
 }

--- a/apps/flutter_parent/lib/screens/courses/details/course_details_interactor.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_details_interactor.dart
@@ -14,7 +14,7 @@
 
 import 'package:flutter_parent/api/assignment_api.dart';
 import 'package:flutter_parent/api/course_api.dart';
-import 'package:flutter_parent/models/assignment.dart';
+import 'package:flutter_parent/models/assignment_group.dart';
 import 'package:flutter_parent/models/course.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
 
@@ -23,7 +23,7 @@ class CourseDetailsInteractor {
     return locator<CourseApi>().getCourse(courseId);
   }
   
-  Future<List<Assignment>> loadAssignments(int courseId, int studentId) {
-    return locator<AssignmentApi>().getAssignmentsWithSubmissionsDepaginated(courseId, studentId);
+  Future<List<AssignmentGroup>> loadAssignmentGroups(int courseId, int studentId) {
+    return locator<AssignmentApi>().getAssignmentGroupsWithSubmissionsDepaginated(courseId, studentId);
   }
 }

--- a/apps/flutter_parent/lib/screens/courses/details/course_details_interactor.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_details_interactor.dart
@@ -1,0 +1,29 @@
+/// Copyright (C) 2019 - present Instructure, Inc.
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, version 3 of the License.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import 'package:flutter_parent/api/assignment_api.dart';
+import 'package:flutter_parent/api/course_api.dart';
+import 'package:flutter_parent/models/assignment.dart';
+import 'package:flutter_parent/models/course.dart';
+import 'package:flutter_parent/utils/service_locator.dart';
+
+class CourseDetailsInteractor {
+  Future<Course> loadCourse(int courseId) {
+    return locator<CourseApi>().getCourse(courseId);
+  }
+  
+  Future<List<Assignment>> loadAssignments(int courseId, int studentId) {
+    return locator<AssignmentApi>().getAssignmentsWithSubmissionsDepaginated(courseId, studentId);
+  }
+}

--- a/apps/flutter_parent/lib/screens/courses/details/course_details_model.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_details_model.dart
@@ -12,7 +12,7 @@
 /// You should have received a copy of the GNU General Public License
 /// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import 'package:flutter_parent/models/assignment.dart';
+import 'package:flutter_parent/models/assignment_group.dart';
 import 'package:flutter_parent/models/course.dart';
 import 'package:flutter_parent/screens/courses/details/course_details_interactor.dart';
 import 'package:flutter_parent/utils/base_model.dart';
@@ -22,25 +22,25 @@ class CourseDetailsModel extends BaseModel {
   int studentId;
   int courseId; // Could be routed to without a full course, only the id may be known
   Course course;
-  List<Assignment> assignments;
+  List<AssignmentGroup> assignmentGroups;
 
-  CourseDetailsModel(this.studentId, this.courseId, {this.assignments});
+  CourseDetailsModel(this.studentId, this.courseId, {this.assignmentGroups});
 
   // A convenience constructor when we already have the course data
-  CourseDetailsModel.withCourse(this.studentId, this.course, {this.assignments}) : this.courseId = course.id;
+  CourseDetailsModel.withCourse(this.studentId, this.course, {this.assignmentGroups}) : this.courseId = course.id;
 
   Future<void> loadData({bool refreshCourse = false, bool refreshAssignments = false}) {
     return work(() async {
       // Declare the futures so we can let both run asynchronously
       final courseFuture =
           (refreshCourse || course == null) ? _interactor().loadCourse(courseId) : Future.value(course);
-      final assignmentsFuture = (refreshAssignments || assignments == null)
-          ? _interactor().loadAssignments(courseId, studentId)
-          : Future.value(assignments);
+      final assignmentsFuture = (refreshAssignments || assignmentGroups == null)
+          ? _interactor().loadAssignmentGroups(courseId, studentId)
+          : Future.value(assignmentGroups);
 
       // Await the results
       course = await courseFuture;
-      assignments = await assignmentsFuture;
+      assignmentGroups = await assignmentsFuture;
     });
   }
 

--- a/apps/flutter_parent/lib/screens/courses/details/course_details_model.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_details_model.dart
@@ -1,0 +1,48 @@
+/// Copyright (C) 2019 - present Instructure, Inc.
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, version 3 of the License.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import 'package:flutter_parent/models/assignment.dart';
+import 'package:flutter_parent/models/course.dart';
+import 'package:flutter_parent/screens/courses/details/course_details_interactor.dart';
+import 'package:flutter_parent/utils/base_model.dart';
+import 'package:flutter_parent/utils/service_locator.dart';
+
+class CourseDetailsModel extends BaseModel {
+  int studentId;
+  int courseId; // Could be routed to without a full course, only the id may be known
+  Course course;
+  List<Assignment> assignments;
+
+  CourseDetailsModel(this.studentId, this.courseId, {this.assignments});
+
+  // A convenience constructor when we already have the course data
+  CourseDetailsModel.withCourse(this.studentId, this.course, {this.assignments}) : this.courseId = course.id;
+
+  Future<void> loadData({bool refreshCourse = false, bool refreshAssignments = false}) {
+    return work(() async {
+      // Declare the futures so we can let both run asynchronously
+      final courseFuture =
+          (refreshCourse || course == null) ? _interactor().loadCourse(courseId) : Future.value(course);
+      final assignmentsFuture = (refreshAssignments || assignments == null)
+          ? _interactor().loadAssignments(courseId, studentId)
+          : Future.value(assignments);
+
+      // Await the results
+      course = await courseFuture;
+      assignments = await assignmentsFuture;
+    });
+  }
+
+  CourseDetailsInteractor _interactor() => locator<CourseDetailsInteractor>();
+}

--- a/apps/flutter_parent/lib/screens/courses/details/course_details_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_details_screen.dart
@@ -1,0 +1,115 @@
+/// Copyright (C) 2019 - present Instructure, Inc.
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, version 3 of the License.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_parent/l10n/app_localizations.dart';
+import 'package:flutter_parent/models/course.dart';
+import 'package:flutter_parent/screens/courses/details/course_details_model.dart';
+import 'package:flutter_parent/screens/courses/details/course_grades_screen.dart';
+import 'package:flutter_parent/screens/courses/details/course_summary_screen.dart';
+import 'package:flutter_parent/screens/courses/details/course_syllabus_screen.dart';
+import 'package:flutter_parent/utils/base_model.dart';
+import 'package:flutter_parent/utils/design/canvas_icons_solid.dart';
+import 'package:flutter_parent/utils/widgets/full_screen_scroll_container.dart';
+import 'package:provider/provider.dart';
+
+class CourseDetailsScreen extends StatefulWidget {
+  final CourseDetailsModel _model;
+
+  CourseDetailsScreen(int studentId, int courseId, {Key key})
+      : this._model = CourseDetailsModel(studentId, courseId),
+        super(key: key);
+
+  // A convenience constructor when we already have the course data, so we don't load something we already have
+  CourseDetailsScreen.withCourse(int studentId, Course course, {Key key})
+      : this._model = CourseDetailsModel.withCourse(studentId, course),
+        super(key: key);
+
+  @override
+  _CourseDetailsScreenState createState() => _CourseDetailsScreenState();
+}
+
+class _CourseDetailsScreenState extends State<CourseDetailsScreen> {
+  @override
+  void initState() {
+    super.initState();
+    widget._model.loadData();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider<CourseDetailsModel>(
+      builder: (context) => widget._model,
+      child: Consumer<CourseDetailsModel>(
+        builder: (context, model, _) {
+          return DefaultTabController(
+            length: 3,
+            child: Scaffold(
+              appBar: AppBar(
+                title: Text(model.course?.name ?? ''),
+                bottom: TabBar(
+                  labelStyle: Theme.of(context).primaryTextTheme.subtitle,
+                  tabs: [
+                    Tab(text: AppLocalizations.of(context).courseGradesLabel.toUpperCase()),
+                    Tab(text: AppLocalizations.of(context).courseSyllabusLabel.toUpperCase()),
+                    Tab(text: AppLocalizations.of(context).courseSummaryLabel.toUpperCase()),
+                  ],
+                ),
+              ),
+              body: _body(context, model),
+              floatingActionButton: FloatingActionButton(
+                onPressed: () => _sendMessage(),
+                child: Semantics(
+                  label: AppLocalizations.of(context).courseMessageHint,
+                  child: Padding(
+                    padding: const EdgeInsets.only(left: 4, top: 4),
+                    child: Icon(CanvasIconsSolid.comment),
+                  ),
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _body(BuildContext context, CourseDetailsModel model) {
+    // Show loading if we're waiting for data, not inside the refresh indicator as it's unnecessary
+    if (model.state == ViewState.Busy) {
+      return Center(child: CircularProgressIndicator());
+    }
+
+    // Get the child widget to show in the refresh indicator
+    if (model.state == ViewState.Error) {
+      return RefreshIndicator(
+        child: FullScreenScrollContainer(children: [Text(AppLocalizations.of(context).unexpectedError)]),
+        onRefresh: () async {
+          return model.loadData(refreshCourse: true, refreshAssignments: true);
+        },
+      );
+    } else {
+      return TabBarView(children: [
+        CourseGradesScreen(),
+        CourseSyllabusScreen(),
+        CourseSummaryScreen(),
+      ]);
+    }
+  }
+
+  void _sendMessage() {
+    // TODO: Send a message in this course
+//    QuickNav.push(context, MessagesScreen());
+  }
+}

--- a/apps/flutter_parent/lib/screens/courses/details/course_grades_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_grades_screen.dart
@@ -1,0 +1,32 @@
+/// Copyright (C) 2019 - present Instructure, Inc.
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, version 3 of the License.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_parent/screens/courses/details/course_details_model.dart';
+import 'package:flutter_parent/utils/widgets/full_screen_scroll_container.dart';
+import 'package:provider/provider.dart';
+
+class CourseGradesScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<CourseDetailsModel>(
+      builder: (context, model, _) => RefreshIndicator(
+        onRefresh: () => model.loadData(refreshCourse: true, refreshAssignments: true),
+        child: FullScreenScrollContainer(
+          children: [Text("Course Grades")],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/flutter_parent/lib/screens/courses/details/course_summary_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_summary_screen.dart
@@ -1,0 +1,32 @@
+/// Copyright (C) 2019 - present Instructure, Inc.
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, version 3 of the License.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_parent/screens/courses/details/course_details_model.dart';
+import 'package:flutter_parent/utils/widgets/full_screen_scroll_container.dart';
+import 'package:provider/provider.dart';
+
+class CourseSummaryScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<CourseDetailsModel>(
+      builder: (context, model, _) => RefreshIndicator(
+        onRefresh: () => model.loadData(refreshCourse: true),
+        child: FullScreenScrollContainer(
+          children: [Text("Course Summary")],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/flutter_parent/lib/screens/courses/details/course_syllabus_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_syllabus_screen.dart
@@ -1,0 +1,32 @@
+/// Copyright (C) 2019 - present Instructure, Inc.
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, version 3 of the License.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_parent/screens/courses/details/course_details_model.dart';
+import 'package:flutter_parent/utils/widgets/full_screen_scroll_container.dart';
+import 'package:provider/provider.dart';
+
+class CourseSyllabusScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<CourseDetailsModel>(
+      builder: (context, model, _) => RefreshIndicator(
+        onRefresh: () => model.loadData(refreshAssignments: true),
+        child: FullScreenScrollContainer(
+          children: [Text("Course Syllabus")],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/flutter_parent/lib/utils/base_model.dart
+++ b/apps/flutter_parent/lib/utils/base_model.dart
@@ -35,6 +35,7 @@ class BaseModel extends ChangeNotifier {
       if (loadBlock != null) await loadBlock();
       setState(viewState: ViewState.Idle);
     } catch (e) {
+      print("error while doing work: $e");
       setState(viewState: ViewState.Error);
     }
   }

--- a/apps/flutter_parent/lib/utils/base_model.dart
+++ b/apps/flutter_parent/lib/utils/base_model.dart
@@ -1,0 +1,41 @@
+/// Copyright (C) 2019 - present Instructure, Inc.
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, version 3 of the License.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+
+/// Represents the state of the view
+enum ViewState { Idle, Busy, Error }
+
+/// Represents the model of the widget
+class BaseModel extends ChangeNotifier {
+  ViewState _state = ViewState.Idle;
+
+  ViewState get state => _state;
+
+  void setState({ViewState viewState}) {
+    if (viewState != null) _state = viewState;
+    notifyListeners();
+  }
+
+  // A helper method to set the state to busy when starting a load, and setting the state back to idle when done
+  Future<void> work(Future Function() loadBlock) async {
+    try {
+      setState(viewState: ViewState.Busy);
+      if (loadBlock != null) await loadBlock();
+      setState(viewState: ViewState.Idle);
+    } catch (e) {
+      setState(viewState: ViewState.Error);
+    }
+  }
+}

--- a/apps/flutter_parent/lib/utils/service_locator.dart
+++ b/apps/flutter_parent/lib/utils/service_locator.dart
@@ -13,10 +13,12 @@
 /// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import 'package:flutter_parent/api/alert_api.dart';
+import 'package:flutter_parent/api/assignment_api.dart';
 import 'package:flutter_parent/api/auth_api.dart';
 import 'package:flutter_parent/api/course_api.dart';
 import 'package:flutter_parent/screens/alerts/alerts_interactor.dart';
 import 'package:flutter_parent/screens/courses/courses_interactor.dart';
+import 'package:flutter_parent/screens/courses/details/course_details_interactor.dart';
 import 'package:flutter_parent/screens/domain_search/domain_search_interactor.dart';
 import 'package:flutter_parent/screens/web_login/web_login_interactor.dart';
 import 'package:get_it/get_it.dart';
@@ -25,10 +27,12 @@ GetIt locator = GetIt.instance;
 
 void setupLocator() {
   locator.registerLazySingleton<AlertsApi>(() => AlertsApi());
+  locator.registerLazySingleton<AssignmentApi>(() => AssignmentApi());
   locator.registerLazySingleton<AuthApi>(() => AuthApi());
   locator.registerLazySingleton<CourseApi>(() => CourseApi());
 
   locator.registerFactory<AlertsInteractor>(() => AlertsInteractor());
+  locator.registerFactory<CourseDetailsInteractor>(() => CourseDetailsInteractor());
   locator.registerFactory<CoursesInteractor>(() => CoursesInteractor());
   locator.registerFactory<DomainSearchInteractor>(() => DomainSearchInteractor());
   locator.registerFactory<WebLoginInteractor>(() => WebLoginInteractor());

--- a/apps/flutter_parent/pubspec.lock
+++ b/apps/flutter_parent/pubspec.lock
@@ -481,6 +481,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.11"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.0+1"
   pub_semver:
     dependency: transitive
     description:

--- a/apps/flutter_parent/pubspec.yaml
+++ b/apps/flutter_parent/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   get_it: ^3.0.1
   intl: ^0.15.8
   package_info: 0.4.0+10
+  provider: ^3.1.0+1
   shared_preferences: 0.5.3+4
   webview_flutter: 0.3.15+1
 

--- a/apps/flutter_parent/test/screens/courses/course_details_interactor_test.dart
+++ b/apps/flutter_parent/test/screens/courses/course_details_interactor_test.dart
@@ -44,9 +44,9 @@ void main() {
     final assignmentApi = _MockAssignmentApi();
     _setupLocator(assignmentApi: assignmentApi);
 
-    CourseDetailsInteractor().loadAssignments(courseId, studentId);
+    CourseDetailsInteractor().loadAssignmentGroups(courseId, studentId);
 
-    verify(assignmentApi.getAssignmentsWithSubmissionsDepaginated(courseId, studentId)).called(1);
+    verify(assignmentApi.getAssignmentGroupsWithSubmissionsDepaginated(courseId, studentId)).called(1);
   });
 }
 

--- a/apps/flutter_parent/test/screens/courses/course_details_interactor_test.dart
+++ b/apps/flutter_parent/test/screens/courses/course_details_interactor_test.dart
@@ -1,0 +1,55 @@
+/// Copyright (C) 2019 - present Instructure, Inc.
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, version 3 of the License.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import 'package:flutter_parent/api/assignment_api.dart';
+import 'package:flutter_parent/api/course_api.dart';
+import 'package:flutter_parent/screens/courses/details/course_details_interactor.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+void main() {
+  _setupLocator({CourseApi courseApi, AssignmentApi assignmentApi}) {
+    final _locator = GetIt.instance;
+    _locator.reset();
+
+    _locator.registerLazySingleton<CourseApi>(() => courseApi ?? _MockCourseApi());
+    _locator.registerLazySingleton<AssignmentApi>(() => assignmentApi ?? _MockAssignmentApi());
+  }
+
+  test('load course calls the api', () async {
+    final courseId = 123;
+    final courseApi = _MockCourseApi();
+    _setupLocator(courseApi: courseApi);
+
+    CourseDetailsInteractor().loadCourse(courseId);
+
+    verify(courseApi.getCourse(courseId)).called(1);
+  });
+
+  test('load assignments calls the api', () async {
+    final courseId = 123;
+    final studentId = 321;
+    final assignmentApi = _MockAssignmentApi();
+    _setupLocator(assignmentApi: assignmentApi);
+
+    CourseDetailsInteractor().loadAssignments(courseId, studentId);
+
+    verify(assignmentApi.getAssignmentsWithSubmissionsDepaginated(courseId, studentId)).called(1);
+  });
+}
+
+class _MockCourseApi extends Mock implements CourseApi {}
+
+class _MockAssignmentApi extends Mock implements AssignmentApi {}

--- a/apps/flutter_parent/test/screens/courses/course_details_model_test.dart
+++ b/apps/flutter_parent/test/screens/courses/course_details_model_test.dart
@@ -12,7 +12,7 @@
 /// You should have received a copy of the GNU General Public License
 /// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import 'package:flutter_parent/models/assignment.dart';
+import 'package:flutter_parent/models/assignment_group.dart';
 import 'package:flutter_parent/models/course.dart';
 import 'package:flutter_parent/screens/courses/details/course_details_interactor.dart';
 import 'package:flutter_parent/screens/courses/details/course_details_model.dart';
@@ -77,44 +77,44 @@ void main() {
     });
 
     test('does not refresh assignments if it has data', () async {
-      final assignments = List<Assignment>();
+      final assignments = List<AssignmentGroup>();
       final interactor = _MockCourseDetailsInteractor();
       _setupLocator(interactor: interactor);
       final model = CourseDetailsModel.withCourse(studentId, course);
-      model.assignments = assignments;
+      model.assignmentGroups = assignments;
 
       await model.loadData();
 
-      verifyNever(interactor.loadAssignments(courseId, studentId));
-      expect(model.assignments, assignments);
+      verifyNever(interactor.loadAssignmentGroups(courseId, studentId));
+      expect(model.assignmentGroups, assignments);
     });
 
     test('refreshes assignments if assignment refresh forced', () async {
       final expected = null;
       final interactor = _MockCourseDetailsInteractor();
-      when(interactor.loadAssignments(courseId, studentId)).thenAnswer((_) => Future.value(expected));
+      when(interactor.loadAssignmentGroups(courseId, studentId)).thenAnswer((_) => Future.value(expected));
       _setupLocator(interactor: interactor);
       final model = CourseDetailsModel.withCourse(studentId, course);
-      model.assignments = List();
+      model.assignmentGroups = List();
 
       await model.loadData(refreshAssignments: true);
 
-      verify(interactor.loadAssignments(courseId, studentId)).called(1);
-      expect(model.assignments, expected);
+      verify(interactor.loadAssignmentGroups(courseId, studentId)).called(1);
+      expect(model.assignmentGroups, expected);
     });
 
     test('refreshes assignments if assignments is null', () async {
-      final expected = List<Assignment>();
+      final expected = List<AssignmentGroup>();
       final interactor = _MockCourseDetailsInteractor();
-      when(interactor.loadAssignments(courseId, studentId)).thenAnswer((_) => Future.value(expected));
+      when(interactor.loadAssignmentGroups(courseId, studentId)).thenAnswer((_) => Future.value(expected));
       _setupLocator(interactor: interactor);
       final model = CourseDetailsModel.withCourse(studentId, course);
 
-      expect(model.assignments, null);
+      expect(model.assignmentGroups, null);
       await model.loadData();
 
-      verify(interactor.loadAssignments(courseId, studentId)).called(1);
-      expect(model.assignments, expected);
+      verify(interactor.loadAssignmentGroups(courseId, studentId)).called(1);
+      expect(model.assignmentGroups, expected);
     });
   });
 }

--- a/apps/flutter_parent/test/screens/courses/course_details_model_test.dart
+++ b/apps/flutter_parent/test/screens/courses/course_details_model_test.dart
@@ -1,0 +1,122 @@
+/// Copyright (C) 2019 - present Instructure, Inc.
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, version 3 of the License.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import 'package:flutter_parent/models/assignment.dart';
+import 'package:flutter_parent/models/course.dart';
+import 'package:flutter_parent/screens/courses/details/course_details_interactor.dart';
+import 'package:flutter_parent/screens/courses/details/course_details_model.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final studentId = 123;
+  final courseId = 321;
+  final course = Course((b) => b..id = courseId);
+
+  _setupLocator({CourseDetailsInteractor interactor}) {
+    final _locator = GetIt.instance;
+    _locator.reset();
+
+    _locator.registerFactory<CourseDetailsInteractor>(() => interactor ?? _MockCourseDetailsInteractor());
+  }
+
+  test('constructing with a course updates the course id', () {
+    final model = CourseDetailsModel.withCourse(studentId, course);
+
+    expect(model.courseId, courseId);
+  });
+
+  group('loadData', () {
+    test('does not refresh course if it has data', () async {
+      final interactor = _MockCourseDetailsInteractor();
+      _setupLocator(interactor: interactor);
+      final model = CourseDetailsModel.withCourse(studentId, course);
+
+      await model.loadData();
+
+      verifyNever(interactor.loadCourse(courseId));
+      expect(model.course, course);
+    });
+
+    test('refreshes course if course refresh forced', () async {
+      final expected = null;
+      final interactor = _MockCourseDetailsInteractor();
+      when(interactor.loadCourse(courseId)).thenAnswer((_) => Future.value(expected));
+      _setupLocator(interactor: interactor);
+      final model = CourseDetailsModel.withCourse(studentId, course);
+
+      await model.loadData(refreshCourse: true);
+
+      verify(interactor.loadCourse(courseId)).called(1);
+      expect(model.course, expected);
+    });
+
+    test('refreshes course if course is null', () async {
+      final expected = null;
+      final interactor = _MockCourseDetailsInteractor();
+      when(interactor.loadCourse(courseId)).thenAnswer((_) => Future.value(expected));
+      _setupLocator(interactor: interactor);
+      final model = CourseDetailsModel(studentId, courseId);
+
+      await model.loadData();
+
+      verify(interactor.loadCourse(courseId)).called(1);
+      expect(model.course, expected);
+    });
+
+    test('does not refresh assignments if it has data', () async {
+      final assignments = List<Assignment>();
+      final interactor = _MockCourseDetailsInteractor();
+      _setupLocator(interactor: interactor);
+      final model = CourseDetailsModel.withCourse(studentId, course);
+      model.assignments = assignments;
+
+      await model.loadData();
+
+      verifyNever(interactor.loadAssignments(courseId, studentId));
+      expect(model.assignments, assignments);
+    });
+
+    test('refreshes assignments if assignment refresh forced', () async {
+      final expected = null;
+      final interactor = _MockCourseDetailsInteractor();
+      when(interactor.loadAssignments(courseId, studentId)).thenAnswer((_) => Future.value(expected));
+      _setupLocator(interactor: interactor);
+      final model = CourseDetailsModel.withCourse(studentId, course);
+      model.assignments = List();
+
+      await model.loadData(refreshAssignments: true);
+
+      verify(interactor.loadAssignments(courseId, studentId)).called(1);
+      expect(model.assignments, expected);
+    });
+
+    test('refreshes assignments if assignments is null', () async {
+      final expected = List<Assignment>();
+      final interactor = _MockCourseDetailsInteractor();
+      when(interactor.loadAssignments(courseId, studentId)).thenAnswer((_) => Future.value(expected));
+      _setupLocator(interactor: interactor);
+      final model = CourseDetailsModel.withCourse(studentId, course);
+
+      expect(model.assignments, null);
+      await model.loadData();
+
+      verify(interactor.loadAssignments(courseId, studentId)).called(1);
+      expect(model.assignments, expected);
+    });
+  });
+}
+
+class _MockCourseDetailsInteractor extends Mock implements CourseDetailsInteractor {}

--- a/apps/flutter_parent/test/screens/courses/course_details_screen_test.dart
+++ b/apps/flutter_parent/test/screens/courses/course_details_screen_test.dart
@@ -1,0 +1,168 @@
+/// Copyright (C) 2019 - present Instructure, Inc.
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, version 3 of the License.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_parent/l10n/app_localizations.dart';
+import 'package:flutter_parent/models/course.dart';
+import 'package:flutter_parent/screens/courses/details/course_details_interactor.dart';
+import 'package:flutter_parent/screens/courses/details/course_details_screen.dart';
+import 'package:flutter_parent/screens/courses/details/course_grades_screen.dart';
+import 'package:flutter_parent/screens/courses/details/course_summary_screen.dart';
+import 'package:flutter_parent/screens/courses/details/course_syllabus_screen.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../utils/accessibility_utils.dart';
+import '../../utils/test_app.dart';
+
+void main() {
+  final studentId = 123;
+  final courseId = 321;
+
+  _setupLocator({CourseDetailsInteractor interactor}) {
+    final _locator = GetIt.instance;
+    _locator.reset();
+
+    _locator.registerFactory<CourseDetailsInteractor>(() => interactor ?? _MockCourseDetailsInteractor());
+  }
+
+  testWidgetsWithAccessibilityChecks('Shows loading', (tester) async {
+    await tester.pumpWidget(TestApp(CourseDetailsScreen(studentId, courseId)));
+    await tester.pump();
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgetsWithAccessibilityChecks('Shows error and can refresh', (tester) async {
+    final interactor = _MockCourseDetailsInteractor();
+    when(interactor.loadCourse(courseId)).thenAnswer((_) => Future.error("This is an error"));
+    _setupLocator(interactor: interactor);
+
+    await tester.pumpWidget(TestApp(CourseDetailsScreen(studentId, courseId)));
+    await tester.pump(); // Widget creation
+    await tester.pump(); // Future resolved
+
+    // Should have the error text
+    expect(find.text(AppLocalizations().unexpectedError), findsOneWidget);
+
+    // Should have the refresh indicator
+    final matchedWidget = find.byType(RefreshIndicator);
+    expect(matchedWidget, findsOneWidget);
+
+    // Try to refresh
+    await tester.drag(matchedWidget, const Offset(0, 200));
+    await tester.pumpAndSettle(); // Loading indicator takes a lot of frames, pump and settle to wait
+
+    verify(interactor.loadCourse(courseId)).called(2); // Once for initial load, another for the refresh
+  });
+
+  testWidgetsWithAccessibilityChecks('Shows course name when given a course', (tester) async {
+    final course = Course((b) => b
+      ..id = courseId
+      ..name = 'Course Name');
+    _setupLocator();
+
+    await tester.pumpWidget(TestApp(CourseDetailsScreen.withCourse(studentId, course)));
+    await tester.pump(); // Widget creation
+
+    expect(find.text(course.name), findsOneWidget);
+  });
+
+  testWidgetsWithAccessibilityChecks('Updates course name', (tester) async {
+    final course = Course((b) => b
+      ..id = courseId
+      ..name = 'Course Name');
+    final interactor = _MockCourseDetailsInteractor();
+    when(interactor.loadCourse(courseId)).thenAnswer((_) => Future.value(course));
+    _setupLocator(interactor: interactor);
+
+    await tester.pumpWidget(TestApp(CourseDetailsScreen(studentId, courseId)));
+    await tester.pump(); // Widget creation
+    await tester.pump(); // Future resolved
+
+    expect(find.text(course.name), findsOneWidget);
+  });
+
+  testWidgetsWithAccessibilityChecks('Shows course tabs', (tester) async {
+    _setupLocator();
+
+    await tester.pumpWidget(TestApp(CourseDetailsScreen(studentId, courseId)));
+    await tester.pump(); // Widget creation
+    await tester.pump(); // Future resolved
+
+    expect(find.text(AppLocalizations().courseGradesLabel.toUpperCase()), findsOneWidget);
+    expect(find.text(AppLocalizations().courseSyllabusLabel.toUpperCase()), findsOneWidget);
+    expect(find.text(AppLocalizations().courseSummaryLabel.toUpperCase()), findsOneWidget);
+  });
+
+  testWidgetsWithAccessibilityChecks('Clicking grades tab shows the grades screen', (tester) async {
+    _setupLocator();
+
+    await tester.pumpWidget(TestApp(CourseDetailsScreen(studentId, courseId)));
+    await tester.pump(); // Widget creation
+    await tester.pump(); // Future resolved
+
+    await tester.tap(find.text(AppLocalizations().courseGradesLabel.toUpperCase()));
+    await tester.pumpAndSettle(); // Let the screen animate to the tab
+
+    expect(find.byType(CourseGradesScreen), findsOneWidget);
+  });
+
+  testWidgetsWithAccessibilityChecks('Clicking syllabus tab shows the syllabus screen', (tester) async {
+    _setupLocator();
+
+    await tester.pumpWidget(TestApp(CourseDetailsScreen(studentId, courseId)));
+    await tester.pump(); // Widget creation
+    await tester.pump(); // Future resolved
+
+    await tester.tap(find.text(AppLocalizations().courseSyllabusLabel.toUpperCase()));
+    await tester.pumpAndSettle(); // Let the screen animate to the tab
+
+    expect(find.byType(CourseSyllabusScreen), findsOneWidget);
+  });
+
+  testWidgetsWithAccessibilityChecks('Clicking summary tab shows the summary screen', (tester) async {
+    _setupLocator();
+
+    await tester.pumpWidget(TestApp(CourseDetailsScreen(studentId, courseId)));
+    await tester.pump(); // Widget creation
+    await tester.pump(); // Future resolved
+
+    await tester.tap(find.text(AppLocalizations().courseSummaryLabel.toUpperCase()));
+    await tester.pumpAndSettle(); // Let the screen animate to the tab
+
+    expect(find.byType(CourseSummaryScreen), findsOneWidget);
+  });
+
+  testWidgetsWithAccessibilityChecks('Tapping message button shows message screen', (tester) async {
+    _setupLocator();
+
+    await tester.pumpWidget(TestApp(CourseDetailsScreen(studentId, courseId)));
+    await tester.pump(); // Widget creation
+    await tester.pump(); // Future resolved
+
+    // Should show the fab
+    final matchedWidget = find.byType(FloatingActionButton);
+    expect(matchedWidget, findsOneWidget);
+
+    // Should launch the message screen
+    await tester.tap(matchedWidget);
+    await tester.pumpAndSettle(); // Let the new screen create itself
+    // TODO: Test once messages are in
+//    expect(find.byType(MessagesScreen), findsOneWidget);
+  });
+}
+
+class _MockCourseDetailsInteractor extends Mock implements CourseDetailsInteractor {}

--- a/apps/flutter_parent/test/screens/courses/courses_screen_test.dart
+++ b/apps/flutter_parent/test/screens/courses/courses_screen_test.dart
@@ -20,11 +20,12 @@ import 'package:flutter_parent/models/enrollment.dart';
 import 'package:flutter_parent/models/user.dart';
 import 'package:flutter_parent/screens/courses/courses_interactor.dart';
 import 'package:flutter_parent/screens/courses/courses_screen.dart';
+import 'package:flutter_parent/screens/courses/details/course_details_screen.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 
-import '../utils/accessibility_utils.dart';
-import '../utils/test_app.dart';
+import '../../utils/accessibility_utils.dart';
+import '../../utils/test_app.dart';
 
 void main() {
   _setupLocator(_MockCoursesInteractor mockInteractor) {
@@ -117,6 +118,29 @@ void main() {
 
     final gradeWidget = find.text('90%');
     expect(gradeWidget, findsNWidgets(courses.length));
+  });
+
+  testWidgetsWithAccessibilityChecks('launces course detail screen when tapping on a course', (tester) async {
+    var student = _mockStudent(1);
+    var courses = List.generate(
+      1, (idx) =>
+        _mockCourse(
+          idx,
+          enrollments: ListBuilder<Enrollment>([_mockEnrollment(idx, userId: student.id, computedCurrentScore: 90)]),
+        ),
+    );
+
+    _setupLocator(_MockCoursesInteractor(courses: courses));
+
+    await tester.pumpWidget(_testableMaterialWidget(CoursesScreen(student)));
+    await tester.pumpAndSettle();
+
+    final matchedWidget = find.text(courses.first.name);
+    expect(matchedWidget, findsOneWidget);
+    await tester.tap(matchedWidget);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(CourseDetailsScreen), findsOneWidget);
   });
 }
 

--- a/apps/flutter_parent/test/screens/courses/courses_screen_test.dart
+++ b/apps/flutter_parent/test/screens/courses/courses_screen_test.dart
@@ -120,7 +120,7 @@ void main() {
     expect(gradeWidget, findsNWidgets(courses.length));
   });
 
-  testWidgetsWithAccessibilityChecks('launces course detail screen when tapping on a course', (tester) async {
+  testWidgetsWithAccessibilityChecks('launches course detail screen when tapping on a course', (tester) async {
     var student = _mockStudent(1);
     var courses = List.generate(
       1, (idx) =>

--- a/apps/flutter_parent/test/utils/base_model_test.dart
+++ b/apps/flutter_parent/test/utils/base_model_test.dart
@@ -1,0 +1,63 @@
+/// Copyright (C) 2019 - present Instructure, Inc.
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, version 3 of the License.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import 'package:flutter_parent/utils/base_model.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Initializes BaseModel state to Idle', () {
+    final model = BaseModel();
+    expect(model.state, ViewState.Idle);
+  });
+
+  test('Calling setState to Busy notifies the liseners', () {
+    final model = BaseModel();
+    model.addListener(() => expect(model.state, ViewState.Busy));
+    model.setState(viewState: ViewState.Busy);
+  });
+
+  test('Calling work notifies listeners that the state is busy', () async {
+    final model = BaseModel();
+    final busyListener = () => expect(model.state, ViewState.Busy);
+    model.addListener(busyListener);
+    await model.work(() async {
+      // Remove the listener, otherwise it will fail for future listener updates
+      model.removeListener(busyListener);
+    });
+  });
+
+  test('Calling work notifies listeners that the state is Idle after the block is run', () async {
+    final model = BaseModel();
+    await model.work(() async {
+      expect(model.state, ViewState.Busy);
+      model.addListener(() => expect(model.state, ViewState.Idle));
+    });
+    expect(model.state, ViewState.Idle);
+  });
+
+  test('Calling work notifies listeners that the state is Error if the block throws an exception', () async {
+    final model = BaseModel();
+    await model.work(() {
+      model.addListener(() => expect(model.state, ViewState.Error));
+      return Future.error('This failed');
+    });
+    expect(model.state, ViewState.Error);
+  });
+
+  test('Calling work ends with a state of Idle if the block null', () async {
+    final model = BaseModel();
+    await model.work(null);
+    expect(model.state, ViewState.Idle);
+  });
+}

--- a/apps/flutter_parent/test/utils/base_model_test.dart
+++ b/apps/flutter_parent/test/utils/base_model_test.dart
@@ -55,7 +55,7 @@ void main() {
     expect(model.state, ViewState.Error);
   });
 
-  test('Calling work ends with a state of Idle if the block null', () async {
+  test('Calling work ends with a state of Idle if the block is null', () async {
     final model = BaseModel();
     await model.work(null);
     expect(model.state, ViewState.Idle);


### PR DESCRIPTION
This is just the holder for the three tabs on the course details screen. Since those 3 screens all share the course and assignment data, this parent widget is loading that information for all of its children. For children to refresh the data, they need a consumer of the model, and just call model on the load. I’ve created 3 stub classes for these finer detail screens and shown how to do a refresh of data.

Also adds a new ‘BaseModel’ class, this is used for complex screens where we want to make use of provider for sharing data with children widgets. It keeps track of the loading state (via the ViewState property) and allows children and parents to use/load/refresh data when needed.