### PR TITLE
[Flutter-Parent][MBL-13619] Event details screen

### DIFF
--- a/apps/flutter_parent/assets/html/html_wrapper.html
+++ b/apps/flutter_parent/assets/html/html_wrapper.html
@@ -59,6 +59,10 @@
             word-wrap: break-word;       /* Internet Explorer 5.5+ */
         }
 
+        #content {
+            padding: 0px {PADDING}px {PADDING}px;
+        }
+
         a {
             word-wrap: break-word;
         }

--- a/apps/flutter_parent/lib/l10n/app_localizations.dart
+++ b/apps/flutter_parent/lib/l10n/app_localizations.dart
@@ -847,11 +847,11 @@ class AppLocalizations {
 
   /// Event details
 
-  String get eventDetailsDefaultTitle =>
-      Intl.message('Event', desc: 'Title for the event details screen if an event does not have a title');
+  String get eventDetailsTitle => Intl.message('Event', desc: 'Title for the event details screen');
 
-  String get eventAllDayLabel =>
-      Intl.message('All Day Event', desc: 'Label for the events that are scheduled for the entire day');
+  String get eventDateLabel => Intl.message('Date', desc: 'Label for the event date');
+
+  String get eventLocationLabel => Intl.message('Location', desc: 'Label for the location information');
 
   String get eventNoLocation =>
       Intl.message('No Location Specified', desc: 'Description for events that do not have a location');

--- a/apps/flutter_parent/lib/l10n/app_localizations.dart
+++ b/apps/flutter_parent/lib/l10n/app_localizations.dart
@@ -845,6 +845,24 @@ class AppLocalizations {
   String get addNewStudent =>
       Intl.message('Add new student', desc: 'Semantics label for the FAB on the Manage Students Screen');
 
+  /// Event details
+
+  String get eventDetailsDefaultTitle =>
+      Intl.message('Event', desc: 'Title for the event details screen if an event does not have a title');
+
+  String get eventAllDayLabel =>
+      Intl.message('All Day Event', desc: 'Label for the events that are scheduled for the entire day');
+
+  String get eventNoLocation =>
+      Intl.message('No Location Specified', desc: 'Description for events that do not have a location');
+
+  String eventTime(String startAt, String endAt) => Intl.message(
+        '$startAt - $endAt',
+        name: 'eventTime',
+        args: [startAt, endAt],
+        desc: 'The time the event is happening, example: "2:00 pm - 4:00 pm"',
+      );
+
   /// Error Report Dialog
 
   String get device => Intl.message('Device', desc: 'Label used for device manufacturer/model in the error report');

--- a/apps/flutter_parent/lib/models/schedule_item.dart
+++ b/apps/flutter_parent/lib/models/schedule_item.dart
@@ -58,7 +58,7 @@ abstract class ScheduleItem implements Built<ScheduleItem, ScheduleItemBuilder> 
   @nullable
   String get locationAddress;
 
-  String get type; // Either 'event' or 'calendar'
+  String get type; // Either 'event' or 'assignment'
 
   @BuiltValueField(wireName: 'location_name')
   @nullable

--- a/apps/flutter_parent/lib/network/api/calendar_events_api.dart
+++ b/apps/flutter_parent/lib/network/api/calendar_events_api.dart
@@ -35,4 +35,7 @@ class CalendarEventsApi {
     };
     return fetchList(dio.get('calendar_events', queryParameters: params), depaginateWith: dio);
   }
+
+  Future<ScheduleItem> getEvent(String eventId, bool forceRefresh) =>
+      fetch(canvasDio(forceRefresh: forceRefresh).get('calendar_events/$eventId'));
 }

--- a/apps/flutter_parent/lib/screens/assignments/assignment_details_screen.dart
+++ b/apps/flutter_parent/lib/screens/assignments/assignment_details_screen.dart
@@ -17,8 +17,8 @@ import 'package:flutter_parent/models/assignment.dart';
 import 'package:flutter_parent/models/course.dart';
 import 'package:flutter_parent/screens/assignments/assignment_details_interactor.dart';
 import 'package:flutter_parent/screens/assignments/grade_cell.dart';
-import 'package:flutter_parent/utils/web_view_utils.dart';
 import 'package:flutter_parent/screens/inbox/create_conversation/create_conversation_screen.dart';
+import 'package:flutter_parent/utils/common_widgets/constrained_web_view.dart';
 import 'package:flutter_parent/utils/common_widgets/error_panda_widget.dart';
 import 'package:flutter_parent/utils/common_widgets/loading_indicator.dart';
 import 'package:flutter_parent/utils/design/canvas_icons_solid.dart';
