### PR TITLE
[Student] A small change to displaying total grades for MGP

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/adapter/GradesListRecyclerAdapter.kt
+++ b/apps/student/src/main/java/com/instructure/student/adapter/GradesListRecyclerAdapter.kt
@@ -246,7 +246,7 @@ open class GradesListRecyclerAdapter(
                     // Fetch the enrollments associated with the selected gradingPeriodID, these will contain the
                     // correct grade for the period
                     val enrollments = awaitApi<List<Enrollment>>{CourseManager.getUserEnrollmentsForGradingPeriod(canvasContext!!.id, ApiPrefs.user!!.id, gradingPeriodID, it, true)}
-                    updateCourseGradeFromEnrollments(enrollments)
+                    updateCourseGradeFromGradingPeriodSpecificEnrollment(enrollments)
 
                     // Inform the spinner things are done
                     adapterToGradesCallback?.setTermSpinnerState(true)
@@ -257,11 +257,11 @@ open class GradesListRecyclerAdapter(
         }
     }
 
-    private fun updateCourseGradeFromEnrollments(enrollments: List<Enrollment>) {
+    private fun updateCourseGradeFromGradingPeriodSpecificEnrollment(enrollments: List<Enrollment>) {
         for (enrollment in enrollments) {
             if (enrollment.isStudent && enrollment.userId == ApiPrefs.user!!.id) {
                 val course = canvasContext as Course?
-                courseGrade = course!!.getCourseGradeFromEnrollment(enrollment, false)
+                courseGrade = course!!.getCourseGradeForGradingPeriodSpecificEnrollment(enrollment = enrollment)
                 adapterToGradesCallback?.notifyGradeChanged(courseGrade)
                 // We need to update the course that the fragment is using
                 course.addEnrollment(enrollment)

--- a/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/unit/CourseTest.kt
+++ b/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/unit/CourseTest.kt
@@ -267,6 +267,32 @@ class CourseTest {
     }
 
     @Test
+    fun isCourseGradeLockedForSpecificPeriod_hideAllGradingPeriods() {
+        val enrollment = Enrollment(
+                type = Enrollment.EnrollmentType.Student,
+                currentGradingPeriodId = 123,
+                multipleGradingPeriodsEnabled = true,
+                totalsForAllGradingPeriodsOption = false)
+        val enrollments = arrayListOf(enrollment)
+        val course = Course(hasGradingPeriods = true, enrollments = enrollments)
+
+        assertFalse(course.getCourseGradeForGradingPeriodSpecificEnrollment(enrollment).isLocked)
+    }
+
+    @Test
+    fun isCourseGradeLockedForSpecificPeriod_hideFinal() {
+        val enrollment = Enrollment(
+                type = Enrollment.EnrollmentType.Student,
+                currentGradingPeriodId = 123,
+                multipleGradingPeriodsEnabled = true,
+                totalsForAllGradingPeriodsOption = false)
+        val enrollments = arrayListOf(enrollment)
+        val course = Course(hasGradingPeriods = true, enrollments = enrollments, hideFinalGrades = true)
+
+        assertTrue(course.getCourseGradeForGradingPeriodSpecificEnrollment(enrollment).isLocked)
+    }
+
+    @Test
     fun courseHasNoCurrentGrade() {
         val enrollment = Enrollment(
                 type = Enrollment.EnrollmentType.Student,


### PR DESCRIPTION
Okay, so going to add some context around this small change.

It was noticed that we were hiding final grades for all periods when outside of the grading period start/end date range. This was happening specifically as a result of our function call that checks for "hasActiveGradingPeriods()". When we combine the boolean result of hasActiveGradingPeriods() w/ isTotalsForAllGradingPeriodsEnabled to determine if the course grade is locked, we run into problems. The problem here is that we (really I) were using hasActiveGradingPeriods() to determine if we should be viewing the "All Grading Periods" period, and forgot about the case of a user attempting to view individual grading periods after their term was over. In order to correct this within the current function for getting a course grade, we would need to make an extra api call to get all grading periods and check if we are outside the date range of all grading periods. This seems unreasonable, especially for such a specific case. As such, I opted to make a new function specific to this situation, that should only be used when viewing a specific grading period.

While this is not an idea solution, we have made a request to the folks working on the graphql endpoints for grades to simplify this for us. Hopefully, some day, we'll be able to have a "display grade" string that we can just display, rather than duplicate all of this logic on the client side.