### PR TITLE
[Flutter-Parent][MBL-13747] Add divider in dark mode

### DIFF
--- a/apps/flutter_parent/lib/screens/courses/details/course_details_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_details_screen.dart
@@ -23,6 +23,7 @@ import 'package:flutter_parent/utils/base_model.dart';
 import 'package:flutter_parent/utils/common_widgets/full_screen_scroll_container.dart';
 import 'package:flutter_parent/utils/common_widgets/loading_indicator.dart';
 import 'package:flutter_parent/utils/design/canvas_icons_solid.dart';
+import 'package:flutter_parent/utils/design/parent_theme.dart';
 import 'package:provider/provider.dart';
 
 class CourseDetailsScreen extends StatefulWidget {
@@ -59,12 +60,14 @@ class _CourseDetailsScreenState extends State<CourseDetailsScreen> {
             child: Scaffold(
               appBar: AppBar(
                 title: Text(model.course?.name ?? ''),
-                bottom: TabBar(
-                  tabs: [
-                    Tab(text: L10n(context).courseGradesLabel.toUpperCase()),
-                    Tab(text: L10n(context).courseSyllabusLabel.toUpperCase()),
-                    Tab(text: L10n(context).courseSummaryLabel.toUpperCase()),
-                  ],
+                bottom: ParentTheme.of(context).appBarDivider(
+                  bottom: TabBar(
+                    tabs: [
+                      Tab(text: L10n(context).courseGradesLabel.toUpperCase()),
+                      Tab(text: L10n(context).courseSyllabusLabel.toUpperCase()),
+                      Tab(text: L10n(context).courseSummaryLabel.toUpperCase()),
+                    ],
+                  ),
                 ),
               ),
               body: _body(context, model),

--- a/apps/flutter_parent/lib/screens/crash_screen.dart
+++ b/apps/flutter_parent/lib/screens/crash_screen.dart
@@ -35,6 +35,7 @@ class CrashScreen extends StatelessWidget {
               elevation: 0,
               backgroundColor: Colors.transparent,
               iconTheme: Theme.of(context).iconTheme,
+              bottom: ParentTheme.of(context).appBarDivider(shadowInLightMode: false),
             )
           : null,
       body: _body(context),

--- a/apps/flutter_parent/lib/screens/dashboard/dashboard_screen.dart
+++ b/apps/flutter_parent/lib/screens/dashboard/dashboard_screen.dart
@@ -28,6 +28,7 @@ import 'package:flutter_parent/utils/common_widgets/dropdown_arrow.dart';
 import 'package:flutter_parent/utils/common_widgets/loading_indicator.dart';
 import 'package:flutter_parent/utils/common_widgets/user_name.dart';
 import 'package:flutter_parent/utils/design/canvas_icons.dart';
+import 'package:flutter_parent/utils/design/parent_theme.dart';
 import 'package:flutter_parent/utils/quick_nav.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
 import 'package:package_info/package_info.dart';
@@ -137,18 +138,20 @@ class DashboardState extends State<DashboardScreen> {
         child: AppBar(
           flexibleSpace: _appBarStudents(_students),
           centerTitle: true,
+          bottom: ParentTheme.of(context).appBarDivider(),
         ),
       ),
       drawer: Drawer(
         child: SafeArea(child: _navDrawer(_self)),
       ),
       body: _currentPage(),
-      bottomNavigationBar: BottomNavigationBar(
-        items: _bottomNavigationBarItems(),
-        currentIndex: this._currentIndex,
-        onTap: (item) {
-          _handleBottomBarClick(item);
-        },
+      bottomNavigationBar: ParentTheme.of(context).bottomNavigationDivider(
+        BottomNavigationBar(
+          backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+          items: _bottomNavigationBarItems(),
+          currentIndex: this._currentIndex,
+          onTap: (item) => _handleBottomBarClick(item),
+        ),
       ),
     );
   }

--- a/apps/flutter_parent/lib/screens/domain_search/domain_search_screen.dart
+++ b/apps/flutter_parent/lib/screens/domain_search/domain_search_screen.dart
@@ -101,7 +101,7 @@ class _DomainSearchScreenState extends State<DomainSearchScreen> {
             L10n(context).findSchoolOrDistrict,
             style: TextStyle(fontSize: 20, fontWeight: FontWeight.w500),
           ),
-          elevation: 0,
+          bottom: ParentTheme.of(context).appBarDivider(shadowInLightMode: false),
           actions: <Widget>[
             FlatButton(
               child: Text(L10n(context).next.toUpperCase()),

--- a/apps/flutter_parent/lib/screens/inbox/conversation_details/conversation_details_screen.dart
+++ b/apps/flutter_parent/lib/screens/inbox/conversation_details/conversation_details_screen.dart
@@ -87,7 +87,6 @@ class _ConversationDetailsScreenState extends State<ConversationDetailsScreen> {
 
   Widget _appBar(BuildContext context) {
     return AppBar(
-      elevation: 0,
       title: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
@@ -99,10 +98,7 @@ class _ConversationDetailsScreenState extends State<ConversationDetailsScreen> {
             Text(widget.courseName, style: Theme.of(context).textTheme.caption),
         ],
       ),
-      bottom: PreferredSize(
-        child: Container(color: Theme.of(context).dividerColor, height: 0.5),
-        preferredSize: Size.fromHeight(0.5),
-      ),
+      bottom: ParentTheme.of(context).appBarDivider(shadowInLightMode: false),
     );
   }
 

--- a/apps/flutter_parent/lib/screens/inbox/conversation_list/conversation_list_screen.dart
+++ b/apps/flutter_parent/lib/screens/inbox/conversation_list/conversation_list_screen.dart
@@ -58,7 +58,7 @@ class ConversationListState extends State<ConversationListScreen> {
       builder: (context) => Scaffold(
         appBar: AppBar(
           title: Text(L10n(context).inbox),
-          elevation: 1,
+          bottom: ParentTheme.of(context).appBarDivider(shadowInLightMode: false),
         ),
         body: FutureBuilder(
           future: _conversationsFuture,

--- a/apps/flutter_parent/lib/screens/inbox/create_conversation/create_conversation_screen.dart
+++ b/apps/flutter_parent/lib/screens/inbox/create_conversation/create_conversation_screen.dart
@@ -170,7 +170,7 @@ class _CreateConversationScreenState extends State<CreateConversationScreen> {
 
   Widget _appBar(BuildContext context) {
     return AppBar(
-      elevation: 0,
+      bottom: ParentTheme.of(context).appBarDivider(shadowInLightMode: false),
       title: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,

--- a/apps/flutter_parent/lib/screens/manage_students/manage_students_screen.dart
+++ b/apps/flutter_parent/lib/screens/manage_students/manage_students_screen.dart
@@ -19,6 +19,7 @@ import 'package:flutter_parent/utils/common_widgets/avatar.dart';
 import 'package:flutter_parent/utils/common_widgets/empty_panda_widget.dart';
 import 'package:flutter_parent/utils/common_widgets/error_panda_widget.dart';
 import 'package:flutter_parent/utils/common_widgets/user_name.dart';
+import 'package:flutter_parent/utils/design/parent_theme.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
 
 import 'add_student_dialog.dart';
@@ -49,6 +50,7 @@ class _ManageStudentsState extends State<ManageStudentsScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text(L10n(context).manageStudents),
+        bottom: ParentTheme.of(context).appBarDivider(),
       ),
       body: FutureBuilder(
           initialData: widget._students,

--- a/apps/flutter_parent/lib/screens/settings/settings_screen.dart
+++ b/apps/flutter_parent/lib/screens/settings/settings_screen.dart
@@ -37,7 +37,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
     return ThemeTransitionTarget(
       child: DefaultParentTheme(
         builder: (context) => Scaffold(
-          appBar: AppBar(title: Text(L10n(context).settings)),
+          appBar: AppBar(
+            title: Text(L10n(context).settings),
+            bottom: ParentTheme.of(context).appBarDivider(shadowInLightMode: false),
+          ),
           body: ListView(
             children: [
               Padding(

--- a/apps/flutter_parent/lib/screens/theme_viewer_screen.dart
+++ b/apps/flutter_parent/lib/screens/theme_viewer_screen.dart
@@ -99,13 +99,15 @@ class _ThemeViewerScreenState extends State<ThemeViewerScreen> {
             IconButton(icon: Icon(CanvasIcons.email), onPressed: () {}),
             IconButton(icon: Icon(CanvasIcons.search), onPressed: () {}),
           ],
-          bottom: TabBar(
-            indicatorColor: Theme.of(context).primaryIconTheme.color,
-            tabs: [
-              Tab(text: "Widgets"),
-              Tab(text: "Text Styles"),
-              Tab(text: 'Icons'),
-            ],
+          bottom: ParentTheme.of(context).appBarDivider(
+            bottom: TabBar(
+              indicatorColor: Theme.of(context).primaryIconTheme.color,
+              tabs: [
+                Tab(text: "Widgets"),
+                Tab(text: "Text Styles"),
+                Tab(text: 'Icons'),
+              ],
+            ),
           ),
         ),
         body: Container(
@@ -421,14 +423,12 @@ class _ThemeViewerScreenState extends State<ThemeViewerScreen> {
   }
 
   Widget _icons(BuildContext context) {
-    return GridView.count(crossAxisCount: 3,
-      children: List.generate(CanvasIcons.allIcons.length, (idx) {
-        return Column(
-          children: <Widget>[
-            Icon(CanvasIcons.allIcons[idx][1]),
-            Text(CanvasIcons.allIcons[idx][0])
-          ],
-        );
-      }));
+    return GridView.count(
+        crossAxisCount: 3,
+        children: List.generate(CanvasIcons.allIcons.length, (idx) {
+          return Column(
+            children: <Widget>[Icon(CanvasIcons.allIcons[idx][1]), Text(CanvasIcons.allIcons[idx][0])],
+          );
+        }));
   }
 }

--- a/apps/flutter_parent/lib/screens/web_login/web_login_screen.dart
+++ b/apps/flutter_parent/lib/screens/web_login/web_login_screen.dart
@@ -45,7 +45,7 @@ class WebLoginScreen extends StatelessWidget {
       builder: (context) => Scaffold(
         appBar: AppBar(
           title: Text(domain),
-          elevation: 0,
+          bottom: ParentTheme.of(context).appBarDivider(shadowInLightMode: false),
         ),
         body: _webLoginBody(),
       ),

--- a/apps/flutter_parent/lib/utils/design/parent_colors.dart
+++ b/apps/flutter_parent/lib/utils/design/parent_colors.dart
@@ -48,6 +48,9 @@ class ParentColors {
   /// Core color for the teacher app
   static const teacherApp = Color(0xFFFFC100);
 
+  /// Color for light mode divider under the app bar
+  static const appBarDividerLight = Color(0x1F000000);
+
   /// Generates a [MaterialColor] swatch for a given color. For best results the source color should have a medium brightness.
   static MaterialColor makeSwatch(Color color) {
     var src = HSLColor.fromColor(color);

--- a/apps/flutter_parent/lib/utils/design/parent_theme.dart
+++ b/apps/flutter_parent/lib/utils/design/parent_theme.dart
@@ -130,6 +130,39 @@ class _ParentThemeState extends State<ParentTheme> {
   /// Returns a Parent App theme styled with the color of the currently selected student
   ThemeData get studentTheme => _buildTheme(studentColor);
 
+  /// Create a preferred size divider that can be used as the bottom of an app bar
+  PreferredSize _appBarDivider(Color color) => PreferredSize(
+        preferredSize: Size.fromHeight(1),
+        child: Divider(height: 1, color: color),
+      );
+
+  /// Returns a light divider if in dark mode, otherwise a light divider that changes color with HC mode
+  PreferredSize get _appBarDividerThemed =>
+      _appBarDivider(isDarkMode ? ParentColors.oxford : ParentColors.appBarDividerLight);
+
+  /// Returns a light divider if in dark mode, dark divider in light mode unless shadowInLightMode is true, wrapping the optional bottom passed in
+  PreferredSizeWidget appBarDivider({PreferredSizeWidget bottom, bool shadowInLightMode = true}) =>
+      (isDarkMode || !shadowInLightMode)
+          ? PreferredSize(
+              preferredSize: Size.fromHeight(1.0 + (bottom?.preferredSize?.height ?? 0)), // Bottom height plus divider
+              child: Column(
+                children: [
+                  if (bottom != null) bottom,
+                  _appBarDividerThemed,
+                ],
+              ),
+            )
+          : bottom;
+
+  /// Returns a widget wrapping a divider on top of the passed in bottom
+  Widget bottomNavigationDivider(Widget bottom) => Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          _appBarDividerThemed,
+          bottom,
+        ],
+      );
+
   @override
   void setState(fn) {
     super.setState(fn);
@@ -260,6 +293,7 @@ class DefaultParentTheme extends StatelessWidget {
       color: theme.scaffoldBackgroundColor,
       textTheme: theme.textTheme,
       iconTheme: theme.iconTheme,
+      elevation: 0,
     );
   }
 }


### PR DESCRIPTION
Cleans up light mode divider for default parent theme as well, and changed the bottom navigation bar to be white/black matching designs rather than the default gray that Flutter uses.

To test:
Navigate around the app in light/dark modes. 
* Verify shadows show up when the app bar is using the student color. 
* Verify dividers show up on screens with a white app bar or for any screen in dark mode
* Verify the bottom nav is white/black in light/dark mode
Note: High Contrast mode doesn't change the divider color at all in the designs.