### PR TITLE
[Flutter Parent] Small tweaks and fixes for conversation create/reply

### DIFF
--- a/apps/flutter_parent/lib/screens/inbox/create_conversation/create_conversation_screen.dart
+++ b/apps/flutter_parent/lib/screens/inbox/create_conversation/create_conversation_screen.dart
@@ -245,28 +245,32 @@ class _CreateConversationScreenState extends State<CreateConversationScreen> {
   }
 
   Widget _attachmentsWidget(BuildContext context) {
-    return Container(
-      height: 104,
-      padding: EdgeInsets.symmetric(vertical: 4),
-      child: ListView.separated(
-        shrinkWrap: true,
-        itemCount: _attachments.length,
-        padding: const EdgeInsets.symmetric(horizontal: 16),
-        scrollDirection: Axis.horizontal,
-        separatorBuilder: (context, index) => SizedBox(width: 12),
-        itemBuilder: (context, index) {
-          var handler = _attachments[index];
-          return ChangeNotifierProvider<AttachmentHandler>.value(
-            value: handler,
-            child: AttachmentWidget(
-              onDelete: (handler) {
-                setState(() {
-                  _attachments.remove(handler);
-                });
-              },
-            ),
-          );
-        },
+    if (_attachments.isEmpty) return Container();
+    return IgnorePointer(
+      ignoring: _sending,
+      child: Container(
+        height: 104,
+        padding: EdgeInsets.symmetric(vertical: 4),
+        child: ListView.separated(
+          shrinkWrap: true,
+          itemCount: _attachments.length,
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          scrollDirection: Axis.horizontal,
+          separatorBuilder: (context, index) => SizedBox(width: 12),
+          itemBuilder: (context, index) {
+            var handler = _attachments[index];
+            return ChangeNotifierProvider<AttachmentHandler>.value(
+              value: handler,
+              child: AttachmentWidget(
+                onDelete: (handler) {
+                  setState(() {
+                    _attachments.remove(handler);
+                  });
+                },
+              ),
+            );
+          },
+        ),
       ),
     );
   }
@@ -430,7 +434,7 @@ class _CreateConversationScreenState extends State<CreateConversationScreen> {
         enabled: !_sending,
         textCapitalization: TextCapitalization.sentences,
         minLines: 4,
-        maxLines: 10,
+        maxLines: null,
         style: Theme.of(context).textTheme.body1,
         decoration: InputDecoration(
           hintText: L10n(context).messageBodyInputHint,
@@ -670,7 +674,10 @@ class AttachmentWidget extends StatelessWidget {
     );
   }
 
-  void _handleMenuOption(String option, AttachmentHandler handler) {
+  void _handleMenuOption(String option, AttachmentHandler handler) async {
+    /* Wait for PopupMenuButton to finish animating closed, otherwise a change in the widget tree could deactivate
+    the widget's ancestor and cause ErrorWidget to briefly flicker on screen */
+    await Future.delayed(Duration(milliseconds: 150));
     switch (option) {
       case "delete":
         if (onDelete != null) onDelete(handler);

--- a/apps/flutter_parent/lib/screens/inbox/reply/conversation_reply_screen.dart
+++ b/apps/flutter_parent/lib/screens/inbox/reply/conversation_reply_screen.dart
@@ -199,28 +199,32 @@ class _ConversationReplyScreenState extends State<ConversationReplyScreen> {
   }
 
   Widget _attachmentsWidget(BuildContext context) {
-    return Container(
-      height: 104,
-      padding: EdgeInsets.symmetric(vertical: 4),
-      child: ListView.separated(
-        shrinkWrap: true,
-        itemCount: _attachments.length,
-        padding: const EdgeInsets.symmetric(horizontal: 16),
-        scrollDirection: Axis.horizontal,
-        separatorBuilder: (context, index) => SizedBox(width: 12),
-        itemBuilder: (context, index) {
-          var handler = _attachments[index];
-          return ChangeNotifierProvider<AttachmentHandler>.value(
-            value: handler,
-            child: AttachmentWidget(
-              onDelete: (handler) {
-                setState(() {
-                  _attachments.remove(handler);
-                });
-              },
-            ),
-          );
-        },
+    if (_attachments.isEmpty) return Container();
+    return IgnorePointer(
+      ignoring: _sending,
+      child: Container(
+        height: 104,
+        padding: EdgeInsets.symmetric(vertical: 4),
+        child: ListView.separated(
+          shrinkWrap: true,
+          itemCount: _attachments.length,
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          scrollDirection: Axis.horizontal,
+          separatorBuilder: (context, index) => SizedBox(width: 12),
+          itemBuilder: (context, index) {
+            var handler = _attachments[index];
+            return ChangeNotifierProvider<AttachmentHandler>.value(
+              value: handler,
+              child: AttachmentWidget(
+                onDelete: (handler) {
+                  setState(() {
+                    _attachments.remove(handler);
+                  });
+                },
+              ),
+            );
+          },
+        ),
       ),
     );
   }
@@ -235,7 +239,7 @@ class _ConversationReplyScreenState extends State<ConversationReplyScreen> {
         enabled: !_sending,
         textCapitalization: TextCapitalization.sentences,
         minLines: 4,
-        maxLines: 10,
+        maxLines: null,
         style: Theme.of(context).textTheme.body1,
         decoration: InputDecoration(
           hintText: L10n(context).messageBodyInputHint,


### PR DESCRIPTION
- Disabled maxLines on the message input to avoid nested scrolling
 - Disabled attachment interactions while message is sending
 - Fixed a condition where ErrorWidget could briefly flicker on screen when deleting an attachment