@@ -27,7 +27,6 @@ import 'package:flutter_parent/utils/quick_nav.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:intl/intl.dart';
-import 'package:webview_flutter/webview_flutter.dart';
 
 class AssignmentDetailsScreen extends StatefulWidget {
   final String courseId;
@@ -225,7 +224,10 @@ class _AssignmentDetailsScreenState extends State<AssignmentDetailsScreen> {
               title: assignment.submissionTypes?.contains(SubmissionTypes.onlineQuiz) == true
                   ? l10n.assignmentInstructionsLabel
                   : l10n.assignmentDescriptionLabel,
-              child: _AssignmentDescription(assignment: assignment),
+              child: ConstrainedWebView(
+                content: assignment.description,
+                emptyDescription: l10n.assignmentNoDescriptionBody,
+              ),
             ),
           // TODO: Add in 'Learn more' feature
 //        Divider(),
@@ -287,53 +289,5 @@ class _AssignmentDetailsScreenState extends State<AssignmentDetailsScreen> {
     String subject = L10n(context).assignmentSubjectMessage(widget.studentName, assignment.name);
     Widget screen = CreateConversationScreen.fromAssignment(course, subject, assignment.htmlUrl);
     locator.get<QuickNav>().push(context, screen);
-  }
-}
-
-class _AssignmentDescription extends StatefulWidget {
-  final Assignment assignment;
-
-  const _AssignmentDescription({Key key, this.assignment}) : super(key: key);
-
-  @override
-  __AssignmentDescriptionState createState() => __AssignmentDescriptionState();
-}
-
-class __AssignmentDescriptionState extends State<_AssignmentDescription> {
-  double _height = 10;
-  WebViewController _controller;
-
-  @override
-  void dispose() {
-    _controller = null;
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = L10n(context);
-    final textTheme = Theme.of(context).textTheme;
-    final assignment = widget.assignment;
-
-    if (assignment.description == null || assignment.description.isEmpty)
-      return Text(l10n.assignmentNoDescriptionBody, style: textTheme.body1);
-
-    return ConstrainedBox(
-      constraints: BoxConstraints(maxHeight: _height),
-      child: WebView(
-        javascriptMode: JavascriptMode.unrestricted,
-        onPageFinished: (url) async {
-          if (!url.startsWith('data:text/html')) return; // An attempt to make links not resize the webview and crash
-          final height =
-              double.parse(await _controller?.evaluateJavascript('document.documentElement.scrollHeight;') ?? '0');
-
-          setState(() => _height = height);
-        },
-        onWebViewCreated: (WebViewController webViewController) async {
-          webViewController.loadHtml(assignment.description);
-          _controller = webViewController;
-        },
-      ),
-    );
   }
 }

--- a/apps/flutter_parent/lib/screens/courses/details/course_summary_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_summary_screen.dart
@@ -17,6 +17,7 @@ import 'package:flutter_parent/l10n/app_localizations.dart';
 import 'package:flutter_parent/models/schedule_item.dart';
 import 'package:flutter_parent/screens/assignments/assignment_details_screen.dart';
 import 'package:flutter_parent/screens/courses/details/course_details_model.dart';
+import 'package:flutter_parent/screens/events/event_details_screen.dart';
 import 'package:flutter_parent/utils/common_widgets/empty_panda_widget.dart';
 import 'package:flutter_parent/utils/common_widgets/error_panda_widget.dart';
 import 'package:flutter_parent/utils/common_widgets/loading_indicator.dart';
