### PR TITLE
[Student][Automation][MBL-13756] : Test on API-29

### DIFF
--- a/apps/student/flank_sweep.yml
+++ b/apps/student/flank_sweep.yml
@@ -23,10 +23,6 @@ gcloud:
     locale: en_US
     orientation: portrait
   - model: NexusLowRes
-    version: 25
-    locale: en_US
-    orientation: portrait
-  - model: NexusLowRes
     version: 26
     locale: en_US
     orientation: portrait
@@ -36,6 +32,10 @@ gcloud:
     orientation: portrait
   - model: NexusLowRes
     version: 28
+    locale: en_US
+    orientation: portrait
+  - model: NexusLowRes
+    version: 29
     locale: en_US
     orientation: portrait
 


### PR DESCRIPTION
Replace API-25 with API-29 in our multi-device test runs.  API-29 is gaining popularity, and we already test API-25 in our PR runs.

Note that I did try one run on API-29, and there were some failures, but they were PdfInteractionTest failures, which are more or less expected at this point.