### PR TITLE
[Flutter-Parent][MBL-13509] Help Dialog

### DIFF
--- a/apps/flutter_parent/lib/l10n/app_localizations.dart
+++ b/apps/flutter_parent/lib/l10n/app_localizations.dart
@@ -160,9 +160,6 @@ class AppLocalizations {
 
   String get help => Intl.message('Help', desc: 'Label text for the help nav drawer button');
 
-  String get shareFeedback =>
-      Intl.message('Send us feedback', desc: 'Label text for the nav drawer button to share feedback');
-
   String get logOut => Intl.message('Log Out', desc: 'Label text for the Log Out nav drawer button');
 
   String get switchUsers => Intl.message('Switch Users', desc: 'Label text for the Switch Users nav drawer button');
@@ -908,6 +905,76 @@ class AppLocalizations {
 
   String get eventRemindMeSet =>
       Intl.message('You will be notified about this event on…', desc: 'Description for when an event reminder is set');
+
+  /// Help Dialog
+
+  String get helpSearchCanvasDocsLabel => Intl.message(
+        'Search the Canvas Guides',
+        desc: 'Label for option to search the Canvas Guides',
+      );
+
+  String get helpSearchCanvasDocsDescription => Intl.message(
+        'Find answers to common questions',
+        desc: 'Description for option to search the Canvas Guides',
+      );
+
+  String get helpReportProblemLabel => Intl.message(
+        'Report a Problem',
+        desc: 'Label for option to report a problem',
+      );
+
+  String get helpReportProblemDescription => Intl.message(
+        'If the app misbehaves, let us know',
+        desc: 'Description for option to report a problem',
+      );
+
+  String get helpRequestFeatureLabel => Intl.message(
+        'Request a Feature',
+        desc: 'Label for option to request a feature',
+      );
+
+  String get helpRequestFeatureDescription => Intl.message(
+        'Have an idea to improve the app?',
+        desc: 'Description for option to request a feature',
+      );
+
+  String get helpShareLoveLabel => Intl.message(
+        'Share Your Love for the App',
+        desc: 'Label for option to open the app store',
+      );
+
+  String get helpShareLoveDescription => Intl.message(
+        'Tell us about your favorite parts of the app',
+        desc: 'Description for option to open the app store',
+      );
+
+  String get helpLegalLabel => Intl.message(
+        'Legal',
+        desc: 'Label for legal information option',
+      );
+
+  String get helpLegalDescription => Intl.message(
+        'Privacy policy, terms of use, open source',
+        desc: 'Description for legal information option',
+      );
+
+  String get featureRequestSubject => Intl.message(
+        'Idea for Canvas Parent App [Android]',
+        desc: 'The subject for the email to request a feature',
+      );
+
+  String get featureRequestHeader => Intl.message(
+        'The following information will help us better understand your idea:',
+        desc: 'The header for the users information that is attached to a feature request',
+      );
+
+  String get helpDomain => Intl.message('Domain:', desc: 'The label for the Canvas domain of the logged in user');
+
+  String get helpUserId => Intl.message('User ID:', desc: 'The label for the Canvas user ID of the logged in user');
+
+  String get helpEmail => Intl.message('Email:', desc: 'The label for the eamil of the logged in user');
+
+  String get helpLocale => Intl.message('Locale:', desc: 'The label for the locale of the logged in user');
 
   /// Error Report Dialog
 

--- a/apps/flutter_parent/lib/screens/dashboard/dashboard_screen.dart
+++ b/apps/flutter_parent/lib/screens/dashboard/dashboard_screen.dart
@@ -22,6 +22,7 @@ import 'package:flutter_parent/screens/courses/courses_screen.dart';
 import 'package:flutter_parent/screens/dashboard/selected_student_notifier.dart';
 import 'package:flutter_parent/screens/dashboard/student_expansion_widget.dart';
 import 'package:flutter_parent/screens/dashboard/student_horizontal_list_view.dart';
+import 'package:flutter_parent/screens/help/help_dialog.dart';
 import 'package:flutter_parent/screens/inbox/conversation_list/conversation_list_screen.dart';
 import 'package:flutter_parent/screens/login_landing_screen.dart';
 import 'package:flutter_parent/screens/manage_students/manage_students_screen.dart';
@@ -36,10 +37,8 @@ import 'package:flutter_parent/utils/design/parent_colors.dart';
 import 'package:flutter_parent/utils/design/parent_theme.dart';
 import 'package:flutter_parent/utils/quick_nav.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:package_info/package_info.dart';
 import 'package:provider/provider.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import 'dashboard_interactor.dart';
 
@@ -348,10 +347,7 @@ class DashboardState extends State<DashboardScreen> {
   _navigateToHelp(context) {
     // Close the drawer, then push the Help screen in
     Navigator.of(context).pop();
-    // TODO: Instead, we should navigate to the help screen, once it's built out (MBL-11509)
-    // Temporary help for the beta is to send feedback through the app store.
-    launch('https://play.google.com/store/apps/details?id=com.instructure.parentapp');
-//    locator<QuickNav>().push(context, HelpScreen());
+    HelpDialog.asDialog(context);
   }
 
   _performLogOut(BuildContext context, {bool switchingUsers = false}) async {
@@ -418,11 +414,8 @@ class DashboardState extends State<DashboardScreen> {
         onTap: () => locator<QuickNav>().push(context, SettingsScreen()),
       );
 
-  // TODO: Change the label to 'Help' and remove the trailing icon when we get in the help screen (MBL-11509)
-  // Temporary help is to 'share feedback' through the app store for the beta.
   _navDrawerHelp() => ListTile(
-        title: Text(L10n(context).shareFeedback),
-        trailing: SvgPicture.asset('assets/svg/external-link.svg'),
+        title: Text(L10n(context).help),
         onTap: () => _navigateToHelp(context),
       );
 

--- a/apps/flutter_parent/lib/screens/help/help_dialog.dart
+++ b/apps/flutter_parent/lib/screens/help/help_dialog.dart
@@ -1,0 +1,172 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import 'package:android_intent/android_intent.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_parent/l10n/app_localizations.dart';
+import 'package:flutter_parent/network/utils/api_prefs.dart';
+import 'package:flutter_parent/utils/common_widgets/error_report/error_report_dialog.dart';
+import 'package:flutter_parent/utils/veneers/AndroidIntentVeneer.dart';
+import 'package:intent/action.dart' as android;
+import 'package:intent/extra.dart' as android;
+import 'package:intent/intent.dart' as android;
+import 'package:package_info/package_info.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class HelpDialog extends StatefulWidget {
+  const HelpDialog._internal({Key key}) : super(key: key);
+
+  static Future<void> asDialog(BuildContext context) {
+    return showDialog(
+      context: context,
+      builder: (context) => HelpDialog._internal(),
+    );
+  }
+
+  @override
+  _HelpDialogState createState() => _HelpDialogState();
+}
+
+class _HelpDialogState extends State<HelpDialog> {
+  @override
+  Widget build(BuildContext context) {
+    final l10n = L10n(context);
+    return SimpleDialog(
+      title: Text(l10n.help),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),
+      children: <Widget>[
+        _HelpRow(
+          label: l10n.helpSearchCanvasDocsLabel,
+          description: l10n.helpSearchCanvasDocsDescription,
+          onTap: _showSearch,
+        ),
+        _HelpRow(
+          label: l10n.helpReportProblemLabel,
+          description: l10n.helpReportProblemDescription,
+          onTap: _showReportProblem,
+        ),
+        _HelpRow(
+          label: l10n.helpRequestFeatureLabel,
+          description: l10n.helpRequestFeatureDescription,
+          onTap: _showRequestFeature,
+        ),
+        _HelpRow(
+          label: l10n.helpShareLoveLabel,
+          description: l10n.helpShareLoveDescription,
+          onTap: _showShareLove,
+        ),
+        // TODO: Add in legal option once we have the dialog
+//        _HelpRow(
+//          label: l10n.helpLegalLabel,
+//          description: l10n.helpLegalDescription,
+//          onTap: _showLegal,
+//        ),
+      ],
+    );
+  }
+
+  void _showSearch() => launch(
+      'https://community.canvaslms.com/community/answers/guides/mobile-guide/content?filterID=contentstatus%5Bpublished%5D~category%5Btable-of-contents%5D');
+
+  void _showReportProblem() => ErrorReportDialog.asDialog(context);
+
+  void _showRequestFeature() async {
+    final l10n = L10n(context);
+
+    final parentId = ApiPrefs.getUser()?.id ?? 0;
+    final email = ApiPrefs.getUser()?.primaryEmail ?? '';
+    final domain = ApiPrefs.getDomain() ?? '';
+    final locale = ApiPrefs.effectiveLocale().toLanguageTag();
+
+    PackageInfo package = await PackageInfo.fromPlatform();
+
+    // Populate the email body with information about the user
+    String emailBody = '' +
+        '${l10n.featureRequestHeader}\r\n' +
+        '${l10n.helpUserId} $parentId\r\n' +
+        '${l10n.helpEmail} $email\r\n' +
+        '${l10n.helpDomain} $domain\r\n' +
+        '${l10n.versionNumber}: ${package.appName} v${package.version} (${package.buildNumber})\r\n' +
+        '${l10n.helpLocale} $locale\r\n' +
+        '----------------------------------------------\r\n';
+
+    final subject = l10n.featureRequestSubject;
+    final canvasEmail = 'mobilesupport@instructure.com';
+
+    _sendIntent(canvasEmail, subject, emailBody);
+//    _sendAndroidIntent(canvasEmail, subject, emailBody);
+  }
+
+  // Can't use yet, this doesn't set the 'email' field properly. Also can't specify all components via the data uri, as
+  //  the encoding isn't properly handled by receiving apps (either spaces are turned into '+' or new lines aren't included).
+  //  Can update once AndroidIntent supports string arrays rather than just string array lists (confirmed this is what's
+  //  breaking, can include a link to the flutter plugin PR to fix this once I get one made)
+  void _sendAndroidIntent(String canvasEmail, String subject, String emailBody) {
+    final intent = AndroidIntent(
+      action: 'android.intent.action.SENDTO',
+      data: Uri(scheme: 'mailto').toString(),
+      arguments: {
+        'android.intent.extra.EMAIL': [canvasEmail],
+        'android.intent.extra.SUBJECT': subject,
+        'android.intent.extra.TEXT': emailBody,
+      },
+    );
+
+    AndroidIntentVeneer().launch(intent);
+  }
+
+  // TODO: Switch to AndroidIntent once it supports emails properly (either can't specify 'to' email, or body doesn't support multiline)
+  void _sendIntent(String canvasEmail, String subject, String emailBody) {
+    android.Intent()
+      ..setAction(android.Action.ACTION_SENDTO)
+      ..setData(Uri(scheme: 'mailto'))
+      ..putExtra(android.Extra.EXTRA_EMAIL, [canvasEmail])
+      ..putExtra(android.Extra.EXTRA_SUBJECT, subject)
+      ..putExtra(android.Extra.EXTRA_TEXT, emailBody)
+      ..startActivity(createChooser: true);
+  }
+
+  void _showShareLove() => launch('https://play.google.com/store/apps/details?id=com.instructure.parentapp');
+
+//  void _showLegal() => LegalDialog.asDialog(context)
+}
+
+class _HelpRow extends StatelessWidget {
+  final String label, description;
+  final VoidCallback onTap;
+
+  const _HelpRow({Key key, this.label, this.description, this.onTap}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return SimpleDialogOption(
+      onPressed: () {
+        Navigator.of(context).pop(true);
+        onTap();
+      },
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(label, style: textTheme.subhead),
+            Text(description, style: textTheme.caption),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/flutter_parent/pubspec.lock
+++ b/apps/flutter_parent/pubspec.lock
@@ -409,6 +409,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.1+4"
+  intent:
+    dependency: "direct main"
+    description:
+      name: intent
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   intl:
     dependency: "direct main"
     description:

--- a/apps/flutter_parent/pubspec.yaml
+++ b/apps/flutter_parent/pubspec.yaml
@@ -44,23 +44,16 @@ dependencies:
   flutter_crashlytics: ^1.0.0
   get_it: ^3.0.1
   intl: ^0.16.0
-  package_info: 0.4.0+10
   provider: ^3.1.0+1
-  shared_preferences: 0.5.3+4
-  webview_flutter: 0.3.19+5
-  device_info: 0.4.1+3
   vector_math: 2.0.8
   tuple: 1.0.3
   flutter_slidable: 0.5.4
-  permission_handler: 4.1.0
   percent_indicator: 2.1.1+1
-  flutter_local_notifications: 1.1.5+1
   sqflite: 1.2.0
 
   # File handling
   path_provider: 1.5.1
   flutter_downloader: 1.4.0
-  android_intent: 0.3.5
   mime: 0.9.6+3
   file_picker: 1.4.2
 
@@ -79,7 +72,16 @@ dependencies:
   built_value: ^7.0.0
   built_collection: 4.2.2
 
+  # Platform interactions
+  android_intent: 0.3.5
+  device_info: 0.4.1+3
+  flutter_local_notifications: 1.1.5+1
+  intent: 1.1.0 # TODO: Remove once android_intent can handle emails properly (see help_dialog.dart for more info)
+  package_info: 0.4.0+10
+  permission_handler: 4.1.0
+  shared_preferences: 0.5.3+4
   url_launcher: 5.2.5
+  webview_flutter: 0.3.19+5
 
 dev_dependencies:
   flutter_driver:

--- a/apps/flutter_parent/test/screens/dashboard/dashboard_screen_test.dart
+++ b/apps/flutter_parent/test/screens/dashboard/dashboard_screen_test.dart
@@ -32,6 +32,7 @@ import 'package:flutter_parent/screens/dashboard/dashboard_screen.dart';
 import 'package:flutter_parent/screens/dashboard/inbox_notifier.dart';
 import 'package:flutter_parent/screens/dashboard/selected_student_notifier.dart';
 import 'package:flutter_parent/screens/dashboard/student_expansion_widget.dart';
+import 'package:flutter_parent/screens/help/help_dialog.dart';
 import 'package:flutter_parent/screens/login_landing_screen.dart';
 import 'package:flutter_parent/screens/manage_students/manage_students_interactor.dart';
 import 'package:flutter_parent/screens/manage_students/manage_students_screen.dart';
@@ -339,21 +340,22 @@ void main() {
       expect(find.byType(SettingsScreen), findsOneWidget);
     });
 
-//  testWidgetsWithAccessibilityChecks('tapping Help from nav drawer shows help', (tester) async {
-//    _setupLocator(MockInteractor());
-//
-//    await tester.pumpWidget(_testableMaterialWidget());
-//    await tester.pumpAndSettle();
-//
-//    // Open the nav drawer
-//    DashboardScreen.scaffoldKey.currentState.openDrawer();
-//    await tester.pumpAndSettle();
-//
-//    // Click on Help
-//    await tester.tap(find.text(AppLocalizations().help));
-//
-//    // TODO: Test that Help screen was loaded
-//  });
+    testWidgetsWithAccessibilityChecks('tapping Help from nav drawer shows help', (tester) async {
+      _setupLocator(interactor: MockInteractor());
+
+      await tester.pumpWidget(_testableMaterialWidget());
+      await tester.pumpAndSettle();
+
+      // Open the nav drawer
+      DashboardScreen.scaffoldKey.currentState.openDrawer();
+      await tester.pumpAndSettle();
+
+      // Click on Help
+      await tester.tap(find.text(AppLocalizations().help));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HelpDialog), findsOneWidget);
+    });
 
     // Not using the accessibility tester due to an issue where the
     // Login Landing screen fails a contrast ratio test after logging out

--- a/apps/flutter_parent/test/screens/help/help_dialog_test.dart
+++ b/apps/flutter_parent/test/screens/help/help_dialog_test.dart
@@ -1,0 +1,165 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_parent/l10n/app_localizations.dart';
+import 'package:flutter_parent/models/login.dart';
+import 'package:flutter_parent/models/user.dart';
+import 'package:flutter_parent/network/utils/api_prefs.dart';
+import 'package:flutter_parent/screens/help/help_dialog.dart';
+import 'package:flutter_parent/utils/common_widgets/error_report/error_report_dialog.dart';
+import 'package:flutter_parent/utils/veneers/AndroidIntentVeneer.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+
+import '../../utils/accessibility_utils.dart';
+import '../../utils/test_app.dart';
+
+void main() {
+  final l10n = AppLocalizations();
+
+  testWidgetsWithAccessibilityChecks('displays all options', (tester) async {
+    await TestApp.showWidgetFromTap(tester, (context) => HelpDialog.asDialog(context));
+
+    expect(find.text(l10n.help), findsOneWidget);
+
+    expect(find.text(l10n.helpSearchCanvasDocsLabel), findsOneWidget);
+    expect(find.text(l10n.helpSearchCanvasDocsDescription), findsOneWidget);
+
+    expect(find.text(l10n.helpReportProblemLabel), findsOneWidget);
+    expect(find.text(l10n.helpReportProblemDescription), findsOneWidget);
+
+    expect(find.text(l10n.helpRequestFeatureLabel), findsOneWidget);
+    expect(find.text(l10n.helpRequestFeatureDescription), findsOneWidget);
+
+    expect(find.text(l10n.helpShareLoveLabel), findsOneWidget);
+    expect(find.text(l10n.helpShareLoveDescription), findsOneWidget);
+    // TODO: Uncomment once legal has been added
+//    expect(find.text(l10n.helpLegalLabel), findsOneWidget);
+//    expect(find.text(l10n.helpLegalDescription), findsOneWidget);
+  });
+
+  testWidgetsWithAccessibilityChecks('tapping search launches url', (tester) async {
+    var mockLauncher = _MockUrlLauncherPlatform();
+    UrlLauncherPlatform.instance = mockLauncher;
+
+    await TestApp.showWidgetFromTap(tester, (context) => HelpDialog.asDialog(context));
+
+    await tester.tap(find.text(l10n.helpSearchCanvasDocsLabel));
+    await tester.pumpAndSettle();
+
+    verify(
+      mockLauncher.launch(
+        'https://community.canvaslms.com/community/answers/guides/mobile-guide/content?filterID=contentstatus%5Bpublished%5D~category%5Btable-of-contents%5D',
+        useSafariVC: anyNamed('useSafariVC'),
+        useWebView: anyNamed('useWebView'),
+        enableJavaScript: anyNamed('enableJavaScript'),
+        enableDomStorage: anyNamed('enableDomStorage'),
+        universalLinksOnly: anyNamed('universalLinksOnly'),
+        headers: anyNamed('headers'),
+      ),
+    ).called(1);
+  });
+
+  testWidgetsWithAccessibilityChecks('tapping share love launches url', (tester) async {
+    var mockLauncher = _MockUrlLauncherPlatform();
+    UrlLauncherPlatform.instance = mockLauncher;
+
+    await TestApp.showWidgetFromTap(tester, (context) => HelpDialog.asDialog(context));
+
+    await tester.tap(find.text(l10n.helpShareLoveLabel));
+    await tester.pumpAndSettle();
+
+    verify(
+      mockLauncher.launch(
+        'https://play.google.com/store/apps/details?id=com.instructure.parentapp',
+        useSafariVC: anyNamed('useSafariVC'),
+        useWebView: anyNamed('useWebView'),
+        enableJavaScript: anyNamed('enableJavaScript'),
+        enableDomStorage: anyNamed('enableDomStorage'),
+        universalLinksOnly: anyNamed('universalLinksOnly'),
+        headers: anyNamed('headers'),
+      ),
+    ).called(1);
+  });
+
+  testWidgetsWithAccessibilityChecks('tapping report problem shows error report dialog', (tester) async {
+    var mockLauncher = _MockUrlLauncherPlatform();
+    UrlLauncherPlatform.instance = mockLauncher;
+
+    await TestApp.showWidgetFromTap(tester, (context) => HelpDialog.asDialog(context), highContrast: true);
+
+    await tester.tap(find.text(l10n.helpReportProblemLabel));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ErrorReportDialog), findsOneWidget);
+  });
+
+  testWidgetsWithAccessibilityChecks('tapping request feature launches email intent', (tester) async {
+    await setupPlatformChannels();
+
+    final user = User((b) => b
+      ..id = '123'
+      ..primaryEmail = '123@321.com'
+      ..effectiveLocale = 'en-jp');
+    final login = Login((b) => b..domain = 'dough main');
+    final veneer = _MockAndroidIntentVeneer();
+    setupTestLocator((locator) {
+      locator.registerLazySingleton<AndroidIntentVeneer>(() => veneer);
+    });
+
+    ApiPrefs.switchLogins(login);
+    ApiPrefs.setUser(user);
+
+    String emailBody = '' +
+        '${l10n.featureRequestHeader}\r\n' +
+        '${l10n.helpUserId} ${user.id}\r\n' +
+        '${l10n.helpEmail} ${user.primaryEmail}\r\n' +
+        '${l10n.helpDomain} ${login.domain}\r\n' +
+        '${l10n.versionNumber}: Canvas v1.0.0 (3)\r\n' +
+        '${l10n.helpLocale} ${user.effectiveLocale}\r\n' +
+        '----------------------------------------------\r\n';
+
+    final completer = Completer();
+    await MethodChannel('intent').setMockMethodCallHandler((MethodCall call) async {
+      expect(call.method, 'startActivity');
+      expect(call.arguments['action'], 'android.intent.action.SENDTO');
+      expect(call.arguments['data'], 'mailto:');
+      expect(call.arguments['extra'], {
+        'android.intent.extra.EMAIL': ['mobilesupport@instructure.com'],
+        'android.intent.extra.SUBJECT': l10n.featureRequestSubject,
+        'android.intent.extra.TEXT': emailBody,
+      });
+
+      completer.complete(); // Finish the completer so the test can finish
+      return null;
+    });
+
+    await TestApp.showWidgetFromTap(tester, (context) => HelpDialog.asDialog(context));
+
+    await tester.tap(find.text(l10n.helpRequestFeatureLabel));
+    await tester.pumpAndSettle();
+
+    await completer.future; // Wait for the completer to finish the test
+  });
+
+  // TODO: Test legal once it's added
+}
+
+class _MockUrlLauncherPlatform extends Mock with MockPlatformInterfaceMixin implements UrlLauncherPlatform {}
+
+class _MockAndroidIntentVeneer extends Mock implements AndroidIntentVeneer {}