@@ -114,7 +115,7 @@ class __CourseSummaryState extends State<_CourseSummary> with AutomaticKeepAlive
       leading: Icon(_getIcon(item), color: Theme.of(context).accentColor),
       onTap: () {
         if (item.type == ScheduleItem.typeCalendar) {
-          // TODO: MBL-13619 Event Details
+          locator<QuickNav>().push(context, EventDetailsScreen.withEvent(event: item));
         } else {
           locator<QuickNav>().push(
             context,

--- a/apps/flutter_parent/lib/screens/courses/details/course_syllabus_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_syllabus_screen.dart
@@ -15,9 +15,9 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_parent/screens/courses/details/course_details_model.dart';
+import 'package:flutter_parent/utils/web_view_utils.dart';
 import 'package:provider/provider.dart';
 import 'package:webview_flutter/webview_flutter.dart';
-import 'package:flutter_parent/utils/web_view_utils.dart';
 
 class CourseSyllabusScreen extends StatelessWidget {
   final String syllabus;
@@ -31,7 +31,7 @@ class CourseSyllabusScreen extends StatelessWidget {
         javascriptMode: JavascriptMode.unrestricted,
         gestureRecognizers: Set()..add(Factory<WebViewGestureRecognizer>(() => WebViewGestureRecognizer())),
         onWebViewCreated: (controller) {
-          controller.loadHtml(syllabus);
+          controller.loadHtml(syllabus, horizontalPadding: 10);
         },
       ),
     );

--- a/apps/flutter_parent/lib/screens/events/event_details_interactor.dart
+++ b/apps/flutter_parent/lib/screens/events/event_details_interactor.dart
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import 'package:flutter_parent/models/schedule_item.dart';
+import 'package:flutter_parent/network/api/calendar_events_api.dart';
+import 'package:flutter_parent/utils/service_locator.dart';
+
+class EventDetailsInteractor {
+  Future<ScheduleItem> loadEvent(String eventId, bool forceRefresh) {
+    return locator<CalendarEventsApi>().getEvent(eventId, forceRefresh);
+  }
+}

--- a/apps/flutter_parent/lib/screens/events/event_details_screen.dart
+++ b/apps/flutter_parent/lib/screens/events/event_details_screen.dart
@@ -1,0 +1,193 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import 'package:flutter/material.dart';
+import 'package:flutter_parent/l10n/app_localizations.dart';
+import 'package:flutter_parent/models/schedule_item.dart';
+import 'package:flutter_parent/screens/events/event_details_interactor.dart';
+import 'package:flutter_parent/utils/common_widgets/constrained_web_view.dart';
+import 'package:flutter_parent/utils/common_widgets/error_panda_widget.dart';
+import 'package:flutter_parent/utils/common_widgets/loading_indicator.dart';
+import 'package:flutter_parent/utils/service_locator.dart';
+import 'package:intl/intl.dart';
+
+class EventDetailsScreen extends StatefulWidget {
+  final ScheduleItem event;
+  final String eventId;
+
+  EventDetailsScreen.withEvent({Key key, this.event})
+      : assert(event != null),
+        eventId = event.id,
+        super(key: key);
+
+  EventDetailsScreen.withId({Key key, this.eventId})
+      : assert(eventId != null),
+        event = null,
+        super(key: key);
+
+  @override
+  _EventDetailsScreenState createState() => _EventDetailsScreenState();
+}
+
+class _EventDetailsScreenState extends State<EventDetailsScreen> {
+  GlobalKey<RefreshIndicatorState> _refreshKey = GlobalKey<RefreshIndicatorState>();
+
+  Future<ScheduleItem> _eventFuture;
+
+  Future<ScheduleItem> _loadEvent({bool forceRefresh = false}) => _interactor.loadEvent(widget.eventId, forceRefresh);
+
+  EventDetailsInteractor get _interactor => locator<EventDetailsInteractor>();
+
+  @override
+  void initState() {
+    if (widget.event != null) {
+      _eventFuture = Future.value(widget.event);
+    } else {
+      _eventFuture = _loadEvent();
+    }
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return RefreshIndicator(
+      key: _refreshKey,
+      onRefresh: () {
+        setState(() {
+          _eventFuture = _loadEvent(forceRefresh: true);
+        });
+        return _eventFuture.catchError((_) {});
+      },
+      child: FutureBuilder(
+        future: _eventFuture,
+        builder: (context, AsyncSnapshot<ScheduleItem> snapshot) {
+          if (snapshot.hasError) {
+            return ErrorPandaWidget(
+              L10n(context).unexpectedError,
+              () => _refreshKey.currentState.show(),
+            );
+          } else if (!snapshot.hasData) {
+            return LoadingIndicator();
+          } else {
+            return _EventDetails(snapshot.data);
+          }
+        },
+      ),
+    );
+  }
+}
+
+class _EventDetails extends StatelessWidget {
+  final ScheduleItem event;
+
+  const _EventDetails(this.event, {Key key})
+      : assert(event != null),
+        super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = L10n(context);
+
+    // Get the date strings
+    String dateLine1, dateLine2;
+    final date = event.startAt ?? event.endAt;
+    if (event.isAllDay) {
+      dateLine1 = l10n.eventAllDayLabel;
+      dateLine2 = _dateFormat(date);
+    } else if (event.startAt != null && event.endAt != null && event.startAt != event.endAt) {
+      dateLine1 = _dateFormat(date);
+      dateLine2 = l10n.eventTime(_timeFormat(event.startAt), _timeFormat(event.endAt));
+    } else {
+      dateLine1 = _dateFormat(date);
+      dateLine2 = _timeFormat(date);
+    }
+
+    // Get the location strings
+    String locationLine1, locationLine2;
+    if ((event.locationAddress == null || event.locationAddress.isEmpty) &&
+        (event.locationName == null || event.locationName.isEmpty)) {
+      locationLine1 = l10n.eventNoLocation;
+    } else if (event.locationName == null || event.locationName.isEmpty) {
+      locationLine1 = event.locationAddress;
+    } else {
+      locationLine1 = event.locationName;
+      locationLine2 = event.locationAddress;
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: Text(event.title ?? l10n.eventDetailsDefaultTitle)),
+      body: ListView(
+        children: [
+          SizedBox(height: 20),
+          _SimpleTile(
+            leading: Icon(Icons.timer),
+            line1: dateLine1,
+            line2: dateLine2,
+          ),
+          SizedBox(height: 20),
+          _SimpleTile(
+            leading: Icon(Icons.location_on),
+            line1: locationLine1,
+            line2: locationLine2,
+          ),
+          SizedBox(height: 16),
+          ConstrainedWebView(content: event.description, horizontalPadding: 10),
+        ],
+      ),
+    );
+  }
+
+  String _dateFormat(DateTime time) {
+    return time == null ? null : DateFormat.EEEE().add_yMMMd().format(time.toLocal());
+  }
+
+  String _timeFormat(DateTime time) {
+    return time == null ? null : DateFormat.jm().format(time.toLocal());
+  }
+}
+
+class _SimpleTile extends StatelessWidget {
+  final Widget leading;
+  final String line1;
+  final String line2;
+
+  const _SimpleTile({Key key, this.leading, this.line1, this.line2}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final style = Theme.of(context).textTheme.subhead;
+
+    return Row(
+      // If wwe only have one line, center the content. Otherwise align start
+      crossAxisAlignment: (line1?.isNotEmpty == true && line2?.isNotEmpty == true)
+          ? CrossAxisAlignment.start
+          : CrossAxisAlignment.center,
+      children: [
+        SizedBox(width: 16),
+        leading,
+        SizedBox(width: 16),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (line1?.isNotEmpty == true) Text(line1, style: style),
+              if (line1?.isNotEmpty == true && line2?.isNotEmpty == true) SizedBox(height: 8),
+              if (line2?.isNotEmpty == true) Text(line2, style: style),
+            ],
+          ),
+        ),
+        SizedBox(width: 16),
+      ],
+    );
+  }
+}

