### PR TITLE
[Parent][MBL-13618] Announcement Details

### DIFF
--- a/apps/flutter_parent/assets/html_wrapper.html
+++ b/apps/flutter_parent/assets/html_wrapper.html
@@ -1,0 +1,73 @@
+<!--
+  ~ Copyright (C) 2020 - present Instructure, Inc.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, version 3 of the License.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!DOCTYPE html>
+
+<html>
+<head>
+    <meta name="viewport" content="width=device-width" charset="utf-8"/>
+</head>
+<style>
+        html,body {
+            width: 100%;
+            height: auto;
+            margin: 0;
+            padding: 0;
+        }
+
+        img {
+            max-width: 100% !important;
+            height: auto;
+            margin: 0;
+            padding: 0;
+        }
+
+        video {
+            width: 100%    !important;
+            height: auto   !important;
+            margin: 0;
+            padding: 0;
+        }
+
+        iframe {
+            width: 100%    !important;
+            margin: 0;
+            padding-top: 0;
+        }
+
+        /* makes the videos in fullscreen black */
+        :-webkit-full-screen-ancestor:not(iframe) { background-color: black }
+
+        pre {
+            white-space: pre-wrap;       /* Since CSS 2.1 */
+            white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+            white-space: -pre-wrap;      /* Opera 4-6 */
+            white-space: -o-pre-wrap;    /* Opera 7 */
+            word-wrap: break-word;       /* Internet Explorer 5.5+ */
+        }
+
+        a {
+            word-wrap: break-word;
+        }
+
+
+</style>
+<body>
+<div id="content">
+    {FLUTTER_CONTENTS}
+</div>
+</body>
+</html>

--- a/apps/flutter_parent/lib/l10n/app_localizations.dart
+++ b/apps/flutter_parent/lib/l10n/app_localizations.dart
@@ -686,7 +686,7 @@ class AppLocalizations {
       desc: 'Message shown when an announcement detail screen fails to load');
 
   String get institutionAnnouncementTitle => Intl.message('Institution Announcement',
-      desc: 'Title text show for institution level announcements');
+      desc: 'Title text shown for institution level announcements');
 
   String get genericNetworkError => Intl.message('Network error');
 }

--- a/apps/flutter_parent/lib/l10n/app_localizations.dart
+++ b/apps/flutter_parent/lib/l10n/app_localizations.dart
@@ -633,4 +633,10 @@ class AppLocalizations {
         name: 'badgeNumberPlus',
         desc: "Formatted string for when too many items are being notified in a badge, generally something like '99+'",
       );
+
+  String get errorLoadingAnnouncement => Intl.message('There was an error loading this announcement',
+      desc: 'Message shown when an announcement detail screen fails to load');
+
+  String get institutionAnnouncementTitle => Intl.message('Institution Announcement',
+      desc: 'Title text show for institution level announcements');
 }

--- a/apps/flutter_parent/lib/models/account_notification.dart
+++ b/apps/flutter_parent/lib/models/account_notification.dart
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'account_notification.g.dart';
+
+/// To have this built_value be generated, run this command from the project root:
+/// flutter packages pub run build_runner build --delete-conflicting-outputs
+abstract class AccountNotification implements Built<AccountNotification, AccountNotificationBuilder> {
+  @BuiltValueSerializer(serializeNulls: true) // Add this line to get nulls to serialize when we convert to JSON
+  static Serializer<AccountNotification> get serializer => _$accountNotificationSerializer;
+
+  AccountNotification._();
+
+  factory AccountNotification([void Function(AccountNotificationBuilder) updates]) = _$AccountNotification;
+
+  String get id;
+
+  String get message;
+
+  String get subject;
+
+  @BuiltValueField(wireName: "start_at")
+  String get startAt;
+
+  static void _initializeBuilder(AccountNotificationBuilder b) => b
+      ..id = ''
+      ..message = ''
+      ..subject = ''
+      ..startAt = '';
+}

