### PR TITLE
[Flutter-Parent] Fix crash when switching users

### DIFF
--- a/apps/flutter_parent/lib/screens/dashboard/dashboard_interactor.dart
+++ b/apps/flutter_parent/lib/screens/dashboard/dashboard_interactor.dart
@@ -19,7 +19,6 @@ import 'package:flutter_parent/network/api/user_api.dart';
 import 'package:flutter_parent/network/utils/api_prefs.dart';
 import 'package:flutter_parent/screens/dashboard/alert_notifier.dart';
 import 'package:flutter_parent/screens/dashboard/inbox_notifier.dart';
-import 'package:flutter_parent/screens/dashboard/selected_student_notifier.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
 
 class DashboardInteractor {
@@ -43,6 +42,4 @@ class DashboardInteractor {
   InboxCountNotifier getInboxCountNotifier() => locator<InboxCountNotifier>();
 
   AlertCountNotifier getAlertCountNotifier() => locator<AlertCountNotifier>();
-
-  SelectedStudentNotifier getSelectedStudentNotifier() => locator<SelectedStudentNotifier>();
 }

--- a/apps/flutter_parent/lib/screens/dashboard/dashboard_screen.dart
+++ b/apps/flutter_parent/lib/screens/dashboard/dashboard_screen.dart
@@ -80,7 +80,7 @@ class DashboardState extends State<DashboardScreen> {
 
   @override
   void initState() {
-    _selectedStudentNotifier = _interactor.getSelectedStudentNotifier();
+    _selectedStudentNotifier = SelectedStudentNotifier();
     _loadSelf();
     if (widget.students?.isNotEmpty == true) {
       _students = widget.students;
@@ -352,6 +352,7 @@ class DashboardState extends State<DashboardScreen> {
   }
 
   _performSignOut(BuildContext context, {bool switchingUsers = false}) async {
+    ParentTheme.of(context).studentIndex = 0;
     await ApiPrefs.performLogout(switchingLogins: switchingUsers);
     Navigator.of(context).pushAndRemoveUntil(MaterialPageRoute(builder: (context) {
       return LoginLandingScreen();

--- a/apps/flutter_parent/lib/utils/service_locator.dart
+++ b/apps/flutter_parent/lib/utils/service_locator.dart
@@ -31,7 +31,6 @@ import 'package:flutter_parent/screens/courses/details/course_details_interactor
 import 'package:flutter_parent/screens/dashboard/alert_notifier.dart';
 import 'package:flutter_parent/screens/dashboard/dashboard_interactor.dart';
 import 'package:flutter_parent/screens/dashboard/inbox_notifier.dart';
-import 'package:flutter_parent/screens/dashboard/selected_student_notifier.dart';
 import 'package:flutter_parent/screens/domain_search/domain_search_interactor.dart';
 import 'package:flutter_parent/screens/events/event_details_interactor.dart';
 import 'package:flutter_parent/screens/inbox/attachment_utils/attachment_picker_interactor.dart';
@@ -102,5 +101,4 @@ void setupLocator() {
   locator.registerLazySingleton<AlertCountNotifier>(() => AlertCountNotifier());
   locator.registerLazySingleton<InboxCountNotifier>(() => InboxCountNotifier());
   locator.registerLazySingleton<QuickNav>(() => QuickNav());
-  locator.registerLazySingleton<SelectedStudentNotifier>(() => SelectedStudentNotifier());
 }


### PR DESCRIPTION
No need to obtain the selected student notifier via locator, since it’s always available through provider. This was causing a crash as provider was disposing of the notifier, and the locator was trying to reuse the same one.
Also reset the selected student to 0 so that the color theme resets on logouts. We'll probably want to persist this later in the login object.

To test:
Currently on master, switching users will show a crash screen once the new user is loaded (after the splash screen). This should no longer happen.