--- a/apps/flutter_parent/test/utils/test_app.dart
+++ b/apps/flutter_parent/test/utils/test_app.dart
@@ -48,6 +48,23 @@ class TestApp extends StatefulWidget {
 
   @override
   _TestAppState createState() => _TestAppState();
+
+  static showWidgetFromTap(WidgetTester tester, Future tapCallback(BuildContext), {bool highContrast = false}) async {
+    await tester.pumpWidget(TestApp(
+      Builder(
+          builder: (context) => RaisedButton(
+                color: Colors.black,
+                child: Text('tap me', style: TextStyle(color: Colors.white)),
+                onPressed: () => tapCallback(context),
+              )),
+      highContrast: highContrast,
+    ));
+    await tester.pumpAndSettle();
+
+    // Tap the button to trigger the onPressed
+    await tester.tap(find.byType(RaisedButton));
+    await tester.pumpAndSettle();
+  }
 }
 
 class _TestAppState extends State<TestApp> {

--- a/apps/flutter_parent/test/utils/widgets/error_report/error_report_dialog_test.dart
+++ b/apps/flutter_parent/test/utils/widgets/error_report/error_report_dialog_test.dart
@@ -23,26 +23,8 @@ import '../../accessibility_utils.dart';
 import '../../test_app.dart';
 
 void main() {
-  TestApp _createTestApp(Future callback(BuildContext)) => TestApp(
-        Builder(
-            builder: (context) => RaisedButton(
-                  child: Text('tap me', style: TextStyle(color: Colors.white)), // So it's 'accessible'
-                  onPressed: () => callback(context),
-                )),
-        highContrast: true,
-      );
-
-  _showDialog(WidgetTester tester, Future callback(BuildContext)) async {
-    await tester.pumpWidget(_createTestApp(callback));
-    await tester.pumpAndSettle();
-
-    // Tap the button to show the dialog
-    await tester.tap(find.byType(RaisedButton));
-    await tester.pumpAndSettle();
-  }
-
   testWidgetsWithAccessibilityChecks('Shows a dialog', (tester) async {
-    await _showDialog(tester, (context) => ErrorReportDialog.asDialog(context));
+    await TestApp.showWidgetFromTap(tester, (context) => ErrorReportDialog.asDialog(context), highContrast: true);
 
     expect(find.byType(ErrorReportDialog), findsOneWidget);
     expect(find.text(AppLocalizations().reportProblemTitle), findsOneWidget);
@@ -59,16 +41,16 @@ void main() {
     final subject = 'subject';
     final severity = ErrorReportSeverity.CRITICAL;
 
-    await _showDialog(
-      tester,
-      (context) => ErrorReportDialog.asDialog(
-        context,
-        title: title,
-        subject: subject,
-        severity: severity,
-        includeEmail: true,
-      ),
-    );
+    await TestApp.showWidgetFromTap(
+        tester,
+        (context) => ErrorReportDialog.asDialog(
+              context,
+              title: title,
+              subject: subject,
+              severity: severity,
+              includeEmail: true,
+            ),
+        highContrast: true);
 
     expect(find.byType(ErrorReportDialog), findsOneWidget);
     expect(find.text(title), findsOneWidget);
@@ -78,7 +60,7 @@ void main() {
   });
 
   testWidgetsWithAccessibilityChecks('Selecting a severity updates dialog', (tester) async {
-    await _showDialog(tester, (context) => ErrorReportDialog.asDialog(context));
+    await TestApp.showWidgetFromTap(tester, (context) => ErrorReportDialog.asDialog(context), highContrast: true);
 
     // Tap on dropdown to show list
     await tester.tap(find.text(AppLocalizations().errorSeverityComment));
@@ -93,7 +75,7 @@ void main() {
   });
 
   testWidgetsWithAccessibilityChecks('Cancel closes the dialog', (tester) async {
-    await _showDialog(tester, (context) => ErrorReportDialog.asDialog(context));
+    await TestApp.showWidgetFromTap(tester, (context) => ErrorReportDialog.asDialog(context), highContrast: true);
 
     await tester.tap(find.text(AppLocalizations().cancel.toUpperCase()));
     await tester.pumpAndSettle();
@@ -102,7 +84,8 @@ void main() {
   });
 
   testWidgetsWithAccessibilityChecks('Submit validates the dialog and shows errors', (tester) async {
-    await _showDialog(tester, (context) => ErrorReportDialog.asDialog(context, includeEmail: true));
+    await TestApp.showWidgetFromTap(tester, (context) => ErrorReportDialog.asDialog(context, includeEmail: true),
+        highContrast: true);
 
     expect(find.text(AppLocalizations().reportProblemSubjectEmpty), findsNothing);
     expect(find.text(AppLocalizations().reportProblemDescriptionEmpty), findsNothing);
@@ -126,7 +109,11 @@ void main() {
     final interactor = _MockErrorReportInteractor();
     setupTestLocator((locator) => locator.registerFactory<ErrorReportInteractor>(() => interactor));
 
-    await _showDialog(tester, (context) => ErrorReportDialog.asDialog(context, includeEmail: true, error: error));
+    await TestApp.showWidgetFromTap(
+      tester,
+      (context) => ErrorReportDialog.asDialog(context, includeEmail: true, error: error),
+      highContrast: true,
+    );
 
     // Enter in the details
     await tester.enterText(find.byKey(ErrorReportDialog.subjectKey), subject);


### PR DESCRIPTION
Also adds a static convenience method to TestApp to enable testing widgets that need a build context (like dialogs).

Main pain point here, I had to include a second intent library to support emails. The url_launcher can start an email activity, but only the default one and it can’t handle a multiline body. There’s also the android_intent library we are using for showing files from inbox, this unfortunately has a bug where we emails aren’t getting set up properly on the actual intent, therefore the email app can’t read the ‘to’ email we’re trying to send to.

Unfortunately, the intent library I found handles emails correctly, but does not support setting both data and a type, so it does not work for the original intent inclusion of viewing a file from a url (just passing the url will usually only prompt for a browser to open, rather than a media viewing app). This means that both intent libraries are required as of right now. I plan on creating a pull request for the originally included android_intent library to fix email intents. That plugin seems better for long term use as it’s a first party library maintained by google, so ideally we will be able to only use that one.