### PR TITLE
[Student][Splunk][MBL-13809] | More splunk

### DIFF
--- a/apps/postProcessTestRun.bash
+++ b/apps/postProcessTestRun.bash
@@ -54,7 +54,7 @@ do
       testName=`echo $line | cut -d " " -f 2 | cut -d = -f 2`
       className=`echo $line | cut -d " " -f 3 | cut -d = -f 2`
       runTime=`echo $line | cut -d " " -f 4 | cut -d = -f 2`
-      payload="{\"sourcetype\" : \"mobile-android-qa-testresult\", \"event\" : {\"buildUrl\" : \"$BITRISE_BUILD_URL\", \"status\" : \"passed\", \"testName\": $testName, \"testClass\" : $className, \"deviceConfig\" : $suiteName, \"runTime\" : $runTime, $commonData}"
+      payload="{\"sourcetype\" : \"mobile-android-qa-testresult\", \"event\" : {\"buildUrl\" : \"$BITRISE_BUILD_URL\", \"status\" : \"passed\", \"testName\": $testName, \"testClass\" : $className, \"deviceConfig\" : $suiteName, \"runTime\" : $runTime, $commonData}}"
       failureEncountered=false
     fi
 
@@ -76,7 +76,7 @@ do
 done < "$reportFile"
 
 # After all tests have been processed, Emit the success report
-#echo -e "\nSuccess payload: $successReport\n"
+echo -e "\nSuccess payload: $successReport\n"
 curl -k "https://http-inputs-inst.splunkcloud.com:443/services/collector" -H "Authorization: Splunk $SPLUNK_MOBILE_TOKEN" -d "$successReport"
 
 # Globals for parsing time/cost info

--- a/apps/postProcessTestRun.bash
+++ b/apps/postProcessTestRun.bash
@@ -79,7 +79,7 @@ do
 done < "$reportFile"
 
 # After all tests have been processed, Emit the success report
-echo -e "\nSuccess payload: $successReport\n"
+#echo -e "\nSuccess payload: $successReport\n"
 curl -k "https://http-inputs-inst.splunkcloud.com:443/services/collector" -H "Authorization: Splunk $SPLUNK_MOBILE_TOKEN" -d "$successReport"
 
 # Globals for parsing time/cost info
@@ -88,7 +88,7 @@ hours=0
 minutes=0
 
 # Process the cost report (CostReport.txt)
-# Sample:
+# Sample file:
 #   CostReport
 #     Virtual devices
 #       $1.15 for 1h 9m

--- a/apps/postProcessTestRun.bash
+++ b/apps/postProcessTestRun.bash
@@ -51,9 +51,12 @@ do
     # Sample line: <testcase name="displaysLoadingState" classname="com.instructure.student.ui.renderTests.SubmissionDetailsRenderTest" time="4.346">
     if [[ $line =~ "testcase name" ]]
     then
+      # Remove the '<' and '>' from around the line
+      line=`echo  $line | tr -d "<>"`
+      # Extract various fields from the line
       testName=`echo $line | cut -d " " -f 2 | cut -d = -f 2`
       className=`echo $line | cut -d " " -f 3 | cut -d = -f 2`
-      runTime=`echo $line | cut -d " " -f 4 | cut -d = -f 2`
+      runTime=`echo $line | cut -d " " -f 4 | cut -d = -f 2 | tr -d '"'`
       payload="{\"sourcetype\" : \"mobile-android-qa-testresult\", \"event\" : {\"buildUrl\" : \"$BITRISE_BUILD_URL\", \"status\" : \"passed\", \"testName\": $testName, \"testClass\" : $className, \"deviceConfig\" : $suiteName, \"runTime\" : $runTime, $commonData}}"
       failureEncountered=false
     fi