--- a/apps/flutter_parent/lib/utils/common_widgets/constrained_web_view.dart
+++ b/apps/flutter_parent/lib/utils/common_widgets/constrained_web_view.dart
@@ -1,0 +1,84 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import 'package:flutter/material.dart';
+import 'package:flutter_parent/utils/web_view_utils.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+class ConstrainedWebView extends StatefulWidget {
+  final String content;
+  final String emptyDescription;
+  final double initialHeight;
+  final double horizontalPadding;
+
+  const ConstrainedWebView(
+      {Key key, @required this.content, this.emptyDescription, this.initialHeight = 10, this.horizontalPadding = 0})
+      : assert(initialHeight != null),
+        assert(horizontalPadding != null),
+        super(key: key);
+
+  @override
+  _ConstrainedWebViewState createState() => _ConstrainedWebViewState();
+}
+
+class _ConstrainedWebViewState extends State<ConstrainedWebView> {
+  double _height;
+  WebViewController _controller;
+
+  @override
+  void initState() {
+    _height = widget.initialHeight;
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _controller = null;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final content = widget.content;
+
+    if (content == null || content.isEmpty) {
+      if (widget.emptyDescription == null || widget.emptyDescription.isEmpty) {
+        return Container(); // No empty text, so just be empty
+      } else {
+        return Padding(
+          padding: EdgeInsets.symmetric(horizontal: widget.horizontalPadding),
+          child: Text(widget.emptyDescription, style: textTheme.body1),
+        );
+      }
+    }
+
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxHeight: _height),
+      child: WebView(
+        javascriptMode: JavascriptMode.unrestricted,
+        onPageFinished: (url) async {
+          if (!url.startsWith('data:text/html')) return; // An attempt to make links not resize the webview and crash
+          final height =
+              double.parse(await _controller?.evaluateJavascript('document.documentElement.scrollHeight;') ?? '0');
+
+          setState(() => _height = height);
+        },
+        onWebViewCreated: (WebViewController webViewController) async {
+          webViewController.loadHtml(content, horizontalPadding: widget.horizontalPadding);
+          _controller = webViewController;
+        },
+      ),
+    );
+  }
+}

--- a/apps/flutter_parent/lib/utils/common_widgets/constrained_web_view.dart
+++ b/apps/flutter_parent/lib/utils/common_widgets/constrained_web_view.dart
@@ -22,7 +22,7 @@ class ConstrainedWebView extends StatefulWidget {
   final double horizontalPadding;
 
   const ConstrainedWebView(
-      {Key key, @required this.content, this.emptyDescription, this.initialHeight = 10, this.horizontalPadding = 0})
+      {Key key, @required this.content, this.emptyDescription, this.initialHeight = 1, this.horizontalPadding = 0})
       : assert(initialHeight != null),
         assert(horizontalPadding != null),
         super(key: key);
@@ -63,6 +63,8 @@ class _ConstrainedWebViewState extends State<ConstrainedWebView> {
       }
     }
 
