### PR TITLE
[Student][MBL-13738] Fix routing to module items

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/CourseModuleProgressionFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/CourseModuleProgressionFragment.kt
@@ -717,11 +717,12 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
                 // Get the current module item. we'll use the id of this down below
                 val current = moduleItemSequence.items!!.firstOrNull { it.current!!.id == moduleItemId.toLong() }?.current ?: moduleItemSequence.items!![0].current
                 val moduleItems = awaitApi<List<ModuleItem>> { ModuleManager.getAllModuleItems(canvasContext, current!!.moduleId, it, true) }
-                items = ArrayList<ArrayList<ModuleItem>>(1).apply { add(ArrayList(moduleItems)) }
+                val unfilteredItems = ArrayList<ArrayList<ModuleItem>>(1).apply { add(ArrayList(moduleItems)) }
                 modules = ArrayList<ModuleObject>(1).apply { moduleItemSequence.modules!!.firstOrNull { it.id == current?.moduleId }?.let { add(it) } }
-                val moduleHelper = ModuleProgressionUtility.prepareModulesForCourseProgression(requireContext(), current!!.id, modules, items)
+                val moduleHelper = ModuleProgressionUtility.prepareModulesForCourseProgression(requireContext(), current!!.id, modules, unfilteredItems)
                 groupPos = moduleHelper.newGroupPosition
                 childPos = moduleHelper.newChildPosition
+                items = moduleHelper.strippedModuleItems
             }
 
             setViewInfo(bundle)


### PR DESCRIPTION
This wasn’t stripping out module items that we couldn’t show in the course module progression (subheader, unlockRequirements), thus was causing content to not be visible and would cause a crash on back press.

To test: see Jira ticket for details