### PR TITLE
[Flutter Parent] Clear nav backstack when switching users

### DIFF
--- a/apps/flutter_parent/lib/screens/login_landing_screen.dart
+++ b/apps/flutter_parent/lib/screens/login_landing_screen.dart
@@ -133,7 +133,7 @@ class LoginLandingScreen extends StatelessWidget {
                   return ListTile(
                     onTap: () {
                       ApiPrefs.switchLogins(login);
-                      locator<QuickNav>().push(context, SplashScreen());
+                      locator<QuickNav>().pushAndRemoveAll(context, SplashScreen());
                     },
                     leading: Avatar.fromUser(login.user),
                     title: UserName.fromUser(login.user),

--- a/apps/flutter_parent/test/screens/login/login_landing_screen_test.dart
+++ b/apps/flutter_parent/test/screens/login/login_landing_screen_test.dart
@@ -145,7 +145,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(ApiPrefs.getCurrentLogin(), logins[0]);
-    verify(nav.push(any, argThat(isA<SplashScreen>())));
+    verify(nav.pushAndRemoveAll(any, argThat(isA<SplashScreen>())));
   });
 }
 


### PR DESCRIPTION
Previously the nav backstack was not being cleared after switching logins, so the user could press the back button and it would return to the login landing page instead of closing the app.