### PR TITLE
[Flutter Parent][MBL-13807] Add app bar divider to conversation reply screen

### DIFF
--- a/apps/flutter_parent/lib/screens/inbox/reply/conversation_reply_screen.dart
+++ b/apps/flutter_parent/lib/screens/inbox/reply/conversation_reply_screen.dart
@@ -124,6 +124,7 @@ class _ConversationReplyScreenState extends State<ConversationReplyScreen> {
 
   Widget _appBar(BuildContext context) {
     return AppBar(
+      bottom: ParentTheme.of(context).appBarDivider(shadowInLightMode: false),
       elevation: 0,
       title: Column(
         crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
To test:
	Make sure the divider shows up in both light and dark mode in the conversation reply screen.