### PR TITLE
[Flutter-Parent] Remove course code dependency for assignment details

### DIFF
--- a/apps/flutter_parent/lib/screens/assignments/assignment_details_interactor.dart
+++ b/apps/flutter_parent/lib/screens/assignments/assignment_details_interactor.dart
@@ -13,6 +13,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import 'package:flutter_parent/models/alarm.dart';
 import 'package:flutter_parent/models/assignment.dart';
+import 'package:flutter_parent/models/course.dart';
 import 'package:flutter_parent/network/api/assignment_api.dart';
 import 'package:flutter_parent/network/api/course_api.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
@@ -30,7 +31,7 @@ class AssignmentDetailsInteractor {
 
     return AssignmentDetails(
       assignment: (await assignment),
-      courseName: (await course).name,
+      course: (await course),
       alarm: alarm,
     );
   }
@@ -38,8 +39,8 @@ class AssignmentDetailsInteractor {
 
 class AssignmentDetails {
   final Alarm alarm;
-  final String courseName;
+  final Course course;
   final Assignment assignment;
 
-  AssignmentDetails({this.alarm, this.courseName, this.assignment});
+  AssignmentDetails({this.alarm, this.course, this.assignment});
 }

--- a/apps/flutter_parent/lib/screens/assignments/assignment_details_screen.dart
+++ b/apps/flutter_parent/lib/screens/assignments/assignment_details_screen.dart
@@ -17,7 +17,6 @@ import 'package:flutter_parent/models/assignment.dart';
 import 'package:flutter_parent/models/course.dart';
 import 'package:flutter_parent/screens/assignments/assignment_details_interactor.dart';
 import 'package:flutter_parent/screens/assignments/grade_cell.dart';
-import 'package:flutter_parent/utils/web_view_utils.dart';
 import 'package:flutter_parent/screens/inbox/create_conversation/create_conversation_screen.dart';
 import 'package:flutter_parent/utils/common_widgets/error_panda_widget.dart';
 import 'package:flutter_parent/utils/common_widgets/loading_indicator.dart';
@@ -25,13 +24,13 @@ import 'package:flutter_parent/utils/design/canvas_icons_solid.dart';
 import 'package:flutter_parent/utils/design/parent_theme.dart';
 import 'package:flutter_parent/utils/quick_nav.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
+import 'package:flutter_parent/utils/web_view_utils.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:intl/intl.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 class AssignmentDetailsScreen extends StatefulWidget {
   final String courseId;
-  final String courseCode;
   final String studentId;
   final String studentName;
   final String assignmentId;
@@ -39,12 +38,10 @@ class AssignmentDetailsScreen extends StatefulWidget {
   const AssignmentDetailsScreen(
       {Key key,
       @required this.courseId,
-      @required this.courseCode,
       @required this.assignmentId,
       @required this.studentId,
       @required this.studentName})
       : assert(courseId != null),
-        assert(courseCode != null),
         assert(assignmentId != null),
         assert(studentId != null),
         assert(studentName != null),
@@ -103,14 +100,14 @@ class _AssignmentDetailsScreenState extends State<AssignmentDetailsScreen> {
           children: [
             Text(L10n(context).assignmentDetailsTitle),
             if (snapshot.hasData)
-              Text(snapshot.data.courseName ?? '', style: Theme.of(context).primaryTextTheme.caption),
+              Text(snapshot.data.course?.name ?? '', style: Theme.of(context).primaryTextTheme.caption),
           ],
         ),
       );
 
   Widget _fab(AsyncSnapshot<AssignmentDetails> snapshot) {
     return FloatingActionButton(
-      onPressed: () => _sendMessage(snapshot.data.assignment),
+      onPressed: () => _sendMessage(snapshot.data),
       tooltip: L10n(context).assignmentMessageHint,
       child: Padding(padding: const EdgeInsets.only(left: 4, top: 4), child: Icon(CanvasIconsSolid.comment)),
     );
@@ -280,12 +277,12 @@ class _AssignmentDetailsScreenState extends State<AssignmentDetailsScreen> {
     // TODO: Show alarm dialog if checked, then call _loadAssignment() to get the new alarm data
   }
 
-  _sendMessage(Assignment assignment) {
+  _sendMessage(AssignmentDetails details) {
     Course course = Course((b) => b
       ..id = widget.courseId
-      ..courseCode = widget.courseCode);
-    String subject = L10n(context).assignmentSubjectMessage(widget.studentName, assignment.name);
-    Widget screen = CreateConversationScreen.fromAssignment(course, subject, assignment.htmlUrl);
+      ..courseCode = details.course?.courseCode ?? '');
+    String subject = L10n(context).assignmentSubjectMessage(widget.studentName, details.assignment.name);
+    Widget screen = CreateConversationScreen.fromAssignment(course, subject, details.assignment.htmlUrl);
     locator.get<QuickNav>().push(context, screen);
   }
 }

--- a/apps/flutter_parent/lib/screens/courses/details/course_grades_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_grades_screen.dart
@@ -252,9 +252,9 @@ class _AssignmentRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final studentId = Provider.of<CourseDetailsModel>(context, listen: false).studentId;
-    final studentName = Provider.of<CourseDetailsModel>(context, listen: false).studentName;
-    final courseCode = Provider.of<CourseDetailsModel>(context, listen: false).course.courseCode;
+    final model = Provider.of<CourseDetailsModel>(context, listen: false);
+    final studentId = model.studentId;
+    final studentName = model.studentName;
 
     final textTheme = Theme.of(context).textTheme;
     final assignmentStatus = _assignmentStatus(context, assignment, studentId);
@@ -264,7 +264,6 @@ class _AssignmentRow extends StatelessWidget {
         context,
         AssignmentDetailsScreen(
           courseId: assignment.courseId,
-          courseCode: courseCode,
           assignmentId: assignment.id,
           studentId: studentId,
           studentName: studentName,

--- a/apps/flutter_parent/lib/screens/courses/details/course_summary_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_summary_screen.dart
@@ -123,7 +123,6 @@ class __CourseSummaryState extends State<_CourseSummary> with AutomaticKeepAlive
               assignmentId: item.assignment.id,
               studentId: widget.model.studentId,
               studentName: widget.model.studentName,
-              courseCode: widget.model.course.courseCode,
             ),
           );
         }

