### PR TITLE
[Student][Teacher][MBL-13725] Don’t filter notifications

### DIFF
--- a/apps/parent/src/main/java/com/instructure/parentapp/tasks/ParentLogoutTask.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/tasks/ParentLogoutTask.kt
@@ -32,4 +32,7 @@ class ParentLogoutTask(type: Type) : LogoutTask(type) {
         return LoginActivity.createIntent(context)
     }
 
+    override fun getFcmToken(listener: (registrationId: String?) -> Unit) {
+        listener(null)
+    }
 }

--- a/apps/polling/src/main/java/com/instructure/androidpolling/app/asynctasks/PollsLogoutTask.kt
+++ b/apps/polling/src/main/java/com/instructure/androidpolling/app/asynctasks/PollsLogoutTask.kt
@@ -38,4 +38,7 @@ class PollsLogoutTask(type: Type) : LogoutTask(type) {
         return InitLoginActivity.createIntent(ContextKeeper.appContext)
     }
 
+    override fun getFcmToken(listener: (registrationId: String?) -> Unit) {
+        listener(null)
+    }
 }

--- a/apps/student/src/main/java/com/instructure/student/tasks/StudentLogoutTask.kt
+++ b/apps/student/src/main/java/com/instructure/student/tasks/StudentLogoutTask.kt
@@ -18,6 +18,7 @@ package com.instructure.student.tasks
 
 import android.content.Context
 import android.content.Intent
+import com.google.firebase.iid.FirebaseInstanceId
 import com.instructure.canvasapi2.utils.ContextKeeper
 import com.instructure.loginapi.login.tasks.LogoutTask
 import com.instructure.student.activity.LoginActivity
@@ -37,4 +38,7 @@ class StudentLogoutTask(type: Type) : LogoutTask(type) {
         return LoginActivity.createIntent(context)
     }
 
+    override fun getFcmToken(listener: (registrationId: String?) -> Unit) {
+        FirebaseInstanceId.getInstance().instanceId.addOnCompleteListener { task -> listener(task.result?.token) }
+    }
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/tasks/TeacherLogoutTask.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/tasks/TeacherLogoutTask.kt
@@ -18,6 +18,7 @@ package com.instructure.teacher.tasks
 
 import android.content.Context
 import android.content.Intent
+import com.google.firebase.iid.FirebaseInstanceId
 import com.instructure.loginapi.login.tasks.LogoutTask
 import com.instructure.teacher.activities.LoginActivity
 import com.instructure.teacher.utils.TeacherPrefs
@@ -32,4 +33,7 @@ class TeacherLogoutTask(type: Type) : LogoutTask(type) {
         return LoginActivity.createIntent(context)
     }
 
+    override fun getFcmToken(listener: (registrationId: String?) -> Unit) {
+        FirebaseInstanceId.getInstance().instanceId.addOnCompleteListener { task -> listener(task.result?.token) }
+    }
 }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CommunicationChannelsAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CommunicationChannelsAPI.kt
@@ -57,9 +57,9 @@ object CommunicationChannelsAPI {
 
     }
 