--- a/apps/flutter_parent/lib/models/account_notification.g.dart
+++ b/apps/flutter_parent/lib/models/account_notification.g.dart
@@ -1,0 +1,204 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'account_notification.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<AccountNotification> _$accountNotificationSerializer =
+    new _$AccountNotificationSerializer();
+
+class _$AccountNotificationSerializer
+    implements StructuredSerializer<AccountNotification> {
+  @override
+  final Iterable<Type> types = const [
+    AccountNotification,
+    _$AccountNotification
+  ];
+  @override
+  final String wireName = 'AccountNotification';
+
+  @override
+  Iterable<Object> serialize(
+      Serializers serializers, AccountNotification object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object>[
+      'id',
+      serializers.serialize(object.id, specifiedType: const FullType(String)),
+      'message',
+      serializers.serialize(object.message,
+          specifiedType: const FullType(String)),
+      'subject',
+      serializers.serialize(object.subject,
+          specifiedType: const FullType(String)),
+      'start_at',
+      serializers.serialize(object.startAt,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  AccountNotification deserialize(
+      Serializers serializers, Iterable<Object> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new AccountNotificationBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final dynamic value = iterator.current;
+      if (value == null) continue;
+      switch (key) {
+        case 'id':
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'message':
+          result.message = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'subject':
+          result.subject = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'start_at':
+          result.startAt = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$AccountNotification extends AccountNotification {
+  @override
+  final String id;
+  @override
+  final String message;
+  @override
+  final String subject;
+  @override
+  final String startAt;
+
+  factory _$AccountNotification(
+          [void Function(AccountNotificationBuilder) updates]) =>
+      (new AccountNotificationBuilder()..update(updates)).build();
+
+  _$AccountNotification._({this.id, this.message, this.subject, this.startAt})
+      : super._() {
+    if (id == null) {
+      throw new BuiltValueNullFieldError('AccountNotification', 'id');
+    }
+    if (message == null) {
+      throw new BuiltValueNullFieldError('AccountNotification', 'message');
+    }
+    if (subject == null) {
+      throw new BuiltValueNullFieldError('AccountNotification', 'subject');
+    }
+    if (startAt == null) {
+      throw new BuiltValueNullFieldError('AccountNotification', 'startAt');
+    }
+  }
+
+  @override
+  AccountNotification rebuild(
+          void Function(AccountNotificationBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  AccountNotificationBuilder toBuilder() =>
+      new AccountNotificationBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is AccountNotification &&
+        id == other.id &&
+        message == other.message &&
+        subject == other.subject &&
+        startAt == other.startAt;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(
+        $jc($jc($jc(0, id.hashCode), message.hashCode), subject.hashCode),
+        startAt.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('AccountNotification')
+          ..add('id', id)
+          ..add('message', message)
+          ..add('subject', subject)
+          ..add('startAt', startAt))
+        .toString();
+  }
+}
+
+class AccountNotificationBuilder
+    implements Builder<AccountNotification, AccountNotificationBuilder> {
+  _$AccountNotification _$v;
+
+  String _id;
+  String get id => _$this._id;
+  set id(String id) => _$this._id = id;
+
+  String _message;
+  String get message => _$this._message;
+  set message(String message) => _$this._message = message;
+
+  String _subject;
+  String get subject => _$this._subject;
+  set subject(String subject) => _$this._subject = subject;
+
+  String _startAt;
+  String get startAt => _$this._startAt;
+  set startAt(String startAt) => _$this._startAt = startAt;
+
+  AccountNotificationBuilder() {
+    AccountNotification._initializeBuilder(this);
+  }
+
+  AccountNotificationBuilder get _$this {
+    if (_$v != null) {
+      _id = _$v.id;
+      _message = _$v.message;
+      _subject = _$v.subject;
+      _startAt = _$v.startAt;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(AccountNotification other) {
+    if (other == null) {
+      throw new ArgumentError.notNull('other');
+    }
+    _$v = other as _$AccountNotification;
+  }
+
+  @override
+  void update(void Function(AccountNotificationBuilder) updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$AccountNotification build() {
+    final _$result = _$v ??
+        new _$AccountNotification._(
+            id: id, message: message, subject: subject, startAt: startAt);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new

--- a/apps/flutter_parent/lib/models/alert.dart
+++ b/apps/flutter_parent/lib/models/alert.dart
@@ -95,6 +95,15 @@ abstract class Alert implements Built<Alert, AlertBuilder> {
       AlertType.courseGradeLow,
     ].contains(alertType);
   }
+
+  String getCourseId() {
+    int index1 = htmlUrl.lastIndexOf('/courses/');
+    if(index1 != -1) {
+      index1 = index1 + '/courses/'.length;
+    }
+    int index2 = htmlUrl.lastIndexOf('/discussion_topics');
+    return htmlUrl.substring(index1, index2);
+  }
 }
 
 /// If you need to change the values sent over the wire when serializing you

--- a/apps/flutter_parent/lib/models/alert.dart
+++ b/apps/flutter_parent/lib/models/alert.dart
@@ -96,7 +96,9 @@ abstract class Alert implements Built<Alert, AlertBuilder> {
     ].contains(alertType);
   }
 
-  String getCourseId() {
+  String getCourseIdForAnnouncement() {
+    assert(alertType == AlertType.courseAnnouncement);
+
     int index1 = htmlUrl.lastIndexOf('/courses/');
     if(index1 != -1) {
       index1 = index1 + '/courses/'.length;

--- a/apps/flutter_parent/lib/models/announcement.dart
+++ b/apps/flutter_parent/lib/models/announcement.dart
@@ -1,0 +1,53 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'remote_file.dart';
+
+part 'announcement.g.dart';
+
+/// To have this built_value be generated, run this command from the project root:
+/// flutter packages pub run build_runner build --delete-conflicting-outputs
+abstract class Announcement implements Built<Announcement, AnnouncementBuilder> {
+  @BuiltValueSerializer(serializeNulls: true) // Add this line to get nulls to serialize when we convert to JSON
+  static Serializer<Announcement> get serializer => _$announcementSerializer;
+
+  Announcement._();
+
+  factory Announcement([void Function(AnnouncementBuilder) updates]) = _$Announcement;
+
+  String get id;
+
+  String get title;
+
+  String get message;
+
+  @BuiltValueField(wireName: "posted_at")
+  DateTime get postedAt;
+
+  @BuiltValueField(wireName: "html_url")
+  String get htmlUrl;
+
+  BuiltList<RemoteFile> get attachments;
+
+  static void _intializeBuilder(AnnouncementBuilder b) => b
+      ..id = ''
+      ..title = ''
+      ..message = ''
+      ..postedAt = DateTime.now()
+      ..htmlUrl = '';
+
+}

--- a/apps/flutter_parent/lib/models/announcement.g.dart
+++ b/apps/flutter_parent/lib/models/announcement.g.dart
@@ -1,0 +1,263 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'announcement.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<Announcement> _$announcementSerializer =
+    new _$AnnouncementSerializer();
+
+class _$AnnouncementSerializer implements StructuredSerializer<Announcement> {
+  @override
+  final Iterable<Type> types = const [Announcement, _$Announcement];
+  @override
+  final String wireName = 'Announcement';
+
+  @override
+  Iterable<Object> serialize(Serializers serializers, Announcement object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object>[
+      'id',
+      serializers.serialize(object.id, specifiedType: const FullType(String)),
+      'title',
+      serializers.serialize(object.title,
+          specifiedType: const FullType(String)),
+      'message',
+      serializers.serialize(object.message,
+          specifiedType: const FullType(String)),
+      'posted_at',
+      serializers.serialize(object.postedAt,
+          specifiedType: const FullType(DateTime)),
+      'html_url',
+      serializers.serialize(object.htmlUrl,
+          specifiedType: const FullType(String)),
+      'attachments',
+      serializers.serialize(object.attachments,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(RemoteFile)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  Announcement deserialize(Serializers serializers, Iterable<Object> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new AnnouncementBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final dynamic value = iterator.current;
+      if (value == null) continue;
+      switch (key) {
+        case 'id':
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'title':
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'message':
+          result.message = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'posted_at':
+          result.postedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime;
+          break;
+        case 'html_url':
+          result.htmlUrl = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'attachments':
+          result.attachments.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(RemoteFile)]))
+              as BuiltList<dynamic>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$Announcement extends Announcement {
+  @override
+  final String id;
+  @override
+  final String title;
+  @override
+  final String message;
+  @override
+  final DateTime postedAt;
+  @override
+  final String htmlUrl;
+  @override
+  final BuiltList<RemoteFile> attachments;
+
+  factory _$Announcement([void Function(AnnouncementBuilder) updates]) =>
+      (new AnnouncementBuilder()..update(updates)).build();
+
+  _$Announcement._(
+      {this.id,
+      this.title,
+      this.message,
+      this.postedAt,
+      this.htmlUrl,
+      this.attachments})
+      : super._() {
+    if (id == null) {
+      throw new BuiltValueNullFieldError('Announcement', 'id');
+    }
+    if (title == null) {
+      throw new BuiltValueNullFieldError('Announcement', 'title');
+    }
+    if (message == null) {
+      throw new BuiltValueNullFieldError('Announcement', 'message');
+    }
+    if (postedAt == null) {
+      throw new BuiltValueNullFieldError('Announcement', 'postedAt');
+    }
+    if (htmlUrl == null) {
+      throw new BuiltValueNullFieldError('Announcement', 'htmlUrl');
+    }
+    if (attachments == null) {
+      throw new BuiltValueNullFieldError('Announcement', 'attachments');
+    }
+  }
+
+  @override
+  Announcement rebuild(void Function(AnnouncementBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  AnnouncementBuilder toBuilder() => new AnnouncementBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Announcement &&
+        id == other.id &&
+        title == other.title &&
+        message == other.message &&
+        postedAt == other.postedAt &&
+        htmlUrl == other.htmlUrl &&
+        attachments == other.attachments;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(
+        $jc(
+            $jc($jc($jc($jc(0, id.hashCode), title.hashCode), message.hashCode),
+                postedAt.hashCode),
+            htmlUrl.hashCode),
+        attachments.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('Announcement')
+          ..add('id', id)
+          ..add('title', title)
+          ..add('message', message)
+          ..add('postedAt', postedAt)
+          ..add('htmlUrl', htmlUrl)
+          ..add('attachments', attachments))
+        .toString();
+  }
+}
+
+class AnnouncementBuilder
+    implements Builder<Announcement, AnnouncementBuilder> {
+  _$Announcement _$v;
+
+  String _id;
+  String get id => _$this._id;
+  set id(String id) => _$this._id = id;
+
+  String _title;
+  String get title => _$this._title;
+  set title(String title) => _$this._title = title;
+
+  String _message;
+  String get message => _$this._message;
+  set message(String message) => _$this._message = message;
+
+  DateTime _postedAt;
+  DateTime get postedAt => _$this._postedAt;
+  set postedAt(DateTime postedAt) => _$this._postedAt = postedAt;
+
+  String _htmlUrl;
+  String get htmlUrl => _$this._htmlUrl;
+  set htmlUrl(String htmlUrl) => _$this._htmlUrl = htmlUrl;
+
+  ListBuilder<RemoteFile> _attachments;
+  ListBuilder<RemoteFile> get attachments =>
+      _$this._attachments ??= new ListBuilder<RemoteFile>();
+  set attachments(ListBuilder<RemoteFile> attachments) =>
+      _$this._attachments = attachments;
+
+  AnnouncementBuilder();
+
+  AnnouncementBuilder get _$this {
+    if (_$v != null) {
+      _id = _$v.id;
+      _title = _$v.title;
+      _message = _$v.message;
+      _postedAt = _$v.postedAt;
+      _htmlUrl = _$v.htmlUrl;
+      _attachments = _$v.attachments?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(Announcement other) {
+    if (other == null) {
+      throw new ArgumentError.notNull('other');
+    }
+    _$v = other as _$Announcement;
+  }
+
+  @override
+  void update(void Function(AnnouncementBuilder) updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$Announcement build() {
+    _$Announcement _$result;
+    try {
+      _$result = _$v ??
+          new _$Announcement._(
+              id: id,
+              title: title,
+              message: message,
+              postedAt: postedAt,
+              htmlUrl: htmlUrl,
+              attachments: attachments.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'attachments';
+        attachments.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'Announcement', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new

--- a/apps/flutter_parent/lib/models/remote_file.dart
+++ b/apps/flutter_parent/lib/models/remote_file.dart
@@ -1,0 +1,41 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'remote_file.g.dart';
+
+/// To have this built_value be generated, run this command from the project root:
+/// flutter packages pub run build_runner build --delete-conflicting-outputs
+abstract class RemoteFile implements Built<RemoteFile, RemoteFileBuilder> {
+  @BuiltValueSerializer(serializeNulls: true) // Add this line to get nulls to serialize when we convert to JSON
+  static Serializer<RemoteFile> get serializer => _$remoteFileSerializer;
+
+  RemoteFile._();
+
+  factory RemoteFile([void Function(RemoteFileBuilder) updates]) = _$RemoteFile;
+
+  String get id;
+
+  String get url;
+
+  String get filename;
+
+  static void _initializeBuilder(RemoteFileBuilder b) => b
+      ..id = ''
+      ..url = ''
+      ..filename = '';
+
+}

--- a/apps/flutter_parent/lib/models/remote_file.g.dart
+++ b/apps/flutter_parent/lib/models/remote_file.g.dart
@@ -1,0 +1,169 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'remote_file.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<RemoteFile> _$remoteFileSerializer = new _$RemoteFileSerializer();
+
+class _$RemoteFileSerializer implements StructuredSerializer<RemoteFile> {
+  @override
+  final Iterable<Type> types = const [RemoteFile, _$RemoteFile];
+  @override
+  final String wireName = 'RemoteFile';
+
+  @override
+  Iterable<Object> serialize(Serializers serializers, RemoteFile object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object>[
+      'id',
+      serializers.serialize(object.id, specifiedType: const FullType(String)),
+      'url',
+      serializers.serialize(object.url, specifiedType: const FullType(String)),
+      'filename',
+      serializers.serialize(object.filename,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RemoteFile deserialize(Serializers serializers, Iterable<Object> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new RemoteFileBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final dynamic value = iterator.current;
+      if (value == null) continue;
+      switch (key) {
+        case 'id':
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'url':
+          result.url = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'filename':
+          result.filename = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RemoteFile extends RemoteFile {
+  @override
+  final String id;
+  @override
+  final String url;
+  @override
+  final String filename;
+
+  factory _$RemoteFile([void Function(RemoteFileBuilder) updates]) =>
+      (new RemoteFileBuilder()..update(updates)).build();
+
+  _$RemoteFile._({this.id, this.url, this.filename}) : super._() {
+    if (id == null) {
+      throw new BuiltValueNullFieldError('RemoteFile', 'id');
+    }
+    if (url == null) {
+      throw new BuiltValueNullFieldError('RemoteFile', 'url');
+    }
+    if (filename == null) {
+      throw new BuiltValueNullFieldError('RemoteFile', 'filename');
+    }
+  }
+
+  @override
+  RemoteFile rebuild(void Function(RemoteFileBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RemoteFileBuilder toBuilder() => new RemoteFileBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RemoteFile &&
+        id == other.id &&
+        url == other.url &&
+        filename == other.filename;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc($jc($jc(0, id.hashCode), url.hashCode), filename.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('RemoteFile')
+          ..add('id', id)
+          ..add('url', url)
+          ..add('filename', filename))
+        .toString();
+  }
+}
+
+class RemoteFileBuilder implements Builder<RemoteFile, RemoteFileBuilder> {
+  _$RemoteFile _$v;
+
+  String _id;
+  String get id => _$this._id;
+  set id(String id) => _$this._id = id;
+
+  String _url;
+  String get url => _$this._url;
+  set url(String url) => _$this._url = url;
+
+  String _filename;
+  String get filename => _$this._filename;
+  set filename(String filename) => _$this._filename = filename;
+
+  RemoteFileBuilder() {
+    RemoteFile._initializeBuilder(this);
+  }
+
+  RemoteFileBuilder get _$this {
+    if (_$v != null) {
+      _id = _$v.id;
+      _url = _$v.url;
+      _filename = _$v.filename;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(RemoteFile other) {
+    if (other == null) {
+      throw new ArgumentError.notNull('other');
+    }
+    _$v = other as _$RemoteFile;
+  }
+
+  @override
+  void update(void Function(RemoteFileBuilder) updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$RemoteFile build() {
+    final _$result =
+        _$v ?? new _$RemoteFile._(id: id, url: url, filename: filename);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new

--- a/apps/flutter_parent/lib/models/serializers.dart
+++ b/apps/flutter_parent/lib/models/serializers.dart
@@ -18,6 +18,7 @@ import 'package:built_collection/built_collection.dart';
 import 'package:built_value/iso_8601_date_time_serializer.dart';
 import 'package:built_value/serializer.dart';
 import 'package:built_value/standard_json_plugin.dart';
+import 'package:flutter_parent/models/account_notification.dart';
 import 'package:flutter_parent/models/alert.dart';
 import 'package:flutter_parent/models/announcement.dart';
 import 'package:flutter_parent/models/assignment.dart';
@@ -46,6 +47,7 @@ part 'serializers.g.dart';
 /// If changes are made, run `flutter pub run build_runner build` from the project root. Alternatively, you can
 /// have it watch for changes and automatically build if you run `flutter pub run build_runner watch`.
 @SerializersFor([
+  AccountNotification,
   Alert,
   Announcement,
   Assignment,

--- a/apps/flutter_parent/lib/models/serializers.dart
+++ b/apps/flutter_parent/lib/models/serializers.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 - present Instructure, Inc.
+// Copyright (C) 2019 - present Instructure, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -20,11 +20,8 @@ import 'package:built_value/serializer.dart';
 import 'package:built_value/standard_json_plugin.dart';
 import 'package:flutter_parent/models/account_notification.dart';
 import 'package:flutter_parent/models/alert.dart';
-<<<<<<< HEAD
 import 'package:flutter_parent/models/announcement.dart';
-=======
 import 'package:flutter_parent/models/alert_threshold.dart';
->>>>>>> master
 import 'package:flutter_parent/models/assignment.dart';
 import 'package:flutter_parent/models/assignment_group.dart';
 import 'package:flutter_parent/models/attachment.dart';

--- a/apps/flutter_parent/lib/models/serializers.dart
+++ b/apps/flutter_parent/lib/models/serializers.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 - present Instructure, Inc.
+// Copyright (C) 2020 - present Instructure, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -19,6 +19,7 @@ import 'package:built_value/iso_8601_date_time_serializer.dart';
 import 'package:built_value/serializer.dart';
 import 'package:built_value/standard_json_plugin.dart';
 import 'package:flutter_parent/models/alert.dart';
+import 'package:flutter_parent/models/announcement.dart';
 import 'package:flutter_parent/models/assignment.dart';
 import 'package:flutter_parent/models/assignment_group.dart';
 import 'package:flutter_parent/models/attachment.dart';
@@ -32,6 +33,7 @@ import 'package:flutter_parent/models/media_comment.dart';
 import 'package:flutter_parent/models/message.dart';
 import 'package:flutter_parent/models/mobile_verify_result.dart';
 import 'package:flutter_parent/models/recipient.dart';
+import 'package:flutter_parent/models/remote_file.dart';
 import 'package:flutter_parent/models/school_domain.dart';
 import 'package:flutter_parent/models/submission.dart';
 import 'package:flutter_parent/models/unread_count.dart';
@@ -45,6 +47,7 @@ part 'serializers.g.dart';
 /// have it watch for changes and automatically build if you run `flutter pub run build_runner watch`.
 @SerializersFor([
   Alert,
+  Announcement,
   Assignment,
   AssignmentGroup,
   Attachment,
@@ -59,6 +62,7 @@ part 'serializers.g.dart';
   Message,
   MobileVerifyResult,
   Recipient,
+  RemoteFile,
   SchoolDomain,
   Submission,
   UnreadCount,

--- a/apps/flutter_parent/lib/models/serializers.g.dart
+++ b/apps/flutter_parent/lib/models/serializers.g.dart
@@ -7,6 +7,7 @@ part of serializers;
 // **************************************************************************
 
 Serializers _$_serializers = (new Serializers().toBuilder()
+      ..add(AccountNotification.serializer)
       ..add(Alert.serializer)
       ..add(AlertType.serializer)
       ..add(AlertWorkflowState.serializer)

--- a/apps/flutter_parent/lib/models/serializers.g.dart
+++ b/apps/flutter_parent/lib/models/serializers.g.dart
@@ -10,6 +10,7 @@ Serializers _$_serializers = (new Serializers().toBuilder()
       ..add(Alert.serializer)
       ..add(AlertType.serializer)
       ..add(AlertWorkflowState.serializer)
+      ..add(Announcement.serializer)
       ..add(Assignment.serializer)
       ..add(AssignmentGroup.serializer)
       ..add(Attachment.serializer)
@@ -26,6 +27,7 @@ Serializers _$_serializers = (new Serializers().toBuilder()
       ..add(Message.serializer)
       ..add(MobileVerifyResult.serializer)
       ..add(Recipient.serializer)
+      ..add(RemoteFile.serializer)
       ..add(SchoolDomain.serializer)
       ..add(Submission.serializer)
       ..add(SubmissionTypes.serializer)
@@ -46,6 +48,9 @@ Serializers _$_serializers = (new Serializers().toBuilder()
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(Enrollment)]),
           () => new ListBuilder<Enrollment>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(RemoteFile)]),
+          () => new ListBuilder<RemoteFile>())
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(String)]),
           () => new ListBuilder<String>())

--- a/apps/flutter_parent/lib/network/api/announcement_api.dart
+++ b/apps/flutter_parent/lib/network/api/announcement_api.dart
@@ -1,0 +1,27 @@
+// Copyright (C) 2019 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+/*
+@GET("{contextType}/{contextId}/discussion_topics/{topicId}?include[]=sections")
+        fun getDetailedDiscussion(@Path("contextType") contextType: String, @Path("contextId") contextId: Long, @Path("topicId") topicId: Long): Call<DiscussionTopicHeader>
+ */
+import 'package:flutter_parent/models/announcement.dart';
+import 'package:flutter_parent/network/utils/dio_config.dart';
+import 'package:flutter_parent/network/utils/fetch.dart';
+
+class AnnouncementApi {
+  Future<Announcement> getCourseAnnouncement(String courseId, String announcementId) {
+    return fetch(canvasDio().get('courses/$courseId/discussion_topics/$announcementId'));
+  }
+}

--- a/apps/flutter_parent/lib/network/api/announcement_api.dart
+++ b/apps/flutter_parent/lib/network/api/announcement_api.dart
@@ -16,6 +16,7 @@
 @GET("{contextType}/{contextId}/discussion_topics/{topicId}?include[]=sections")
         fun getDetailedDiscussion(@Path("contextType") contextType: String, @Path("contextId") contextId: Long, @Path("topicId") topicId: Long): Call<DiscussionTopicHeader>
  */
+import 'package:flutter_parent/models/account_notification.dart';
 import 'package:flutter_parent/models/announcement.dart';
 import 'package:flutter_parent/network/utils/dio_config.dart';
 import 'package:flutter_parent/network/utils/fetch.dart';
@@ -23,5 +24,9 @@ import 'package:flutter_parent/network/utils/fetch.dart';
 class AnnouncementApi {
   Future<Announcement> getCourseAnnouncement(String courseId, String announcementId) {
     return fetch(canvasDio().get('courses/$courseId/discussion_topics/$announcementId'));
+  }
+
+  Future<AccountNotification> getAccountNotification(String accountNotificationid) {
+    return fetch(canvasDio().get('accounts/self/users/self/account_notifications/$accountNotificationid'));
   }
 }

--- a/apps/flutter_parent/lib/network/api/announcement_api.dart
+++ b/apps/flutter_parent/lib/network/api/announcement_api.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 - present Instructure, Inc.
+// Copyright (C) 2020 - present Instructure, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,10 +12,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-/*
-@GET("{contextType}/{contextId}/discussion_topics/{topicId}?include[]=sections")
-        fun getDetailedDiscussion(@Path("contextType") contextType: String, @Path("contextId") contextId: Long, @Path("topicId") topicId: Long): Call<DiscussionTopicHeader>
- */
 import 'package:flutter_parent/models/account_notification.dart';
 import 'package:flutter_parent/models/announcement.dart';
 import 'package:flutter_parent/network/utils/dio_config.dart';

--- a/apps/flutter_parent/lib/screens/alerts/alerts_screen.dart
+++ b/apps/flutter_parent/lib/screens/alerts/alerts_screen.dart
@@ -17,6 +17,7 @@ import 'package:flutter_parent/l10n/app_localizations.dart';
 import 'package:flutter_parent/models/alert.dart';
 import 'package:flutter_parent/models/user.dart';
 import 'package:flutter_parent/screens/alerts/alerts_interactor.dart';
+import 'package:flutter_parent/screens/announcements/announcement_details_screen.dart';
 import 'package:flutter_parent/screens/dashboard/alert_notifier.dart';
 import 'package:flutter_parent/utils/common_widgets/badges.dart';
 import 'package:flutter_parent/utils/common_widgets/empty_panda_widget.dart';
@@ -25,6 +26,7 @@ import 'package:flutter_parent/utils/common_widgets/loading_indicator.dart';
 import 'package:flutter_parent/utils/design/canvas_icons.dart';
 import 'package:flutter_parent/utils/design/parent_colors.dart';
 import 'package:flutter_parent/utils/design/parent_theme.dart';
+import 'package:flutter_parent/utils/quick_nav.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
 import 'package:intl/intl.dart';
 
@@ -157,7 +159,9 @@ class __AlertsListState extends State<_AlertsList> {
   }
 
   void _routeAlert(Alert alert, int index) async {
-    // TODO: Show detail page for alert
+    if(alert.alertType == AlertType.courseAnnouncement) {
+      locator<QuickNav>().push(context, AnnouncementDetailScreen(alert.contextId, alert.getCourseId()));
+    }
 
     // We're done if the alert was already read, otherwise mark it read
     if (alert.workflowState == AlertWorkflowState.read) return;

--- a/apps/flutter_parent/lib/screens/alerts/alerts_screen.dart
+++ b/apps/flutter_parent/lib/screens/alerts/alerts_screen.dart
@@ -160,7 +160,7 @@ class __AlertsListState extends State<_AlertsList> {
 
   void _routeAlert(Alert alert, int index) async {
     if(alert.alertType == AlertType.courseAnnouncement) {
-      locator<QuickNav>().push(context, AnnouncementDetailScreen(alert.contextId, AnnouncementType.COURSE, alert.getCourseId(), context));
+      locator<QuickNav>().push(context, AnnouncementDetailScreen(alert.contextId, AnnouncementType.COURSE, alert.getCourseIdForAnnouncement(), context));
     }
 
     if(alert.alertType == AlertType.institutionAnnouncement) {

--- a/apps/flutter_parent/lib/screens/alerts/alerts_screen.dart
+++ b/apps/flutter_parent/lib/screens/alerts/alerts_screen.dart
@@ -160,11 +160,11 @@ class __AlertsListState extends State<_AlertsList> {
 
   void _routeAlert(Alert alert, int index) async {
     if(alert.alertType == AlertType.courseAnnouncement) {
-      locator<QuickNav>().push(context, AnnouncementDetailScreen(alert.contextId, AnnouncementType.COURSE, alert.getCourseId()));
+      locator<QuickNav>().push(context, AnnouncementDetailScreen(alert.contextId, AnnouncementType.COURSE, alert.getCourseId(), context));
     }
 
     if(alert.alertType == AlertType.institutionAnnouncement) {
-      locator<QuickNav>().push(context, AnnouncementDetailScreen(alert.contextId, AnnouncementType.INSTITUTION, ''));
+      locator<QuickNav>().push(context, AnnouncementDetailScreen(alert.contextId, AnnouncementType.INSTITUTION, '', context));
     }
 
     // We're done if the alert was already read, otherwise mark it read

--- a/apps/flutter_parent/lib/screens/alerts/alerts_screen.dart
+++ b/apps/flutter_parent/lib/screens/alerts/alerts_screen.dart
@@ -160,7 +160,11 @@ class __AlertsListState extends State<_AlertsList> {
 
   void _routeAlert(Alert alert, int index) async {
     if(alert.alertType == AlertType.courseAnnouncement) {
-      locator<QuickNav>().push(context, AnnouncementDetailScreen(alert.contextId, alert.getCourseId()));
+      locator<QuickNav>().push(context, AnnouncementDetailScreen(alert.contextId, AnnouncementType.COURSE, alert.getCourseId()));
+    }
+
+    if(alert.alertType == AlertType.institutionAnnouncement) {
+      locator<QuickNav>().push(context, AnnouncementDetailScreen(alert.contextId, AnnouncementType.INSTITUTION, ''));
     }
 
     // We're done if the alert was already read, otherwise mark it read

--- a/apps/flutter_parent/lib/screens/announcements/announcement_details_interactor.dart
+++ b/apps/flutter_parent/lib/screens/announcements/announcement_details_interactor.dart
@@ -1,0 +1,33 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import 'package:flutter_parent/models/course.dart';
+import 'package:flutter_parent/network/api/course_api.dart';
+import 'package:tuple/tuple.dart';
+import 'package:flutter_parent/models/announcement.dart';
+import 'package:flutter_parent/network/api/announcement_api.dart';
+import 'package:flutter_parent/utils/service_locator.dart';
+
+class AnnouncementDetailsInteractor {
+  AnnouncementApi _announcementApi() => locator<AnnouncementApi>();
+  CourseApi _courseApi() => locator<CourseApi>();
+
+  Future<Tuple2<Announcement, Course>> getCourseAnnouncement(String courseId, String announcementId) async {
+    Announcement announcement = await _announcementApi().getCourseAnnouncement(courseId, announcementId);
+    Course course = await _courseApi().getCourse(courseId);
+
+    return Tuple2(announcement, course);
+  }
+}

--- a/apps/flutter_parent/lib/screens/announcements/announcement_details_interactor.dart
+++ b/apps/flutter_parent/lib/screens/announcements/announcement_details_interactor.dart
@@ -28,9 +28,13 @@ class AnnouncementDetailsInteractor {
   AnnouncementApi _announcementApi() => locator<AnnouncementApi>();
   CourseApi _courseApi() => locator<CourseApi>();
 
-  Future<AnnouncementViewState> getAnnouncement(String announcementId, AnnouncementType type, String courseId, BuildContext context) async {
+  Future<AnnouncementViewState> getAnnouncement(String announcementId,
+      AnnouncementType type, String courseId,
+      String institutionToolbarTitle) async {
     if(type == AnnouncementType.COURSE) {
-      Announcement announcement = await _announcementApi().getCourseAnnouncement(courseId, announcementId);
+      Announcement announcement = await _announcementApi()
+          .getCourseAnnouncement(courseId, announcementId);
+
       Course course = await _courseApi().getCourse(courseId);
 
       return AnnouncementViewState(
@@ -40,10 +44,11 @@ class AnnouncementDetailsInteractor {
           announcement.postedAt
       );
     } else {
-      AccountNotification accountNotification = await _announcementApi().getAccountNotification(announcementId);
+      AccountNotification accountNotification = await _announcementApi()
+          .getAccountNotification(announcementId);
 
       return AnnouncementViewState(
-          L10n(context).institutionAnnouncementTitle,
+          institutionToolbarTitle,
           accountNotification.subject,
           accountNotification.message,
           DateTime.parse(accountNotification.startAt)

--- a/apps/flutter_parent/lib/screens/announcements/announcement_details_interactor.dart
+++ b/apps/flutter_parent/lib/screens/announcements/announcement_details_interactor.dart
@@ -13,9 +13,13 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_parent/l10n/app_localizations.dart';
+import 'package:flutter_parent/models/account_notification.dart';
 import 'package:flutter_parent/models/course.dart';
 import 'package:flutter_parent/network/api/course_api.dart';
-import 'package:tuple/tuple.dart';
+import 'package:flutter_parent/screens/announcements/announcement_details_screen.dart';
+import 'package:flutter_parent/screens/announcements/announcement_view_state.dart';
 import 'package:flutter_parent/models/announcement.dart';
 import 'package:flutter_parent/network/api/announcement_api.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
@@ -24,10 +28,26 @@ class AnnouncementDetailsInteractor {
   AnnouncementApi _announcementApi() => locator<AnnouncementApi>();
   CourseApi _courseApi() => locator<CourseApi>();
 
-  Future<Tuple2<Announcement, Course>> getCourseAnnouncement(String courseId, String announcementId) async {
-    Announcement announcement = await _announcementApi().getCourseAnnouncement(courseId, announcementId);
-    Course course = await _courseApi().getCourse(courseId);
+  Future<AnnouncementViewState> getAnnouncement(String announcementId, AnnouncementType type, String courseId, BuildContext context) async {
+    if(type == AnnouncementType.COURSE) {
+      Announcement announcement = await _announcementApi().getCourseAnnouncement(courseId, announcementId);
+      Course course = await _courseApi().getCourse(courseId);
 
-    return Tuple2(announcement, course);
+      return AnnouncementViewState(
+          course.name,
+          announcement.title,
+          announcement.message,
+          announcement.postedAt
+      );
+    } else {
+      AccountNotification accountNotification = await _announcementApi().getAccountNotification(announcementId);
+
+      return AnnouncementViewState(
+          L10n(context).institutionAnnouncementTitle,
+          accountNotification.subject,
+          accountNotification.message,
+          DateTime.parse(accountNotification.startAt)
+      );
+    }
   }
-}
+ }

--- a/apps/flutter_parent/lib/screens/announcements/announcement_details_screen.dart
+++ b/apps/flutter_parent/lib/screens/announcements/announcement_details_screen.dart
@@ -17,15 +17,11 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_parent/l10n/app_localizations.dart';
-import 'package:flutter_parent/models/account_notification.dart';
-import 'package:flutter_parent/models/announcement.dart';
-import 'package:flutter_parent/models/course.dart';
 import 'package:flutter_parent/screens/announcements/announcement_view_state.dart';
 import 'package:flutter_parent/utils/common_widgets/error_panda_widget.dart';
 import 'package:flutter_parent/utils/common_widgets/loading_indicator.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
 import 'package:intl/intl.dart';
-import 'package:tuple/tuple.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 import 'announcement_details_interactor.dart';
@@ -37,9 +33,10 @@ class AnnouncementDetailScreen extends StatefulWidget {
   final String _announcementId;
   final String _courseId;
   final AnnouncementType _announcementType;
+  final String _toolbarTitle;
 
-  AnnouncementDetailScreen(this._announcementId, this._announcementType, this._courseId, {Key key})
-      : super(key: key);
+  AnnouncementDetailScreen(this._announcementId, this._announcementType, this._courseId, BuildContext context, {Key key})
+      : this._toolbarTitle = L10n(context).institutionAnnouncementTitle, super(key: key);
 
   @override
   State createState() => _AnnouncementDetailScreenState();
@@ -49,7 +46,7 @@ class _AnnouncementDetailScreenState extends State<AnnouncementDetailScreen> {
   Future<AnnouncementViewState> _announcementFuture;
 
   Future<AnnouncementViewState> _loadAnnouncement() =>
-      widget._interactor.getAnnouncement(widget._announcementId, widget._announcementType, widget._courseId, context);
+      widget._interactor.getAnnouncement(widget._announcementId, widget._announcementType, widget._courseId, widget._toolbarTitle);
 
   @override
   void initState() {
@@ -130,7 +127,7 @@ class _AnnouncementDetailScreenState extends State<AnnouncementDetailScreen> {
         setState(() {
           _announcementFuture = widget._interactor.getAnnouncement(
               widget._announcementId, widget._announcementType,
-              widget._courseId, context);
+              widget._courseId, L10n(context).institutionAnnouncementTitle);
         });
       }));
   }

--- a/apps/flutter_parent/lib/screens/announcements/announcement_details_screen.dart
+++ b/apps/flutter_parent/lib/screens/announcements/announcement_details_screen.dart
@@ -1,0 +1,108 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+
+import 'package:flutter/material.dart';
+import 'package:flutter_parent/models/announcement.dart';
+import 'package:flutter_parent/models/course.dart';
+import 'package:flutter_parent/utils/common_widgets/loading_indicator.dart';
+import 'package:flutter_parent/utils/service_locator.dart';
+import 'package:tuple/tuple.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import 'announcement_details_interactor.dart';
+
+class AnnouncementDetailScreen extends StatefulWidget {
+  final _interactor = locator<AnnouncementDetailsInteractor>();
+  final String _announcementId;
+  final String _courseId;
+
+  AnnouncementDetailScreen(this._announcementId, this._courseId, {Key key}) : super(key: key);
+
+  @override
+  State createState() => _AnnouncementDetailScreenState();
+}
+
+class _AnnouncementDetailScreenState extends State<AnnouncementDetailScreen> {
+  Future<Tuple2<Announcement, Course>> _announcementFuture;
+
+  Future<Tuple2<Announcement, Course>> _loadAnnouncement() =>
+      widget._interactor.getCourseAnnouncement(
+          widget._courseId, widget._announcementId);
+
+
+  @override
+  void initState() {
+    super.initState();
+    _announcementFuture = _loadAnnouncement();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder(
+      future: _announcementFuture,
+      builder: (context, AsyncSnapshot<Tuple2<Announcement, Course>> snapshot) {
+        if(snapshot.connectionState == ConnectionState.waiting) {
+          return Container(child: LoadingIndicator());
+        }
+
+        if(snapshot.hasError || snapshot.data == null) {
+          return _error();
+        } else {
+          return _courseAnnouncementWidget(snapshot.data.item1, snapshot.data.item2);
+        }
+      },
+    );
+  }
+
+  Widget _courseAnnouncementWidget(Announcement announcement, Course course) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(course.name),
+      ),
+      body: _announcementBody(announcement),
+    );
+  }
+
+  Widget _announcementBody(Announcement announcement) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 16),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.fromLTRB(0, 0, 0, 4),
+            child: Text("This is a course announcement title"),
+          ),
+          Text("Jun 19 at 10:02pm"),
+          Divider(),
+          Container(
+            height: 400,
+            child: WebView(
+              initialUrl: '',
+
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _error() {
+    // TODO ERROR STATE
+    return Container(color: Colors.red);
+  }
+}

--- a/apps/flutter_parent/lib/screens/announcements/announcement_view_state.dart
+++ b/apps/flutter_parent/lib/screens/announcements/announcement_view_state.dart
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class AnnouncementViewState {
+  final String _toolbarTitle;
+  final String _announcementTitle;
+  final String _announcementMessage;
+  final DateTime _postedAt;
+
+  AnnouncementViewState(this._toolbarTitle, this._announcementTitle,
+      this._announcementMessage, this._postedAt);
+
+  String get toolbarTitle => _toolbarTitle;
+  String get announcementTitle => _announcementTitle;
+  String get announcementMessage => _announcementMessage;
+  DateTime get postedAt => _postedAt;
+}

--- a/apps/flutter_parent/lib/utils/service_locator.dart
+++ b/apps/flutter_parent/lib/utils/service_locator.dart
@@ -13,6 +13,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import 'package:flutter_parent/network/api/alert_api.dart';
+import 'package:flutter_parent/network/api/announcement_api.dart';
 import 'package:flutter_parent/network/api/assignment_api.dart';
 import 'package:flutter_parent/network/api/auth_api.dart';
 import 'package:flutter_parent/network/api/course_api.dart';
@@ -20,6 +21,7 @@ import 'package:flutter_parent/network/api/enrollments_api.dart';
 import 'package:flutter_parent/network/api/file_upload_api.dart';
 import 'package:flutter_parent/network/api/inbox_api.dart';
 import 'package:flutter_parent/screens/alerts/alerts_interactor.dart';
+import 'package:flutter_parent/screens/announcements/announcement_details_interactor.dart';
 import 'package:flutter_parent/screens/courses/courses_interactor.dart';
 import 'package:flutter_parent/screens/courses/details/course_details_interactor.dart';
 import 'package:flutter_parent/screens/dashboard/alert_notifier.dart';
@@ -41,6 +43,7 @@ GetIt locator = GetIt.instance;
 void setupLocator() {
   // APIs
   locator.registerLazySingleton<AlertsApi>(() => AlertsApi());
+  locator.registerLazySingleton<AnnouncementApi>(() => AnnouncementApi());
   locator.registerLazySingleton<AssignmentApi>(() => AssignmentApi());
   locator.registerLazySingleton<AuthApi>(() => AuthApi());
   locator.registerLazySingleton<CourseApi>(() => CourseApi());
@@ -50,6 +53,7 @@ void setupLocator() {
 
   // Interactors
   locator.registerFactory<AlertsInteractor>(() => AlertsInteractor());
+  locator.registerFactory<AnnouncementDetailsInteractor>(() => AnnouncementDetailsInteractor());
   locator.registerFactory<AttachmentPickerInteractor>(() => AttachmentPickerInteractor());
   locator.registerFactory<ConversationListInteractor>(() => ConversationListInteractor());
   locator.registerFactory<CourseDetailsInteractor>(() => CourseDetailsInteractor());

--- a/apps/flutter_parent/pubspec.yaml
+++ b/apps/flutter_parent/pubspec.yaml
@@ -94,6 +94,7 @@ flutter:
   assets:
     - assets/svg/
     - assets/fonts/
+    - assets/html_wrapper.html
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware.

--- a/apps/flutter_parent/test/models/alert_test.dart
+++ b/apps/flutter_parent/test/models/alert_test.dart
@@ -36,4 +36,28 @@ void main() {
     expect(false, AlertType.assignmentGradeLow.isSwitch());
     expect(false, AlertType.assignmentGradeHigh.isSwitch());
   });
+
+  test('returns valid courseId for course announcement alert', () {
+    final courseId = '1234';
+    final alert = Alert((b) => b
+      ..id = '123'
+      ..title = 'Hodor'
+      ..workflowState = AlertWorkflowState.unread
+      ..htmlUrl = 'https://instructure.com/api/v1/courses/$courseId/discussion_topics/1234'
+      ..alertType = AlertType.courseAnnouncement);
+
+    expect(alert.getCourseIdForAnnouncement(), courseId);
+  });
+
+  test('assertion fails for not a course announcement alert', () {
+    final alert = Alert((b) => b
+      ..id = '123'
+      ..title = 'Hodor'
+      ..workflowState = AlertWorkflowState.unread
+      ..alertType = AlertType.institutionAnnouncement);
+
+    expect(() {
+      alert.getCourseIdForAnnouncement();
+    }, throwsA(isA<AssertionError>()));
+  });
 }

--- a/apps/flutter_parent/test/screens/announcements/announcement_details_interactor_test.dart
+++ b/apps/flutter_parent/test/screens/announcements/announcement_details_interactor_test.dart
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'package:built_collection/built_collection.dart';
+import 'package:flutter_parent/models/account_notification.dart';
+import 'package:flutter_parent/models/announcement.dart';
+import 'package:flutter_parent/models/course.dart';
+import 'package:flutter_parent/models/enrollment.dart';
+import 'package:flutter_parent/network/api/announcement_api.dart';
+import 'package:flutter_parent/network/api/course_api.dart';
+import 'package:flutter_parent/screens/announcements/announcement_details_interactor.dart';
+import 'package:flutter_parent/screens/announcements/announcement_details_screen.dart';
+import 'package:flutter_parent/screens/announcements/announcement_view_state.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+void main() {
+  void _setupLocator({AnnouncementApi announcementApi, CourseApi courseApi}) {
+    final _locator = GetIt.instance;
+    _locator.reset();
+
+    _locator.registerFactory<AnnouncementApi>(() => announcementApi ?? _MockAnnouncementApi());
+    _locator.registerFactory<CourseApi>(() => courseApi ?? _MockCourseApi());
+  }
+
+  test('get course announcement returns a proper view state', () async {
+    final announcementId = '123';
+    final courseId = '123';
+    final announcementMessage = 'hodor';
+    final announcementSubject = 'hodor subject';
+    final announcementType = AnnouncementType.COURSE;
+    final postedAt = DateTime.now();
+    final courseName = 'flowers for hodornon';
+
+    final announcementData = Announcement((b) => b
+      ..id = announcementId
+      ..postedAt = postedAt
+      ..message = announcementMessage
+      ..title = announcementSubject
+      ..htmlUrl = ''
+    );
+
+    final courseData = Course((b) => b
+      ..id = courseId
+      ..enrollments = ListBuilder<Enrollment>()
+      ..name = courseName
+      ..needsGradingCount = 0
+      ..hideFinalGrades = false
+      ..isPublic = false
+      ..applyAssignmentGroupWeights = false
+      ..isFavorite = false
+      ..accessRestrictedByDate = false
+      ..hasWeightedGradingPeriods = false
+      ..hasGradingPeriods = false
+      ..restrictEnrollmentsToCourseDates = false
+    );
+
+    final expectedViewState = AnnouncementViewState(
+      courseName, announcementSubject, announcementMessage, postedAt);
+
+    final announcementApi = _MockAnnouncementApi();
+    final courseApi = _MockCourseApi();
+    when(announcementApi.getCourseAnnouncement(courseId, announcementId)).thenAnswer((_) =>
+      Future.value(announcementData));
+    when(courseApi.getCourse(courseId)).thenAnswer((_) =>
+      Future.value(courseData));
+
+    _setupLocator(announcementApi: announcementApi, courseApi: courseApi);
+
+    final actualViewState = await AnnouncementDetailsInteractor().getAnnouncement(
+      announcementId, announcementType, courseId, '');
+
+    verify(announcementApi.getCourseAnnouncement(courseId, announcementId)).called(1);
+    verify(courseApi.getCourse(courseId)).called(1);
+
+    expect(actualViewState.toolbarTitle, expectedViewState.toolbarTitle);
+    expect(actualViewState.announcementMessage, expectedViewState.announcementMessage);
+    expect(actualViewState.announcementTitle, expectedViewState.announcementTitle);
+    expect(actualViewState.postedAt, expectedViewState.postedAt);
+  });
+
+  test('get institution announcement returns a proper view state', () async {
+    final announcementId = '123';
+    final courseId = '123';
+    final announcementMessage = 'hodor';
+    final announcementSubject = 'hodor subject';
+    final announcementType = AnnouncementType.INSTITUTION;
+    final postedAt = DateTime.now();
+    final toolbarTitle = 'Institution Announcement';
+
+    final accountNotificationData = AccountNotification((b) => b
+      ..id = announcementId
+      ..startAt = postedAt.toIso8601String()
+      ..message = announcementMessage
+      ..subject = announcementSubject
+    );
+
+    final expectedViewState = AnnouncementViewState(
+        toolbarTitle, announcementSubject, announcementMessage, postedAt);
+
+    final announcementApi = _MockAnnouncementApi();
+    when(announcementApi.getAccountNotification(announcementId)).thenAnswer((_) =>
+        Future.value(accountNotificationData));
+
+    _setupLocator(announcementApi: announcementApi);
+
+    final actualViewState = await AnnouncementDetailsInteractor().getAnnouncement(
+        announcementId, announcementType, courseId, toolbarTitle);
+
+    verify(announcementApi.getAccountNotification(announcementId)).called(1);
+
+    expect(actualViewState.toolbarTitle, expectedViewState.toolbarTitle);
+    expect(actualViewState.announcementMessage, expectedViewState.announcementMessage);
+    expect(actualViewState.announcementTitle, expectedViewState.announcementTitle);
+    expect(actualViewState.postedAt, expectedViewState.postedAt);
+  });
+}
+
+class _MockAnnouncementApi extends Mock implements AnnouncementApi {}
+class _MockCourseApi extends Mock implements CourseApi {}

--- a/apps/flutter_parent/test/screens/announcements/announcement_details_screen_test.dart
+++ b/apps/flutter_parent/test/screens/announcements/announcement_details_screen_test.dart
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'package:flutter/material.dart';
+import 'package:flutter_parent/l10n/app_localizations.dart';
+import 'package:flutter_parent/screens/announcements/announcement_details_interactor.dart';
+import 'package:flutter_parent/screens/announcements/announcement_details_screen.dart';
+import 'package:flutter_parent/screens/announcements/announcement_view_state.dart';
+import 'package:flutter_parent/utils/common_widgets/loading_indicator.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:intl/intl.dart';
+import 'package:mockito/mockito.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import '../../utils/accessibility_utils.dart';
+import '../../utils/platform_config.dart';
+import '../../utils/test_app.dart';
+
+void main() {
+  _setupLocator({AnnouncementDetailsInteractor interactor}) {
+    final _locator = GetIt.instance;
+    _locator.reset();
+
+    _locator.registerFactory<AnnouncementDetailsInteractor>(() => interactor ?? _MockAnnouncementDetailsInteractor());
+  }
+
+  group('Loading', () {
+    testWidgetsWithAccessibilityChecks('Shows while waiting for future', (tester) async {
+      final interactor = _MockAnnouncementDetailsInteractor();
+      when(interactor.getAnnouncement(any, any, any, any)).thenAnswer((_) => Future.value());
+      _setupLocator(interactor: interactor);
+
+      await tester.pumpWidget(_testableWidget('', AnnouncementType.COURSE, ''));
+      await tester.pump();
+
+      expect(find.byType(LoadingIndicator), findsOneWidget);
+    });
+
+    testWidgetsWithAccessibilityChecks('Does not show once loaded', (tester) async {
+      final interactor = _MockAnnouncementDetailsInteractor();
+      when(interactor.getAnnouncement(any, any, any, any)).thenAnswer((_) => Future.value());
+      _setupLocator(interactor: interactor);
+
+      await tester.pumpWidget(_testableWidget('', AnnouncementType.COURSE, ''));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.byType(LoadingIndicator), findsNothing);
+    });
+  });
+
+  testWidgetsWithAccessibilityChecks('Shows error', (tester) async {
+    final interactor = _MockAnnouncementDetailsInteractor();
+    when(interactor.getAnnouncement(any, any, any, any)).thenAnswer((_) => Future.error('error'));
+    _setupLocator(interactor: interactor);
+
+    await tester.pumpWidget(_testableWidget('', AnnouncementType.COURSE, ''));
+    await tester.pumpAndSettle();
+
+    expect(find.text(AppLocalizations().errorLoadingAnnouncement), findsOneWidget);
+  });
+
+  group('With data', () {
+    testWidgetsWithAccessibilityChecks('Shows course announcement', (tester) async {
+      final interactor = _MockAnnouncementDetailsInteractor();
+      final announcementId = '123';
+      final courseId = '123';
+      final announcementMessage = 'hodor';
+      final announcementSubject = 'hodor subject';
+      final postedAt = DateTime.now();
+      final courseName = 'flowers for hodornon';
+
+      final response = AnnouncementViewState(
+          courseName, announcementSubject, announcementMessage, postedAt);
+      when(interactor.getAnnouncement(announcementId, AnnouncementType.COURSE, courseId, AppLocalizations().institutionAnnouncementTitle)).thenAnswer((_) => Future.value(response));
+      _setupLocator(interactor: interactor);
+
+      await tester.pumpWidget(_testableWidget(announcementId, AnnouncementType.COURSE, courseId));
+      await tester.pumpAndSettle();
+
+      expect(find.text(announcementSubject), findsOneWidget);
+      expect(find.text(courseName), findsOneWidget);
+      expect(find.text(DateFormat(AppLocalizations().dateTimeFormat).format(postedAt)), findsOneWidget);
+      expect(find.byType(WebView), findsOneWidget);
+    });
+
+    testWidgetsWithAccessibilityChecks('Shows institution announcement', (tester) async {
+      final interactor = _MockAnnouncementDetailsInteractor();
+      final announcementId = '123';
+      final courseId = '123';
+      final announcementMessage = 'hodor';
+      final announcementSubject = 'hodor subject';
+      final postedAt = DateTime.now();
+      final toolbarTitle = AppLocalizations().institutionAnnouncementTitle;
+
+      final response = AnnouncementViewState(
+          toolbarTitle, announcementSubject, announcementMessage, postedAt);
+      when(interactor.getAnnouncement(announcementId, AnnouncementType.INSTITUTION, courseId, toolbarTitle)).thenAnswer((_) => Future.value(response));
+      _setupLocator(interactor: interactor);
+
+      await tester.pumpWidget(_testableWidget(announcementId, AnnouncementType.INSTITUTION, courseId));
+      await tester.pumpAndSettle();
+
+      expect(find.text(announcementSubject), findsOneWidget);
+      expect(find.text(toolbarTitle), findsOneWidget);
+      expect(find.text(DateFormat(AppLocalizations().dateTimeFormat).format(postedAt)), findsOneWidget);
+      expect(find.byType(WebView), findsOneWidget);
+    });
+  });
+}
+
+Widget _testableWidget(String announcementId, AnnouncementType type, String courseId) {
+  return TestApp(Builder(
+    builder: (BuildContext context) {
+      return AnnouncementDetailScreen(announcementId, type, courseId, context);
+    },
+  ), highContrast: true, platformConfig: PlatformConfig(initWebview: true),);
+}
+
+class _MockAnnouncementDetailsInteractor extends Mock implements AnnouncementDetailsInteractor {}


### PR DESCRIPTION
Couple of things to note:
-Institution level announcements that don't target the observer role will result in an error screen. This behavior is consistent with the current playstore version, I'm not sure if this is an api issue or not. It seems odd that the alert would show up, but not be viewable (api returns a 401).
-The webview in use needs a bit of work. I'm going to start on another commit that adds an extension function to format/load Html, so we can use the html_wrapper consistently. We also need to handle a few of the things that CanvasWebView is doing for us, so things like the new RCE images work.