### PR TITLE
[Flutter-Parent][MBL-13683] Report a problem dialog

### DIFF
--- a/apps/flutter_parent/lib/l10n/app_localizations.dart
+++ b/apps/flutter_parent/lib/l10n/app_localizations.dart
@@ -24,41 +24,41 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
 
   List<Locale> get supportedLocales {
     return const <Locale>[
-      Locale("en", ""), // First so it's our fallback
+      Locale('en', ''), // First so it's our fallback
 
       // Supported languages
-      Locale("ar", ""),
-      Locale("cy", ""),
-      Locale("da", ""),
-      Locale("de", ""),
-      Locale("en", "AU"),
-      Locale("en", "CY"),
-      Locale("en", "GB"),
-      Locale("es", ""),
-      Locale("fi", ""),
-      Locale("fr", ""),
-      Locale("fr", "CA"),
-      Locale("ht", ""),
-      Locale("ja", ""),
-      Locale("mi", ""),
-      Locale("nb", ""),
-      Locale("nl", ""),
-      Locale("pl", ""),
-      Locale("pl", ""),
-      Locale("pl", "BR"),
-      Locale("pl", "PT"),
-      Locale("ru", ""),
-      Locale("sl", ""),
-      Locale("sv", ""),
-      Locale("zh", ""),
-      Locale("zh", "HK"),
+      Locale('ar', ''),
+      Locale('cy', ''),
+      Locale('da', ''),
+      Locale('de', ''),
+      Locale('en', 'AU'),
+      Locale('en', 'CY'),
+      Locale('en', 'GB'),
+      Locale('es', ''),
+      Locale('fi', ''),
+      Locale('fr', ''),
+      Locale('fr', 'CA'),
+      Locale('ht', ''),
+      Locale('ja', ''),
+      Locale('mi', ''),
+      Locale('nb', ''),
+      Locale('nl', ''),
+      Locale('pl', ''),
+      Locale('pl', ''),
+      Locale('pl', 'BR'),
+      Locale('pl', 'PT'),
+      Locale('ru', ''),
+      Locale('sl', ''),
+      Locale('sv', ''),
+      Locale('zh', ''),
+      Locale('zh', 'HK'),
 
       // Custom language packs
-      Locale.fromSubtags(languageCode: "da", scriptCode: "instk12"),
-      Locale.fromSubtags(languageCode: "en", scriptCode: "unimelb", countryCode: "AU"),
-      Locale.fromSubtags(languageCode: "en", scriptCode: "instukhe", countryCode: "GB"),
-      Locale.fromSubtags(languageCode: "nb", scriptCode: "instk12"),
-      Locale.fromSubtags(languageCode: "sv", scriptCode: "instk12"),
+      Locale.fromSubtags(languageCode: 'da', scriptCode: 'instk12'),
+      Locale.fromSubtags(languageCode: 'en', scriptCode: 'unimelb', countryCode: 'AU'),
+      Locale.fromSubtags(languageCode: 'en', scriptCode: 'instukhe', countryCode: 'GB'),
+      Locale.fromSubtags(languageCode: 'nb', scriptCode: 'instk12'),
+      Locale.fromSubtags(languageCode: 'sv', scriptCode: 'instk12'),
     ];
   }
 
@@ -103,7 +103,7 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
     if (supported.contains(locale)) {
       return locale;
     } else {
-      return Locale(locale.languageCode, "");
+      return Locale(locale.languageCode, '');
     }
   }
 }
