### PR TITLE
Modified manage students screen to be testable for failures

### DIFF
--- a/apps/flutter_parent/test/screens/manage_students_screen_test.dart
+++ b/apps/flutter_parent/test/screens/manage_students_screen_test.dart
@@ -74,72 +74,70 @@ void main() {
       // See if we got our new student
       expect(find.text('Sally'), findsOneWidget);
     });
+  });
 
-    // TODO: The following two tests require updating the error in the snapshot that the FutureBuilder gets in the main ManageStudentScreen widget.
-    //  There doesn't appear to be a way to change that error state in tests.
+  testWidgetsWithAccessibilityChecks('Error on pull to refresh', (tester) async {
+    // Mock the behavior of the interactor so it returns a Future error
+    var interactor = _MockManageStudentsInteractor();
+    Future<List<User>> err;
+    expect(() => err = Future<List<User>>.error('rorre'), throwsA(anything));
+    when(interactor.getStudents(forceRefresh: anyNamed('forceRefresh'))).thenAnswer((_) => err);
 
-//    testWidgetsWithAccessibilityChecks('Error on pull to refresh', (tester) async {
-//      // Mock the behavior of the interactor so it returns a Future error
-//      var interactor = _MockManageStudentsInteractor();
-//      Completer completer = Completer<List<User>>();
-////      when(interactor.getStudents(forceRefresh: anyNamed('forceRefresh')))
-////          .thenAnswer((_) => completer.future.catchError((_) {
-////                completer.completeError('');
-////              }));
-//
-//      when(interactor.getStudents(forceRefresh: anyNamed('forceRefresh')))
-//          .thenAnswer((_) => Future<List<User>>.error('error'));
-//
-//      _setupLocator(interactor);
-//
-//      List<User> observedStudents = [];
-//
-//      // Start the screen with one user
-//      await tester.pumpWidget(TestApp(ManageStudentsScreen(observedStudents)));
-//      await tester.pumpAndSettle();
-//
-//      // Pull to refresh
-//      await tester.drag(find.byType(RefreshIndicator), const Offset(0, 200));
-//      await tester.pump();
-//      await tester.pump(Duration(seconds: 3));
-//      await tester.pumpAndSettle();
-//      print('After completer error');
-//
-//      // Check if we show the error message
-//      expect(find.text(AppLocalizations().errorLoadingStudents), findsOneWidget);
-////      expect(find.text('Retry'), findsOneWidget);
-//    });
+    _setupLocator(interactor);
 
-//    testWidgetsWithAccessibilityChecks('Retry button on error page loads students', (tester) async {
-//      var observedStudents = [_mockUser('Billy')];
-//
-//      // Mock the behavior of the interactor so it returns a Future error
-//      final interactor = _MockManageStudentsInteractor();
-//      when(interactor.getStudents(forceRefresh: anyNamed('forceRefresh'))).thenAnswer((_) => Future.error('error'));
-//      _setupLocator(interactor);
-//
-//      // Start the page with a single student
-//      await tester.pumpWidget(TestApp(ManageStudentsScreen(observedStudents)));
-//      await tester.pumpAndSettle();
-//
-//      // Pull to refresh, causing an error which will show the error screen with the retry button
-//      await tester.drag(find.byType(RefreshIndicator), const Offset(0, 200));
-//      await tester.pumpAndSettle();
-//
-//      // Tap retry button to refresh list
-//      await tester.tap(find.text(AppLocalizations().retry));
-//      await tester.pumpAndSettle();
-//
-//      // Change the interactor to return a student instead of an error
-//      when(interactor.getStudents(forceRefresh: anyNamed('forceRefresh')))
-//          .thenAnswer((_) => Future.value(observedStudents));
-//
-//      await tester.drag(find.byType(RefreshIndicator), const Offset(0, 200));
-//      await tester.pumpAndSettle();
-//
-//      // See if we got the student back from the retry
-//      expect(find.text('Billy'), findsOneWidget);
-//    });
+    List<User> observedStudents = [];
+
+    // Start the screen with one user
+    await tester.pumpWidget(TestApp(ManageStudentsScreen(observedStudents), highContrast: true));
+    await tester.pumpAndSettle();
+
+    // Pull to refresh
+    final refresh = find.byType(RefreshIndicator);
+    expect(refresh, findsOneWidget);
+
+    await tester.drag(refresh, const Offset(0, 300));
+    await tester.pump();
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    verify(interactor.getStudents(forceRefresh: anyNamed('forceRefresh'))).called(1);
+
+    // Check if we show the error message
+    expect(find.text(AppLocalizations().errorLoadingStudents), findsOneWidget);
+    expect(find.text(AppLocalizations().retry), findsOneWidget);
+  });
+
+  testWidgetsWithAccessibilityChecks('Retry button on error page loads students', (tester) async {
+    var observedStudents = [_mockUser('Billy')];
+
+    // Mock the behavior of the interactor so it returns a Future error
+    final interactor = _MockManageStudentsInteractor();
+    Future<List<User>> err;
+    expect(() => err = Future<List<User>>.error('rorre'), throwsA(anything));
+    when(interactor.getStudents(forceRefresh: anyNamed('forceRefresh'))).thenAnswer((_) => err);
+    _setupLocator(interactor);
+
+    // Start the page with a single student
+    await tester.pumpWidget(TestApp(ManageStudentsScreen(observedStudents)));
+    await tester.pumpAndSettle();
+
+    // Pull to refresh, causing an error which will show the error screen with the retry button
+    await tester.drag(find.byType(RefreshIndicator), const Offset(0, 200));
+    await tester.pumpAndSettle();
+
+    // Tap retry button to refresh list
+    await tester.tap(find.text(AppLocalizations().retry));
+    await tester.pumpAndSettle();
+
+    // Change the interactor to return a student instead of an error
+    when(interactor.getStudents(forceRefresh: anyNamed('forceRefresh')))
+        .thenAnswer((_) => Future.value(observedStudents));
+
+    await tester.drag(find.byType(RefreshIndicator), const Offset(0, 200));
+    await tester.pumpAndSettle();
+
+    // See if we got the student back from the retry
+    expect(find.text('Billy'), findsOneWidget);
   });
 
   group('Student List', () {


### PR DESCRIPTION
This just moves the handling of errors into the widget itself, rather than relying on FutureBuilder to handle it. This was the only way I could see to test the screen based on testing Future.error (stupid flutter uncaught exceptions for that).