+    // Unfortunately, there is an issue where the web view will load a black screen first before it's initialized. This
+    // is a known problem and can be followed here: https://github.com/flutter/flutter/issues/27198
     return ConstrainedBox(
       constraints: BoxConstraints(maxHeight: _height),
       child: WebView(

--- a/apps/flutter_parent/lib/utils/service_locator.dart
+++ b/apps/flutter_parent/lib/utils/service_locator.dart
@@ -32,6 +32,7 @@ import 'package:flutter_parent/screens/dashboard/alert_notifier.dart';
 import 'package:flutter_parent/screens/dashboard/dashboard_interactor.dart';
 import 'package:flutter_parent/screens/dashboard/inbox_notifier.dart';
 import 'package:flutter_parent/screens/domain_search/domain_search_interactor.dart';
+import 'package:flutter_parent/screens/events/event_details_interactor.dart';
 import 'package:flutter_parent/screens/inbox/attachment_utils/attachment_picker_interactor.dart';
 import 'package:flutter_parent/screens/inbox/conversation_details/conversation_details_interactor.dart';
 import 'package:flutter_parent/screens/inbox/conversation_list/conversation_list_interactor.dart';
@@ -84,6 +85,7 @@ void setupLocator() {
   locator.registerFactory<DashboardInteractor>(() => DashboardInteractor());
   locator.registerFactory<DomainSearchInteractor>(() => DomainSearchInteractor());
   locator.registerFactory<ErrorReportInteractor>(() => ErrorReportInteractor());
+  locator.registerFactory<EventDetailsInteractor>(() => EventDetailsInteractor());
   locator.registerFactory<ManageStudentsInteractor>(() => ManageStudentsInteractor());
   locator.registerFactory<SettingsInteractor>(() => SettingsInteractor());
   locator.registerFactory<ViewAttachmentInteractor>(() => ViewAttachmentInteractor());

--- a/apps/flutter_parent/lib/utils/web_view_utils.dart
+++ b/apps/flutter_parent/lib/utils/web_view_utils.dart
@@ -26,11 +26,14 @@ extension WebViewUtils on WebViewController {
    *
    * See html_wrapper.html for more details
    */
-  Future<void> loadHtml(String html, {Map<String, String> headers}) async {
+  Future<void> loadHtml(String html, {Map<String, String> headers, double horizontalPadding = 0}) async {
+    assert(horizontalPadding != null);
+
     String fileText = await rootBundle.loadString('assets/html/html_wrapper.html');
     html = _applyWorkAroundForDoubleSlashesAsUrlSource(html);
     html = _addProtocolToLinks(html);
     html = fileText.replaceAll('{CANVAS_CONTENT}', html);
+    html = html.replaceAll('{PADDING}', horizontalPadding.toString());
     String uri = Uri.dataFromString(html, mimeType: 'text/html', encoding: Encoding.getByName('utf-8')).toString();
     this.loadUrl(uri);
   }

--- a/apps/flutter_parent/test/screens/courses/course_summary_screen_test.dart
+++ b/apps/flutter_parent/test/screens/courses/course_summary_screen_test.dart
@@ -23,6 +23,7 @@ import 'package:flutter_parent/models/schedule_item.dart';
 import 'package:flutter_parent/screens/assignments/assignment_details_screen.dart';
 import 'package:flutter_parent/screens/courses/details/course_details_model.dart';
 import 'package:flutter_parent/screens/courses/details/course_summary_screen.dart';
+import 'package:flutter_parent/screens/events/event_details_screen.dart';
 import 'package:flutter_parent/utils/common_widgets/empty_panda_widget.dart';
 import 'package:flutter_parent/utils/common_widgets/error_panda_widget.dart';
 import 'package:flutter_parent/utils/common_widgets/loading_indicator.dart';
@@ -277,6 +278,26 @@ void main() {
     await tester.tap(find.text(event.title));
 
     verify(nav.push(any, argThat(isA<AssignmentDetailsScreen>())));
+  });
+
+  testWidgetsWithAccessibilityChecks('Tapping calendar event item loads event details', (tester) async {
+    final event = ScheduleItem((s) => s
+      ..type = ScheduleItem.typeCalendar
+      ..title = 'Normal Event'
+      ..startAt = DateTime.now());
+
+    final model = _MockModel();
+    when(model.loadSummary(refresh: false)).thenAnswer((_) async => [event]);
+
+    var nav = _MockNav();
+    setupTestLocator((locator) => locator.registerLazySingleton<QuickNav>(() => nav));
+
+    await tester.pumpWidget(_testableWidget(model));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text(event.title));
+
+    verify(nav.push(any, argThat(isA<EventDetailsScreen>())));
   });
 }
 

--- a/apps/flutter_parent/test/screens/events/event_details_interactor_test.dart
+++ b/apps/flutter_parent/test/screens/events/event_details_interactor_test.dart
@@ -1,0 +1,42 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import 'package:flutter_parent/network/api/calendar_events_api.dart';
+import 'package:flutter_parent/screens/events/event_details_interactor.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../../utils/test_app.dart';
+
+void main() {
+  // Setup
+  final eventsApi = _MockEventsApi();
+
+  setupTestLocator((locator) {
+    locator.registerLazySingleton<CalendarEventsApi>(() => eventsApi);
+  });
+
+  setUp(() {
+    reset(eventsApi);
+  });
+
+  // Start tests
+  test('loadEvent calls api', () {
+    final itemId = 'id';
+    final interactor = EventDetailsInteractor();
+    interactor.loadEvent(itemId, true);
+    verify(eventsApi.getEvent(itemId, true)).called(1);
+  });
+}
+
+class _MockEventsApi extends Mock implements CalendarEventsApi {}

--- a/apps/flutter_parent/test/screens/events/event_details_screen_test.dart
+++ b/apps/flutter_parent/test/screens/events/event_details_screen_test.dart
@@ -1,0 +1,283 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import 'package:flutter/material.dart';
+import 'package:flutter_parent/l10n/app_localizations.dart';
+import 'package:flutter_parent/models/schedule_item.dart';
+import 'package:flutter_parent/screens/events/event_details_interactor.dart';
+import 'package:flutter_parent/screens/events/event_details_screen.dart';
+import 'package:flutter_parent/utils/common_widgets/error_panda_widget.dart';
+import 'package:flutter_parent/utils/common_widgets/loading_indicator.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import '../../utils/accessibility_utils.dart';
+import '../../utils/platform_config.dart';
+import '../../utils/test_app.dart';
+
+void main() {
+  // Setup
+  final eventId = '123';
+  final baseEvent = ScheduleItem((b) => b
+    ..id = eventId
+    ..type = ScheduleItem.typeCalendar);
+  final interactor = _MockEventDetailsInteractor();
+
+  final l10n = AppLocalizations();
+
+  setupTestLocator((locator) {
+    locator.registerLazySingleton<EventDetailsInteractor>(() => interactor);
+  });
+
+  setUp(() {
+    reset(interactor);
+  });
+
+  // Start tests
+  test('with id throws if id is null', () {
+    expect(() => EventDetailsScreen.withId(eventId: null), throwsAssertionError);
+  });
+
+  test('with event throws if event is null', () {
+    expect(() => EventDetailsScreen.withEvent(event: null), throwsAssertionError);
+  });
+
+  testWidgetsWithAccessibilityChecks('shows error', (tester) async {
+    when(interactor.loadEvent(eventId, any)).thenAnswer((_) => Future<ScheduleItem>.error('Failed to load event'));
+
+    await tester.pumpWidget(TestApp(EventDetailsScreen.withId(eventId: eventId), highContrast: true));
+    await tester.pumpAndSettle(); // Let the future finish
+
+    expect(find.byType(ErrorPandaWidget), findsOneWidget);
+    expect(find.text(l10n.unexpectedError), findsOneWidget);
+
+    await tester.tap(find.text(l10n.retry));
+    await tester.pumpAndSettle();
+
+    verify(interactor.loadEvent(eventId, any)).called(2); // Once for initial load, second for retry
+  });
+
+  group('shows loading', () {
+    testWidgetsWithAccessibilityChecks('with id', (tester) async {
+      await tester.pumpWidget(TestApp(EventDetailsScreen.withId(eventId: eventId)));
+      await tester.pump(); // Let the widget build
+
+      expect(find.byType(LoadingIndicator), findsOneWidget);
+    });
+
+    testWidgetsWithAccessibilityChecks('with event', (tester) async {
+      await tester.pumpWidget(TestApp(EventDetailsScreen.withEvent(event: baseEvent)));
+      await tester.pump(); // Let the widget build
+
+      expect(find.byType(LoadingIndicator), findsOneWidget);
+    });
+  });
+
+  group('can refresh', () {
+    testWidgetsWithAccessibilityChecks('with id', (tester) async {
+      when(interactor.loadEvent(eventId, any)).thenAnswer((_) async => baseEvent);
+
+      await tester.pumpWidget(TestApp(EventDetailsScreen.withId(eventId: eventId)));
+      await tester.pump(); // Let the widget build
+      await tester.pump(); // Let the future finish
+
+      final refresh = find.byType(RefreshIndicator);
+      expect(refresh, findsOneWidget);
+      await tester.drag(refresh, const Offset(0, 200));
+      await tester.pumpAndSettle();
+
+      verify(interactor.loadEvent(eventId, any)).called(2); // Once for initial load, second for refresh
+    });
+
+    testWidgetsWithAccessibilityChecks('with event', (tester) async {
+      when(interactor.loadEvent(eventId, any)).thenAnswer((_) async => baseEvent);
+
+      await tester.pumpWidget(TestApp(EventDetailsScreen.withEvent(event: baseEvent)));
+      await tester.pump(); // Let the widget build
+      await tester.pump(); // Let the future finish
+
+      final refresh = find.byType(RefreshIndicator);
+      expect(refresh, findsOneWidget);
+      await tester.drag(refresh, const Offset(0, 200));
+      await tester.pumpAndSettle();
+
+      verify(interactor.loadEvent(eventId, true)).called(1); // Only once for refresh, since initial load isn't required
+    });
+  });
+
+  group('date', () {
+    testWidgetsWithAccessibilityChecks('shows all day events', (tester) async {
+      final date = DateTime(2000);
+      final event = baseEvent.rebuild((b) => b
+        ..isAllDay = true
+        ..startAt = date);
+
+      await tester.pumpWidget(TestApp(EventDetailsScreen.withEvent(event: event)));
+      await tester.pump(); // Let the widget build
+      await tester.pump(); // Let the future finish
+
+      expect(find.byIcon(Icons.timer), findsOneWidget);
+      expect(find.text(l10n.eventAllDayLabel), findsOneWidget);
+      expect(find.text('Saturday Jan 1, 2000'), findsOneWidget);
+    });
+
+    testWidgetsWithAccessibilityChecks('shows all day events for endAt', (tester) async {
+      final date = DateTime(2000);
+      final event = baseEvent.rebuild((b) => b
+        ..isAllDay = true
+        ..endAt = date);
+
+      await tester.pumpWidget(TestApp(EventDetailsScreen.withEvent(event: event)));
+      await tester.pump(); // Let the widget build
+      await tester.pump(); // Let the future finish
+
+      expect(find.byIcon(Icons.timer), findsOneWidget);
+      expect(find.text(l10n.eventAllDayLabel), findsOneWidget);
+      expect(find.text('Saturday Jan 1, 2000'), findsOneWidget);
+    });
+
+    testWidgetsWithAccessibilityChecks('shows events with a duration', (tester) async {
+      final startDate = DateTime(2000);
+      final endDate = startDate.add(Duration(hours: 2));
+      final event = baseEvent.rebuild((b) => b
+        ..startAt = startDate
+        ..endAt = endDate);
+
+      await tester.pumpWidget(TestApp(EventDetailsScreen.withEvent(event: event)));
+      await tester.pump(); // Let the widget build
+      await tester.pump(); // Let the future finish
+
+      expect(find.byIcon(Icons.timer), findsOneWidget);
+      expect(find.text('Saturday Jan 1, 2000'), findsOneWidget);
+      expect(find.text(l10n.eventTime('12:00 AM', '2:00 AM')), findsOneWidget);
+    });
+
+    testWidgetsWithAccessibilityChecks('shows events with only a start time', (tester) async {
+      final date = DateTime(2000);
+      final event = baseEvent.rebuild((b) => b..startAt = date);
+
+      await tester.pumpWidget(TestApp(EventDetailsScreen.withEvent(event: event)));
+      await tester.pump(); // Let the widget build
+      await tester.pump(); // Let the future finish
+
+      expect(find.byIcon(Icons.timer), findsOneWidget);
+      expect(find.text('Saturday Jan 1, 2000'), findsOneWidget);
+      expect(find.text('12:00 AM'), findsOneWidget);
+    });
+
+    testWidgetsWithAccessibilityChecks('shows events with only an end time', (tester) async {
+      final date = DateTime(2000);
+      final event = baseEvent.rebuild((b) => b..endAt = date);
+
+      await tester.pumpWidget(TestApp(EventDetailsScreen.withEvent(event: event)));
+      await tester.pump(); // Let the widget build
+      await tester.pump(); // Let the future finish
+
+      expect(find.byIcon(Icons.timer), findsOneWidget);
+      expect(find.text('Saturday Jan 1, 2000'), findsOneWidget);
+      expect(find.text('12:00 AM'), findsOneWidget);
+    });
+  });
+
+  group('location', () {
+    testWidgetsWithAccessibilityChecks('shows name and address', (tester) async {
+      final name = 'loc name';
+      final address = 'loc address';
+      final event = baseEvent.rebuild((b) => b
+        ..locationName = name
+        ..locationAddress = address);
+
+      await tester.pumpWidget(TestApp(EventDetailsScreen.withEvent(event: event)));
+      await tester.pump(); // Let the widget build
+      await tester.pump(); // Let the future finish
+
+      expect(find.byIcon(Icons.location_on), findsOneWidget);
+      expect(find.text(name), findsOneWidget);
+      expect(find.text(address), findsOneWidget);
+    });
+
+    testWidgetsWithAccessibilityChecks('shows location name without address', (tester) async {
+      final name = 'loc name';
+      final event = baseEvent.rebuild((b) => b..locationName = name);
+
+      await tester.pumpWidget(TestApp(EventDetailsScreen.withEvent(event: event)));
+      await tester.pump(); // Let the widget build
+      await tester.pump(); // Let the future finish
+
+      expect(find.byIcon(Icons.location_on), findsOneWidget);
+      expect(find.text(name), findsOneWidget);
+    });
+
+    testWidgetsWithAccessibilityChecks('shows address without location name', (tester) async {
+      final address = 'loc address';
+      final event = baseEvent.rebuild((b) => b..locationAddress = address);
+
+      await tester.pumpWidget(TestApp(EventDetailsScreen.withEvent(event: event)));
+      await tester.pump(); // Let the widget build
+      await tester.pump(); // Let the future finish
+
+      expect(find.byIcon(Icons.location_on), findsOneWidget);
+      expect(find.text(address), findsOneWidget);
+    });
+
+    testWidgetsWithAccessibilityChecks('shows no location message', (tester) async {
+      final event = baseEvent;
+
+      await tester.pumpWidget(TestApp(EventDetailsScreen.withEvent(event: event)));
+      await tester.pump(); // Let the widget build
+      await tester.pump(); // Let the future finish
+
+      expect(find.byIcon(Icons.location_on), findsOneWidget);
+      expect(find.text(l10n.eventNoLocation), findsOneWidget);
+    });
+  });
+
+  testWidgetsWithAccessibilityChecks('shows event title as app bar title', (tester) async {
+    final title = 'Event Test Title';
+    final event = baseEvent.rebuild((b) => b..title = title);
+
+    await tester.pumpWidget(TestApp(EventDetailsScreen.withEvent(event: event)));
+    await tester.pump(); // Let the widget build
+    await tester.pump(); // Let the future finish
+
+    expect(find.descendant(of: find.byType(AppBar), matching: find.text(title)), findsOneWidget);
+  });
+
+  testWidgetsWithAccessibilityChecks('shows default title as app bar title when event has no title', (tester) async {
+    final event = baseEvent;
+
+    await tester.pumpWidget(TestApp(EventDetailsScreen.withEvent(event: event)));
+    await tester.pump(); // Let the widget build
+    await tester.pump(); // Let the future finish
+
+    expect(
+        find.descendant(of: find.byType(AppBar), matching: find.text(l10n.eventDetailsDefaultTitle)), findsOneWidget);
+  });
+
+  testWidgetsWithAccessibilityChecks('shows webview', (tester) async {
+    final description = 'test description';
+    final event = baseEvent.rebuild((b) => b..description = description);
+
+    await tester.pumpWidget(TestApp(
+      EventDetailsScreen.withEvent(event: event),
+      platformConfig: PlatformConfig(initWebview: true),
+    ));
+    await tester.pump(); // Let the widget build
+    await tester.pump(); // Let the future finish
+
+    expect(find.byType(WebView), findsOneWidget);
+  });
+}
+
+class _MockEventDetailsInteractor extends Mock implements EventDetailsInteractor {}

--- a/apps/flutter_parent/test/screens/events/event_details_screen_test.dart
+++ b/apps/flutter_parent/test/screens/events/event_details_screen_test.dart
@@ -127,8 +127,7 @@ void main() {
       await tester.pump(); // Let the widget build
       await tester.pump(); // Let the future finish
 
-      expect(find.byIcon(Icons.timer), findsOneWidget);
-      expect(find.text(l10n.eventAllDayLabel), findsOneWidget);
+      expect(find.text(l10n.eventDateLabel), findsOneWidget);
       expect(find.text('Saturday Jan 1, 2000'), findsOneWidget);
     });
 
@@ -142,8 +141,7 @@ void main() {
       await tester.pump(); // Let the widget build
       await tester.pump(); // Let the future finish
 
-      expect(find.byIcon(Icons.timer), findsOneWidget);
-      expect(find.text(l10n.eventAllDayLabel), findsOneWidget);
+      expect(find.text(l10n.eventDateLabel), findsOneWidget);
       expect(find.text('Saturday Jan 1, 2000'), findsOneWidget);
     });
 
