### PR TITLE
[Flutter-Parent] Moar grade fixes

### DIFF
--- a/apps/flutter_parent/.gitignore
+++ b/apps/flutter_parent/.gitignore
@@ -1,4 +1,5 @@
 # Private data
+key.properties
 fabric.properties
 google-services.json
 

--- a/apps/flutter_parent/lib/models/course.dart
+++ b/apps/flutter_parent/lib/models/course.dart
@@ -29,6 +29,7 @@ abstract class Course implements Built<Course, CourseBuilder> {
   static Serializer<Course> get serializer => _$courseSerializer;
 
   Course._();
+
   factory Course([void Function(CourseBuilder) updates]) = _$Course;
 
   // Helper variables
@@ -49,6 +50,7 @@ abstract class Course implements Built<Course, CourseBuilder> {
   String get finalGrade;
 
   String get id;
+
   String get name;
 
   @nullable
@@ -127,8 +129,33 @@ abstract class Course implements Built<Course, CourseBuilder> {
     ..hasGradingPeriods = false
     ..restrictEnrollmentsToCourseDates = false;
 
-  CourseGrade getCourseGrade(String studentId) =>
-      CourseGrade(this, enrollments.firstWhere((enrollment) => enrollment.userId == studentId));
+  /// Get the course grade.
+  /// Optional:
+  /// [forceAllPeriods] -> Used to determine if there's an active grading period on the enrollment, true for this will
+  ///   always force no active grading period
+  /// [enrollment] -> If specified, will use for the grading period grades, unless a non-null value is provided this
+  ///   will default to the student's enrollment in the course
+  /// [gradingPeriodId] -> Only used when [enrollment] is not provided or is null, when pulling the student's enrollment
+  ///   from the course will also match based on [Enrollment.currentGradingPeriodId]
+  CourseGrade getCourseGrade(
+    String studentId, {
+    Enrollment enrollment,
+    String gradingPeriodId,
+    bool forceAllPeriods = false,
+  }) =>
+      CourseGrade(
+        this,
+        enrollment ??
+            enrollments.firstWhere(
+              (enrollment) =>
+                  enrollment.userId == studentId &&
+                  (gradingPeriodId == null ||
+                      gradingPeriodId.isEmpty ||
+                      gradingPeriodId == enrollment.currentGradingPeriodId),
+              orElse: () => null,
+            ),
+        forceAllPeriods: forceAllPeriods,
+      );
 }
 
 @BuiltValueEnum(wireName: 'default_view')

--- a/apps/flutter_parent/lib/models/course_grade.dart
+++ b/apps/flutter_parent/lib/models/course_grade.dart
@@ -35,8 +35,17 @@ import 'enrollment.dart';
 class CourseGrade {
   Course _course;
   Enrollment _enrollment;
+  bool _forceAllPeriods;
 
-  CourseGrade(this._course, this._enrollment);
+  CourseGrade(this._course, this._enrollment, {bool forceAllPeriods = false}) : _forceAllPeriods = forceAllPeriods;
+
+  operator ==(Object other) {
+    if (!(other is CourseGrade)) {
+      return false;
+    }
+    final grade = other as CourseGrade;
+    return _course == grade._course && _enrollment == grade._enrollment && _forceAllPeriods == grade._forceAllPeriods;
+  }
 
   /// Represents the lock status of a course, this is different from hideFinalGrades, as it takes both that value, and
   /// totalsForAllGradingPeriodsOption into account. The latter is only used when relevant.
@@ -63,7 +72,8 @@ class CourseGrade {
       currentScore() == null && (currentGrade() == null || currentGrade().contains('N/A') || currentGrade().isEmpty);
 
   bool _hasActiveGradingPeriod() =>
-      _course?.enrollments?.toList()?.any((enrollment) => enrollment.hasActiveGradingPeriod()) ?? false;
+      !_forceAllPeriods &&
+      (_course?.enrollments?.toList()?.any((enrollment) => enrollment.hasActiveGradingPeriod()) ?? false);
 
   bool _isTotalsForAllGradingPeriodsEnabled() =>
       _course?.enrollments?.toList()?.any((enrollment) => enrollment.isTotalsForAllGradingPeriodsEnabled()) ?? false;

--- a/apps/flutter_parent/lib/screens/courses/details/course_details_model.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_details_model.dart
@@ -55,6 +55,14 @@ class CourseDetailsModel extends BaseModel {
       course = await courseFuture;
       tabs = await tabsFuture;
 
+      // Set the _nextGradingPeriod to the current enrollment period (if active and if not already set)
+      final enrollment =
+          course?.enrollments?.firstWhere((enrollment) => enrollment.userId == studentId, orElse: () => null);
+      if (_nextGradingPeriod == null && enrollment?.hasActiveGradingPeriod() == true) {
+        _nextGradingPeriod = GradingPeriod((b) => b
+          ..id = enrollment.currentGradingPeriodId
+          ..title = enrollment.currentGradingPeriodTitle);
+      }
       return Future<void>.value();
     });
   }

--- a/apps/flutter_parent/lib/screens/courses/details/course_grades_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_grades_screen.dart
@@ -222,8 +222,14 @@ class _CourseGradeHeader extends StatelessWidget {
 
   /// The total grade in the course/grading period
   Widget _gradeTotal(BuildContext context, CourseDetailsModel model) {
+    final grade = model.course.getCourseGrade(
+      model.studentId,
+      enrollment: termEnrollment,
+      gradingPeriodId: model.currentGradingPeriod()?.id,
+      forceAllPeriods: termEnrollment == null && model.currentGradingPeriod()?.id == null,
+    );
+
     // Don't show the total if the grade is locked
-    final grade = CourseGrade(model.course, termEnrollment);
     if (grade.isCourseGradeLocked(forAllGradingPeriods: model.currentGradingPeriod()?.id == null)) return null;
 
     final textTheme = Theme.of(context).textTheme;

--- a/apps/flutter_parent/test/models/course_grade_test.dart
+++ b/apps/flutter_parent/test/models/course_grade_test.dart
@@ -18,6 +18,7 @@ import 'package:flutter_parent/models/enrollment.dart';
 import 'package:test/test.dart';
 
 void main() {
+  final _course = Course((b) => b..id = 'course_123');
   final _enrollment = Enrollment((b) => b..enrollmentState = 'active');
 
   group('isCourseGradeLocked', () {
@@ -58,6 +59,22 @@ void main() {
       final grade = CourseGrade(course, null);
 
       expect(grade.isCourseGradeLocked(), false);
+    });
+
+    test(
+        'returns true if hasGradingPeriods is true and an active grading period on the course enrollment is set but forcing all periods',
+        () {
+      final enrollment = _enrollment.rebuild((b) => b
+        ..currentGradingPeriodId = '101'
+        ..multipleGradingPeriodsEnabled = true);
+
+      final course = Course((b) => b
+        ..hasGradingPeriods = true
+        ..enrollments = BuiltList.of([enrollment]).toBuilder());
+
+      final grade = CourseGrade(course, null, forceAllPeriods: true);
+
+      expect(grade.isCourseGradeLocked(), true);
     });
 
     test('returns false if hasGradingPeriods is true and NO active grading period on the course enrollment is set', () {
@@ -104,6 +121,53 @@ void main() {
       final grade = CourseGrade(course, null);
 
       expect(grade.isCourseGradeLocked(), true);
+    });
+  });
+
+  group('equals', () {
+    test('returns true if the course is the same', () {
+      final grade = CourseGrade(_course, null);
+      expect(true, grade == CourseGrade(_course, null));
+    });
+
+    test('returns false if the courses are different', () {
+      final grade = CourseGrade(_course, null);
+      expect(false, grade == CourseGrade(_course.rebuild((b) => b..id = 'copy'), null));
+    });
+
+    test('returns true if the enrollment is the same', () {
+      final grade = CourseGrade(null, _enrollment);
+      expect(true, grade == CourseGrade(null, _enrollment));
+    });
+
+    test('returns false if the enrollments are different', () {
+      final grade = CourseGrade(null, _enrollment);
+      expect(false, grade == CourseGrade(null, _enrollment.rebuild((b) => b..enrollmentState = 'completed')));
+    });
+
+    test('returns true if the course and enrollment are the same', () {
+      final grade = CourseGrade(_course, _enrollment);
+      expect(true, grade == CourseGrade(_course, _enrollment));
+    });
+
+    test('returns true if the course and enrollment are the same and forceAllPeriod is true', () {
+      final grade = CourseGrade(_course, _enrollment, forceAllPeriods: true);
+      expect(true, grade == CourseGrade(_course, _enrollment, forceAllPeriods: true));
+    });
+
+    test('returns true if the course and enrollment are the same and forceAllPeriod is false', () {
+      final grade = CourseGrade(_course, _enrollment, forceAllPeriods: true);
+      expect(true, grade == CourseGrade(_course, _enrollment, forceAllPeriods: true));
+    });
+
+    test('returns false if the course and enrollment are the same but have different forceAllPeriod', () {
+      final grade = CourseGrade(_course, _enrollment, forceAllPeriods: true);
+      expect(false, grade == CourseGrade(_course, _enrollment));
+    });
+
+    test('returns false if the other side is not a course grade', () {
+      final grade = CourseGrade(null, null);
+      expect(false, grade == _course);
     });
   });
 }

--- a/apps/flutter_parent/test/models/course_test.dart
+++ b/apps/flutter_parent/test/models/course_test.dart
@@ -1,0 +1,81 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import 'package:built_collection/built_collection.dart';
+import 'package:flutter_parent/models/course.dart';
+import 'package:flutter_parent/models/course_grade.dart';
+import 'package:flutter_parent/models/enrollment.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final _studentId = '123';
+  final _gradingPeriodId = '321';
+  final _course = Course((b) => b..id = 'course_123');
+  final _enrollment = Enrollment((b) => b
+    ..enrollmentState = 'active'
+    ..userId = _studentId);
+
+  group('getCourseGrade', () {
+    test('returns a course grade with the course and enrollment', () {
+      final grade = _course.getCourseGrade(_studentId, enrollment: _enrollment);
+      expect(grade, CourseGrade(_course, _enrollment, forceAllPeriods: false));
+    });
+
+    test('returns a course grade with the course and student enrollment', () {
+      final course = _course.rebuild((b) => b..enrollments = ListBuilder([_enrollment]));
+
+      final grade = course.getCourseGrade(_studentId);
+      expect(grade, CourseGrade(course, course.enrollments.first, forceAllPeriods: false));
+    });
+
+    test('returns a course grade with the course and student gradinig period enrollment', () {
+      final enrollmentInGradingPeriod = _enrollment.rebuild((b) => b..currentGradingPeriodId = _gradingPeriodId);
+      final course = _course.rebuild((b) => b..enrollments = ListBuilder([_enrollment, enrollmentInGradingPeriod]));
+
+      final grade = course.getCourseGrade(_studentId, gradingPeriodId: _gradingPeriodId);
+      expect(grade, CourseGrade(course, enrollmentInGradingPeriod, forceAllPeriods: false));
+    });
+
+    test('returns a course grade with the course and student enrollment without grading period', () {
+      final enrollmentInGradingPeriod = _enrollment.rebuild((b) => b..currentGradingPeriodId = _gradingPeriodId);
+      final course = _course.rebuild((b) => b..enrollments = ListBuilder([_enrollment, enrollmentInGradingPeriod]));
+
+      // Test the various ways that grading period can not be set
+      CourseGrade grade = course.getCourseGrade(_studentId);
+      expect(grade, CourseGrade(course, _enrollment, forceAllPeriods: false));
+
+      grade = course.getCourseGrade(_studentId, gradingPeriodId: null);
+      expect(grade, CourseGrade(course, _enrollment, forceAllPeriods: false));
+
+      grade = course.getCourseGrade(_studentId, gradingPeriodId: '');
+      expect(grade, CourseGrade(course, _enrollment, forceAllPeriods: false));
+    });
+
+    test('returns a course grade with the course and no enrollment without matchinig grading period', () {
+      final course = _course.rebuild((b) => b..enrollments = ListBuilder([_enrollment]));
+
+      // Test the various ways that grading period can not be set
+      final grade = course.getCourseGrade(_studentId, gradingPeriodId: _gradingPeriodId);
+      expect(grade, CourseGrade(course, null, forceAllPeriods: false));
+    });
+
+    test('returns a course grade with the course and passed in enrollment when course has matching enrollment', () {
+      final enrollment = _enrollment.rebuild((b) => b..currentGradingPeriodId = _gradingPeriodId);
+      final course = _course.rebuild((b) => b..enrollments = ListBuilder([_enrollment]));
+
+      // Test the various ways that grading period can not be set
+      final grade = course.getCourseGrade(_studentId, enrollment: enrollment);
+      expect(grade, CourseGrade(course, enrollment, forceAllPeriods: false));
+    });
+  });
+}

--- a/apps/flutter_parent/test/screens/courses/course_grades_screen_test.dart
+++ b/apps/flutter_parent/test/screens/courses/course_grades_screen_test.dart
@@ -404,6 +404,123 @@ void main() {
       expect(find.text(AppLocalizations().courseTotalGradeLabel), findsOneWidget);
       expect(find.text('test period'), findsOneWidget);
     });
+
+    testWidgetsWithAccessibilityChecks('is shown when looking at all grading periods with an active period set',
+        (tester) async {
+      final groups = [
+        _mockAssignmentGroup(assignments: [_mockAssignment()])
+      ];
+      final gradingPeriod = GradingPeriod((b) => b
+        ..id = null
+        ..title = 'All Grading Periods');
+      final enrollment = Enrollment((b) => b
+        ..enrollmentState = 'active'
+        ..role = 'observer'
+        ..userId = _studentId
+        ..currentGradingPeriodId = '1212'
+        ..totalsForAllGradingPeriodsOption = true
+        ..multipleGradingPeriodsEnabled = true
+        ..currentPeriodComputedCurrentScore = 12
+        ..computedCurrentScore = 1);
+      final model = CourseDetailsModel(_studentId, '', _courseId);
+      model.updateGradingPeriod(gradingPeriod);
+      model.course = _mockCourse().rebuild((b) => b
+        ..hasGradingPeriods = true
+        ..enrollments = ListBuilder([enrollment]));
+
+      // Mock stuff
+      when(interactor.loadAssignmentGroups(_courseId, _studentId, gradingPeriod.id)).thenAnswer((_) async => groups);
+      when(interactor.loadGradingPeriods(_courseId)).thenAnswer(
+          (_) async => GradingPeriodResponse((b) => b..gradingPeriods = BuiltList.of([gradingPeriod]).toBuilder()));
+      when(interactor.loadEnrollmentsForGradingPeriod(_courseId, _studentId, null)).thenAnswer((_) async => null);
+
+      await tester.pumpWidget(_testableWidget(model, highContrastMode: true));
+      await tester.pump(); // Build the widget
+      await tester.pump(); // Let the future finish
+
+      // Verify that we are showing the course grade when not locked
+      expect(find.text(AppLocalizations().courseTotalGradeLabel), findsOneWidget);
+      expect(find.text('1%'), findsOneWidget);
+      expect(find.text(AppLocalizations().noGrade), findsNothing);
+    });
+
+    testWidgetsWithAccessibilityChecks(
+        'is shown when looking at a period with an active period set (given no enrollment response)', (tester) async {
+      final groups = [
+        _mockAssignmentGroup(assignments: [_mockAssignment()])
+      ];
+      final gradingPeriod = GradingPeriod((b) => b
+        ..id = '1212'
+        ..title = 'All Grading Periods');
+      final enrollment = Enrollment((b) => b
+        ..enrollmentState = 'active'
+        ..role = 'observer'
+        ..userId = _studentId
+        ..currentGradingPeriodId = gradingPeriod.id
+        ..totalsForAllGradingPeriodsOption = true
+        ..multipleGradingPeriodsEnabled = true
+        ..currentPeriodComputedCurrentScore = 12
+        ..computedCurrentScore = 1);
+      final model = CourseDetailsModel(_studentId, '', _courseId);
+      model.updateGradingPeriod(gradingPeriod);
+      model.course = _mockCourse().rebuild((b) => b
+        ..hasGradingPeriods = true
+        ..enrollments = ListBuilder([enrollment]));
+
+      // Mock stuff
+      when(interactor.loadAssignmentGroups(_courseId, _studentId, gradingPeriod.id)).thenAnswer((_) async => groups);
+      when(interactor.loadGradingPeriods(_courseId)).thenAnswer(
+          (_) async => GradingPeriodResponse((b) => b..gradingPeriods = BuiltList.of([gradingPeriod]).toBuilder()));
+      when(interactor.loadEnrollmentsForGradingPeriod(_courseId, _studentId, null)).thenAnswer((_) async => null);
+
+      await tester.pumpWidget(_testableWidget(model, highContrastMode: true));
+      await tester.pump(); // Build the widget
+      await tester.pump(); // Let the future finish
+
+      // Verify that we are showing the course grade when not locked
+      expect(find.text(AppLocalizations().courseTotalGradeLabel), findsOneWidget);
+      expect(find.text('12%'), findsOneWidget);
+      expect(find.text(AppLocalizations().noGrade), findsNothing);
+    });
+
+    testWidgetsWithAccessibilityChecks(
+        'is not shown when looking at all grading periods with an active period set and final grades hidden',
+        (tester) async {
+      final groups = [
+        _mockAssignmentGroup(assignments: [_mockAssignment()])
+      ];
+      final gradingPeriod = GradingPeriod((b) => b
+        ..id = null
+        ..title = 'All Grading Periods');
+      final enrollment = Enrollment((b) => b
+        ..enrollmentState = 'active'
+        ..role = 'observer'
+        ..userId = _studentId
+        ..currentGradingPeriodId = '1212'
+        ..totalsForAllGradingPeriodsOption = true
+        ..multipleGradingPeriodsEnabled = true
+        ..currentPeriodComputedCurrentScore = 12
+        ..computedCurrentScore = 1);
+      final model = CourseDetailsModel(_studentId, '', _courseId);
+      model.updateGradingPeriod(gradingPeriod);
+      model.course = _mockCourse().rebuild((b) => b
+        ..hasGradingPeriods = true
+        ..hideFinalGrades = true
+        ..enrollments = ListBuilder([enrollment]));
+
+      // Mock stuff
+      when(interactor.loadAssignmentGroups(_courseId, _studentId, gradingPeriod.id)).thenAnswer((_) async => groups);
+      when(interactor.loadGradingPeriods(_courseId)).thenAnswer(
+          (_) async => GradingPeriodResponse((b) => b..gradingPeriods = BuiltList.of([gradingPeriod]).toBuilder()));
+      when(interactor.loadEnrollmentsForGradingPeriod(_courseId, _studentId, null)).thenAnswer((_) async => null);
+
+      await tester.pumpWidget(_testableWidget(model, highContrastMode: true));
+      await tester.pump(); // Build the widget
+      await tester.pump(); // Let the future finish
+
+      // Verify that we are showing the course grade when not locked
+      expect(find.text(AppLocalizations().courseTotalGradeLabel), findsNothing);
+    });
   });
 
   testWidgetsWithAccessibilityChecks('grading period not shown when noot multiple grading periods', (tester) async {


### PR DESCRIPTION
Now shows current grading period by default when going into course details.
Will default to showing the course enrollments current_grade for All Grading Periods if we can’t get the enrollment from the individual enrollment endpoint. i.e., for legacy parents (didn’t pair via pairing code) we can’t get grades by the enrollment endpoint, we can only see the course enrollment which has current_grade (all grading periods) and the current_period_computed_current_grade (current period).