### PR TITLE
[Flutter-Parent][MBL-13675] Use fetch/fetchList for api calls

### DIFF
--- a/apps/flutter_parent/lib/api/accounts_api.dart
+++ b/apps/flutter_parent/lib/api/accounts_api.dart
@@ -12,23 +12,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import 'package:dio/dio.dart';
-import 'package:dio_http_cache/dio_http_cache.dart';
+import 'package:flutter_parent/api/utils/dio_config.dart';
+import 'package:flutter_parent/api/utils/fetch.dart';
 import 'package:flutter_parent/models/school_domain.dart';
-import 'package:flutter_parent/models/serializers.dart';
 
 class AccountsApi {
   static Future<List<SchoolDomain>> searchDomains(String query) async {
-    var dio = Dio();
-    dio.interceptors.add(DioCacheManager(CacheConfig(baseUrl: "canvas.instructure.com")).interceptor);
-    var response = await dio.get(
-      "https://canvas.instructure.com/api/v1/accounts/search",
-      queryParameters: {'search_term': query},
-      options: buildCacheOptions(Duration(minutes: 5)),
-    );
-    if (response.statusCode == 200) {
-      return Future.value(deserializeList<SchoolDomain>(response.data));
-    }
-    return Future.error(response.statusCode);
+    var dio = DioConfig.core(cacheMaxAge: Duration(minutes: 5)).dio;
+    return fetchList(dio.get('accounts/search', queryParameters: {'search_term': query}));
   }
 }

--- a/apps/flutter_parent/lib/api/alert_api.dart
+++ b/apps/flutter_parent/lib/api/alert_api.dart
@@ -12,47 +12,18 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import 'package:dio/dio.dart';
-import 'package:flutter_parent/api/utils/api_prefs.dart';
-import 'package:flutter_parent/api/utils/paged_list.dart';
+import 'package:flutter_parent/api/utils/dio_config.dart';
+import 'package:flutter_parent/api/utils/fetch.dart';
 import 'package:flutter_parent/models/alert.dart';
-import 'package:flutter_parent/models/serializers.dart';
 
 class AlertsApi {
   /// Alerts were depaginated in the original parent app, then sorted by date. Depaginating here to follow suite.
   Future<List<Alert>> getAlertsDepaginated(int studentId) async {
-    var response = await Dio().get(ApiPrefs.getApiUrl(path: 'users/self/observer_alerts/$studentId'),
-        options: Options(headers: ApiPrefs.getHeaderMap()));
-
-    if (response.statusCode == 200 || response.statusCode == 201) {
-      final list = PagedList<Alert>(response);
-      return (list.nextUrl == null) ? list.data : _getAlertsDepaginated(list);
-    } else {
-      return Future.error(response.statusMessage);
-    }
-  }
-
-  Future<List<Alert>> _getAlertsDepaginated(PagedList<Alert> prevList) async {
-    var response = await Dio().get(prevList.nextUrl, options: Options(headers: ApiPrefs.getHeaderMap()));
-
-    if (response.statusCode == 200 || response.statusCode == 201) {
-      prevList.updateWithResponse(response);
-      return (prevList.nextUrl == null) ? prevList.data : _getAlertsDepaginated(prevList);
-    } else {
-      return Future.error(response.statusMessage);
-    }
+    var dio = canvasDio();
+    return fetchList(canvasDio().get('users/self/observer_alerts/$studentId'), depaginateWith: dio);
   }
 
   Future<Alert> updateAlertWorkflow(int alertId, String workflowState) async {
-    var response = await Dio().put(
-      ApiPrefs.getApiUrl(path: "users/self/observer_alerts/$alertId/$workflowState"),
-      options: Options(headers: ApiPrefs.getHeaderMap()),
-    );
-
-    if (response.statusCode == 200 || response.statusCode == 201) {
-      return deserialize<Alert>(response.data);
-    } else {
-      return Future.error(response.statusMessage);
-    }
+    return fetch(canvasDio().put('users/self/observer_alerts/$alertId/$workflowState'));
   }
 }