@@ -158,7 +156,7 @@ void main() {
       await tester.pump(); // Let the widget build
       await tester.pump(); // Let the future finish
 
-      expect(find.byIcon(Icons.timer), findsOneWidget);
+      expect(find.text(l10n.eventDateLabel), findsOneWidget);
       expect(find.text('Saturday Jan 1, 2000'), findsOneWidget);
       expect(find.text(l10n.eventTime('12:00 AM', '2:00 AM')), findsOneWidget);
     });
@@ -171,7 +169,7 @@ void main() {
       await tester.pump(); // Let the widget build
       await tester.pump(); // Let the future finish
 
-      expect(find.byIcon(Icons.timer), findsOneWidget);
+      expect(find.text(l10n.eventDateLabel), findsOneWidget);
       expect(find.text('Saturday Jan 1, 2000'), findsOneWidget);
       expect(find.text('12:00 AM'), findsOneWidget);
     });
@@ -184,7 +182,7 @@ void main() {
       await tester.pump(); // Let the widget build
       await tester.pump(); // Let the future finish
 
-      expect(find.byIcon(Icons.timer), findsOneWidget);
+      expect(find.text(l10n.eventDateLabel), findsOneWidget);
       expect(find.text('Saturday Jan 1, 2000'), findsOneWidget);
       expect(find.text('12:00 AM'), findsOneWidget);
     });
