### PR TITLE
[Student][MBL-13932] Support LTI file uploads

### DIFF
--- a/libs/pandautils/src/main/res/values/strings.xml
+++ b/libs/pandautils/src/main/res/values/strings.xml
@@ -96,7 +96,7 @@
     <string name="filePermissionGranted">File is now ready to download, please try again.</string>
     <string name="filePermissionDenied">The file cannot be downloaded without granting permission.</string>
     <string name="pleaseTryAgain">Permission Granted, please try again.</string>
-    <string name="pickVideo">Select a Video</string>
+    <string name="pickFile">Select a File</string>
     <string name="assignmentSubmissionUpload">Uploading submission for %s</string>
     <string name="assignmentSubmissionError">Submission failed for %s</string>
     <string name="assignmentSubmissionComplete">Successfully submitted %s</string>


### PR DESCRIPTION
We were only supporting uploading video files through the Studio LTI. Now we will allow uploads for any of the allowed file types that the web view is asking for. This enables LTIs like turnitin to be used from the mobile apps.

To test:
See ticket for test credentials to use the Turnitin LTI
Also should test with other LTIs (Studio is the only one I could think of)