### PR TITLE
[Student][MBL-13739] Fix crash when closing module list immediately after routing to it with a module_id route param

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/adapter/ModuleListRecyclerAdapter.kt
+++ b/apps/student/src/main/java/com/instructure/student/adapter/ModuleListRecyclerAdapter.kt
@@ -29,7 +29,10 @@ import android.widget.ProgressBar
 import androidx.recyclerview.widget.RecyclerView
 import com.instructure.canvasapi2.StatusCallback
 import com.instructure.canvasapi2.managers.ModuleManager
-import com.instructure.canvasapi2.models.*
+import com.instructure.canvasapi2.models.CanvasContext
+import com.instructure.canvasapi2.models.Course
+import com.instructure.canvasapi2.models.ModuleItem
+import com.instructure.canvasapi2.models.ModuleObject
 import com.instructure.canvasapi2.utils.APIHelper
 import com.instructure.canvasapi2.utils.ApiType
 import com.instructure.canvasapi2.utils.DateHelper
@@ -133,6 +136,11 @@ open class ModuleListRecyclerAdapter(
         mModuleItemCallbacks.clear()
         collapseAll()
         super.refresh()
+    }
+
+    override fun cancel() {
+        mModuleItemCallbacks.values.forEach { it.cancel() }
+        mModuleObjectCallback?.cancel()
     }
 
     override fun contextReady() {

--- a/apps/student/src/main/java/com/instructure/student/fragment/ModuleListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/ModuleListFragment.kt
@@ -74,6 +74,11 @@ class ModuleListFragment : ParentFragment(), Bookmarkable {
         retainInstance = true
     }
 
+    override fun onDestroy() {
+        recyclerAdapter.cancel()
+        super.onDestroy()
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View?
             = layoutInflater.inflate(R.layout.fragment_module_list, container, false)
 


### PR DESCRIPTION
To repro: Deep link to the module list via a module url, e.g. `https://jmarshall.instructure.com/courses/1/modules/1`, and then quickly back out of the page before it has finished loading