### PR TITLE
[Flutter-Parent][MBL-13600] Add crashlytics support

### DIFF
--- a/apps/flutter_parent/android/app/build.gradle
+++ b/apps/flutter_parent/android/app/build.gradle
@@ -22,8 +22,17 @@ if (flutterVersionName == null) {
 }
 
 apply plugin: 'com.android.application'
+apply plugin: 'com.google.gms.google-services'
+apply plugin: 'io.fabric'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
+
+// Without the following setup, a native crash like SIGSEGV will appear as a blank stacktrace in Crashlytics
+crashlytics {
+    enableNdk true
+    androidNdkOut "../../debugSymbols"
+    androidNdkLibsOut "../../build/app/intermediates/transforms/stripDebugSymbol/release/0/lib"
+}
 
 android {
     compileSdkVersion Versions.COMPILE_SDK
@@ -47,6 +56,9 @@ android {
 
         //noinspection GroovyAccessibility
         PrivateData.merge(project, "parent")
+        addManifestPlaceholders([
+                fabricApiKey:"$fabricApiKey"
+        ])
     }
 
     buildTypes {

--- a/apps/flutter_parent/android/app/src/main/AndroidManifest.xml
+++ b/apps/flutter_parent/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,11 @@
         android:name="io.flutter.app.FlutterApplication"
         android:label="Canvas Parent"
         android:icon="@mipmap/ic_launcher">
+
+        <meta-data
+            android:name="io.fabric.ApiKey"
+            android:value="${fabricApiKey}" />
+
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"

--- a/apps/flutter_parent/android/build.gradle
+++ b/apps/flutter_parent/android/build.gradle
@@ -3,11 +3,13 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven { url 'https://maven.fabric.io/public' }
     }
 
     dependencies {
-        classpath Plugins.GOOGLE_SERVICES
         classpath Plugins.ANDROID_GRADLE_TOOLS
+        classpath Plugins.FABRIC
+        classpath Plugins.GOOGLE_SERVICES
         classpath Plugins.KOTLIN
     }
 }

--- a/apps/flutter_parent/lib/main.dart
+++ b/apps/flutter_parent/lib/main.dart
@@ -12,18 +12,24 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_parent/api/utils/api_prefs.dart';
 import 'package:flutter_parent/parent_app.dart';
 import 'package:flutter_parent/utils/crash_utils.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
 
-void main() async {
-  WidgetsFlutterBinding.ensureInitialized();
+void main() {
+  runZoned<Future<void>>(() async {
+    WidgetsFlutterBinding.ensureInitialized();
 
-  CrashUtils.init(); // Sets up crash screen widget and crash report behavior
-  setupLocator();
-  await ApiPrefs.init();
+    await Future.wait([
+      ApiPrefs.init(),
+      CrashUtils.init(),
+    ]);
+    setupLocator();
 
-  runApp(ParentApp());
+    runApp(ParentApp());
+  }, onError: (error, stacktrace) => CrashUtils.reportCrash(error, stacktrace));
 }

--- a/apps/flutter_parent/lib/utils/crash_utils.dart
+++ b/apps/flutter_parent/lib/utils/crash_utils.dart
@@ -19,7 +19,7 @@ import 'package:flutter_parent/screens/crash_screen.dart';
 
 class CrashUtils {
   static Future<void> init() async {
-    await FlutterCrashlytics().initialize();
+    if (kReleaseMode) await FlutterCrashlytics().initialize();
 
     // Set up custom crash screen
     ErrorWidget.builder = (error) {

--- a/apps/flutter_parent/pubspec.lock
+++ b/apps/flutter_parent/pubspec.lock
@@ -265,6 +265,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.3"
+  flutter_crashlytics:
+    dependency: "direct main"
+    description:
+      name: flutter_crashlytics
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   flutter_driver:
     dependency: "direct dev"
     description: flutter

--- a/apps/flutter_parent/pubspec.yaml
+++ b/apps/flutter_parent/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
     sdk: flutter
   firebase_analytics: ^5.0.2
   firebase_core: ^0.4.0+9
+  flutter_crashlytics: ^1.0.0
   get_it: ^3.0.1
   intl: ^0.16.0
   package_info: 0.4.0+10


### PR DESCRIPTION
To test: verify crashes show up in Crashlytics. They show up as non-fatals (unless we change the forceCrash flag).

An easy way to test, pull the branch `parent/MBL-13600-crashlytics-CRASH` and run it in release mode (on a real device). This branch allows the app crash in three different ways to test crashlytics:
1. Tapping on a course (no UI change)
2. Trying to pair a student (no UI change)
3. Clicking on ‘alerts’ or ‘calendar’ (shows crash panda)