--- a/apps/flutter_parent/lib/api/alert_api.dart
+++ b/apps/flutter_parent/lib/api/alert_api.dart
@@ -20,7 +20,7 @@ class AlertsApi {
   /// Alerts were depaginated in the original parent app, then sorted by date. Depaginating here to follow suite.
   Future<List<Alert>> getAlertsDepaginated(int studentId) async {
     var dio = canvasDio();
-    return fetchList(canvasDio().get('users/self/observer_alerts/$studentId'), depaginateWith: dio);
+    return fetchList(dio.get('users/self/observer_alerts/$studentId'), depaginateWith: dio);
   }
 
   Future<Alert> updateAlertWorkflow(int alertId, String workflowState) async {

--- a/apps/flutter_parent/lib/api/auth_api.dart
+++ b/apps/flutter_parent/lib/api/auth_api.dart
@@ -14,66 +14,47 @@
 
 import 'package:dio/dio.dart';
 import 'package:flutter_parent/api/utils/api_prefs.dart';
+import 'package:flutter_parent/api/utils/dio_config.dart';
+import 'package:flutter_parent/api/utils/fetch.dart';
 import 'package:flutter_parent/models/canvas_token.dart';
 import 'package:flutter_parent/models/mobile_verify_result.dart';
-import 'package:flutter_parent/models/serializers.dart';
 
 class AuthApi {
   Future<CanvasToken> refreshToken() async {
-    var response = await Dio().post(
-      "${ApiPrefs.getDomain()}/login/oauth2/token",
-      queryParameters: {
-        'client_id': ApiPrefs.getClientId(),
-        'client_secret': ApiPrefs.getClientSecret(),
-        'redirect_uri': 'urn:ietf:wg:oauth:2.0:oob',
-        'grant_type': 'refresh_token',
-        'refresh_token': ApiPrefs.getRefreshToken(),
-      },
-    );
-
-    if (response.statusCode == 200) {
-      return deserialize<CanvasToken>(response.data);
-    } else {
-      return Future.error("Unknown Error");
-    }
+    var dio = DioConfig.canvas(includeApiPath: false).dio;
+    var params = {
+      'client_id': ApiPrefs.getClientId(),
+      'client_secret': ApiPrefs.getClientSecret(),
+      'redirect_uri': 'urn:ietf:wg:oauth:2.0:oob',
+      'grant_type': 'refresh_token',
+      'refresh_token': ApiPrefs.getRefreshToken(),
+    };
+    return fetch(dio.post('login/oauth2/token', queryParameters: params));
   }
 
   Future<CanvasToken> getTokens(MobileVerifyResult verifyResult, String requestCode) async {
-    var response = await Dio().post(
-      "${verifyResult.baseUrl}/login/oauth2/token",
-      queryParameters: {
-        'client_id': verifyResult.clientId,
-        'client_secret': verifyResult.clientSecret,
-        'code': requestCode,
-        'redirect_uri': 'urn:ietf:wg:oauth:2.0:oob',
-      },
-    );
-
-    if (response.statusCode == 200 || response.statusCode == 201) {
-      return deserialize<CanvasToken>(response.data);
-    } else {
-      return Future.error(response.statusMessage);
-    }
+    var dio = DioConfig().dio;
+    var params = {
+      'client_id': verifyResult.clientId,
+      'client_secret': verifyResult.clientSecret,
+      'code': requestCode,
+      'redirect_uri': 'urn:ietf:wg:oauth:2.0:oob',
+    };
+    return fetch(dio.post('${verifyResult.baseUrl}/login/oauth2/token', queryParameters: params));
   }
 
   Future<MobileVerifyResult> mobileVerify(String domain) async {
-    var userAgent = ApiPrefs.getUserAgent();
-    var encodedAgent = Uri.encodeQueryComponent(userAgent);
-    var encodedDomain = Uri.encodeQueryComponent(domain);
-
-    var response = await Dio().get(
-      "https://canvas.instructure.com/api/v1/mobile_verify.json",
-      queryParameters: {
-        'domain': encodedDomain,
-        'user_agent': encodedAgent,
-      },
-      options: Options(headers: {'User-Agent': userAgent}),
+    Dio dio = DioConfig.core().dio;
+    String userAgent = ApiPrefs.getUserAgent();
+    return fetch(
+      dio.get(
+        'mobile_verify.json',
+        queryParameters: {
+          'domain': domain,
+          'user_agent': userAgent,
+        },
+        options: Options(headers: {'User-Agent': userAgent}),
+      ),
     );
-
-    if (response.statusCode == 200) {
-      return deserialize<MobileVerifyResult>(response.data);
-    } else {
-      return Future.error("Unknown Error");
-    }
   }
 }

--- a/apps/flutter_parent/lib/api/course_api.dart
+++ b/apps/flutter_parent/lib/api/course_api.dart
@@ -18,7 +18,7 @@ import 'package:flutter_parent/models/course.dart';
 
 class CourseApi {
   Future<List<Course>> getObserveeCourses({bool forceRefresh: false}) async {
-    final dio = canvasDio(forceRefresh: forceRefresh, usePerPageParam: true);
+    final dio = canvasDio(forceRefresh: forceRefresh, pageSize: PageSize.canvasMax);
     final params = {
       'include': [
         'term',

--- a/apps/flutter_parent/lib/api/enrollments_api.dart
+++ b/apps/flutter_parent/lib/api/enrollments_api.dart
@@ -18,7 +18,7 @@ import 'package:flutter_parent/models/enrollment.dart';
 
 class EnrollmentsApi {
   static Future<List<Enrollment>> getObserveeEnrollments({bool forceRefresh = false}) async {
-    var dio = canvasDio(usePerPageParam: true, forceRefresh: forceRefresh);
+    var dio = canvasDio(pageSize: PageSize.canvasMax, forceRefresh: forceRefresh);
     var params = {
       'include': ['observed_users', 'avatar_url'],
       'state': ['creation_pending', 'invited', 'active']

--- a/apps/flutter_parent/lib/api/inbox_api.dart
+++ b/apps/flutter_parent/lib/api/inbox_api.dart
@@ -21,7 +21,7 @@ import 'package:flutter_parent/models/unread_count.dart';
 
 class InboxApi {
   Future<List<Conversation>> getConversations({String scope: null, bool forceRefresh: false}) async {
-    final dio = canvasDio(forceRefresh: forceRefresh, usePerPageParam: true);
+    final dio = canvasDio(forceRefresh: forceRefresh, pageSize: PageSize.canvasMax);
     final params = {
       'scope': scope,
       'include': ['participant_avatars'],
@@ -40,7 +40,7 @@ class InboxApi {
   }
 
   Future<List<Recipient>> getRecipients(Course course, {bool forceRefresh: false}) {
-    var dio = canvasDio(forceRefresh: forceRefresh, usePerPageParam: true);
+    var dio = canvasDio(forceRefresh: forceRefresh, pageSize: PageSize.canvasMax);
     var params = {
       'permissions': ['send_messages_all'],
       'messageable_only': true,

--- a/apps/flutter_parent/lib/api/user_api.dart
+++ b/apps/flutter_parent/lib/api/user_api.dart
@@ -12,20 +12,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import 'package:dio/dio.dart';
-import 'package:flutter_parent/api/utils/api_prefs.dart';
-import 'package:flutter_parent/models/serializers.dart';
+import 'package:flutter_parent/api/utils/dio_config.dart';
+import 'package:flutter_parent/api/utils/fetch.dart';
 import 'package:flutter_parent/models/user.dart';
 
 class UserApi {
-  static Future<User> getSelf() async {
-    var selfResponse = await Dio().get(ApiPrefs.getApiUrl() + 'users/self/profile',
-        options: Options(headers: ApiPrefs.getHeaderMap(forceDeviceLanguage: true)));
-
-    if (selfResponse.statusCode == 200 || selfResponse.statusCode == 201) {
-      return deserialize<User>(selfResponse.data);
-    } else {
-      return Future.error(selfResponse.statusMessage);
-    }
-  }
+  static Future<User> getSelf() => fetch(canvasDio(forceDeviceLanguage: true).get('users/self/profile'));
 }

--- a/apps/flutter_parent/test/api/dio_config_test.dart
+++ b/apps/flutter_parent/test/api/dio_config_test.dart
@@ -27,11 +27,11 @@ void main() {
     expect(canvasDio(), isA<Dio>());
   });
 
-  test('DioDOnfig.canvas returns a config object', () async {
+  test('DioConfig.canvas returns a config object', () async {
     expect(DioConfig.canvas(), isA<DioConfig>());
   });
 
-  test('DioDOnfig.core returns a config object', () async {
+  test('DioConfig.core returns a config object', () async {
     expect(DioConfig.core(), isA<DioConfig>());
   });
 


### PR DESCRIPTION
Also finishes fleshing out DioConfig which helps to set up and configure Dio instances for different use cases while retaining core functinality like logging, cache options, per_page query param, etc. For example, a configuration for typical Canvas API usage can be obtained with `DioConfig.canvas()`, and a Dio instance can be obtained by calling `.dio` on that config.

For convenience, the `canvasDio()` function has been kept and now just calls through to `DioConfig.canvas().dio`