### PR TITLE
[Flutter-Parent] Upgrade dependencies and update gitignore

### DIFF
--- a/apps/flutter_parent/.gitignore
+++ b/apps/flutter_parent/.gitignore
@@ -29,6 +29,7 @@ coverage/
 **/doc/api/
 .dart_tool/
 .flutter-plugins
+.flutter-plugins-dependencies
 .packages
 .pub-cache/
 .pub/

--- a/apps/flutter_parent/pubspec.lock
+++ b/apps/flutter_parent/pubspec.lock
@@ -112,7 +112,7 @@ packages:
       name: cached_network_image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "2.0.0-rc"
   charcode:
     dependency: transitive
     description:

--- a/apps/flutter_parent/pubspec.lock
+++ b/apps/flutter_parent/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.36.4"
+    version: "0.38.5"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -15,6 +15,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.1"
+  archive:
+    dependency: transitive
+    description:
+      name: archive
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.11"
   args:
     dependency: transitive
     description:
@@ -28,7 +35,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.4.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -70,14 +77,14 @@ packages:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.1"
+    version: "1.7.2"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "4.2.1"
   built_collection:
     dependency: "direct main"
     description:
@@ -141,13 +148,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
+  coverage:
+    dependency: transitive
+    description:
+      name: coverage
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.3+3"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1+1"
+    version: "2.1.3"
   csslib:
     dependency: transitive
     description:
@@ -161,7 +175,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.9"
+    version: "1.3.3"
   device_info:
     dependency: "direct main"
     description:
@@ -189,7 +203,7 @@ packages:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.8+1"
+    version: "5.1.0"
   file_picker:
     dependency: "direct main"
     description:
@@ -197,27 +211,41 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.2"
+  firebase:
+    dependency: transitive
+    description:
+      name: firebase
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "7.1.0"
   firebase_analytics:
     dependency: "direct main"
     description:
       name: firebase_analytics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.6"
+    version: "5.0.9"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2+1"
+    version: "0.4.3+1"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.2"
+  firebase_core_web:
+    dependency: transitive
+    description:
+      name: firebase_core_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.1"
   fixnum:
     dependency: transitive
     description:
@@ -259,13 +287,18 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   front_end:
     dependency: transitive
     description:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.19"
+    version: "0.1.27"
   fuchsia_remote_debug_protocol:
     dependency: transitive
     description: flutter
@@ -320,6 +353,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.3"
+  image:
+    dependency: transitive
+    description:
+      name: image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.4"
   image_picker:
     dependency: "direct main"
     description:
@@ -333,7 +373,7 @@ packages:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.8"
+    version: "0.16.0"
   intl_translation:
     dependency: "direct dev"
     description:
@@ -375,14 +415,14 @@ packages:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.2"
+    version: "3.2.3"
   kernel:
     dependency: transitive
     description:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.19"
+    version: "0.3.27"
   logging:
     dependency: transitive
     description:
@@ -396,14 +436,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.5"
+    version: "0.12.6"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.7"
+    version: "1.1.8"
   mime:
     dependency: transitive
     description:
@@ -494,7 +534,7 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.1"
   pedantic:
     dependency: transitive
     description:
@@ -516,6 +556,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.2.1"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   pool:
     dependency: transitive
     description:
@@ -529,7 +576,7 @@ packages:
       name: process
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.11"
+    version: "3.0.12"
   provider:
     dependency: "direct main"
     description:
@@ -558,13 +605,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.5"
-  quiver_hashcode:
-    dependency: transitive
-    description:
-      name: quiver_hashcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -611,7 +651,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.4+4"
+    version: "0.9.4+6"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -639,7 +679,7 @@ packages:
       name: sqflite
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.7+3"
+    version: "1.1.8"
   stack_trace:
     dependency: transitive
     description:
@@ -660,7 +700,7 @@ packages:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.19"
+    version: "0.0.20"
   string_scanner:
     dependency: transitive
     description:
@@ -688,21 +728,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.3"
+    version: "1.9.4"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.15"
   timing:
     dependency: transitive
     description:
@@ -737,7 +777,7 @@ packages:
       name: url_launcher_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.4"
   uuid:
     dependency: transitive
     description:
@@ -752,6 +792,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.8"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.3"
   vm_service_client:
     dependency: transitive
     description:
@@ -772,7 +819,7 @@ packages:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.15"
+    version: "1.1.0"
   webview_flutter:
     dependency: "direct main"
     description:
@@ -795,5 +842,5 @@ packages:
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=2.5.0 <3.0.0"
-  flutter: ">=1.9.1+hotfix.5 <2.0.0"
+  dart: ">=2.6.0 <3.0.0"
+  flutter: ">=1.12.13+hotfix.4 <2.0.0"

--- a/apps/flutter_parent/pubspec.yaml
+++ b/apps/flutter_parent/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   image_picker: 0.6.1+4
   file_picker: 1.4.2
   transparent_image: 1.0.0
-  cached_network_image: 1.1.3
+  cached_network_image: 2.0.0-rc
 
   # Networking / Serialization
   dio: 3.0.5

--- a/apps/flutter_parent/pubspec.yaml
+++ b/apps/flutter_parent/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   firebase_analytics: ^5.0.2
   firebase_core: ^0.4.0+9
   get_it: ^3.0.1
-  intl: ^0.15.8
+  intl: ^0.16.0
   package_info: 0.4.0+10
   provider: ^3.1.0+1
   shared_preferences: 0.5.3+4

--- a/apps/flutter_parent/test/api/api_prefs_test.dart
+++ b/apps/flutter_parent/test/api/api_prefs_test.dart
@@ -18,14 +18,16 @@ import 'package:flutter_parent/api/utils/api_prefs.dart';
 import 'package:flutter_parent/models/canvas_token.dart';
 import 'package:flutter_parent/models/mobile_verify_result.dart';
 import 'package:flutter_parent/models/user.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:package_info/package_info.dart';
-import 'package:test/test.dart';
 
 import '../utils/platform_config.dart';
 import '../utils/test_app.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   tearDown(() {
     ApiPrefs.clean();
   });
