### PR TITLE
[Teacher][RC-1.9.1] Fix crashlytics | version bump

### DIFF
--- a/apps/parent/build.gradle
+++ b/apps/parent/build.gradle
@@ -56,6 +56,9 @@ android {
         PrivateData.merge(project, "parent")
         buildConfigField "String", "LOGIN_CLIENT_ID", "\"$loginClientId\""
         buildConfigField "String", "LOGIN_CLIENT_SECRET", "\"$loginClientSecret\""
+        addManifestPlaceholders([
+                fabricApiKey:"$fabricApiKey"
+        ])
     }
 
     bundle {

--- a/apps/parent/src/main/AndroidManifest.xml
+++ b/apps/parent/src/main/AndroidManifest.xml
@@ -126,6 +126,10 @@
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
+
+        <meta-data
+            android:name="io.fabric.ApiKey"
+            android:value="${fabricApiKey}" />
     </application>
 
 </manifest>

--- a/apps/parent/src/main/java/com/instructure/parentapp/util/ApplicationManager.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/util/ApplicationManager.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.util.Log
 import android.webkit.WebView
 import com.crashlytics.android.Crashlytics
+import com.crashlytics.android.core.CrashlyticsCore
 import com.google.android.play.core.missingsplits.MissingSplitsManagerFactory
 import com.instructure.canvasapi2.AppManager
 import com.instructure.loginapi.login.tasks.LogoutTask
@@ -42,7 +43,10 @@ class ApplicationManager : AppManager() {
 
         super.onCreate()
 
-        Fabric.with(this, Crashlytics())
+        val crashlytics = Crashlytics.Builder()
+            .core(CrashlyticsCore.Builder().disabled(BuildConfig.DEBUG).build())
+            .build()
+        Fabric.with(this, crashlytics)
 
         // there appears to be a bug when the user is installing/updating the android webview stuff.
         // http://code.google.com/p/android/issues/detail?id=175124

--- a/apps/teacher/build.gradle
+++ b/apps/teacher/build.gradle
@@ -43,7 +43,7 @@ android {
     defaultConfig {
         minSdkVersion Versions.MIN_SDK
         targetSdkVersion Versions.TARGET_SDK
-        versionCode = 25
+        versionCode = 26
         versionName = '1.9.1'
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true
@@ -70,7 +70,9 @@ android {
 
         /* Add private data */
         PrivateData.merge(project, "teacher")
-
+        addManifestPlaceholders([
+                fabricApiKey:"$fabricApiKey"
+        ])
         buildConfigField "String", "PSPDFKIT_LICENSE_KEY", "\"$pspdfkitLicenseKey\""
     }
 

--- a/apps/teacher/src/main/AndroidManifest.xml
+++ b/apps/teacher/src/main/AndroidManifest.xml
@@ -178,6 +178,10 @@
             android:configChanges="orientation|screenSize"
             android:theme="@style/Theme.AppCompat.NoActionBar"/>
 
+        <meta-data
+            android:name="io.fabric.ApiKey"
+            android:value="${fabricApiKey}" />
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.provider"


### PR DESCRIPTION
Essentially a revert of https://github.com/instructure/canvas-android/commit/f44b66defe5a4664cc8c0a6afc168aaedf1b5422

In an attempt to fix the ‘crash statistics’ in firebase that reports crash free users, I removed the old fabric API key as the new setup docs didn’t state anything about it. Turns out, that just broke crashlytics entirely for us. Since we are an old firebase project, we still need to provide the api key.

Also, bump to next version to do a new hotfix