### PR TITLE
[Flutter-Parent] Fix course grade screen bugs

### DIFF
--- a/apps/flutter_parent/lib/models/course_grade.dart
+++ b/apps/flutter_parent/lib/models/course_grade.dart
@@ -41,9 +41,9 @@ class CourseGrade {
   /// Represents the lock status of a course, this is different from hideFinalGrades, as it takes both that value, and
   /// totalsForAllGradingPeriodsOption into account. The latter is only used when relevant.
   bool isCourseGradeLocked({bool forAllGradingPeriods = true}) {
-    if (_course.hideFinalGrades) {
+    if (_course?.hideFinalGrades == true) {
       return true;
-    } else if (_course.hasGradingPeriods) {
+    } else if (_course?.hasGradingPeriods == true) {
       return forAllGradingPeriods && !_hasActiveGradingPeriod() && !_isTotalsForAllGradingPeriodsEnabled();
     } else {
       return false;
@@ -63,10 +63,10 @@ class CourseGrade {
       currentScore() == null && (currentGrade() == null || currentGrade().contains('N/A') || currentGrade().isEmpty);
 
   bool _hasActiveGradingPeriod() =>
-      _course.enrollments.toList().any((enrollment) => enrollment.hasActiveGradingPeriod());
+      _course?.enrollments?.toList()?.any((enrollment) => enrollment.hasActiveGradingPeriod()) ?? false;
 
   bool _isTotalsForAllGradingPeriodsEnabled() =>
-      _course.enrollments.toList().any((enrollment) => enrollment.isTotalsForAllGradingPeriodsEnabled());
+      _course?.enrollments?.toList()?.any((enrollment) => enrollment.isTotalsForAllGradingPeriodsEnabled()) ?? false;
 
   double _getCurrentScore() => _enrollment?.grades?.currentScore ?? _enrollment?.computedCurrentScore;
 

--- a/apps/flutter_parent/lib/screens/courses/details/course_details_model.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_details_model.dart
@@ -39,7 +39,7 @@ class CourseDetailsModel extends BaseModel {
   // A convenience constructor when we already have the course data
   CourseDetailsModel.withCourse(this.studentId, this.studentName, this.course) : this.courseId = course.id;
 
-  /// Used only be the skeleton to load the course data for
+  /// Used only be the skeleton to load the course data for creating tabs and the app bar
   Future<void> loadData({bool refreshCourse = false}) {
     return work(() async {
       // Declare the futures so we can let both run asynchronously

--- a/apps/flutter_parent/lib/screens/courses/details/course_details_model.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_details_model.dart
@@ -39,8 +39,8 @@ class CourseDetailsModel extends BaseModel {
   // A convenience constructor when we already have the course data
   CourseDetailsModel.withCourse(this.studentId, this.studentName, this.course) : this.courseId = course.id;
 
-  /// gradingPeriodId is optional, but only used if refreshAssignmentGroups is true
-  Future<void> loadData({bool refreshCourse = false, bool refreshSummaryList = false}) {
+  /// Used only be the skeleton to load the course data for
+  Future<void> loadData({bool refreshCourse = false}) {
     return work(() async {
       // Declare the futures so we can let both run asynchronously
       final courseFuture =
@@ -54,6 +54,10 @@ class CourseDetailsModel extends BaseModel {
   }
 
   Future<GradeDetails> loadAssignments({bool forceRefresh = false}) async {
+    if (forceRefresh) {
+      course = await _interactor().loadCourse(courseId);
+    }
+
     final groupFuture = _interactor()
         .loadAssignmentGroups(courseId, studentId, _nextGradingPeriod?.id, forceRefresh: forceRefresh)
         ?.then((groups) async {
@@ -65,7 +69,7 @@ class CourseDetailsModel extends BaseModel {
 
     final gradingPeriodsFuture =
         _interactor().loadGradingPeriods(courseId, forceRefresh: forceRefresh)?.then((periods) {
-      return periods.gradingPeriods.toList();
+      return periods?.gradingPeriods?.toList() ?? [];
     });
 
     // Get the grades for the term
@@ -73,7 +77,7 @@ class CourseDetailsModel extends BaseModel {
         .loadEnrollmentsForGradingPeriod(courseId, studentId, _nextGradingPeriod?.id, forceRefresh: forceRefresh)
         ?.then((enrollments) {
       return enrollments.length > 0 ? enrollments.first : null;
-    });
+    })?.catchError((_) => null); // Some 'legacy' parents can't read grades for students, so catch and return null
 
     final gradeDetails = GradeDetails(
       assignmentGroups: await groupFuture,

--- a/apps/flutter_parent/lib/screens/courses/details/course_grades_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_grades_screen.dart
@@ -78,12 +78,19 @@ class _CourseGradesScreenState extends State<CourseGradesScreen> {
   }
 
   Widget _body(AsyncSnapshot<GradeDetails> snapshot, CourseDetailsModel model) {
-    if (snapshot.hasError) {
-      return ErrorPandaWidget(L10n(context).unexpectedError, () {
-        _refreshIndicatorKey.currentState.show();
-      });
-    } else if (snapshot.connectionState == ConnectionState.waiting && !snapshot.hasData) {
+    final header = _CourseGradeHeader(context, snapshot.data?.gradingPeriods ?? [], snapshot.data?.termEnrollment);
+    if (snapshot.connectionState == ConnectionState.waiting && !snapshot.hasData) {
       return LoadingIndicator();
+    }
+
+    if (snapshot.hasError) {
+      return ErrorPandaWidget(
+        L10n(context).unexpectedError,
+        () {
+          _refreshIndicatorKey.currentState.show();
+        },
+        header: header,
+      );
     } else if (!snapshot.hasData ||
         snapshot.data.assignmentGroups == null ||
         snapshot.data.assignmentGroups.every((group) => group.assignments.isEmpty) == true) {
@@ -91,12 +98,13 @@ class _CourseGradesScreenState extends State<CourseGradesScreen> {
         svgPath: 'assets/svg/panda-space-no-assignments.svg',
         title: L10n(context).noAssignmentsTitle,
         subtitle: L10n(context).noAssignmentsMessage,
+        header: header,
       );
     }
 
     return ListView(
       children: [
-        _CourseGradeHeader(context, snapshot.data.gradingPeriods, snapshot.data.termEnrollment),
+        header,
         ..._assignmentListChildren(context, snapshot.data.assignmentGroups),
       ],
     );

--- a/apps/flutter_parent/lib/screens/courses/details/course_grades_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_grades_screen.dart
@@ -89,7 +89,6 @@ class _CourseGradesScreenState extends State<CourseGradesScreen> {
         () {
           _refreshIndicatorKey.currentState.show();
         },
-        header: header,
       );
     } else if (!snapshot.hasData ||
         snapshot.data.assignmentGroups == null ||
@@ -98,7 +97,8 @@ class _CourseGradesScreenState extends State<CourseGradesScreen> {
         svgPath: 'assets/svg/panda-space-no-assignments.svg',
         title: L10n(context).noAssignmentsTitle,
         subtitle: L10n(context).noAssignmentsMessage,
-        header: header,
+        // Don't show the header if we have no assignments at all (null grading period id corresponds to all grading periods)
+        header: (model.currentGradingPeriod()?.id == null) ? null : header,
       );
     }
 

--- a/apps/flutter_parent/lib/utils/common_widgets/empty_panda_widget.dart
+++ b/apps/flutter_parent/lib/utils/common_widgets/empty_panda_widget.dart
@@ -25,6 +25,7 @@ class EmptyPandaWidget extends StatelessWidget {
   final String subtitle;
   final String buttonText;
   final GestureTapCallback onButtonTap;
+  final Widget header;
 
   const EmptyPandaWidget({
     Key key,
@@ -33,11 +34,13 @@ class EmptyPandaWidget extends StatelessWidget {
     this.subtitle,
     this.buttonText,
     this.onButtonTap,
+    this.header,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return FullScreenScrollContainer(
+      header: header,
       children: <Widget>[
         if (svgPath != null) SvgPicture.asset(svgPath, excludeFromSemantics: true),
         if (svgPath != null && (title != null || subtitle != null)) SizedBox(height: 64),

--- a/apps/flutter_parent/lib/utils/common_widgets/error_panda_widget.dart
+++ b/apps/flutter_parent/lib/utils/common_widgets/error_panda_widget.dart
@@ -26,12 +26,14 @@ import 'package:flutter_parent/utils/design/parent_colors.dart';
 class ErrorPandaWidget extends StatelessWidget {
   final Function callback;
   final String errorString;
+  final Widget header;
 
-  ErrorPandaWidget(this.errorString, this.callback);
+  ErrorPandaWidget(this.errorString, this.callback, {this.header});
 
   @override
   Widget build(BuildContext context) {
     return FullScreenScrollContainer(
+      header: header,
       children: <Widget>[
         Icon(CanvasIcons.warning, size: 40, color: ParentColors.failure),
         Padding(

--- a/apps/flutter_parent/lib/utils/common_widgets/full_screen_scroll_container.dart
+++ b/apps/flutter_parent/lib/utils/common_widgets/full_screen_scroll_container.dart
@@ -20,9 +20,10 @@ import 'package:flutter/material.dart';
 /// Mostly pulling from the example by Flutter for SingleChildScrollView:
 /// https://api.flutter.dev/flutter/widgets/SingleChildScrollView-class.html
 class FullScreenScrollContainer extends StatelessWidget {
+  final Widget header;
   final List<Widget> children;
 
-  const FullScreenScrollContainer({@required this.children, Key key}) : super(key: key);
+  const FullScreenScrollContainer({@required this.children, this.header, Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -34,11 +35,22 @@ class FullScreenScrollContainer extends StatelessWidget {
             minHeight: viewportConstraints.maxHeight,
             minWidth: viewportConstraints.maxWidth,
           ),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 32),
+          child: IntrinsicHeight(
             child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: children,
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: <Widget>[
+                if (header != null) header,
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 32),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      mainAxisSize: MainAxisSize.max,
+                      children: children,
+                    ),
+                  ),
+                ),
+              ],
             ),
           ),
         ),

--- a/apps/flutter_parent/test/screens/courses/course_grades_screen_test.dart
+++ b/apps/flutter_parent/test/screens/courses/course_grades_screen_test.dart
@@ -103,6 +103,50 @@ void main() {
     verify(interactor.loadAssignmentGroups(_courseId, _studentId, null, forceRefresh: true)).called(1);
   });
 
+  testWidgetsWithAccessibilityChecks('Shows error with period header', (tester) async {
+    final model = CourseDetailsModel(_studentId, '', _courseId);
+
+    final gradingPeriod = GradingPeriod((b) => b
+      ..id = '123'
+      ..title = 'test period');
+    final enrollment = Enrollment((b) => b
+      ..enrollmentState = 'active'
+      ..grades = _mockGrade(currentScore: 12)
+      ..multipleGradingPeriodsEnabled = true);
+    model.updateGradingPeriod(gradingPeriod);
+    model.course = _mockCourse();
+
+    // Mock stuff
+    when(interactor.loadAssignmentGroups(_courseId, _studentId, null)).thenAnswer((_) async => List<AssignmentGroup>());
+    when(interactor.loadGradingPeriods(_courseId))
+        .thenAnswer((_) => Future<GradingPeriodResponse>.error('Failed to load grading periods').catchError((_) {}));
+    when(interactor.loadEnrollmentsForGradingPeriod(_courseId, _studentId, null)).thenAnswer((_) async => [enrollment]);
+
+    await tester.pumpWidget(_testableWidget(model, highContrastMode: true));
+    await tester.pump(); // Build the widget
+    await tester.pump(); // Let the future finish
+
+    // Verify that we are showing the course grade when not locked
+    expect(find.text(AppLocalizations().courseTotalGradeLabel), findsOneWidget);
+
+    // Verify that we are showing the empty message
+    expect(find.byType(ErrorPandaWidget), findsOneWidget);
+  });
+
+  // We still want to show the grades page even if we can't get the term enrollment
+  testWidgetsWithAccessibilityChecks('Does not show error for term enrollment failure', (tester) async {
+    final model = CourseDetailsModel(_studentId, '', _courseId);
+    when(interactor.loadEnrollmentsForGradingPeriod(_courseId, _studentId, any, forceRefresh: anyNamed('forceRefresh')))
+        .thenAnswer((_) async => Future<List<Enrollment>>.error('Error getting term enrollment'));
+
+    await tester.pumpWidget(_testableWidget(model, highContrastMode: true));
+    await tester.pump(); // Build the widget
+    await tester.pump(); // Let the future finish
+
+    expect(find.text(AppLocalizations().noAssignmentsTitle), findsOneWidget);
+    expect(find.text(AppLocalizations().noAssignmentsMessage), findsOneWidget);
+  });
+
   testWidgetsWithAccessibilityChecks('Shows empty', (tester) async {
     final model = CourseDetailsModel(_studentId, '', _courseId);
     when(interactor.loadAssignmentGroups(_courseId, _studentId, null)).thenAnswer((_) async => List<AssignmentGroup>());
@@ -111,6 +155,38 @@ void main() {
     await tester.pump(); // Build the widget
     await tester.pump(); // Let the future finish
 
+    expect(find.text(AppLocalizations().noAssignmentsTitle), findsOneWidget);
+    expect(find.text(AppLocalizations().noAssignmentsMessage), findsOneWidget);
+  });
+
+  testWidgetsWithAccessibilityChecks('Shows empty with period header', (tester) async {
+    final model = CourseDetailsModel(_studentId, '', _courseId);
+
+    final gradingPeriod = GradingPeriod((b) => b
+      ..id = '123'
+      ..title = 'test period');
+    final enrollment = Enrollment((b) => b
+      ..enrollmentState = 'active'
+      ..grades = _mockGrade(currentScore: 12)
+      ..multipleGradingPeriodsEnabled = true);
+    model.updateGradingPeriod(gradingPeriod);
+    model.course = _mockCourse().rebuild((b) => b..hasGradingPeriods = true);
+
+    // Mock stuff
+    when(interactor.loadAssignmentGroups(_courseId, _studentId, null)).thenAnswer((_) async => List<AssignmentGroup>());
+    when(interactor.loadGradingPeriods(_courseId)).thenAnswer(
+        (_) async => GradingPeriodResponse((b) => b..gradingPeriods = BuiltList.of([gradingPeriod]).toBuilder()));
+    when(interactor.loadEnrollmentsForGradingPeriod(_courseId, _studentId, null)).thenAnswer((_) async => [enrollment]);
+
+    await tester.pumpWidget(_testableWidget(model, highContrastMode: true));
+    await tester.pump(); // Build the widget
+    await tester.pump(); // Let the future finish
+
+    // Verify that we are showing the course grade when not locked
+    expect(find.text(AppLocalizations().courseTotalGradeLabel), findsOneWidget);
+    expect(find.text('test period'), findsOneWidget);
+
+    // Verify that we are showing the empty message
     expect(find.text(AppLocalizations().noAssignmentsTitle), findsOneWidget);
     expect(find.text(AppLocalizations().noAssignmentsMessage), findsOneWidget);
   });

--- a/apps/flutter_parent/test/utils/widgets/empty_panda_widget_test.dart
+++ b/apps/flutter_parent/test/utils/widgets/empty_panda_widget_test.dart
@@ -128,6 +128,14 @@ void main() {
     expect(find.text(subtitle), findsOneWidget);
     expect(find.widgetWithText(FlatButton, buttonText), findsOneWidget);
   });
+
+  testWidgetsWithAccessibilityChecks('shows a header', (tester) async {
+    await tester.pumpWidget(_testableWidget(EmptyPandaWidget(header: Text('h'))));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Text), findsOneWidget);
+    expect(find.text('h'), findsOneWidget);
+  });
 }
 
 Widget _testableWidget(EmptyPandaWidget child) {

--- a/apps/flutter_parent/test/utils/widgets/error_panda_widget_test.dart
+++ b/apps/flutter_parent/test/utils/widgets/error_panda_widget_test.dart
@@ -73,4 +73,16 @@ void main() {
     // Verify the callback was called
     expect(called, true);
   });
+
+  testWidgetsWithAccessibilityChecks('Shows a header', (tester) async {
+    await tester.pumpWidget(TestApp(
+      ErrorPandaWidget(errorString, callback, header: Text('header here')),
+      highContrast: true,
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(FlatButton), findsOneWidget);
+    expect(find.text(AppLocalizations().retry), findsOneWidget);
+    expect(find.text('header here'), findsOneWidget);
+  });
 }

--- a/apps/flutter_parent/test/utils/widgets/full_screen_scroll_container_test.dart
+++ b/apps/flutter_parent/test/utils/widgets/full_screen_scroll_container_test.dart
@@ -57,6 +57,34 @@ void main() {
       // Verify we had our refresh called
       verify(refresher.refresh()).called(1);
     });
+
+    testWidgetsWithAccessibilityChecks('can add header', (tester) async {
+      final children = [Text('a')];
+      final header = Text('h');
+
+      // Pump the widget
+      await tester.pumpWidget(_refreshingWidget(children, header: header));
+      await tester.pumpAndSettle();
+
+      // Should show the text
+      expect(find.text('a'), findsOneWidget);
+
+      // Should be at the center of the screen (in relation to the header)
+      final positionA = tester.getCenter(find.text('a'));
+      final positionHeaderCenter = tester.getCenter(find.text('h'));
+      final positionCenter = tester.getCenter(find.byType(MaterialApp));
+      expect(positionA.dx, positionCenter.dx);
+      expect(positionA.dy - positionHeaderCenter.dy, positionCenter.dy);
+
+      // Should show the text
+      expect(find.text('h'), findsOneWidget);
+
+      // Should be at the center of the screen
+      final positionHeader = tester.getTopLeft(find.text('h'));
+      final positionTop = tester.getTopLeft(find.byType(MaterialApp));
+      expect(positionHeaderCenter.dx, positionCenter.dx);
+      expect(positionHeader.dy, positionTop.dy);
+    });
   });
 
   group('Multiple children', () {
@@ -98,6 +126,37 @@ void main() {
       // Verify we had our refresh called
       verify(refresher.refresh()).called(1);
     });
+
+    testWidgetsWithAccessibilityChecks('can add header', (tester) async {
+      final children = [Text('a'), Text('b'), Text('c')];
+      final header = Text('h');
+
+      // Pump the widget
+      await tester.pumpWidget(_refreshingWidget(children, header: header));
+      await tester.pumpAndSettle();
+
+      // Should show the text
+      // The widgets should all be visible
+      expect(find.text('a'), findsOneWidget);
+      expect(find.text('b'), findsOneWidget);
+      expect(find.text('c'), findsOneWidget);
+
+      // The middle widget should be at the center of the screen (in relation to the header)
+      final positionA = tester.getCenter(find.text('b'));
+      final positionHeaderCenter = tester.getCenter(find.text('h'));
+      final positionCenter = tester.getCenter(find.byType(MaterialApp));
+      expect(positionA.dx, positionCenter.dx);
+      expect(positionA.dy - positionHeaderCenter.dy, positionCenter.dy);
+
+      // Should show the text
+      expect(find.text('h'), findsOneWidget);
+
+      // Should be at the center of the screen
+      final positionHeader = tester.getTopLeft(find.text('h'));
+      final positionTop = tester.getTopLeft(find.byType(MaterialApp));
+      expect(positionHeaderCenter.dx, positionCenter.dx);
+      expect(positionHeader.dy, positionTop.dy);
+    });
   });
 }
 
@@ -105,11 +164,11 @@ class _Refresher extends Mock {
   void refresh();
 }
 
-Widget _refreshingWidget(List<Widget> children, {_Refresher refresher}) {
+Widget _refreshingWidget(List<Widget> children, {_Refresher refresher, Widget header}) {
   return MaterialApp(
     home: Scaffold(
       body: RefreshIndicator(
-        child: FullScreenScrollContainer(children: children),
+        child: FullScreenScrollContainer(children: children, header: header),
         onRefresh: () {
           refresher?.refresh();
           return Future.value();


### PR DESCRIPTION
Fix ‘legacy’ parents failing to load enrollments for a given user.
Show period header in empty/error states (so they can still switch around to different grading periods)