@@ -202,7 +200,7 @@ void main() {
       await tester.pump(); // Let the widget build
       await tester.pump(); // Let the future finish
 
-      expect(find.byIcon(Icons.location_on), findsOneWidget);
+      expect(find.text(l10n.eventLocationLabel), findsOneWidget);
       expect(find.text(name), findsOneWidget);
       expect(find.text(address), findsOneWidget);
     });
@@ -215,7 +213,7 @@ void main() {
       await tester.pump(); // Let the widget build
       await tester.pump(); // Let the future finish
 
-      expect(find.byIcon(Icons.location_on), findsOneWidget);
+      expect(find.text(l10n.eventLocationLabel), findsOneWidget);
       expect(find.text(name), findsOneWidget);
     });
 
@@ -227,7 +225,7 @@ void main() {
       await tester.pump(); // Let the widget build
       await tester.pump(); // Let the future finish
 
-      expect(find.byIcon(Icons.location_on), findsOneWidget);
+      expect(find.text(l10n.eventLocationLabel), findsOneWidget);
       expect(find.text(address), findsOneWidget);
     });
 
@@ -238,12 +236,12 @@ void main() {
       await tester.pump(); // Let the widget build
       await tester.pump(); // Let the future finish
 
-      expect(find.byIcon(Icons.location_on), findsOneWidget);
+      expect(find.text(l10n.eventLocationLabel), findsOneWidget);
       expect(find.text(l10n.eventNoLocation), findsOneWidget);
     });
   });
 
