### PR TITLE
[Student][Interaction][MBL-13558]: Fix intermittent problems with discussion replies

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DiscussionDetailsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DiscussionDetailsPage.kt
@@ -16,6 +16,7 @@
  */
 package com.instructure.student.ui.pages
 
+import android.os.SystemClock.sleep
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.swipeDown
@@ -99,6 +100,7 @@ class DiscussionDetailsPage : BasePage(R.id.discussionDetailsPage) {
         clickReply()
         onView(withId(R.id.rce_webView)).perform(TypeInRCETextEditor(replyMessage))
         onView(withId(R.id.menu_send)).click()
+        sleep(2000) // Allow time for the reply to propagate to webview
     }
 
     fun assertReplyDisplayed(reply: DiscussionEntry) {
@@ -180,6 +182,7 @@ class DiscussionDetailsPage : BasePage(R.id.discussionDetailsPage) {
                 .perform(webClick())
         onView(withId(R.id.rce_webView)).perform(TypeInRCETextEditor(replyMessage))
         onView(withId(R.id.menu_send)).click()
+        sleep(2000) // Allow time for reply to propagate to webview
     }
 
     fun assertMainAttachmentDisplayed() {


### PR DESCRIPTION
Evidently, it can take a little time from when you reply to a discussion (or a reply) and when that reply shows up in the webview (and therefore our asserts for its existence pass).  Espresso does not naturally wait for this action, so I had to add a sleep().  And I found that 1 second was not long enough, so I made it 2 seconds.  The methods where these sleeps were added are called a total of 8 times by our interaction test suite, and once by our E2E test suite.

The sleep() calls are unfortunate, but I think they are necessary, and it's annoying when your PR is blocked on these tests failing.

If desired, I can create a ticket to find a way to create an idling resource to wait for the webview to be updated.