### PR TITLE
[Student][Tests][MBL-13802] : Stabilized PickerSubmissionUploadInteractionTest.testSubmit

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/PickerSubmissionUploadInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/PickerSubmissionUploadInteractionTest.kt
@@ -112,8 +112,15 @@ class PickerSubmissionUploadInteractionTest : StudentTest() {
             Intents.release()
         }
 
+        // It's possible for the Submit button to wait a beat before appearing
+        pickerSubmissionUploadPage.waitForSubmitButtonToAppear()
+
         // Now submit the file
         pickerSubmissionUploadPage.submit()
+
+        // The screen may go through several refactorings while the submission is being submitted,
+        // which could potentially throw off our tests.  So wait until we get the "all clear".
+        assignmentDetailsPage.waitForSubmissionComplete()
 
         // Should be back to assignment details page
         assignmentDetailsPage.goToSubmissionDetails()

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/AssignmentDetailsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/AssignmentDetailsPage.kt
@@ -21,13 +21,23 @@ import android.widget.ScrollView
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.instructure.canvas.espresso.containsTextCaseInsensitive
 import com.instructure.canvasapi2.models.Assignment
-import com.instructure.espresso.*
+import com.instructure.espresso.assertContainsText
+import com.instructure.espresso.assertDisplayed
+import com.instructure.espresso.assertHasText
+import com.instructure.espresso.click
 import com.instructure.espresso.page.BasePage
 import com.instructure.espresso.page.onView
 import com.instructure.espresso.page.waitForViewWithId
+import com.instructure.espresso.page.waitForViewWithText
+import com.instructure.espresso.scrollTo
+import com.instructure.espresso.swipeDown
+import com.instructure.espresso.waitForCheck
 import com.instructure.student.R
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
@@ -61,6 +71,10 @@ open class AssignmentDetailsPage : BasePage(R.id.assignmentDetailsPage) {
 
         // Now swipe down -- twice, just for good measure (may update twice)
         onView(allOf(withId(R.id.swipeRefreshLayout),  isDisplayed())).swipeDown().swipeDown()
+    }
+
+    fun waitForSubmissionComplete() {
+        waitForViewWithText(R.string.submissionStatusSuccessTitle)
     }
 
     fun goToSubmissionDetails() {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/PickerSubmissionUploadPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/PickerSubmissionUploadPage.kt
@@ -22,6 +22,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.instructure.espresso.OnViewWithId
 import com.instructure.espresso.click
 import com.instructure.espresso.page.BasePage
+import com.instructure.espresso.page.waitForViewWithText
 import com.instructure.student.R
 import org.hamcrest.core.AllOf.allOf
 
@@ -40,6 +41,10 @@ class PickerSubmissionUploadPage : BasePage(R.id.pickerSubmissionUploadPage) {
 
     fun chooseGallery() {
         galleryIcon.click()
+    }
+
+    fun waitForSubmitButtonToAppear() {
+        waitForViewWithText(R.string.submit)
     }
 
     fun submit() {

--- a/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasTest.kt
+++ b/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasTest.kt
@@ -63,6 +63,7 @@ abstract class CanvasTest : InstructureTest(BuildConfig.GLOBAL_DITTO_MODE) {
         // Let's set ourselves up to log information about our retries.
         ScreenshotTestRule.registerRetryHandler( handler = { error, testMethod, testClass ->
 
+            Log.d("TEST RETRY", "testMethod: $testMethod, error=$error, stacktrace=${error.stackTrace.joinToString("\n")} cause=${error.cause}")
             // Grab the Splunk-mobile token from Bitrise
             val splunkToken = InstrumentationRegistry.getArguments().getString("SPLUNK_MOBILE_TOKEN")
 


### PR DESCRIPTION
These changes seemed to make a difference locally (where I was always failing the first attempt but passing the retry.  ???)  And I suspect that they will address the other failure modes I was seeing on FTL as well.

(And, to follow up on a Slack thread, I don't think that notifications are interfering with the test.)