@@ -190,7 +192,8 @@ void main() {
     final user = _mockUser().rebuild((b) => b..effectiveLocale = 'ar');
     await ApiPrefs.setUser(user);
 
-    expect(ApiPrefs.getHeaderMap(forceDeviceLanguage: true)['accept-language'], deviceLocale.toLanguageTag().replaceAll("-", ","));
+    expect(ApiPrefs.getHeaderMap(forceDeviceLanguage: true)['accept-language'],
+        deviceLocale.toLanguageTag().replaceAll("-", ","));
   });
 
   test('getHeaderMap returns a map with the token from prefs', () async {

--- a/apps/flutter_parent/test/api/api_prefs_test.dart
+++ b/apps/flutter_parent/test/api/api_prefs_test.dart
@@ -26,8 +26,6 @@ import '../utils/platform_config.dart';
 import '../utils/test_app.dart';
 
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
-
   tearDown(() {
     ApiPrefs.clean();
   });

--- a/apps/flutter_parent/test/api/dio_config_test.dart
+++ b/apps/flutter_parent/test/api/dio_config_test.dart
@@ -21,8 +21,6 @@ import '../utils/platform_config.dart';
 import '../utils/test_app.dart';
 
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
-
   setUpAll(() async => await setupPlatformChannels());
 
   test('returns a dio object', () async {

--- a/apps/flutter_parent/test/api/dio_config_test.dart
+++ b/apps/flutter_parent/test/api/dio_config_test.dart
@@ -21,6 +21,7 @@ import '../utils/platform_config.dart';
 import '../utils/test_app.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
 
   setUpAll(() async => await setupPlatformChannels());
 

--- a/apps/flutter_parent/test/screens/courses/courses_screen_test.dart
+++ b/apps/flutter_parent/test/screens/courses/courses_screen_test.dart
@@ -20,6 +20,7 @@ import 'package:flutter_parent/models/enrollment.dart';
 import 'package:flutter_parent/models/user.dart';
 import 'package:flutter_parent/screens/courses/courses_interactor.dart';
 import 'package:flutter_parent/screens/courses/courses_screen.dart';
+import 'package:flutter_parent/screens/courses/details/course_details_interactor.dart';
 import 'package:flutter_parent/screens/courses/details/course_details_screen.dart';
 import 'package:flutter_parent/utils/quick_nav.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -33,6 +34,7 @@ void main() {
     final _locator = GetIt.instance;
     _locator.reset();
     _locator.registerFactory<CoursesInteractor>(() => mockInteractor);
+    _locator.registerFactory<CourseDetailsInteractor>(() => _MockCourseDetailsInteractor());
     _locator.registerFactory<QuickNav>(() => QuickNav());
   }
 
@@ -162,6 +164,8 @@ class _MockCoursesInteractor extends CoursesInteractor {
   @override
   Future<List<Course>> getCourses() async => courses ?? ListBuilder<Course>([_mockCourse(1)]).build().toList();
 }
+
+class _MockCourseDetailsInteractor extends CourseDetailsInteractor {}
 
 List<Course> generateCoursesForStudent([int userId]) {
   var student = _mockStudent(userId ?? 1);

--- a/apps/flutter_parent/test/screens/not_a_parent_screen_test.dart
+++ b/apps/flutter_parent/test/screens/not_a_parent_screen_test.dart
@@ -17,6 +17,7 @@ import 'package:flutter_parent/screens/not_a_parent_screen.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 import '../utils/accessibility_utils.dart';
@@ -52,7 +53,6 @@ void main() {
 
   testWidgetsWithAccessibilityChecks('Launches intent to open student app in play store', (tester) async {
     var mockLauncher = _MockUrlLauncherPlatform();
-    when(mockLauncher.isMock).thenReturn(true);
     UrlLauncherPlatform.instance = mockLauncher;
 
     await tester.pumpWidget(TestApp(NotAParentScreen(), highContrast: true));
@@ -82,7 +82,6 @@ void main() {
 
   testWidgetsWithAccessibilityChecks('Launches intent to open teacher app in play store', (tester) async {
     var mockLauncher = _MockUrlLauncherPlatform();
-    when(mockLauncher.isMock).thenReturn(true);
     UrlLauncherPlatform.instance = mockLauncher;
 
     await tester.pumpWidget(TestApp(NotAParentScreen(), highContrast: true));
@@ -111,4 +110,4 @@ void main() {
   });
 }
 
-class _MockUrlLauncherPlatform extends Mock implements UrlLauncherPlatform {}
+class _MockUrlLauncherPlatform extends Mock with MockPlatformInterfaceMixin implements UrlLauncherPlatform {}

--- a/apps/flutter_parent/test/utils/test_app.dart
+++ b/apps/flutter_parent/test/utils/test_app.dart
@@ -22,6 +22,7 @@ import 'package:flutter_parent/api/utils/api_prefs.dart';
 import 'package:flutter_parent/l10n/app_localizations.dart';
 import 'package:flutter_parent/utils/common_widgets/respawn.dart';
 import 'package:flutter_parent/utils/design/parent_theme.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -113,6 +114,8 @@ void setupTestLocator(config(GetIt locator)) {
 /// Returned is a future that completes when all async tasks spawned by this method call have completed. Waiting isn't
 /// required, though is probably good practice and results in more stable tests.
 Future<void> setupPlatformChannels({PlatformConfig config = const PlatformConfig()}) {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   if (config.initPackageInfo) {
     const MethodChannel('plugins.flutter.io/package_info').setMockMethodCallHandler((MethodCall methodCall) async {
       if (methodCall.method == 'getAll') {


### PR DESCRIPTION
Upgrading Flutter to the newest stable requires a newer version of the intl dependency. I also ran a package upgrade to our dependencies.

I added `.flutter-plugins-dependencies` to the gitignore as well.