--- a/apps/postProcessTestRun.bash
+++ b/apps/postProcessTestRun.bash
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# fail if any commands fails
+set -e
+# debug log
+# set -x
+
+# Script post-process our test results and reports the results to Splunk.
+# Only works on Bitrise, as certain secrets (like the Splunk token) will not be defined locally.
+
+# Capture our command line arguments
+if [[ $# < 2 ]]
+then
+  echo "usage: $0 <appName> <resultsDir>"
+  echo "Arg count: $#"
+  echo "Args: $@"
+  exit 1
+fi
+appName=$1
+resultsDir=$2
+reportFile="$resultsDir/JUnitReport.xml"
+costFile="$resultsDir/CostReport.txt"
+
+# Make this global so that we can remember it when reporting on passed tests.
+suiteName=""
+
+# Common JSON parameters for all event types
+commonData="\"workflow\" : \"$BITRISE_TRIGGERED_WORKFLOW_ID\", \"app\" : \"$appName\", \"branch\" : \"$BITRISE_GIT_BRANCH\""
+
+# A running collection of info for all passed tests.  JSON object strings are just concatenated together.
+successReport=""
+
+# Process the test report (JUnitReport.xml)
+while IFS= read -r line
+do
+    # For <testsuite> lines, emit a deviceSummary event and remember the suiteName
+    # Sample line: <testsuite name="NexusLowRes-29-en_US-portrait" tests="275" failures="3" errors="0" skipped="0" time="3577.053" timestamp="2020-01-08T15:32:23" hostname="localhost">
+    if [[ $line =~ "testsuite name" ]]
+    then
+      suiteName=`echo $line | cut -d " " -f 2 | cut -d = -f 2`
+      numTests=`echo $line | cut -d " " -f 3 | cut -d = -f 2 | tr -d '"'`
+      numFailures=`echo $line | cut -d " " -f 4 | cut -d = -f 2 | tr -d '"'`
+      runTime=`echo $line | cut -d " " -f 7 | cut -d = -f 2 | tr -d '"'`
+      
+      payload="{\"deviceConfig\" : $suiteName, \"numTests\" : $numTests, \"numFailures\" : $numFailures, \"runTime\" : $runTime, $commonData}"
+      echo -e "\nsummary payload: $payload"
+      curl -k "https://http-inputs-inst.splunkcloud.com:443/services/collector" -H "Authorization: Splunk $SPLUNK_MOBILE_TOKEN" -d "{\"sourcetype\" : \"mobile-android-qa-summary\", \"event\" : $payload}"
+    fi
+
+    # For <testcase> lines, create a "test passed" payload.  We won't include it in our "successReport" until we've
+    # verified that the test didn't fail.
+    # Sample line: <testcase name="displaysLoadingState" classname="com.instructure.student.ui.renderTests.SubmissionDetailsRenderTest" time="4.346">
+    if [[ $line =~ "testcase name" ]]
+    then
+      testName=`echo $line | cut -d " " -f 2 | cut -d = -f 2`
+      className=`echo $line | cut -d " " -f 3 | cut -d = -f 2`
+      runTime=`echo $line | cut -d " " -f 4 | cut -d = -f 2`
+      payload="{\"sourcetype\" : \"mobile-android-qa-testresult\", \"event\" : {\"buildUrl\" : \"$BITRISE_BUILD_URL\", \"status\" : \"passed\", \"testName\": $testName, \"testClass\" : $className, \"deviceConfig\" : $suiteName, \"runTime\" : $runTime, $commonData}"
+      failureEncountered=false
+    fi
+
+    # For failures, record the failure so that we don't emit a "passed" event for this test.
+    if [[ $line =~ '<failure>' ]]
+    then
+       failureEncountered=true
+    fi
+
+    # If we get to the end of a testcase and no failure has been recorded, then include the test info 
+    # in our "successReport".
+    if [[ $line =~ "</testcase>" ]]
+    then
+        if [[ $failureEncountered = false ]]
+        then
+            successReport="$successReport $payload"
+        fi
+    fi
+done < "$reportFile"
+
+# After all tests have been processed, Emit the success report
+#echo -e "\nSuccess payload: $successReport\n"
+curl -k "https://http-inputs-inst.splunkcloud.com:443/services/collector" -H "Authorization: Splunk $SPLUNK_MOBILE_TOKEN" -d "$successReport"
+
+# Globals for parsing time/cost info
+cost=0
+hours=0
+minutes=0
+
+# Process the cost report (CostReport.txt)
+# Sample:
+#   CostReport
+#     Virtual devices
+#       $1.15 for 1h 9m
+
+
+while IFS= read -r line
+do
+    # We're only interested in the line with the cost / time info in it
+    if [[ $line =~ '$' ]]
+    then
+      #echo "cost report line:$line"
+      #if [[ $line =~ '.*[0-9]h.*' ]] ## Argghh -- why wouldn't this work?
+      if [[ $line =~ 'h' ]]
+      then
+         #The line has an 'hours' component.  Parse accordingly.
+         #echo "Doing H+M path"
+         regex='\$([0-9]\.[0-9]+) for ([0-9])h ([0-9]+)m'
+         [[ $line =~ $regex ]]
+         cost=${BASH_REMATCH[1]}
+         hours=${BASH_REMATCH[2]}
+         minutes=${BASH_REMATCH[3]}
+      else
+         #The line has no 'hours' component.  Parse accordingly.
+         #echo "doing M path"
+         regex='\$([0-9]\.[0-9]+) for ([0-9]+)m'
+         [[ $line =~ $regex ]]
+         cost=${BASH_REMATCH[1]}
+         minutes=${BASH_REMATCH[2]}
+     fi # done with conditional parsing logic
+
+     totalMinutes=$((hours * 60 + minutes))
+     #echo "totalMinutes: $totalMinutes"
+     payload="{\"minutes\" : $totalMinutes, \"cost\" : $cost, $commonData}"
+     echo -e "\ncost payload: $payload"
+     #curl -X POST -H "Content-Type: application/json" -d "$payload" $SUMOLOGIC_ENDPOINT
+     curl -k "https://http-inputs-inst.splunkcloud.com:443/services/collector" -H "Authorization: Splunk $SPLUNK_MOBILE_TOKEN" -d "{\"sourcetype\" : \"mobile-android-qa-cost\", \"event\" : $payload}"
+    fi
+done < "$costFile"

--- a/apps/student/flank.yml
+++ b/apps/student/flank.yml
@@ -15,7 +15,7 @@ gcloud:
   - notAnnotation com.instructure.canvas.espresso.E2E, com.instructure.canvas.espresso.Stub
   device:
   - model: NexusLowRes
-    version: 25
+    version: 28
     locale: en_US
     orientation: portrait
 

--- a/apps/student/flank.yml
+++ b/apps/student/flank.yml
@@ -15,7 +15,7 @@ gcloud:
   - notAnnotation com.instructure.canvas.espresso.E2E, com.instructure.canvas.espresso.Stub
   device:
   - model: NexusLowRes
-    version: 28
+    version: 25
     locale: en_US
     orientation: portrait
 

--- a/automation/canvas_espresso/build.gradle
+++ b/automation/canvas_espresso/build.gradle
@@ -74,7 +74,7 @@ android {
 dependencies {
     implementation project(':canvas-api-2')
     implementation 'com.github.javafaker:javafaker:0.18'
-    api('com.github.instructure:espresso:1.0.3') {
+    api('com.github.instructure:espresso:1.0.4') {
         exclude module: 'kotlin-stdlib'
     }
     /* Mock web server */

--- a/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasTest.kt
+++ b/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasTest.kt
@@ -60,10 +60,13 @@ abstract class CanvasTest : InstructureTest(BuildConfig.GLOBAL_DITTO_MODE) {
         enableAndConfigureAccessibilityChecks()
         super.preLaunchSetup()
 
-        // Let's set ourselves up to log information about our retries.
-        ScreenshotTestRule.registerRetryHandler( handler = { error, testMethod, testClass ->
+        // Let's set ourselves up to log information about our retries and failures.
+        ScreenshotTestRule.registerFailureHandler( handler = { error, testMethod, testClass, disposition ->
 
-            Log.d("TEST RETRY", "testMethod: $testMethod, error=$error, stacktrace=${error.stackTrace.joinToString("\n")} cause=${error.cause}")
+            if(disposition == "retry") {
+                Log.d("TEST RETRY", "testMethod: $testMethod, error=$error, stacktrace=${error.stackTrace.joinToString("\n")} cause=${error.cause}")
+            }
+
             // Grab the Splunk-mobile token from Bitrise
             val splunkToken = InstrumentationRegistry.getArguments().getString("SPLUNK_MOBILE_TOKEN")
 
@@ -79,12 +82,16 @@ abstract class CanvasTest : InstructureTest(BuildConfig.GLOBAL_DITTO_MODE) {
                 eventObject.put("workflow", bitriseWorkflow)
                 eventObject.put("branch", bitriseBranch)
                 eventObject.put("bitriseApp", bitriseApp)
-                eventObject.put("status", "retry")
+                eventObject.put("status", disposition)
                 eventObject.put("testName", testMethod)
                 eventObject.put("testClass", testClass)
                 eventObject.put("stackTrace", error.stackTrace.take(15).joinToString(", "))
-                eventObject.put("message", error.toString())
                 eventObject.put("osVersion", Build.VERSION.SDK_INT.toString())
+                eventObject.put("orientation", if(inLandscape()) "landscape" else "portrait")
+                // Limit our error message to 4096 chars; they can be unreasonably long (e.g., 137K!) when
+                // they contain a view hierarchy, and there is typically not much useful info after the
+                // first few lines.
+                eventObject.put("message", error.toString().take(4096))
 
                 val payloadObject = JSONObject()
                 payloadObject.put("sourcetype", "mobile-android-qa-testresult")

--- a/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasTest.kt
+++ b/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasTest.kt
@@ -87,7 +87,6 @@ abstract class CanvasTest : InstructureTest(BuildConfig.GLOBAL_DITTO_MODE) {
                 eventObject.put("testClass", testClass)
                 eventObject.put("stackTrace", error.stackTrace.take(15).joinToString(", "))
                 eventObject.put("osVersion", Build.VERSION.SDK_INT.toString())
-                eventObject.put("orientation", if(inLandscape()) "landscape" else "portrait")
                 // Limit our error message to 4096 chars; they can be unreasonably long (e.g., 137K!) when
                 // they contain a view hierarchy, and there is typically not much useful info after the
                 // first few lines.


### PR DESCRIPTION
Changes:
--Test failure reporting is now routed through the same callback as test retry reporting.  This will allow us to see failure message + stack trace for failures, just like we do for retries.
--I capped the failure message at 4096 bytes.
--We are now reporting info on passing tests.  This will allow us to analyze which tests are taking the most time to run.
--I converted a reporting script that only existed in a Bitrise step to a script file that lives in our repo.