-    fun deletePushCommunicationChannelSynchronous(registrationId: String, adapter: RestBuilder, params: RestParams) {
+    fun deletePushCommunicationChannelSynchronous(registrationId: String) {
         try {
-            adapter.build(CommunicationChannelInterface::class.java, params)
+            RestBuilder().build(CommunicationChannelInterface::class.java, RestParams())
                 .deletePushCommunicationChannel(registrationId)
                 .execute()
         } catch (e: Exception) {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CommunicationChannelsAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CommunicationChannelsAPI.kt
@@ -25,10 +25,7 @@ import com.instructure.canvasapi2.models.CommunicationChannel
 import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.Response
-import retrofit2.http.GET
-import retrofit2.http.POST
-import retrofit2.http.Path
-import retrofit2.http.Query
+import retrofit2.http.*
 
 object CommunicationChannelsAPI {
 
@@ -38,6 +35,9 @@ object CommunicationChannelsAPI {
 
         @POST("users/self/communication_channels?communication_channel[type]=push")
         fun addPushCommunicationChannel(@Query("communication_channel[token]") registrationId: String): Call<ResponseBody>
+
+        @DELETE("users/self/communication_channels/push")
+        fun deletePushCommunicationChannel(@Query("push_token") registrationId: String): Call<ResponseBody>
     }
 
     fun getCommunicationChannels(
@@ -55,6 +55,16 @@ object CommunicationChannelsAPI {
             null
         }
 
+    }
+
+    fun deletePushCommunicationChannelSynchronous(registrationId: String, adapter: RestBuilder, params: RestParams) {
+        try {
+            adapter.build(CommunicationChannelInterface::class.java, params)
+                .deletePushCommunicationChannel(registrationId)
+                .execute()
+        } catch (e: Exception) {
+            // Don't crash, just catch
+        }
     }
 
     fun addNewPushCommunicationChannel(

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/CommunicationChannelsManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/CommunicationChannelsManager.kt
@@ -48,8 +48,6 @@ object CommunicationChannelsManager {
     }
 
     fun deletePushCommunicationChannelSynchronous(registrationId: String) {
-        val adapter = RestBuilder()
-        val params = RestParams()
-        return CommunicationChannelsAPI.deletePushCommunicationChannelSynchronous(registrationId, adapter, params)
+        return CommunicationChannelsAPI.deletePushCommunicationChannelSynchronous(registrationId)
     }
 }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/CommunicationChannelsManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/CommunicationChannelsManager.kt
@@ -20,6 +20,7 @@ import com.instructure.canvasapi2.apis.CommunicationChannelsAPI
 import com.instructure.canvasapi2.builders.RestBuilder
 import com.instructure.canvasapi2.builders.RestParams
 import com.instructure.canvasapi2.models.CommunicationChannel
+import com.instructure.canvasapi2.utils.weave.apiAsync
 import okhttp3.ResponseBody
 import retrofit2.Response
 
@@ -44,5 +45,11 @@ object CommunicationChannelsManager {
         val adapter = RestBuilder(callback)
         val params = RestParams(isForceReadFromNetwork = true)
         return CommunicationChannelsAPI.addNewPushCommunicationChannelSynchronous(registrationId, adapter, params)
+    }
+
+    fun deletePushCommunicationChannelSynchronous(registrationId: String) {
+        val adapter = RestBuilder()
+        val params = RestParams()
+        return CommunicationChannelsAPI.deletePushCommunicationChannelSynchronous(registrationId, adapter, params)
     }
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/models/PushNotification.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/models/PushNotification.kt
@@ -22,17 +22,15 @@ import com.google.gson.reflect.TypeToken
 import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.pandautils.BuildConfig
 import com.instructure.pandautils.utils.PandaPrefs
-import java.net.MalformedURLException
-import java.net.URL
 import java.util.*
 
 data class PushNotification(
-
-    var htmlUrl: String  = "",
-    var from: String  = "",
-    var alert: String  = "",
-    var collapseKey: String  = "",
-    var userId: String  = "") {
+    var htmlUrl: String = "",
+    var from: String = "",
+    var alert: String = "",
+    var collapseKey: String = "",
+    var userId: String = ""
+) {
     /**
      * Basic idea is that we STORE push notification info based on the incoming PUSH data.
      * But we RETRIEVE push notification info based on the current users data.
@@ -43,7 +41,13 @@ data class PushNotification(
      * have to strip off the shard so we have the actual user id. With the domain and user id we can make
      * a key to store push notifications with.
      */
-    fun PushNotification(html_url: String, from: String, alert: String, collapse_key: String, user_id: String): PushNotification {
+    fun PushNotification(
+        html_url: String,
+        from: String,
+        alert: String,
+        collapse_key: String,
+        user_id: String
+    ): PushNotification {
         this.htmlUrl = html_url
         this.from = from
         this.alert = alert
@@ -54,53 +58,56 @@ data class PushNotification(
     }
 
     companion object {
-        val HTML_URL: String = "html_url"
-        val FROM: String = "from"
-        val ALERT: String = "alert"
-        val COLLAPSE_KEY: String = "collapse_key"
-        val USER_ID: String = "user_id"
+        const val HTML_URL: String = "html_url"
+        const val FROM: String = "from"
+        const val ALERT: String = "alert"
+        const val COLLAPSE_KEY: String = "collapse_key"
+        const val USER_ID: String = "user_id"
+        const val NOTIFY_ID = 555443
 
+        private const val PUSH_NOTIFICATIONS_KEY = "pushNotificationsKey"
 
-        private val PUSH_NOTIFICATIONS_KEY = "pushNotificationsKey"
-
-
-
-
-        fun store(push: PushNotification): Boolean {
-            val pushes = getStoredPushes()
+        fun store(push: PushNotification) {
+            val pushes = getPushNotifications(PUSH_NOTIFICATIONS_KEY)
             pushes.add(push)
-            val json = Gson().toJson(pushes)
-            val key = getPushStoreKey(push)
-            if (!key.isNullOrBlank()) {
-                PandaPrefs.putString(key!!, json)
-                return true
-            }
-            return false
+
+            PandaPrefs.putString(PUSH_NOTIFICATIONS_KEY, Gson().toJson(pushes))
         }
 
         fun clearPushHistory() {
-            val key = getPushStoreKey()
-            if (key != null) PandaPrefs.remove(key)
+            // Delete the old notifications keyed off of user/domain (deprecated)
+            getPushStoreKey()?.let { key -> PandaPrefs.remove(key) }
+
+            // Delete the new notifications (no longer filtering)
+            PandaPrefs.remove(PUSH_NOTIFICATIONS_KEY)
         }
 
-        fun getStoredPushes(): ArrayList<PushNotification> {
-            val key = getPushStoreKey()
-            if (!key.isNullOrEmpty()) {
-                val json = PandaPrefs.getString(key!!, "")
-                if (!TextUtils.isEmpty(json)) {
-                    val type = object : TypeToken<List<PushNotification>>() {
+        fun getAllStoredPushes(): ArrayList<PushNotification> {
+            val pushes = ArrayList<PushNotification>()
 
-                    }.type
-                    var pushes: ArrayList<PushNotification>? = Gson().fromJson(json, type)
-                    if (pushes == null) {
-                        pushes = ArrayList()
-                    }
-                    return pushes
+            // Combine both the old and new notifications to display to the user
+            pushes.addAll(getPushNotifications(getPushStoreKey()))
+            pushes.addAll(getPushNotifications(PUSH_NOTIFICATIONS_KEY))
+
+            return pushes
+        }
+
+        /**
+         * A helper function introduced in MBL-13725 to help retrieve notifications. This supports the old keys that are
+         * unique per user id and domain (that is now deprecated), as well as the single key PUSH_NOTIFICATIONS_KEY that
+         * should be used since filtering is no longer happening.
+         */
+        private fun getPushNotifications(key: String?): ArrayList<PushNotification> {
+            if (!key.isNullOrBlank()) {
+                val json = PandaPrefs.getString(key, "")
+                if (!json.isNullOrBlank()) {
+                    val type = object : TypeToken<List<PushNotification>>() {}.type
+                    return Gson().fromJson(json, type) ?: ArrayList()
                 }
             }
+
             return ArrayList()
         }
-
 
         private fun getPushStorePrefix(): String? {
             val user = ApiPrefs.user
@@ -117,58 +124,12 @@ data class PushNotification(
             return user.id.toString() + "___" + domain + "___"
         }
 
-        private fun getPushStorePrefix(push: PushNotification): String? {
-            val userId = getUserIdFromPush(push)
-            var domain: String
-            try {
-                val url = URL(push.htmlUrl)
-                domain = url.host
-            } catch (e: MalformedURLException) {
-                domain = ""
-            }
-
-            return if (TextUtils.isEmpty(userId) || TextUtils.isEmpty(domain)) {
-                null
-            } else userId + "___" + domain + "___"
-        }
-
-
+        // TODO: Remove this in a future release from the version that this was deprecated (MBL-13725) and clean up some
+        //  comments in this file (and inline getPushNotifications into getAllStoredPushes)
+        @Deprecated("Push notifications are no longer filtered by user/domain, going forward should just use PUSH_NOTIFICATIONS_KEY")
         private fun getPushStoreKey(): String? {
             val prefix = getPushStorePrefix() ?: return null
             return prefix + PUSH_NOTIFICATIONS_KEY
         }
-
-        private fun getPushStoreKey(push: PushNotification): String? {
-            val prefix = getPushStorePrefix(push) ?: return null
-            return prefix + PUSH_NOTIFICATIONS_KEY
-        }
-
-        /**
-         * To get the user id when the shard is added we have to mod the number by 10 trillion.
-         * @param push The notification which should always have a valid user id with the shard.
-         * @return the users id after removal of the shard id
-         */
-        private fun getUserIdFromPush(push: PushNotification): String = try {
-                val temp = 1000000000000L
-                val userId = java.lang.Long.parseLong(push.userId)
-                val remainder = userId % temp
-                remainder.toString()
-            } catch (e: Exception) {
-                ""
-            }
-
-        /**
-         * Removes the shard from a user id. It is expcted that the user id passed in has a mixed in.
-         * @param userIdWithShard
-         * @return
-         */
-        fun getUserIdFromPush(userIdWithShard: String): String = try {
-                val temp = 1000000000000L
-                val userId = java.lang.Long.parseLong(userIdWithShard)
-                val remainder = userId % temp
-                remainder.toString()
-            } catch (e: Exception) {
-                ""
-            }
     }
 }


### PR DESCRIPTION
Filtering notifications is problematic, as the domain users log in with may be different that the account’s root domain. This makes it hard to store notifications based on user info. Instead, we will just always show notifications.

Instead of keeping old communication channels alive, we now delete them when logging out or switching users. This prevents the currently logged in account from seeing notifications meant for an account which they don’t have access to.

To test: (student and teacher)
Log into an account, verify you can get notifications.
Switch users, verify notifications disappear from the status bar.
Log out, verify you no don't get any notifications.
*vanity domain* would be nice to test, don't think we have an instance of this (should be able to log in via the non vanity domain and receive notifications).