@@ -173,18 +173,18 @@ class AppLocalizations {
   String get domainSearchInputHint => Intl.message(
         'Enter school name or district…',
         name: 'domainSearchInputHint',
-        desc: "Input hint for the text box on the domain search screen",
+        desc: 'Input hint for the text box on the domain search screen',
       );
 
   String noDomainResults(String query) => Intl.message(
-        "Unable to find schools matching '$query'",
+        'Unable to find schools matching \'$query\'',
         name: 'noDomainResults',
         args: [query],
         desc: 'Message shown to users when the domain search query did not return any results',
       );
 
   String get domainSearchHelpLabel => Intl.message(
-        "How do I find my school or district?",
+        'How do I find my school or district?',
         name: 'domainSearchHelpLabel',
         desc: 'Label for the help button on the domain search screen',
       );
@@ -193,14 +193,14 @@ class AppLocalizations {
         'Canvas Guides',
         name: 'canvasGuides',
         desc:
-            "Proper name for the Canvas Guides. This will be used in the domainSearchHelpBody text and will be highlighted and clickable",
+            'Proper name for the Canvas Guides. This will be used in the domainSearchHelpBody text and will be highlighted and clickable',
       );
 
   String get canvasSupport => Intl.message(
         'Canvas Support',
         name: 'canvasSupport',
         desc:
-            "Proper name for Canvas Support. This will be used in the domainSearchHelpBody text and will be highlighted and clickable",
+            'Proper name for Canvas Support. This will be used in the domainSearchHelpBody text and will be highlighted and clickable',
       );
 
   String domainSearchHelpBody(String canvasGuides, String canvasSupport) => Intl.message(
@@ -248,8 +248,8 @@ class AppLocalizations {
   String get noSubject => Intl.message('No Subject', desc: 'Title used for inbox messages that have no subject');
 
   String get errorFetchingCourses =>
-      Intl.message("Unable to fetch courses. Please check your connection and try again.",
-          desc: "Message shown when an error occured while loading courses");
+      Intl.message('Unable to fetch courses. Please check your connection and try again.',
+          desc: 'Message shown when an error occured while loading courses');
 
   String get messageChooseCourse => Intl.message('Choose a course to message',
       desc: 'Header in the course list shown when the user is choosing which course to associate with a new message');
@@ -275,10 +275,10 @@ class AppLocalizations {
       Intl.message('Are you sure you wish to close this page? Your unsent message will be lost.',
           desc: 'Body text of the dialog shown when the user tries leave with unsaved changes');
 
-  String get newMessageTitle => Intl.message('New message', desc: "Title of the new-message screen");
+  String get newMessageTitle => Intl.message('New message', desc: 'Title of the new-message screen');
 
   String get addAttachment =>
-      Intl.message("Add attachment", desc: 'Tooltip for the add-attachment button in the new-message screen');
+      Intl.message('Add attachment', desc: 'Tooltip for the add-attachment button in the new-message screen');
 
   String get sendMessage =>
       Intl.message('Send message', desc: 'Tooltip for the send-message button in the new-message screen');
@@ -299,7 +299,7 @@ class AppLocalizations {
 
   String plusRecipientCount(int count) => Intl.message(
         '+$count',
-        desc: "Shows the number of recipients that are selected but not displayed on screen.",
+        desc: 'Shows the number of recipients that are selected but not displayed on screen.',
         args: [count],
         examples: const {'count': 5},
       );
@@ -358,7 +358,7 @@ class AppLocalizations {
   String get noCoursesTitle => Intl.message('No Courses', desc: 'Title for having no courses');
 
   String get noCoursesMessage =>
-      Intl.message("Your students’s courses might not be published yet.", desc: 'Message for having no courses');
+      Intl.message('Your students\’s courses might not be published yet.', desc: 'Message for having no courses');
 
   String get noGrade => Intl.message(
         'No Grade',
@@ -428,20 +428,20 @@ class AppLocalizations {
       );
 
   String get noAssignmentsMessage => Intl.message(
-        "It looks like assignments haven't been created in this space yet.",
+        'It looks like assignments haven\'t been created in this space yet.',
         desc: 'Message for no assignments',
       );
 
   String gradeFormatScoreOutOfPointsPossible(String score, String pointsPossible) => Intl.message(
         '${score} / ${pointsPossible}',
-        desc: "Formatted string for a student's score out of the points possible",
+        desc: 'Formatted string for a student score out of the points possible',
         name: 'gradeFormatScoreOutOfPointsPossible',
         args: [score, pointsPossible],
       );
 
   String contentDescriptionScoreOutOfPointsPossible(String score, String pointsPossible) => Intl.message(
         '${score} out of ${pointsPossible} points',
-        desc: "Formatted string for a student's score out of the points possible",
+        desc: 'Formatted string for a student score out of the points possible',
         name: 'contentDescriptionScoreOutOfPointsPossible',
         args: [score, pointsPossible],
       );
@@ -473,7 +473,7 @@ class AppLocalizations {
   String get notAParentTitle => Intl.message('Not a parent?',
       desc: 'Title for the screen that shows when the user is not observing any students');
 
-  String get notAParentSubtitle => Intl.message("We couldn't find any students associated with this account",
+  String get notAParentSubtitle => Intl.message('We couldn\'t find any students associated with this account',
       desc: 'Subtitle for the screen that shows when the user is not observing any students');
 
   String get studentOrTeacherTitle => Intl.message('Are you a student or teacher?',
@@ -580,7 +580,7 @@ class AppLocalizations {
 
   String get enrollmentTypeTA => Intl.message('TA',
       desc:
-          "Label for the Teaching Assistant enrollment type (also known as Teacher's Aid or Education Assistant), reduced to a short acronym/initialism if appropriate.");
+          'Label for the Teaching Assistant enrollment type (also known as Teacher Aid or Education Assistant), reduced to a short acronym/initialism if appropriate.');
 
   String get enrollmentTypeObserver => Intl.message('Observer', desc: 'Label for the Observer enrollment type');
 
@@ -654,12 +654,12 @@ class AppLocalizations {
 
   String get errorSeverityComment => Intl.message('Just a casual question, comment, idea, suggestion…');
 
-  String get errorSeverityNotUrgent => Intl.message("I need some help but it's not urgent.");
+  String get errorSeverityNotUrgent => Intl.message('I need some help but it\'s not urgent.');
 
   String get errorSeverityWorkaroundPossible =>
-      Intl.message("Something's broken but I can work around it to get what I need done.");
+      Intl.message('Something\'s broken but I can work around it to get what I need done.');
 
-  String get errorSeverityBlocking => Intl.message("I can't get things done until I hear back from you.");
+  String get errorSeverityBlocking => Intl.message('I can\'t get things done until I hear back from you.');
 
   String get errorSeverityCritical => Intl.message('EXTREME CRITICAL EMERGENCY!!');
 
@@ -675,9 +675,9 @@ class AppLocalizations {
 
   String get no => Intl.message('No');
 
-  String get retry => Intl.message("Retry");
+  String get retry => Intl.message('Retry');
 
-  String get delete => Intl.message("Delete", desc: 'Label used for general delete/remove actions');
+  String get delete => Intl.message('Delete', desc: 'Label used for general delete/remove actions');
 
   String get done => Intl.message('Done', desc: 'Label for general done/finished actions');
 
@@ -718,7 +718,7 @@ class AppLocalizations {
         '${count}+',
         args: [count],
         name: 'badgeNumberPlus',
-        desc: "Formatted string for when too many items are being notified in a badge, generally something like '99+'",
+        desc: 'Formatted string for when too many items are being notified in a badge, generally something like: 99+',
       );
 
   String get genericNetworkError => Intl.message('Network error');

--- a/apps/flutter_parent/lib/l10n/app_localizations.dart
+++ b/apps/flutter_parent/lib/l10n/app_localizations.dart
@@ -619,6 +619,50 @@ class AppLocalizations {
   String get addNewStudent =>
       Intl.message('Add new student', desc: 'Semantics label for the FAB on the Manage Students Screen');
 
+  /// Error Report Dialog
+
+  String get device => Intl.message('Device', desc: 'Label used for device manufacturer/model in the error report');
+
+  String get osVersion =>
+      Intl.message('OS Version', desc: 'Label used for device operating system version in the error report');
+
+  String get versionNumber =>
+      Intl.message('Version Number', desc: 'Label used for the app version number in the error report');
+
+  String get reportProblemTitle =>
+      Intl.message('Report A Problem', desc: 'Title used for generic dialog to report problems');
+
+  String get reportProblemSubject => Intl.message('Subject', desc: 'Label used for Subject text field');
+
+  String get reportProblemSubjectEmpty =>
+      Intl.message('A subject is required.', desc: 'Error shown when the subject field is empty');
+
+  String get reportProblemEmail => Intl.message('Email Address', desc: 'Label used for Email Address text field');
+
+  String get reportProblemEmailEmpty =>
+      Intl.message('An email address is required.', desc: 'Error shown when the email field is empty');
+
+  String get reportProblemDescription => Intl.message('Description', desc: 'Label used for Description text field');
+
+  String get reportProblemDescriptionEmpty =>
+      Intl.message('A description is required.', desc: 'Error shown when the description field is empty');
+
+  String get reportProblemSeverity =>
+      Intl.message('How is this affecting you?', desc: 'Label used for the dropdown to select how severe the issue is');
+
+  String get sendReport => Intl.message('send', desc: 'Label used for send button when reporting a problem');
+
+  String get errorSeverityComment => Intl.message('Just a casual question, comment, idea, suggestion…');
+
+  String get errorSeverityNotUrgent => Intl.message("I need some help but it's not urgent.");
+
+  String get errorSeverityWorkaroundPossible =>
+      Intl.message("Something's broken but I can work around it to get what I need done.");
+
+  String get errorSeverityBlocking => Intl.message("I can't get things done until I hear back from you.");
+
+  String get errorSeverityCritical => Intl.message('EXTREME CRITICAL EMERGENCY!!');
+
   /// Miscellaneous
 
   String get cancel => Intl.message('Cancel');

--- a/apps/flutter_parent/lib/network/api/enrollments_api.dart
+++ b/apps/flutter_parent/lib/network/api/enrollments_api.dart
@@ -23,7 +23,15 @@ class EnrollmentsApi {
     var dio = canvasDio(pageSize: PageSize.canvasMax, forceRefresh: forceRefresh);
     var params = {
       'include': ['observed_users', 'avatar_url'],
-      'state': ['creation_pending', 'invited', 'active']
+      'state': ['creation_pending', 'invited', 'active', 'completed']
+    };
+    return fetchList(dio.get('users/self/enrollments', queryParameters: params), depaginateWith: dio);
+  }
+
+  Future<List<Enrollment>> getSelfEnrollments({bool forceRefresh = false}) async {
+    var dio = canvasDio(pageSize: PageSize.canvasMax, forceRefresh: forceRefresh);
+    var params = {
+      'state': ['creation_pending', 'invited', 'active', 'completed']
     };
     return fetchList(dio.get('users/self/enrollments', queryParameters: params), depaginateWith: dio);
   }

--- a/apps/flutter_parent/lib/network/api/error_report_api.dart
+++ b/apps/flutter_parent/lib/network/api/error_report_api.dart
@@ -1,0 +1,48 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import 'package:flutter_parent/network/utils/dio_config.dart';
+
+class ErrorReportApi {
+  static const DEFAULT_DOMAIN = "https://canvas.instructure.com";
+
+  Future<void> submitErrorReport({
+    String subject,
+    String description,
+    String email,
+    String severity,
+    String stacktrace,
+    String domain,
+    String name,
+    String becomeUser,
+    String userRoles,
+  }) {
+    var config = domain == DEFAULT_DOMAIN ? DioConfig.core() : DioConfig.canvas();
+
+    return config.dio.post(
+      '/error_reports.json',
+      queryParameters: {
+        'error[subject]': subject,
+        'error[url]': domain,
+        'error[email]': email,
+        'error[comments]': description,
+        'error[user_perceived_severity]': severity,
+        'error[name]': name,
+        'error[user_roles]': userRoles,
+        'error[become_user]': becomeUser,
+        if (stacktrace != null) 'error[backtrace]': stacktrace,
+      },
+    );
+  }
+}

--- a/apps/flutter_parent/lib/screens/crash_screen.dart
+++ b/apps/flutter_parent/lib/screens/crash_screen.dart
@@ -16,6 +16,7 @@ import 'package:device_info/device_info.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_parent/l10n/app_localizations.dart';
+import 'package:flutter_parent/utils/common_widgets/error_report/error_report_dialog.dart';
 import 'package:flutter_parent/utils/common_widgets/respawn.dart';
 import 'package:flutter_parent/utils/design/parent_colors.dart';
 import 'package:flutter_parent/utils/design/parent_theme.dart';
@@ -72,9 +73,7 @@ class CrashScreen extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: <Widget>[
                   FlatButton(
-                    onPressed: () {
-                      // TODO: Implement this once we know the best way to let users contact support
-                    },
+                    onPressed: () => ErrorReportDialog.asDialog(context, error: error),
                     child: Text(
                       L10n(context).crashScreenContact,
                       style: Theme.of(context).textTheme.caption.copyWith(fontSize: 16),

--- a/apps/flutter_parent/lib/screens/dashboard/dashboard_screen.dart
+++ b/apps/flutter_parent/lib/screens/dashboard/dashboard_screen.dart
@@ -25,6 +25,7 @@ import 'package:flutter_parent/screens/settings/settings_screen.dart';
 import 'package:flutter_parent/utils/common_widgets/avatar.dart';
 import 'package:flutter_parent/utils/common_widgets/badges.dart';
 import 'package:flutter_parent/utils/common_widgets/dropdown_arrow.dart';
+import 'package:flutter_parent/utils/common_widgets/error_report/error_report_dialog.dart';
 import 'package:flutter_parent/utils/common_widgets/loading_indicator.dart';
 import 'package:flutter_parent/utils/common_widgets/user_name.dart';
 import 'package:flutter_parent/utils/design/canvas_icons.dart';
@@ -276,6 +277,7 @@ class DashboardState extends State<DashboardScreen> {
     // Close the drawer, then push the Help screen in
     Navigator.of(context).pop();
     // TODO: Navigate to the help screen
+    ErrorReportDialog.asDialog(context);
 //    locator<QuickNav>().push(context, HelpScreen());
   }
 

--- a/apps/flutter_parent/lib/utils/common_widgets/error_report/error_report_dialog.dart
+++ b/apps/flutter_parent/lib/utils/common_widgets/error_report/error_report_dialog.dart
@@ -1,0 +1,224 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import 'package:device_info/device_info.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_parent/l10n/app_localizations.dart';
+import 'package:flutter_parent/utils/common_widgets/error_report/error_report_interactor.dart';
+import 'package:flutter_parent/utils/design/parent_theme.dart';
+import 'package:flutter_parent/utils/service_locator.dart';
+import 'package:package_info/package_info.dart';
+
+class ErrorReportDialog extends StatefulWidget {
+  static const Key subjectKey = Key('subject');
+  static const Key descriptionKey = Key('description');
+  static const Key emailKey = Key('email');
+
+  final String title; // Used to specify different titles depending on how this dialog was shown
+  final String subject;
+  final ErrorReportSeverity severity;
+  final FlutterErrorDetails error;
+  final bool includeEmail; // Used when shown during login, so that users can get responses from created service tickets
+
+  const ErrorReportDialog._internal(this.title, this.subject, this.severity, this.includeEmail, this.error, {Key key})
+      : super(key: key);
+
+  @override
+  _ErrorReportDialogState createState() => _ErrorReportDialogState();
+
+  static Future<void> asDialog(BuildContext context,
+      {String title,
+      String subject,
+      ErrorReportSeverity severity,
+      bool includeEmail = false,
+      FlutterErrorDetails error}) {
+    return showDialog(
+      context: context,
+      builder: (context) => ErrorReportDialog._internal(
+        title ?? L10n(context).reportProblemTitle,
+        subject,
+        severity ?? ErrorReportSeverity.COMMENT,
+        includeEmail,
+        error,
+      ),
+    );
+  }
+}
+
+class _ErrorReportDialogState extends State<ErrorReportDialog> {
+  final _formKey = GlobalKey<FormState>();
+
+  // Non state changing variables
+  FocusScopeNode _focusScopeNode = FocusScopeNode();
+  String _subject;
+  String _email;
+  String _description;
+
+  // State changing variables
+  ErrorReportSeverity _selectedSeverity;
+  bool _autoValidate;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _autoValidate = false;
+    _subject = widget.subject;
+    _selectedSeverity = widget.severity;
+  }
+
+  @override
+  void dispose() {
+    _focusScopeNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),
+      title: Text(widget.title),
+      actions: <Widget>[
+        FlatButton(
+          child: Text(L10n(context).cancel.toUpperCase()),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        FlatButton(
+          child: Text(L10n(context).sendReport.toUpperCase()),
+          onPressed: () async {
+            if (_formKey.currentState.validate()) {
+              await _submitReport();
+              Navigator.of(context).pop();
+            } else {
+              // Start auto validating since they've tried to submit once
+              setState(() => _autoValidate = true);
+            }
+          },
+        ),
+      ],
+      content: _content(context),
+    );
+  }
+
+  Widget _content(BuildContext context) {
+    final severityOptions = _getSeverityOptions();
+    return SingleChildScrollView(
+      child: Form(
+        key: _formKey,
+        autovalidate: _autoValidate,
+        child: FocusScope(
+          node: _focusScopeNode,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextFormField(
+                key: ErrorReportDialog.subjectKey,
+                initialValue: _subject,
+                decoration: _decoration(L10n(context).reportProblemSubject),
+                validator: (text) => text.isEmpty ? L10n(context).reportProblemSubjectEmpty : null,
+                onChanged: (text) => _subject = text,
+                textInputAction: TextInputAction.next,
+                onFieldSubmitted: (_) => _focusScopeNode.nextFocus(),
+              ),
+              if (widget.includeEmail) SizedBox(height: 16),
+              if (widget.includeEmail)
+                TextFormField(
+                  key: ErrorReportDialog.emailKey,
+                  decoration: _decoration(L10n(context).reportProblemEmail),
+                  validator: (text) =>
+                      (widget.includeEmail && text.isEmpty) ? L10n(context).reportProblemEmailEmpty : null,
+                  onChanged: (text) => _email = text,
+                  textInputAction: TextInputAction.next,
+                  onFieldSubmitted: (_) => _focusScopeNode.nextFocus(),
+                ),
+              SizedBox(height: 16),
+              TextFormField(
+                key: ErrorReportDialog.descriptionKey,
+                minLines: 3,
+                maxLines: null,
+                decoration: _decoration(L10n(context).reportProblemDescription, alignLabelWithHint: true),
+                validator: (text) => text.isEmpty ? L10n(context).reportProblemDescriptionEmpty : null,
+                onChanged: (text) => _description = text,
+              ),
+              SizedBox(height: 16),
+              Text(L10n(context).reportProblemSeverity),
+              Container(
+                color: ParentTheme.of(context).nearSurfaceColor,
+                padding: EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                child: DropdownButton<_SeverityOption>(
+                  itemHeight: null,
+                  isExpanded: true,
+                  underline: SizedBox(),
+                  onChanged: (option) async {
+                    setState(() => _selectedSeverity = option.severity);
+                    // Clear focus here, as it can go back to the text forms if they were previously selected
+                    _focusScopeNode.requestFocus(FocusNode());
+                  },
+                  value: severityOptions.firstWhere((option) => option.severity == _selectedSeverity),
+                  items: severityOptions.map((option) {
+                    return DropdownMenuItem<_SeverityOption>(value: option, child: Text(option.label));
+                  }).toList(),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  _submitReport() async {
+    final l10n = L10n(context);
+    final info = await Future.wait([PackageInfo.fromPlatform(), DeviceInfoPlugin().androidInfo]);
+    PackageInfo package = info[0];
+    AndroidDeviceInfo device = info[1];
+
+    // Add device and package info before the users description
+    final comment = '' +
+        '${l10n.device}: ${device.manufacturer} ${device.model}\n' +
+        '${l10n.osVersion}: Android ${device.version.release}\n' +
+        '${l10n.versionNumber}: ${package.appName} v${package.version} (${package.buildNumber})\n\n' +
+        '-------------------------\n\n' +
+        '$_description';
+
+    // Send to the API; with stacktrace and device info
+    await locator<ErrorReportInteractor>()
+        .submitErrorReport(_subject, comment, _email, _selectedSeverity, widget.error?.stack?.toString());
+  }
+
+  InputDecoration _decoration(String label, {bool alignLabelWithHint = false}) => InputDecoration(
+        labelText: label,
+        alignLabelWithHint: alignLabelWithHint,
+        fillColor: ParentTheme.of(context).nearSurfaceColor,
+        filled: true,
+      );
+
+  List<_SeverityOption> _getSeverityOptions() {
+    final l10n = L10n(context);
+    return [
+      _SeverityOption(ErrorReportSeverity.COMMENT, l10n.errorSeverityComment),
+      _SeverityOption(ErrorReportSeverity.NOT_URGENT, l10n.errorSeverityNotUrgent),
+      _SeverityOption(ErrorReportSeverity.WORKAROUND_POSSIBLE, l10n.errorSeverityWorkaroundPossible),
+      _SeverityOption(ErrorReportSeverity.BLOCKING, l10n.errorSeverityBlocking),
+      _SeverityOption(ErrorReportSeverity.CRITICAL, l10n.errorSeverityCritical),
+    ];
+  }
+}
+
+class _SeverityOption {
+  final ErrorReportSeverity severity;
+  final String label;
+
+  _SeverityOption(this.severity, this.label);
+}

--- a/apps/flutter_parent/lib/utils/common_widgets/error_report/error_report_interactor.dart
+++ b/apps/flutter_parent/lib/utils/common_widgets/error_report/error_report_interactor.dart
@@ -1,0 +1,68 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import 'package:flutter_parent/network/api/enrollments_api.dart';
+import 'package:flutter_parent/network/api/error_report_api.dart';
+import 'package:flutter_parent/network/utils/api_prefs.dart';
+import 'package:flutter_parent/utils/service_locator.dart';
+
+class ErrorReportInteractor {
+  Future<void> submitErrorReport(
+      String subject, String description, String email, ErrorReportSeverity severity, String stacktrace) async {
+    final user = ApiPrefs.getUser();
+    final domain = (ApiPrefs.getDomain()?.isNotEmpty == true) ? ApiPrefs.getDomain() : ErrorReportApi.DEFAULT_DOMAIN;
+    final becomeUser = (user?.id?.isNotEmpty == true) ? '$domain?become_user_id=${user.id}' : '';
+    final userEmail = (email?.isNotEmpty == true) ? email : user?.primaryEmail ?? '';
+
+    final enrollments = await locator<EnrollmentsApi>().getSelfEnrollments(forceRefresh: true);
+    final userRoles = Set.from(enrollments?.map((enrollment) => enrollment.type) ?? []).toList().join(',');
+
+    return locator<ErrorReportApi>().submitErrorReport(
+      subject: subject,
+      description: description,
+      email: userEmail,
+      severity: _errorReportSeverityTag(severity),
+      stacktrace: stacktrace,
+      domain: domain,
+      name: user?.name ?? '',
+      becomeUser: becomeUser,
+      userRoles: userRoles,
+    );
+  }
+
+  String _errorReportSeverityTag(ErrorReportSeverity severity) {
+    switch (severity) {
+      case ErrorReportSeverity.COMMENT:
+        return 'just_a_comment';
+      case ErrorReportSeverity.NOT_URGENT:
+        return 'not_urgent';
+      case ErrorReportSeverity.WORKAROUND_POSSIBLE:
+        return 'workaround_possible';
+      case ErrorReportSeverity.BLOCKING:
+        return 'blocks_what_i_need_to_do';
+      case ErrorReportSeverity.CRITICAL:
+        return 'extreme_critical_emergency';
+    }
+    throw ArgumentError(
+        'The provided severity is not supported: ${severity.toString()} not in ${ErrorReportSeverity.values.toString()}');
+  }
+}
+
+enum ErrorReportSeverity {
+  COMMENT,
+  NOT_URGENT,
+  WORKAROUND_POSSIBLE,
+  BLOCKING,
+  CRITICAL,
+}

--- a/apps/flutter_parent/lib/utils/service_locator.dart
+++ b/apps/flutter_parent/lib/utils/service_locator.dart
@@ -17,6 +17,7 @@ import 'package:flutter_parent/network/api/assignment_api.dart';
 import 'package:flutter_parent/network/api/auth_api.dart';
 import 'package:flutter_parent/network/api/course_api.dart';
 import 'package:flutter_parent/network/api/enrollments_api.dart';
+import 'package:flutter_parent/network/api/error_report_api.dart';
 import 'package:flutter_parent/network/api/file_upload_api.dart';
 import 'package:flutter_parent/network/api/inbox_api.dart';
 import 'package:flutter_parent/screens/alert_thresholds/alert_thresholds_interactor.dart';
@@ -35,6 +36,7 @@ import 'package:flutter_parent/screens/inbox/reply/conversation_reply_interactor
 import 'package:flutter_parent/screens/manage_students/manage_students_interactor.dart';
 import 'package:flutter_parent/screens/settings/settings_interactor.dart';
 import 'package:flutter_parent/screens/web_login/web_login_interactor.dart';
+import 'package:flutter_parent/utils/common_widgets/error_report/error_report_interactor.dart';
 import 'package:flutter_parent/utils/quick_nav.dart';
 import 'package:get_it/get_it.dart';
 
@@ -47,6 +49,7 @@ void setupLocator() {
   locator.registerLazySingleton<AuthApi>(() => AuthApi());
   locator.registerLazySingleton<CourseApi>(() => CourseApi());
   locator.registerLazySingleton<EnrollmentsApi>(() => EnrollmentsApi());
+  locator.registerLazySingleton<ErrorReportApi>(() => ErrorReportApi());
   locator.registerLazySingleton<FileUploadApi>(() => FileUploadApi());
   locator.registerLazySingleton<InboxApi>(() => InboxApi());
 
@@ -62,6 +65,7 @@ void setupLocator() {
   locator.registerFactory<CreateConversationInteractor>(() => CreateConversationInteractor());
   locator.registerFactory<DashboardInteractor>(() => DashboardInteractor());
   locator.registerFactory<DomainSearchInteractor>(() => DomainSearchInteractor());
+  locator.registerFactory<ErrorReportInteractor>(() => ErrorReportInteractor());
   locator.registerFactory<ManageStudentsInteractor>(() => ManageStudentsInteractor());
   locator.registerFactory<SettingsInteractor>(() => SettingsInteractor());
   locator.registerFactory<WebLoginInteractor>(() => WebLoginInteractor());

--- a/apps/flutter_parent/test/utils/widgets/error_report/error_report_dialog_test.dart
+++ b/apps/flutter_parent/test/utils/widgets/error_report/error_report_dialog_test.dart
@@ -1,0 +1,154 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_parent/l10n/app_localizations.dart';
+import 'package:flutter_parent/utils/common_widgets/error_report/error_report_dialog.dart';
+import 'package:flutter_parent/utils/common_widgets/error_report/error_report_interactor.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../accessibility_utils.dart';
+import '../../test_app.dart';
+
+void main() {
+  TestApp _createTestApp(Future callback(BuildContext)) => TestApp(
+        Builder(
+            builder: (context) => RaisedButton(
+                  child: Text('tap me', style: TextStyle(color: Colors.white)), // So it's 'accessible'
+                  onPressed: () => callback(context),
+                )),
+        highContrast: true,
+      );
+
+  _showDialog(WidgetTester tester, Future callback(BuildContext)) async {
+    await tester.pumpWidget(_createTestApp(callback));
+    await tester.pumpAndSettle();
+
+    // Tap the button to show the dialog
+    await tester.tap(find.byType(RaisedButton));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgetsWithAccessibilityChecks('Shows a dialog', (tester) async {
+    await _showDialog(tester, (context) => ErrorReportDialog.asDialog(context));
+
+    expect(find.byType(ErrorReportDialog), findsOneWidget);
+    expect(find.text(AppLocalizations().reportProblemTitle), findsOneWidget);
+    expect(find.text(AppLocalizations().errorSeverityComment), findsOneWidget);
+
+    expect(find.text(AppLocalizations().reportProblemEmail), findsNothing);
+    expect(find.text(AppLocalizations().reportProblemEmailEmpty), findsNothing);
+    expect(find.text(AppLocalizations().reportProblemSubjectEmpty), findsNothing);
+    expect(find.text(AppLocalizations().reportProblemDescriptionEmpty), findsNothing);
+  });
+
+  testWidgetsWithAccessibilityChecks('Shows a dialog with customizations', (tester) async {
+    final title = 'title';
+    final subject = 'subject';
+    final severity = ErrorReportSeverity.CRITICAL;
+
+    await _showDialog(
+      tester,
+      (context) => ErrorReportDialog.asDialog(
+        context,
+        title: title,
+        subject: subject,
+        severity: severity,
+        includeEmail: true,
+      ),
+    );
+
+    expect(find.byType(ErrorReportDialog), findsOneWidget);
+    expect(find.text(title), findsOneWidget);
+    expect(find.text(subject), findsOneWidget);
+    expect(find.text(AppLocalizations().errorSeverityCritical), findsOneWidget);
+    expect(find.text(AppLocalizations().reportProblemEmail), findsOneWidget);
+  });
+
+  testWidgetsWithAccessibilityChecks('Selecting a severity updates dialog', (tester) async {
+    await _showDialog(tester, (context) => ErrorReportDialog.asDialog(context));
+
+    // Tap on dropdown to show list
+    await tester.tap(find.text(AppLocalizations().errorSeverityComment));
+    await tester.pumpAndSettle();
+
+    // Tap new item in a list
+    final x = find.text(AppLocalizations().errorSeverityBlocking);
+    await tester.tap(x.last);
+    await tester.pumpAndSettle();
+
+    expect(find.text(AppLocalizations().errorSeverityBlocking), findsOneWidget);
+  });
+
+  testWidgetsWithAccessibilityChecks('Cancel closes the dialog', (tester) async {
+    await _showDialog(tester, (context) => ErrorReportDialog.asDialog(context));
+
+    await tester.tap(find.text(AppLocalizations().cancel.toUpperCase()));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ErrorReportDialog), findsNothing);
+  });
+
+  testWidgetsWithAccessibilityChecks('Submit validates the dialog and shows errors', (tester) async {
+    await _showDialog(tester, (context) => ErrorReportDialog.asDialog(context, includeEmail: true));
+
+    expect(find.text(AppLocalizations().reportProblemSubjectEmpty), findsNothing);
+    expect(find.text(AppLocalizations().reportProblemDescriptionEmpty), findsNothing);
+    expect(find.text(AppLocalizations().reportProblemEmailEmpty), findsNothing);
+
+    // Try to send the report
+    await tester.tap(find.text(AppLocalizations().sendReport.toUpperCase()));
+    await tester.pumpAndSettle();
+
+    expect(find.text(AppLocalizations().reportProblemSubjectEmpty), findsOneWidget);
+    expect(find.text(AppLocalizations().reportProblemDescriptionEmpty), findsOneWidget);
+    expect(find.text(AppLocalizations().reportProblemEmailEmpty), findsOneWidget);
+  });
+
+  testWidgetsWithAccessibilityChecks('Submit calls through to the interactor', (tester) async {
+    final subject = 'Test subject';
+    final description = 'Test description';
+    final email = 'test@email.com';
+    final error = FlutterErrorDetails(stack: StackTrace.fromString('fake stack'));
+
+    final interactor = _MockErrorReportInteractor();
+    setupTestLocator((locator) => locator.registerFactory<ErrorReportInteractor>(() => interactor));
+
+    await _showDialog(tester, (context) => ErrorReportDialog.asDialog(context, includeEmail: true, error: error));
+
+    // Enter in the details
+    await tester.enterText(find.byKey(ErrorReportDialog.subjectKey), subject);
+    await tester.testTextInput.receiveAction(TextInputAction.next);
+    await tester.enterText(find.byKey(ErrorReportDialog.emailKey), email);
+    await tester.testTextInput.receiveAction(TextInputAction.next);
+    await tester.enterText(find.byKey(ErrorReportDialog.descriptionKey), description);
+
+    // Try to send the report
+    await tester.tap(find.text(AppLocalizations().sendReport.toUpperCase()));
+    await tester.pumpAndSettle();
+
+    final comment = '' +
+        '${AppLocalizations().device}: Instructure Canvas Phone\n' +
+        '${AppLocalizations().osVersion}: Android FakeOS 9000\n' +
+        '${AppLocalizations().versionNumber}: Canvas v1.0.0 (3)\n\n' +
+        '-------------------------\n\n' +
+        '$description';
+
+    verify(interactor.submitErrorReport(subject, comment, email, ErrorReportSeverity.COMMENT, error.stack.toString()))
+        .called(1);
+  });
+}
+
+class _MockErrorReportInteractor extends Mock implements ErrorReportInteractor {}

--- a/apps/flutter_parent/test/utils/widgets/error_report/error_report_interactor_test.dart
+++ b/apps/flutter_parent/test/utils/widgets/error_report/error_report_interactor_test.dart
@@ -1,0 +1,198 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import 'package:flutter_parent/models/canvas_token.dart';
+import 'package:flutter_parent/models/enrollment.dart';
+import 'package:flutter_parent/models/mobile_verify_result.dart';
+import 'package:flutter_parent/models/user.dart';
+import 'package:flutter_parent/network/api/enrollments_api.dart';
+import 'package:flutter_parent/network/api/error_report_api.dart';
+import 'package:flutter_parent/network/utils/api_prefs.dart';
+import 'package:flutter_parent/utils/common_widgets/error_report/error_report_interactor.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../../test_app.dart';
+
+void main() {
+  final user = User((b) => b
+    ..id = '123'
+    ..name = 'UserName'
+    ..primaryEmail = 'PrimaryEmail');
+
+  final api = _MockErrorReportApi();
+  final enrollmentsApi = _MockEnrollmentsApi();
+
+  setUp(() => clearInteractions(api));
+
+  // Setup test dependencies
+  setupPlatformChannels();
+  setupTestLocator((locator) {
+    locator.registerLazySingleton<ErrorReportApi>(() => api);
+    locator.registerLazySingleton<EnrollmentsApi>(() => enrollmentsApi);
+  });
+
+  test('Submit error report calls to the api', () async {
+    final subject = 'subject';
+    final description = 'description';
+    final email = 'email';
+    final severity = ErrorReportSeverity.COMMENT;
+    final stacktrace = 'error stack';
+
+    await ErrorReportInteractor().submitErrorReport(subject, description, email, severity, stacktrace);
+
+    verify(api.submitErrorReport(
+      subject: subject,
+      description: description,
+      email: email,
+      stacktrace: stacktrace,
+      userRoles: '',
+      severity: anyNamed('severity'),
+      domain: anyNamed('domain'),
+      name: anyNamed('name'),
+      becomeUser: anyNamed('becomeUser'),
+    )).called(1);
+  });
+
+  test('Uses user data from api prefs', () async {
+    await ApiPrefs.performLogout(); // Clear domain data
+    await ApiPrefs.setUser(user);
+    await ErrorReportInteractor().submitErrorReport('', '', '', ErrorReportSeverity.COMMENT, '');
+
+    verify(api.submitErrorReport(
+      email: user.primaryEmail,
+      name: user.name,
+      becomeUser: '${ErrorReportApi.DEFAULT_DOMAIN}?become_user_id=${user.id}',
+      subject: anyNamed('subject'),
+      description: anyNamed('description'),
+      stacktrace: anyNamed('stacktrace'),
+      severity: anyNamed('severity'),
+      domain: anyNamed('domain'),
+      userRoles: anyNamed('userRoles'),
+    )).called(1);
+  });
+
+  test('Uses empty string for no user data in api prefs', () async {
+    await ApiPrefs.setUser(User());
+    await ErrorReportInteractor().submitErrorReport('', '', null, ErrorReportSeverity.COMMENT, '');
+
+    verify(api.submitErrorReport(
+      email: '',
+      name: '',
+      becomeUser: '',
+      subject: anyNamed('subject'),
+      description: anyNamed('description'),
+      stacktrace: anyNamed('stacktrace'),
+      severity: anyNamed('severity'),
+      domain: anyNamed('domain'),
+      userRoles: anyNamed('userRoles'),
+    )).called(1);
+  });
+
+  test('Uses domain from api prefs', () async {
+    String domain = 'domain';
+    await ApiPrefs.updateLoginInfo(
+        CanvasToken((b) => b..accessToken = ''), MobileVerifyResult((b) => b..baseUrl = domain));
+    await ErrorReportInteractor().submitErrorReport('', '', '', ErrorReportSeverity.COMMENT, '');
+
+    verify(api.submitErrorReport(
+      domain: domain,
+      subject: anyNamed('subject'),
+      description: anyNamed('description'),
+      email: anyNamed('email'),
+      stacktrace: anyNamed('stacktrace'),
+      severity: anyNamed('severity'),
+      name: anyNamed('name'),
+      becomeUser: anyNamed('becomeUser'),
+      userRoles: anyNamed('userRoles'),
+    )).called(1);
+  });
+
+  test('Uses domain from ErrorReportApi if api prefs has none', () async {
+    await ApiPrefs.performLogout(); // Clear domain data in ApiPrefs
+    await ErrorReportInteractor().submitErrorReport('', '', '', ErrorReportSeverity.COMMENT, '');
+
+    verify(api.submitErrorReport(
+      domain: ErrorReportApi.DEFAULT_DOMAIN,
+      subject: anyNamed('subject'),
+      description: anyNamed('description'),
+      email: anyNamed('email'),
+      stacktrace: anyNamed('stacktrace'),
+      severity: anyNamed('severity'),
+      name: anyNamed('name'),
+      becomeUser: anyNamed('becomeUser'),
+      userRoles: anyNamed('userRoles'),
+    )).called(1);
+  });
+
+  test('Retrieves user roles and removes duplicates', () async {
+    final enrollmentBuilder = (String type) => Enrollment((b) => b
+      ..enrollmentState = 'active'
+      ..type = type);
+    when(enrollmentsApi.getSelfEnrollments(forceRefresh: true)).thenAnswer((_) async => List.from([
+          enrollmentBuilder('ObserverEnrollment'),
+          enrollmentBuilder('ObserverEnrollment'),
+          enrollmentBuilder('StudentEnrollment'),
+        ]));
+    await ErrorReportInteractor().submitErrorReport('', '', '', ErrorReportSeverity.COMMENT, '');
+
+    verify(api.submitErrorReport(
+      userRoles: 'ObserverEnrollment,StudentEnrollment',
+      subject: anyNamed('subject'),
+      description: anyNamed('description'),
+      email: anyNamed('email'),
+      stacktrace: anyNamed('stacktrace'),
+      severity: anyNamed('severity'),
+      domain: anyNamed('domain'),
+      name: anyNamed('name'),
+      becomeUser: anyNamed('becomeUser'),
+    )).called(1);
+  });
+
+  test('ErrorReportSeverity serializes', () async {
+    final _verifySeverityString = (String severity) {
+      verify(api.submitErrorReport(
+        severity: severity,
+        subject: anyNamed('subject'),
+        description: anyNamed('description'),
+        email: anyNamed('email'),
+        stacktrace: anyNamed('stacktrace'),
+        domain: anyNamed('domain'),
+        name: anyNamed('name'),
+        becomeUser: anyNamed('becomeUser'),
+        userRoles: anyNamed('userRoles'),
+      )).called(1);
+    };
+
+    await ErrorReportInteractor().submitErrorReport('', '', '', ErrorReportSeverity.COMMENT, '');
+    _verifySeverityString('just_a_comment');
+
+    await ErrorReportInteractor().submitErrorReport('', '', '', ErrorReportSeverity.NOT_URGENT, '');
+    _verifySeverityString('not_urgent');
+
+    await ErrorReportInteractor().submitErrorReport('', '', '', ErrorReportSeverity.WORKAROUND_POSSIBLE, '');
+    _verifySeverityString('workaround_possible');
+
+    await ErrorReportInteractor().submitErrorReport('', '', '', ErrorReportSeverity.BLOCKING, '');
+    _verifySeverityString('blocks_what_i_need_to_do');
+
+    await ErrorReportInteractor().submitErrorReport('', '', '', ErrorReportSeverity.CRITICAL, '');
+    _verifySeverityString('extreme_critical_emergency');
+
+    expect(() async => await ErrorReportInteractor().submitErrorReport('', '', '', null, ''), throwsArgumentError);
+  });
+}
+
+class _MockErrorReportApi extends Mock implements ErrorReportApi {}
+
+class _MockEnrollmentsApi extends Mock implements EnrollmentsApi {}


### PR DESCRIPTION
This lets app users contact support via the error report endpoint. Added to the ‘contact support’ button on crash screens. Also defaulted our ‘help’ button in the drawer to use this dialog to make it easier for testing. Should not be the default for the ‘help’ dialog in the end game.

To test:
Verify the dialog shows up. If you hit send, it will send an actual error report to canvas support, so probably don't hit send without commenting out the api call. I have done this and will not move the ticket to done until I get a response.