### PR TITLE
[Teacher][RC-1.9.1] Fix student context page having full height views

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/adapters/StudentContextFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/adapters/StudentContextFragment.kt
@@ -18,7 +18,6 @@ package com.instructure.teacher.adapters
 import android.graphics.Color
 import android.os.Bundle
 import android.view.*
-import android.widget.LinearLayout.LayoutParams
 import android.widget.TextView
 import com.instructure.canvasapi2.StudentContextCardQuery.*
 import com.instructure.canvasapi2.models.BasicUser
@@ -207,10 +206,7 @@ class StudentContextFragment : PresenterFragment<StudentContextPresenter, Studen
             val visibleGradeItems = gradeItems.children.filter { it.isVisible }
             if (visibleGradeItems.size == 1) {
                 // If there is only one grade item, add a second empty child so the first doesn't stretch to the full parent width
-                gradeItems.addView(
-                    View(context),
-                    LayoutParams(0, LayoutParams.MATCH_PARENT, 1.0f)
-                )
+                emptyGradeItemSpace.setVisible()
             } else {
                 // Set color of last grade item
                 visibleGradeItems.lastOrNull()?.apply {

--- a/apps/teacher/src/main/res/layout/fragment_student_context.xml
+++ b/apps/teacher/src/main/res/layout/fragment_student_context.xml
@@ -229,6 +229,13 @@
 
                     </LinearLayout>
 
+                    <Space
+                        android:id="@+id/emptyGradeItemSpace"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"
+                        android:visibility="gone" />
+
                 </LinearLayout>
 
                 <TextView


### PR DESCRIPTION
On Android 10, adding a view during runtime was having it take the entire view height. Placing it in the xml file and toggling the visibility allows the children to actually wrap_content like we want.