-  testWidgetsWithAccessibilityChecks('shows event title as app bar title', (tester) async {
+  testWidgetsWithAccessibilityChecks('shows event title', (tester) async {
     final title = 'Event Test Title';
     final event = baseEvent.rebuild((b) => b..title = title);
 
@@ -251,18 +249,8 @@ void main() {
     await tester.pump(); // Let the widget build
     await tester.pump(); // Let the future finish
 
-    expect(find.descendant(of: find.byType(AppBar), matching: find.text(title)), findsOneWidget);
-  });
-
-  testWidgetsWithAccessibilityChecks('shows default title as app bar title when event has no title', (tester) async {
-    final event = baseEvent;
-
-    await tester.pumpWidget(TestApp(EventDetailsScreen.withEvent(event: event)));
-    await tester.pump(); // Let the widget build
-    await tester.pump(); // Let the future finish
-
-    expect(
-        find.descendant(of: find.byType(AppBar), matching: find.text(l10n.eventDetailsDefaultTitle)), findsOneWidget);
+    expect(find.text(l10n.eventDetailsTitle), findsOneWidget);
+    expect(find.text(title), findsOneWidget);
   });
 
   testWidgetsWithAccessibilityChecks('shows webview', (tester) async {
@@ -276,6 +264,7 @@ void main() {
     await tester.pump(); // Let the widget build
     await tester.pump(); // Let the future finish
 
+    expect(find.text(l10n.assignmentDescriptionLabel), findsOneWidget);
     expect(find.byType(WebView), findsOneWidget);
   });
 }

--- a/apps/flutter_parent/test/utils/widgets/constrained_web_view_test.dart
+++ b/apps/flutter_parent/test/utils/widgets/constrained_web_view_test.dart
@@ -1,0 +1,78 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import 'package:flutter/material.dart';
+import 'package:flutter_parent/utils/common_widgets/constrained_web_view.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import '../accessibility_utils.dart';
+import '../test_app.dart';
+
+void main() {
+  group('completely empty', () {
+    testWidgetsWithAccessibilityChecks('Shows an empty container with null content and null label', (tester) async {
+      await tester.pumpWidget(TestApp(ConstrainedWebView(content: null)));
+      await tester.pump();
+
+      expect(find.descendant(of: find.byType(ConstrainedWebView), matching: find.byType(Container)), findsOneWidget);
+      expect(find.byType(WebView), findsNothing);
+    });
+
+    testWidgetsWithAccessibilityChecks('Shows an empty container with empty content and empty label', (tester) async {
+      await tester.pumpWidget(TestApp(ConstrainedWebView(content: '', emptyDescription: '')));
+      await tester.pump();
+
+      expect(find.descendant(of: find.byType(ConstrainedWebView), matching: find.byType(Container)), findsOneWidget);
+      expect(find.byType(WebView), findsNothing);
+    });
+  });
+
+  group('empty description', () {
+    testWidgetsWithAccessibilityChecks('Shows with null content', (tester) async {
+      final empty = 'empty';
+
+      await tester.pumpWidget(TestApp(ConstrainedWebView(content: null, emptyDescription: empty)));
+      await tester.pump();
+
+      expect(find.descendant(of: find.byType(ConstrainedWebView), matching: find.text(empty)), findsOneWidget);
+      expect(find.byType(WebView), findsNothing);
+    });
+
+    testWidgetsWithAccessibilityChecks('Shows with empty content', (tester) async {
+      final empty = 'empty';
+
+      await tester.pumpWidget(TestApp(ConstrainedWebView(content: '', emptyDescription: empty)));
+      await tester.pump();
+
+      expect(find.descendant(of: find.byType(ConstrainedWebView), matching: find.text(empty)), findsOneWidget);
+      expect(find.byType(WebView), findsNothing);
+    });
+  });
+
+  testWidgetsWithAccessibilityChecks('adds padding to empty text', (tester) async {
+    final empty = 'empty';
+    final horizontal = 16.0;
+
+    await tester.pumpWidget(TestApp(ConstrainedWebView(
+      content: null,
+      emptyDescription: empty,
+      horizontalPadding: horizontal,
+    )));
+    await tester.pump();
+
+    final padding = find.descendant(of: find.byType(ConstrainedWebView), matching: find.byType(Padding));
+    expect(padding, findsOneWidget);
+    expect((tester.widget(padding) as Padding).padding, EdgeInsets.symmetric(horizontal: horizontal));
+  });
+}


### PR DESCRIPTION
Made a 'ConstrainedWebView' that is reusable between assignment details and this. Really, any scrollable screen that needs a webview as one of it's children can use it.

Also added optional padding to our loadHtml function to let webviews add padding if they want it. Made this optional as there are a few places where webviews are getting padded via the parent container padding. In the old app this was always getting set to 10px. (touched the syllabus to add padding as well)

To test:
My sandbox' Course 1 has some calendar events on Feb 17 that can be used for testing the different cases.