--- a/apps/flutter_parent/test/screens/assignments/assignment_details_interactor_test.dart
+++ b/apps/flutter_parent/test/screens/assignments/assignment_details_interactor_test.dart
@@ -42,12 +42,12 @@ void main() {
 
   group('loadAssignmentDetails', () {
     test('returns the course name', () async {
-      final courseName = 'course name';
-      when(courseApi.getCourse(courseId)).thenAnswer((_) async => Course((b) => b..name = courseName));
+      final course = Course((b) => b..name = 'course name');
+      when(courseApi.getCourse(courseId)).thenAnswer((_) async => course);
       final details =
           await AssignmentDetailsInteractor().loadAssignmentDetails(false, courseId, assignmentId, studentId);
 
-      expect(details.courseName, courseName);
+      expect(details.course, course);
     });
 
     test('returns a null alarm if none exist for the assignment', () async {

--- a/apps/flutter_parent/test/screens/assignments/assignment_details_screen_test.dart
+++ b/apps/flutter_parent/test/screens/assignments/assignment_details_screen_test.dart
@@ -16,6 +16,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_parent/l10n/app_localizations.dart';
 import 'package:flutter_parent/models/alarm.dart';
 import 'package:flutter_parent/models/assignment.dart';
+import 'package:flutter_parent/models/course.dart';
 import 'package:flutter_parent/models/lock_info.dart';
 import 'package:flutter_parent/models/locked_module.dart';
 import 'package:flutter_parent/models/submission.dart';
@@ -69,7 +70,6 @@ void main() {
     await tester.pumpWidget(TestApp(
       AssignmentDetailsScreen(
         courseId: courseId,
-        courseCode: '',
         assignmentId: assignmentId,
         studentId: studentId,
         studentName: '',
@@ -86,14 +86,13 @@ void main() {
     final courseName = 'name';
     when(interactor.loadAssignmentDetails(any, courseId, assignmentId, studentId))
         .thenAnswer((_) async => AssignmentDetails(
-              courseName: courseName,
+              course: Course((b) => b..name = courseName),
               assignment: assignment,
             ));
 
     await tester.pumpWidget(TestApp(
       AssignmentDetailsScreen(
         courseId: courseId,
-        courseCode: '',
         assignmentId: assignmentId,
         studentId: studentId,
         studentName: '',
@@ -113,7 +112,6 @@ void main() {
     await tester.pumpWidget(TestApp(
       AssignmentDetailsScreen(
         courseId: courseId,
-        courseCode: '',
         assignmentId: assignmentId,
         studentId: studentId,
         studentName: '',
@@ -144,7 +142,6 @@ void main() {
     await tester.pumpWidget(TestApp(
       AssignmentDetailsScreen(
         courseId: courseId,
-        courseCode: '',
         assignmentId: assignmentId,
         studentId: studentId,
         studentName: studentName,
@@ -171,7 +168,6 @@ void main() {
     await tester.pumpWidget(TestApp(
       AssignmentDetailsScreen(
         courseId: courseId,
-        courseCode: '',
         assignmentId: assignmentId,
         studentId: studentId,
         studentName: '',
@@ -207,7 +203,6 @@ void main() {
     await tester.pumpWidget(TestApp(
       AssignmentDetailsScreen(
         courseId: courseId,
-        courseCode: '',
         assignmentId: assignmentId,
         studentId: studentId,
         studentName: '',
@@ -252,7 +247,6 @@ void main() {
     await tester.pumpWidget(TestApp(
       AssignmentDetailsScreen(
         courseId: courseId,
-        courseCode: '',
         assignmentId: assignmentId,
         studentId: studentId,
         studentName: '',
@@ -278,7 +272,6 @@ void main() {
     await tester.pumpWidget(TestApp(
       AssignmentDetailsScreen(
         courseId: courseId,
-        courseCode: '',
         assignmentId: assignmentId,
         studentId: studentId,
         studentName: '',
@@ -299,7 +292,6 @@ void main() {
     await tester.pumpWidget(TestApp(
       AssignmentDetailsScreen(
         courseId: courseId,
-        courseCode: '',
         assignmentId: assignmentId,
         studentId: studentId,
         studentName: '',
@@ -327,7 +319,6 @@ void main() {
     await tester.pumpWidget(TestApp(
       AssignmentDetailsScreen(
         courseId: courseId,
-        courseCode: '',
         assignmentId: assignmentId,
         studentId: studentId,
         studentName: '',
@@ -353,7 +344,6 @@ void main() {
     await tester.pumpWidget(TestApp(
       AssignmentDetailsScreen(
         courseId: courseId,
-        courseCode: '',
         assignmentId: assignmentId,
         studentId: studentId,
         studentName: '',
@@ -378,7 +368,6 @@ void main() {
     await tester.pumpWidget(TestApp(
       AssignmentDetailsScreen(
         courseId: courseId,
-        courseCode: '',
         assignmentId: assignmentId,
         studentId: studentId,
         studentName: '',
@@ -401,7 +390,6 @@ void main() {
     await tester.pumpWidget(TestApp(
       AssignmentDetailsScreen(
         courseId: courseId,
-        courseCode: '',
         assignmentId: assignmentId,
         studentId: studentId,
         studentName: '',
@@ -422,7 +410,6 @@ void main() {
     await tester.pumpWidget(TestApp(
       AssignmentDetailsScreen(
         courseId: courseId,
-        courseCode: '',
         assignmentId: assignmentId,
         studentId: studentId,
         studentName: '',


### PR DESCRIPTION
Using the course fetch that it already had instead, so that screens routing to assignment details don’t have to have a course code.