### PR TITLE
[Flutter-Parent] Fix incorrect lockAt usage in assignment details

### DIFF
--- a/apps/flutter_parent/lib/l10n/app_localizations.dart
+++ b/apps/flutter_parent/lib/l10n/app_localizations.dart
@@ -553,13 +553,6 @@ class AppLocalizations {
         desc: 'The locked description when an assignment is locked by a module',
       );
 
-  String assignmentLockedDate(String date) => Intl.message(
-        'This assignment is locked until $date.',
-        name: 'assignmentLockedDate',
-        args: [date],
-        desc: 'The locked description when an assignment is locked until a future date',
-      );
-
   String get assignmentRemindMeLabel => Intl.message('Remind Me', desc: 'Label for the row to set reminders');
 
   String get assignmentRemindMeSwitch =>

--- a/apps/flutter_parent/lib/models/locked_module.dart
+++ b/apps/flutter_parent/lib/models/locked_module.dart
@@ -40,7 +40,7 @@ abstract class LockedModule implements Built<LockedModule, LockedModuleBuilder> 
 
   @nullable
   @BuiltValueField(wireName: 'unlock_at')
-  String get unlockAt;
+  DateTime get unlockAt;
 
   @BuiltValueField(wireName: 'require_sequential_progress')
   bool get isRequireSequentialProgress;

--- a/apps/flutter_parent/lib/models/locked_module.g.dart
+++ b/apps/flutter_parent/lib/models/locked_module.g.dart
@@ -47,7 +47,7 @@ class _$LockedModuleSerializer implements StructuredSerializer<LockedModule> {
       result.add(null);
     } else {
       result.add(serializers.serialize(object.unlockAt,
-          specifiedType: const FullType(String)));
+          specifiedType: const FullType(DateTime)));
     }
     return result;
   }
@@ -82,7 +82,7 @@ class _$LockedModuleSerializer implements StructuredSerializer<LockedModule> {
           break;
         case 'unlock_at':
           result.unlockAt = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(DateTime)) as DateTime;
           break;
         case 'require_sequential_progress':
           result.isRequireSequentialProgress = serializers.deserialize(value,
@@ -105,7 +105,7 @@ class _$LockedModule extends LockedModule {
   @override
   final String name;
   @override
-  final String unlockAt;
+  final DateTime unlockAt;
   @override
   final bool isRequireSequentialProgress;
 
@@ -196,9 +196,9 @@ class LockedModuleBuilder
   String get name => _$this._name;
   set name(String name) => _$this._name = name;
 
-  String _unlockAt;
-  String get unlockAt => _$this._unlockAt;
-  set unlockAt(String unlockAt) => _$this._unlockAt = unlockAt;
+  DateTime _unlockAt;
+  DateTime get unlockAt => _$this._unlockAt;
+  set unlockAt(DateTime unlockAt) => _$this._unlockAt = unlockAt;
 
   bool _isRequireSequentialProgress;
   bool get isRequireSequentialProgress => _$this._isRequireSequentialProgress;

--- a/apps/flutter_parent/lib/screens/assignments/assignment_details_screen.dart
+++ b/apps/flutter_parent/lib/screens/assignments/assignment_details_screen.dart
@@ -17,7 +17,6 @@ import 'package:flutter_parent/models/assignment.dart';
 import 'package:flutter_parent/models/course.dart';
 import 'package:flutter_parent/screens/assignments/assignment_details_interactor.dart';
 import 'package:flutter_parent/screens/assignments/grade_cell.dart';
-import 'package:flutter_parent/utils/web_view_utils.dart';
 import 'package:flutter_parent/screens/inbox/create_conversation/create_conversation_screen.dart';
 import 'package:flutter_parent/utils/common_widgets/error_panda_widget.dart';
 import 'package:flutter_parent/utils/common_widgets/loading_indicator.dart';
@@ -25,6 +24,7 @@ import 'package:flutter_parent/utils/design/canvas_icons_solid.dart';
 import 'package:flutter_parent/utils/design/parent_theme.dart';
 import 'package:flutter_parent/utils/quick_nav.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
+import 'package:flutter_parent/utils/web_view_utils.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:intl/intl.dart';
 import 'package:webview_flutter/webview_flutter.dart';
@@ -253,9 +253,8 @@ class _AssignmentDetailsScreenState extends State<AssignmentDetailsScreen> {
     String message = null;
     if (assignment.lockInfo.hasModuleName) {
       message = L10n(context).assignmentLockedModule(assignment.lockInfo.contextModule.name);
-    } else if (assignment.unlockAt != null) {
-      message = L10n(context).assignmentLockedDate(_dateFormat(assignment.unlockAt));
-    } else {
+    } else if (assignment.isFullyLocked ||
+        (assignment.lockExplanation?.isNotEmpty == true && assignment.lockAt?.isBefore(DateTime.now()) == true)) {
       message = assignment.lockExplanation;
     }
 


### PR DESCRIPTION
No need to manually build the ‘unlock_at’ message, it is included in the lock explanation of the assignment (which the fullyLocked check makes sure the unlock_at is after the current date).