### PR TITLE
[Flutter-Parent] Add more logs and info for crashes to help debugging

### DIFF
--- a/apps/flutter_parent/lib/utils/crash_utils.dart
+++ b/apps/flutter_parent/lib/utils/crash_utils.dart
@@ -46,12 +46,14 @@ class CrashUtils {
     debugPrintStack(stackTrace: stacktrace);
 
     if (kReleaseMode) {
-      // Report to crashlytics
+      // Set any user info that will help to debug the issue
       await Future.wait([
         FlutterCrashlytics().setInfo('domain', ApiPrefs.getDomain()),
         FlutterCrashlytics().setInfo('user_id', ApiPrefs.getUser()?.id),
-        FlutterCrashlytics().reportCrash(exception, stacktrace, forceCrash: false),
       ]);
+
+      // Report to crashlytics
+      await FlutterCrashlytics().reportCrash(exception, stacktrace, forceCrash: false);
     }
   }
 }

--- a/apps/flutter_parent/lib/utils/crash_utils.dart
+++ b/apps/flutter_parent/lib/utils/crash_utils.dart
@@ -15,6 +15,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_crashlytics/flutter_crashlytics.dart';
+import 'package:flutter_parent/network/utils/api_prefs.dart';
 import 'package:flutter_parent/screens/crash_screen.dart';
 
 class CrashUtils {
@@ -46,7 +47,11 @@ class CrashUtils {
 
     if (kReleaseMode) {
       // Report to crashlytics
-      await FlutterCrashlytics().reportCrash(exception, stacktrace, forceCrash: false);
+      await Future.wait([
+        FlutterCrashlytics().setInfo('domain', ApiPrefs.getDomain()),
+        FlutterCrashlytics().setInfo('user_id', ApiPrefs.getUser()?.id),
+        FlutterCrashlytics().reportCrash(exception, stacktrace, forceCrash: false),
+      ]);
     }
   }
 }

--- a/apps/flutter_parent/lib/utils/quick_nav.dart
+++ b/apps/flutter_parent/lib/utils/quick_nav.dart
@@ -12,21 +12,34 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_crashlytics/flutter_crashlytics.dart';
 
 class QuickNav {
   Future<T> push<T extends Object>(BuildContext context, Widget widget) {
+    _logShow(widget);
     return Navigator.of(context).push(MaterialPageRoute(builder: (context) => widget));
   }
 
   /// Clears the back stack of any routes currently in the navigation and adds the new widget
   Future<T> pushAndRemoveAll<T extends Object>(BuildContext context, Widget widget) {
+    _logShow(widget);
     return Navigator.of(context).pushAndRemoveUntil(MaterialPageRoute(builder: (context) => widget), (_) => false);
   }
 
   /// Replace the current route of the navigator with the provided route
   Future<T> replaceRoute<T extends Object>(BuildContext context, Route<T> newRoute) {
     return Navigator.pushReplacement(context, newRoute);
+  }
+
+  void _logShow(Widget widget) {
+    final message = 'Pushing widget: ${widget.runtimeType.toString()}';
+    if (kReleaseMode) {
+      FlutterCrashlytics().log(message);
+    } else {
+      print(message);
+    }
   }
 }


### PR DESCRIPTION
You can test by throwing an exception somewhere in the code, running in release mode, and making the crash happen.

Or you can view what it looks like when this is done: https://console.firebase.google.com/project/automatic-rite-88319/crashlytics/app/android:com.instructure.parentapp/issues/c3c4934e105770e3ee0ee85bcfd20db0