### PR TITLE
[Flutter-Parent][MBL-13226]: Multiple grading periods

### DIFF
--- a/apps/flutter_parent/lib/l10n/app_localizations.dart
+++ b/apps/flutter_parent/lib/l10n/app_localizations.dart
@@ -395,6 +395,8 @@ class AppLocalizations {
 
   /// Course Details Screen
 
+  String get filterBy => Intl.message('Filter by', desc: 'Title for list of terms to filter grades by');
+
   String get courseGradesLabel => Intl.message(
         'Grades',
         desc: 'Label for the "Grades" tab in course details',

--- a/apps/flutter_parent/lib/models/assignment_group.g.dart
+++ b/apps/flutter_parent/lib/models/assignment_group.g.dart
@@ -181,7 +181,9 @@ class AssignmentGroupBuilder
   set assignments(ListBuilder<Assignment> assignments) =>
       _$this._assignments = assignments;
 
-  AssignmentGroupBuilder();
+  AssignmentGroupBuilder() {
+    AssignmentGroup._initializeBuilder(this);
+  }
 
   AssignmentGroupBuilder get _$this {
     if (_$v != null) {

--- a/apps/flutter_parent/lib/models/course.dart
+++ b/apps/flutter_parent/lib/models/course.dart
@@ -122,5 +122,5 @@ abstract class Course implements Built<Course, CourseBuilder> {
     ..restrictEnrollmentsToCourseDates = false;
 
   CourseGrade getCourseGrade(String studentId) =>
-      CourseGrade(enrollments.firstWhere((enrollment) => enrollment.userId == studentId));
+      CourseGrade(this, enrollments.firstWhere((enrollment) => enrollment.userId == studentId));
 }

--- a/apps/flutter_parent/lib/models/enrollment.dart
+++ b/apps/flutter_parent/lib/models/enrollment.dart
@@ -97,6 +97,7 @@ abstract class Enrollment implements Built<Enrollment, EnrollmentBuilder> {
   @BuiltValueField(wireName: 'current_period_computed_final_grade')
   String get currentPeriodComputedFinalGrade;
 
+  @nullable
   @BuiltValueField(wireName: 'current_grading_period_id')
   String get currentGradingPeriodId;
 
@@ -133,6 +134,16 @@ abstract class Enrollment implements Built<Enrollment, EnrollmentBuilder> {
   bool isObserver() => ['observer', 'ObserverEnrollment'].any(_matchesEnrollment);
 
   bool isDesigner() => ['designer', 'DesignerEnrollment'].any(_matchesEnrollment);
+
+  bool hasActiveGradingPeriod() =>
+      multipleGradingPeriodsEnabled &&
+      currentGradingPeriodId != null &&
+      currentGradingPeriodId.isNotEmpty &&
+      currentGradingPeriodId != '0';
+
+  // NOTE: Looks like the API will never return multipleGradingPeriodsEnabled for observer enrollments, still checking just in case
+  bool isTotalsForAllGradingPeriodsEnabled() =>
+      (isStudent() || isObserver()) && multipleGradingPeriodsEnabled && totalsForAllGradingPeriodsOption;
 
 // NOTE: There is also a StudentViewEnrollment that allows Teachers to view the course as a student - we don't handle that right now, and we probably don't have to worry about it
 

--- a/apps/flutter_parent/lib/models/enrollment.g.dart
+++ b/apps/flutter_parent/lib/models/enrollment.g.dart
@@ -32,9 +32,6 @@ class _$EnrollmentSerializer implements StructuredSerializer<Enrollment> {
       'totals_for_all_grading_periods_option',
       serializers.serialize(object.totalsForAllGradingPeriodsOption,
           specifiedType: const FullType(bool)),
-      'current_grading_period_id',
-      serializers.serialize(object.currentGradingPeriodId,
-          specifiedType: const FullType(String)),
       'associated_user_id',
       serializers.serialize(object.associatedUserId,
           specifiedType: const FullType(String)),
@@ -131,6 +128,13 @@ class _$EnrollmentSerializer implements StructuredSerializer<Enrollment> {
       result.add(null);
     } else {
       result.add(serializers.serialize(object.currentPeriodComputedFinalGrade,
+          specifiedType: const FullType(String)));
+    }
+    result.add('current_grading_period_id');
+    if (object.currentGradingPeriodId == null) {
+      result.add(null);
+    } else {
+      result.add(serializers.serialize(object.currentGradingPeriodId,
           specifiedType: const FullType(String)));
     }
     result.add('current_grading_period_title');
@@ -385,10 +389,6 @@ class _$Enrollment extends Enrollment {
     if (totalsForAllGradingPeriodsOption == null) {
       throw new BuiltValueNullFieldError(
           'Enrollment', 'totalsForAllGradingPeriodsOption');
-    }
-    if (currentGradingPeriodId == null) {
-      throw new BuiltValueNullFieldError(
-          'Enrollment', 'currentGradingPeriodId');
     }
     if (associatedUserId == null) {
       throw new BuiltValueNullFieldError('Enrollment', 'associatedUserId');

--- a/apps/flutter_parent/lib/models/grading_period.dart
+++ b/apps/flutter_parent/lib/models/grading_period.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 - present Instructure, Inc.
+// Copyright (C) 2020 - present Instructure, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -11,36 +11,35 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:flutter_parent/models/assignment.dart';
 
-part 'assignment_group.g.dart';
+part 'grading_period.g.dart';
 
 /// To have this built_value be generated, run this command from the project root:
 /// flutter packages pub run build_runner build --delete-conflicting-outputs
-abstract class AssignmentGroup implements Built<AssignmentGroup, AssignmentGroupBuilder> {
-  @BuiltValueSerializer(serializeNulls: true)
-  static Serializer<AssignmentGroup> get serializer => _$assignmentGroupSerializer;
+abstract class GradingPeriod implements Built<GradingPeriod, GradingPeriodBuilder> {
+  @BuiltValueSerializer(serializeNulls: true) // Add this line to get nulls to serialize when we convert to JSON
+  static Serializer<GradingPeriod> get serializer => _$gradingPeriodSerializer;
 
-  AssignmentGroup._();
+  GradingPeriod._();
 
-  factory AssignmentGroup([void Function(AssignmentGroupBuilder) updates]) = _$AssignmentGroup;
+  factory GradingPeriod([void Function(GradingPeriodBuilder) updates]) = _$GradingPeriod;
 
+  @nullable
   String get id;
 
-  String get name;
+  @nullable
+  String get title;
 
-  int get position;
+  @nullable
+  @BuiltValueField(wireName: 'start_date')
+  DateTime get startDate;
 
-  @BuiltValueField(wireName: 'group_weight')
-  double get groupWeight;
+  @nullable
+  @BuiltValueField(wireName: 'end_date')
+  DateTime get endDate;
 
-  BuiltList<Assignment> get assignments;
-
-  static void _initializeBuilder(AssignmentGroupBuilder b) => b
-    ..position = 0
-    ..groupWeight = 0;
+  @nullable
+  int get weight;
 }

--- a/apps/flutter_parent/lib/models/grading_period.g.dart
+++ b/apps/flutter_parent/lib/models/grading_period.g.dart
@@ -1,0 +1,222 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'grading_period.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<GradingPeriod> _$gradingPeriodSerializer =
+    new _$GradingPeriodSerializer();
+
+class _$GradingPeriodSerializer implements StructuredSerializer<GradingPeriod> {
+  @override
+  final Iterable<Type> types = const [GradingPeriod, _$GradingPeriod];
+  @override
+  final String wireName = 'GradingPeriod';
+
+  @override
+  Iterable<Object> serialize(Serializers serializers, GradingPeriod object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object>[];
+    result.add('id');
+    if (object.id == null) {
+      result.add(null);
+    } else {
+      result.add(serializers.serialize(object.id,
+          specifiedType: const FullType(String)));
+    }
+    result.add('title');
+    if (object.title == null) {
+      result.add(null);
+    } else {
+      result.add(serializers.serialize(object.title,
+          specifiedType: const FullType(String)));
+    }
+    result.add('start_date');
+    if (object.startDate == null) {
+      result.add(null);
+    } else {
+      result.add(serializers.serialize(object.startDate,
+          specifiedType: const FullType(DateTime)));
+    }
+    result.add('end_date');
+    if (object.endDate == null) {
+      result.add(null);
+    } else {
+      result.add(serializers.serialize(object.endDate,
+          specifiedType: const FullType(DateTime)));
+    }
+    result.add('weight');
+    if (object.weight == null) {
+      result.add(null);
+    } else {
+      result.add(serializers.serialize(object.weight,
+          specifiedType: const FullType(int)));
+    }
+    return result;
+  }
+
+  @override
+  GradingPeriod deserialize(
+      Serializers serializers, Iterable<Object> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new GradingPeriodBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final dynamic value = iterator.current;
+      if (value == null) continue;
+      switch (key) {
+        case 'id':
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'title':
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'start_date':
+          result.startDate = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime;
+          break;
+        case 'end_date':
+          result.endDate = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime;
+          break;
+        case 'weight':
+          result.weight = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GradingPeriod extends GradingPeriod {
+  @override
+  final String id;
+  @override
+  final String title;
+  @override
+  final DateTime startDate;
+  @override
+  final DateTime endDate;
+  @override
+  final int weight;
+
+  factory _$GradingPeriod([void Function(GradingPeriodBuilder) updates]) =>
+      (new GradingPeriodBuilder()..update(updates)).build();
+
+  _$GradingPeriod._(
+      {this.id, this.title, this.startDate, this.endDate, this.weight})
+      : super._();
+
+  @override
+  GradingPeriod rebuild(void Function(GradingPeriodBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GradingPeriodBuilder toBuilder() => new GradingPeriodBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GradingPeriod &&
+        id == other.id &&
+        title == other.title &&
+        startDate == other.startDate &&
+        endDate == other.endDate &&
+        weight == other.weight;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(
+        $jc($jc($jc($jc(0, id.hashCode), title.hashCode), startDate.hashCode),
+            endDate.hashCode),
+        weight.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('GradingPeriod')
+          ..add('id', id)
+          ..add('title', title)
+          ..add('startDate', startDate)
+          ..add('endDate', endDate)
+          ..add('weight', weight))
+        .toString();
+  }
+}
+
+class GradingPeriodBuilder
+    implements Builder<GradingPeriod, GradingPeriodBuilder> {
+  _$GradingPeriod _$v;
+
+  String _id;
+  String get id => _$this._id;
+  set id(String id) => _$this._id = id;
+
+  String _title;
+  String get title => _$this._title;
+  set title(String title) => _$this._title = title;
+
+  DateTime _startDate;
+  DateTime get startDate => _$this._startDate;
+  set startDate(DateTime startDate) => _$this._startDate = startDate;
+
+  DateTime _endDate;
+  DateTime get endDate => _$this._endDate;
+  set endDate(DateTime endDate) => _$this._endDate = endDate;
+
+  int _weight;
+  int get weight => _$this._weight;
+  set weight(int weight) => _$this._weight = weight;
+
+  GradingPeriodBuilder();
+
+  GradingPeriodBuilder get _$this {
+    if (_$v != null) {
+      _id = _$v.id;
+      _title = _$v.title;
+      _startDate = _$v.startDate;
+      _endDate = _$v.endDate;
+      _weight = _$v.weight;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GradingPeriod other) {
+    if (other == null) {
+      throw new ArgumentError.notNull('other');
+    }
+    _$v = other as _$GradingPeriod;
+  }
+
+  @override
+  void update(void Function(GradingPeriodBuilder) updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$GradingPeriod build() {
+    final _$result = _$v ??
+        new _$GradingPeriod._(
+            id: id,
+            title: title,
+            startDate: startDate,
+            endDate: endDate,
+            weight: weight);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new

--- a/apps/flutter_parent/lib/models/grading_period_response.dart
+++ b/apps/flutter_parent/lib/models/grading_period_response.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 - present Instructure, Inc.
+// Copyright (C) 2020 - present Instructure, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -11,36 +11,23 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:flutter_parent/models/assignment.dart';
+import 'package:flutter_parent/models/grading_period.dart';
 
-part 'assignment_group.g.dart';
+part 'grading_period_response.g.dart';
 
 /// To have this built_value be generated, run this command from the project root:
 /// flutter packages pub run build_runner build --delete-conflicting-outputs
-abstract class AssignmentGroup implements Built<AssignmentGroup, AssignmentGroupBuilder> {
-  @BuiltValueSerializer(serializeNulls: true)
-  static Serializer<AssignmentGroup> get serializer => _$assignmentGroupSerializer;
+abstract class GradingPeriodResponse implements Built<GradingPeriodResponse, GradingPeriodResponseBuilder> {
+  @BuiltValueSerializer(serializeNulls: true) // Add this line to get nulls to serialize when we convert to JSON
+  static Serializer<GradingPeriodResponse> get serializer => _$gradingPeriodResponseSerializer;
 
-  AssignmentGroup._();
+  GradingPeriodResponse._();
 
-  factory AssignmentGroup([void Function(AssignmentGroupBuilder) updates]) = _$AssignmentGroup;
+  factory GradingPeriodResponse([void Function(GradingPeriodResponseBuilder) updates]) = _$GradingPeriodResponse;
 
-  String get id;
-
-  String get name;
-
-  int get position;
-
-  @BuiltValueField(wireName: 'group_weight')
-  double get groupWeight;
-
-  BuiltList<Assignment> get assignments;
-
-  static void _initializeBuilder(AssignmentGroupBuilder b) => b
-    ..position = 0
-    ..groupWeight = 0;
+  @BuiltValueField(wireName: 'grading_periods')
+  BuiltList<GradingPeriod> get gradingPeriods;
 }

--- a/apps/flutter_parent/lib/models/grading_period_response.g.dart
+++ b/apps/flutter_parent/lib/models/grading_period_response.g.dart
@@ -1,0 +1,161 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'grading_period_response.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<GradingPeriodResponse> _$gradingPeriodResponseSerializer =
+    new _$GradingPeriodResponseSerializer();
+
+class _$GradingPeriodResponseSerializer
+    implements StructuredSerializer<GradingPeriodResponse> {
+  @override
+  final Iterable<Type> types = const [
+    GradingPeriodResponse,
+    _$GradingPeriodResponse
+  ];
+  @override
+  final String wireName = 'GradingPeriodResponse';
+
+  @override
+  Iterable<Object> serialize(
+      Serializers serializers, GradingPeriodResponse object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object>[
+      'grading_periods',
+      serializers.serialize(object.gradingPeriods,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(GradingPeriod)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  GradingPeriodResponse deserialize(
+      Serializers serializers, Iterable<Object> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new GradingPeriodResponseBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final dynamic value = iterator.current;
+      if (value == null) continue;
+      switch (key) {
+        case 'grading_periods':
+          result.gradingPeriods.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(GradingPeriod)]))
+              as BuiltList<Object>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GradingPeriodResponse extends GradingPeriodResponse {
+  @override
+  final BuiltList<GradingPeriod> gradingPeriods;
+
+  factory _$GradingPeriodResponse(
+          [void Function(GradingPeriodResponseBuilder) updates]) =>
+      (new GradingPeriodResponseBuilder()..update(updates)).build();
+
+  _$GradingPeriodResponse._({this.gradingPeriods}) : super._() {
+    if (gradingPeriods == null) {
+      throw new BuiltValueNullFieldError(
+          'GradingPeriodResponse', 'gradingPeriods');
+    }
+  }
+
+  @override
+  GradingPeriodResponse rebuild(
+          void Function(GradingPeriodResponseBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GradingPeriodResponseBuilder toBuilder() =>
+      new GradingPeriodResponseBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GradingPeriodResponse &&
+        gradingPeriods == other.gradingPeriods;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(0, gradingPeriods.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('GradingPeriodResponse')
+          ..add('gradingPeriods', gradingPeriods))
+        .toString();
+  }
+}
+
+class GradingPeriodResponseBuilder
+    implements Builder<GradingPeriodResponse, GradingPeriodResponseBuilder> {
+  _$GradingPeriodResponse _$v;
+
+  ListBuilder<GradingPeriod> _gradingPeriods;
+  ListBuilder<GradingPeriod> get gradingPeriods =>
+      _$this._gradingPeriods ??= new ListBuilder<GradingPeriod>();
+  set gradingPeriods(ListBuilder<GradingPeriod> gradingPeriods) =>
+      _$this._gradingPeriods = gradingPeriods;
+
+  GradingPeriodResponseBuilder();
+
+  GradingPeriodResponseBuilder get _$this {
+    if (_$v != null) {
+      _gradingPeriods = _$v.gradingPeriods?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GradingPeriodResponse other) {
+    if (other == null) {
+      throw new ArgumentError.notNull('other');
+    }
+    _$v = other as _$GradingPeriodResponse;
+  }
+
+  @override
+  void update(void Function(GradingPeriodResponseBuilder) updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$GradingPeriodResponse build() {
+    _$GradingPeriodResponse _$result;
+    try {
+      _$result = _$v ??
+          new _$GradingPeriodResponse._(gradingPeriods: gradingPeriods.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'gradingPeriods';
+        gradingPeriods.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'GradingPeriodResponse', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new

--- a/apps/flutter_parent/lib/models/serializers.dart
+++ b/apps/flutter_parent/lib/models/serializers.dart
@@ -31,6 +31,8 @@ import 'package:flutter_parent/models/conversation.dart';
 import 'package:flutter_parent/models/course.dart';
 import 'package:flutter_parent/models/enrollment.dart';
 import 'package:flutter_parent/models/grade.dart';
+import 'package:flutter_parent/models/grading_period.dart';
+import 'package:flutter_parent/models/grading_period_response.dart';
 import 'package:flutter_parent/models/lock_info.dart';
 import 'package:flutter_parent/models/locked_module.dart';
 import 'package:flutter_parent/models/media_comment.dart';
@@ -64,6 +66,8 @@ part 'serializers.g.dart';
   Enrollment,
   FileUploadConfig,
   Grade,
+  GradingPeriod,
+  GradingPeriodResponse,
   LockInfo,
   LockedModule,
   MediaComment,

--- a/apps/flutter_parent/lib/models/serializers.g.dart
+++ b/apps/flutter_parent/lib/models/serializers.g.dart
@@ -24,6 +24,8 @@ Serializers _$_serializers = (new Serializers().toBuilder()
       ..add(Enrollment.serializer)
       ..add(FileUploadConfig.serializer)
       ..add(Grade.serializer)
+      ..add(GradingPeriod.serializer)
+      ..add(GradingPeriodResponse.serializer)
       ..add(GradingType.serializer)
       ..add(LockInfo.serializer)
       ..add(LockedModule.serializer)
@@ -53,6 +55,9 @@ Serializers _$_serializers = (new Serializers().toBuilder()
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(Enrollment)]),
           () => new ListBuilder<Enrollment>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(GradingPeriod)]),
+          () => new ListBuilder<GradingPeriod>())
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(RemoteFile)]),
           () => new ListBuilder<RemoteFile>())

--- a/apps/flutter_parent/lib/network/api/assignment_api.dart
+++ b/apps/flutter_parent/lib/network/api/assignment_api.dart
@@ -14,7 +14,6 @@
 
 import 'package:flutter_parent/models/assignment.dart';
 import 'package:flutter_parent/models/assignment_group.dart';
-import 'package:flutter_parent/models/submission.dart';
 import 'package:flutter_parent/network/utils/dio_config.dart';
 import 'package:flutter_parent/network/utils/fetch.dart';
 import 'package:flutter_parent/network/utils/paged_list.dart';
@@ -31,8 +30,10 @@ class AssignmentApi {
     return fetchList(dio.get('courses/$courseId/assignments', queryParameters: params), depaginateWith: dio);
   }
 
-  Future<List<AssignmentGroup>> getAssignmentGroupsWithSubmissionsDepaginated(String courseId, String studentId) async {
-    var dio = canvasDio();
+  Future<List<AssignmentGroup>> getAssignmentGroupsWithSubmissionsDepaginated(
+      String courseId, String studentId, String gradingPeriodId,
+      {bool forceRefresh = false}) async {
+    var dio = canvasDio(forceRefresh: forceRefresh);
     var params = {
       'include': [
         'assignments',
@@ -43,6 +44,7 @@ class AssignmentApi {
         'observed_users',
       ],
       'override_assignment_dates': 'true',
+      if (gradingPeriodId?.isNotEmpty == true) 'grading_period_id': gradingPeriodId,
     };
     return fetchList(dio.get('courses/$courseId/assignment_groups', queryParameters: params), depaginateWith: dio);
   }
@@ -66,20 +68,5 @@ class AssignmentApi {
     };
     return fetch(canvasDio(forceRefresh: forceRefresh)
         .get('courses/$courseId/assignments/$assignmentId', queryParameters: params));
-  }
-
-  // TODO: Remove once LA-274 is implemented, and submissions are given with assignment groups (for observers)
-  Future<List<Submission>> getSubmissions(
-    String courseId,
-    String studentId,
-    List<String> assignmentIds, {
-    bool forceRefresh,
-  }) {
-    final dio = canvasDio(forceRefresh: forceRefresh);
-    final params = {
-      'student_ids': [studentId],
-      'assignment_ids': assignmentIds,
-    };
-    return fetchList(dio.get('courses/$courseId/students/submissions', queryParameters: params), depaginateWith: dio);
   }
 }

--- a/apps/flutter_parent/lib/network/api/course_api.dart
+++ b/apps/flutter_parent/lib/network/api/course_api.dart
@@ -13,6 +13,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import 'package:flutter_parent/models/course.dart';
+import 'package:flutter_parent/models/grading_period_response.dart';
 import 'package:flutter_parent/network/utils/dio_config.dart';
 import 'package:flutter_parent/network/utils/fetch.dart';
 
@@ -55,5 +56,10 @@ class CourseApi {
       ]
     };
     return fetch(canvasDio().get('courses/${courseId}', queryParameters: params));
+  }
+
+  // TODO: Set up pagination when API is fixed (no header link) and remove per_page query parameter
+  Future<GradingPeriodResponse> getGradingPeriods(String courseId, {bool forceRefresh = false}) {
+    return fetch(canvasDio(forceRefresh: forceRefresh).get('courses/$courseId/grading_periods?per_page=100'));
   }
 }

--- a/apps/flutter_parent/lib/network/api/enrollments_api.dart
+++ b/apps/flutter_parent/lib/network/api/enrollments_api.dart
@@ -36,6 +36,24 @@ class EnrollmentsApi {
     return fetchList(dio.get('users/self/enrollments', queryParameters: params), depaginateWith: dio);
   }
 
+  Future<List<Enrollment>> getEnrollmentsByGradingPeriod(String courseId, String studentId, String gradingPeriodId,
+      {bool forceRefresh = false}) {
+    final dio = canvasDio(forceRefresh: forceRefresh);
+    final params = {
+      'state': ['active', 'completed'], // current_and_concluded state not supported for observers
+      'user_id': studentId,
+      if (gradingPeriodId?.isNotEmpty == true)
+        'grading_period_id': gradingPeriodId,
+    };
+    return fetchList(
+      dio.get(
+        'courses/$courseId/enrollments',
+        queryParameters: params,
+      ),
+      depaginateWith: dio,
+    );
+  }
+
   Future<bool> pairWithStudent(String pairingCode) async {
     try {
       var pairingResponse = await canvasDio().post(ApiPrefs.getApiUrl(path: 'users/${ApiPrefs.getUser().id}/observees'),

--- a/apps/flutter_parent/lib/screens/courses/details/course_details_interactor.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_details_interactor.dart
@@ -14,8 +14,11 @@
 
 import 'package:flutter_parent/models/assignment_group.dart';
 import 'package:flutter_parent/models/course.dart';
+import 'package:flutter_parent/models/enrollment.dart';
+import 'package:flutter_parent/models/grading_period_response.dart';
 import 'package:flutter_parent/network/api/assignment_api.dart';
 import 'package:flutter_parent/network/api/course_api.dart';
+import 'package:flutter_parent/network/api/enrollments_api.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
 
 class CourseDetailsInteractor {
@@ -23,7 +26,19 @@ class CourseDetailsInteractor {
     return locator<CourseApi>().getCourse(courseId);
   }
 
-  Future<List<AssignmentGroup>> loadAssignmentGroups(String courseId, String studentId) {
-    return locator<AssignmentApi>().getAssignmentGroupsWithSubmissionsDepaginated(courseId, studentId);
+  Future<List<AssignmentGroup>> loadAssignmentGroups(String courseId, String studentId, String gradingPeriodId,
+      {bool forceRefresh = false}) {
+    return locator<AssignmentApi>().getAssignmentGroupsWithSubmissionsDepaginated(courseId, studentId, gradingPeriodId,
+        forceRefresh: forceRefresh);
+  }
+
+  Future<GradingPeriodResponse> loadGradingPeriods(String courseId, {bool forceRefresh = false}) {
+    return locator<CourseApi>().getGradingPeriods(courseId, forceRefresh: forceRefresh);
+  }
+
+  Future<List<Enrollment>> loadEnrollmentsForGradingPeriod(String courseId, String studentId, String gradingPeriodId,
+      {bool forceRefresh = false}) {
+    return locator<EnrollmentsApi>()
+        .getEnrollmentsByGradingPeriod(courseId, studentId, gradingPeriodId, forceRefresh: forceRefresh);
   }
 }

--- a/apps/flutter_parent/lib/screens/courses/details/grading_period_modal.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/grading_period_modal.dart
@@ -1,0 +1,49 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import 'package:flutter/material.dart';
+import 'package:flutter_parent/l10n/app_localizations.dart';
+import 'package:flutter_parent/models/grading_period.dart';
+
+class GradingPeriodModal extends StatelessWidget {
+  final List<GradingPeriod> gradingPeriods;
+
+  const GradingPeriodModal._internal({Key key, this.gradingPeriods}) : super(key: key);
+
+  static Future<GradingPeriod> asBottomSheet(BuildContext context, List<GradingPeriod> gradingPeriods) =>
+      showModalBottomSheet(
+        context: context,
+        builder: (context) => GradingPeriodModal._internal(gradingPeriods: gradingPeriods),
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      shrinkWrap: true,
+      itemCount: gradingPeriods.length + 1, // Add one for the header
+      itemBuilder: (context, index) {
+        if (index == 0) {
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+            child: Text(L10n(context).filterBy, style: Theme.of(context).textTheme.caption),
+          );
+        }
+        final gradingPeriod = gradingPeriods[index - 1];
+        return ListTile(
+          title: Text(gradingPeriod.title, style: Theme.of(context).textTheme.subhead),
+          onTap: () => Navigator.of(context).pop(gradingPeriod),
+        );
+      },
+    );
+  }
+}

--- a/apps/flutter_parent/test/models/enrollment_test.dart
+++ b/apps/flutter_parent/test/models/enrollment_test.dart
@@ -1,0 +1,94 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import 'package:flutter_parent/models/enrollment.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final _enrollment = Enrollment((b) => b..enrollmentState = 'active');
+
+  group('hasActiveGradingPeriod', () {
+    test('returns false if multipleGradingPeriodsEnabled is false', () {
+      final enrollment = _enrollment.rebuild((b) => b..multipleGradingPeriodsEnabled = false);
+      expect(enrollment.hasActiveGradingPeriod(), false);
+    });
+
+    test('returns false if currentGradingPeriodId is null', () {
+      final enrollment = _enrollment.rebuild((b) => b
+        ..multipleGradingPeriodsEnabled = true
+        ..currentGradingPeriodId = null);
+      expect(enrollment.hasActiveGradingPeriod(), false);
+    });
+
+    test('returns false if currentGradingPeriodId is empty', () {
+      final enrollment = _enrollment.rebuild((b) => b
+        ..multipleGradingPeriodsEnabled = true
+        ..currentGradingPeriodId = '');
+      expect(enrollment.hasActiveGradingPeriod(), false);
+    });
+
+    test('returns false if currentGradingPeriodId is 0', () {
+      final enrollment = _enrollment.rebuild((b) => b
+        ..multipleGradingPeriodsEnabled = true
+        ..currentGradingPeriodId = '0');
+      expect(enrollment.hasActiveGradingPeriod(), false);
+    });
+
+    test('returns true if multipleGradingPeriodsEnabled and currentGradingPeriodId is set', () {
+      final enrollment = _enrollment.rebuild((b) => b
+        ..multipleGradingPeriodsEnabled = true
+        ..currentGradingPeriodId = '123');
+      expect(enrollment.hasActiveGradingPeriod(), true);
+    });
+  });
+
+  group('isTotalsForAllGradingPeriodsEnabled', () {
+    test('returns false if enrollment is not student or observer', () {
+      final enrollment = _enrollment.rebuild((b) => b);
+      expect(enrollment.isTotalsForAllGradingPeriodsEnabled(), false);
+    });
+
+    test('returns false if enrollment has multipleGradingPeriodsEnabled false', () {
+      final enrollment = _enrollment.rebuild((b) => b
+        ..role = 'student'
+        ..multipleGradingPeriodsEnabled = false);
+      expect(enrollment.isTotalsForAllGradingPeriodsEnabled(), false);
+    });
+
+    test('returns false if enrollment has totalsForAllGradingPeriodsOption false', () {
+      final enrollment = _enrollment.rebuild((b) => b
+        ..role = 'student'
+        ..multipleGradingPeriodsEnabled = true
+        ..totalsForAllGradingPeriodsOption = false);
+      expect(enrollment.isTotalsForAllGradingPeriodsEnabled(), false);
+    });
+
+    test('returns false if student enrollment has multipleGradingPeriodsEnabled and totalsForAllGradingPeriodsOption',
+        () {
+      final enrollment = _enrollment.rebuild((b) => b
+        ..role = 'student'
+        ..multipleGradingPeriodsEnabled = true
+        ..totalsForAllGradingPeriodsOption = true);
+      expect(enrollment.isTotalsForAllGradingPeriodsEnabled(), true);
+    });
+
+    test('returns false if observer enrollment has multipleGradingPeriodsEnabled and totalsForAllGradingPeriodsOption',
+        () {
+      final enrollment = _enrollment.rebuild((b) => b
+        ..role = 'observer'
+        ..multipleGradingPeriodsEnabled = true
+        ..totalsForAllGradingPeriodsOption = true);
+      expect(enrollment.isTotalsForAllGradingPeriodsEnabled(), true);
+    });
+  });
+}

--- a/apps/flutter_parent/test/screens/assignments/assignment_details_interactor_test.dart
+++ b/apps/flutter_parent/test/screens/assignments/assignment_details_interactor_test.dart
@@ -36,8 +36,8 @@ void main() {
 
   // Reset the interactions for the shared mocks
   setUp(() {
-    clearInteractions(assignmentApi);
-    clearInteractions(courseApi);
+    reset(assignmentApi);
+    reset(courseApi);
   });
 
   group('loadAssignmentDetails', () {
@@ -51,6 +51,7 @@ void main() {
     });
 
     test('returns a null alarm if none exist for the assignment', () async {
+      when(courseApi.getCourse(courseId)).thenAnswer((_) async => Course((b) => b..name = ''));
       final details =
           await AssignmentDetailsInteractor().loadAssignmentDetails(false, courseId, assignmentId, studentId);
 
@@ -71,6 +72,7 @@ void main() {
         ..courseId = courseId
         ..assignmentGroupId = ''
         ..position = 0);
+      when(courseApi.getCourse(courseId)).thenAnswer((_) async => Course((b) => b..name = ''));
       when(assignmentApi.getAssignment(courseId, assignmentId, forceRefresh: false))
           .thenAnswer((_) async => assignment);
       final details =

--- a/apps/flutter_parent/test/screens/assignments/assignment_details_screen_test.dart
+++ b/apps/flutter_parent/test/screens/assignments/assignment_details_screen_test.dart
@@ -52,7 +52,7 @@ void main() {
   });
 
   setUp(() {
-    clearInteractions(interactor);
+    reset(interactor);
   });
 
   testWidgetsWithAccessibilityChecks('Shows loading', (tester) async {

--- a/apps/flutter_parent/test/screens/courses/courses_screen_test.dart
+++ b/apps/flutter_parent/test/screens/courses/courses_screen_test.dart
@@ -41,8 +41,8 @@ void main() {
     _locator.registerFactory<QuickNav>(() => QuickNav());
   }
 
-  Widget _testableMaterialWidget([Widget widget]) =>
-      TestApp(Scaffold(body: widget ?? CoursesScreen(_mockStudent('0'))));
+  Widget _testableMaterialWidget([Widget widget, highContrast = false]) =>
+      TestApp(Scaffold(body: widget ?? CoursesScreen(_mockStudent('0'))), highContrast: highContrast);
 
   testWidgetsWithAccessibilityChecks('shows loading indicator when retrieving courses', (tester) async {
     _setupLocator(_MockCoursesInteractor());
@@ -158,7 +158,7 @@ void main() {
 
     _setupLocator(_MockCoursesInteractor(courses: courses));
 
-    await tester.pumpWidget(_testableMaterialWidget(CoursesScreen(student)));
+    await tester.pumpWidget(_testableMaterialWidget(CoursesScreen(student), true));
     await tester.pumpAndSettle();
 
     final matchedWidget = find.text(courses.first.name);

--- a/apps/flutter_parent/test/utils/widgets/error_report/error_report_interactor_test.dart
+++ b/apps/flutter_parent/test/utils/widgets/error_report/error_report_interactor_test.dart
@@ -33,7 +33,7 @@ void main() {
   final api = _MockErrorReportApi();
   final enrollmentsApi = _MockEnrollmentsApi();
 
-  setUp(() => clearInteractions(api));
+  setUp(() => reset(api));
 
   // Setup test dependencies
   setupPlatformChannels();


### PR DESCRIPTION
MGP filter on course grades.

Also, fixes tests that aren't actually clearing mocks via `clearInteractions` and replaced with `reset`.

Note: While it looks like a massive PR, here's some stats:
model line count - 99
generated line count - 406
test line count - 753
other code lines - 262