### PR TITLE
[Student][E2E][MBL-13604]: Stubbing out video comment logic that breaks E2E test

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/AssignmentsE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/AssignmentsE2ETest.kt
@@ -246,10 +246,13 @@ class AssignmentsE2ETest: StudentTest() {
         assignmentDetailsPage.goToSubmissionDetails()
         submissionDetailsPage.openComments()
 
+        // MBL-13604: This does not work on FTL, so we're commenting it out for now.
+        // You could also break this out to a separate E2E test and annotate it with
+        // @Stub, so that we can run it locally but it doesn't run as part of our CI suite.
         // send video comment
-        submissionDetailsPage.addAndSendVideoComment()
-        sleep(3000) // wait for video comment submission to propagate
-        submissionDetailsPage.assertVideoCommentDisplayed()
+//        submissionDetailsPage.addAndSendVideoComment()
+//        sleep(3000) // wait for video comment submission to propagate
+//        submissionDetailsPage.assertVideoCommentDisplayed()
 
         // send audio comment
         submissionDetailsPage.addAndSendAudioComment()


### PR DESCRIPTION
I'll leave MBL-13604 open,  to remind us that we have no automated video submission comment test.