### PR TITLE
[Flutter-Parent][MBL-13681] Support white app bar in default theme

### DIFF
--- a/apps/flutter_parent/lib/screens/domain_search/domain_search_screen.dart
+++ b/apps/flutter_parent/lib/screens/domain_search/domain_search_screen.dart
@@ -97,9 +97,6 @@ class _DomainSearchScreenState extends State<DomainSearchScreen> {
     return DefaultParentTheme(
       builder: (context) => Scaffold(
         appBar: AppBar(
-          textTheme: Theme.of(context).textTheme,
-          iconTheme: Theme.of(context).iconTheme,
-          backgroundColor: Theme.of(context).scaffoldBackgroundColor,
           title: Text(
             L10n(context).findSchoolOrDistrict,
             style: TextStyle(fontSize: 20, fontWeight: FontWeight.w500),

--- a/apps/flutter_parent/lib/screens/inbox/conversation_list/conversation_list_screen.dart
+++ b/apps/flutter_parent/lib/screens/inbox/conversation_list/conversation_list_screen.dart
@@ -54,9 +54,6 @@ class ConversationListState extends State<ConversationListScreen> {
     return DefaultParentTheme(
       builder: (context) => Scaffold(
         appBar: AppBar(
-          textTheme: Theme.of(context).textTheme,
-          iconTheme: Theme.of(context).iconTheme,
-          backgroundColor: Theme.of(context).scaffoldBackgroundColor,
           title: Text(L10n(context).inbox),
           elevation: 1,
         ),

--- a/apps/flutter_parent/lib/screens/inbox/create_conversation/create_conversation_screen.dart
+++ b/apps/flutter_parent/lib/screens/inbox/create_conversation/create_conversation_screen.dart
@@ -168,9 +168,6 @@ class _CreateConversationScreenState extends State<CreateConversationScreen> {
 
   Widget _appBar(BuildContext context) {
     return AppBar(
-      textTheme: Theme.of(context).textTheme,
-      iconTheme: Theme.of(context).iconTheme,
-      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       elevation: 0,
       title: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/apps/flutter_parent/lib/screens/web_login/web_login_screen.dart
+++ b/apps/flutter_parent/lib/screens/web_login/web_login_screen.dart
@@ -42,13 +42,9 @@ class WebLoginScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return DefaultParentTheme(
       builder: (context) => Scaffold(
-        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
         appBar: AppBar(
-          textTheme: Theme.of(context).textTheme,
-          iconTheme: Theme.of(context).iconTheme,
           title: Text(domain),
           elevation: 0,
-          backgroundColor: Theme.of(context).scaffoldBackgroundColor,
         ),
         body: _webLoginBody(),
       ),

--- a/apps/flutter_parent/lib/utils/design/parent_theme.dart
+++ b/apps/flutter_parent/lib/utils/design/parent_theme.dart
@@ -236,18 +236,34 @@ class ParentThemeStateChangeNotifier with ChangeNotifier {
 /// Applies a 'default' Parent App theme to descendant widgets. This theme is identical to the one provided by
 /// ParentTheme with the exception of the primary and accent colors, which are fixed and do not respond to changes
 /// to the selected student color.
+/// Additionally, the app bar can be specified to the non primary app bar when emphasizing that there is no student
+/// context. This makes the app bar use the scaffold background color, altering the text and icon themes so that they
+/// still show properly as well.
 class DefaultParentTheme extends StatelessWidget {
   final WidgetBuilder builder;
+  final bool useNonPrimaryAppBar;
 
-  const DefaultParentTheme({Key key, @required this.builder}) : super(key: key);
+  const DefaultParentTheme({Key key, @required this.builder, this.useNonPrimaryAppBar = true}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    var theme = ParentTheme.of(context).defaultTheme;
+    if (useNonPrimaryAppBar) theme = theme.copyWith(appBarTheme: _scaffoldColoredAppBarTheme(context));
+
     return Consumer<ParentThemeStateChangeNotifier>(
       builder: (context, state, _) => Theme(
-        data: ParentTheme.of(context).defaultTheme,
         child: builder(context),
+        data: theme,
       ),
+    );
+  }
+
+  AppBarTheme _scaffoldColoredAppBarTheme(BuildContext context) {
+    final theme = Theme.of(context);
+    return AppBarTheme(
+      color: theme.scaffoldBackgroundColor,
+      textTheme: theme.textTheme,
+      iconTheme: theme.iconTheme,
     );
   }
 }


### PR DESCRIPTION
An optional flag has been added to allow screens to have a white app bar that are using the default parent theme (that has no student context, so colors won’t change). Defaults to true, as every screen using this default theme right now wants a white app bar. And by white, I really mean the background color (white normally, black in dark mode).