### PR TITLE
[Flutter Parent] Add keep-alive mixin to course details screens

### DIFF
--- a/apps/flutter_parent/lib/screens/courses/details/course_grades_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_grades_screen.dart
@@ -40,10 +40,13 @@ class CourseGradesScreen extends StatefulWidget {
   _CourseGradesScreenState createState() => _CourseGradesScreenState();
 }
 
-class _CourseGradesScreenState extends State<CourseGradesScreen> {
+class _CourseGradesScreenState extends State<CourseGradesScreen> with AutomaticKeepAliveClientMixin {
   Set<String> _collapsedGroupIds;
   Future<GradeDetails> _detailsFuture;
   static final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey = new GlobalKey<RefreshIndicatorState>();
+
+  @override
+  bool get wantKeepAlive => true;
 
   @override
   void initState() {
@@ -53,6 +56,7 @@ class _CourseGradesScreenState extends State<CourseGradesScreen> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context); // Required super call for AutomaticKeepAliveClientMixin
     CourseDetailsModel.selectedTab = 0;
     return Consumer<CourseDetailsModel>(
       builder: (context, model, _) {

--- a/apps/flutter_parent/lib/screens/courses/details/course_home_page_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_home_page_screen.dart
@@ -33,8 +33,11 @@ class CourseHomePageScreen extends StatefulWidget {
   _CourseHomePageScreenState createState() => _CourseHomePageScreenState();
 }
 
-class _CourseHomePageScreenState extends State<CourseHomePageScreen> {
+class _CourseHomePageScreenState extends State<CourseHomePageScreen> with AutomaticKeepAliveClientMixin {
   Future<Page> _pageFuture;
+
+  @override
+  bool get wantKeepAlive => true;
 
   Future<Page> _refreshPage() {
     setState(() {
@@ -53,6 +56,7 @@ class _CourseHomePageScreenState extends State<CourseHomePageScreen> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context); // Required super call for AutomaticKeepAliveClientMixin
     CourseDetailsModel.selectedTab = 1;
     return RefreshIndicator(
       onRefresh: () {

--- a/apps/flutter_parent/lib/screens/courses/details/course_syllabus_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_syllabus_screen.dart
@@ -19,19 +19,28 @@ import 'package:flutter_parent/utils/web_view_utils.dart';
 import 'package:provider/provider.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
-class CourseSyllabusScreen extends StatelessWidget {
+class CourseSyllabusScreen extends StatefulWidget {
   final String syllabus;
   CourseSyllabusScreen(this.syllabus);
 
   @override
+  _CourseSyllabusScreenState createState() => _CourseSyllabusScreenState();
+}
+
+class _CourseSyllabusScreenState extends State<CourseSyllabusScreen> with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
   Widget build(BuildContext context) {
+    super.build(context); // Required super call for AutomaticKeepAliveClientMixin
     CourseDetailsModel.selectedTab = 1;
     return Consumer<CourseDetailsModel>(
       builder: (context, model, _) => WebView(
         javascriptMode: JavascriptMode.unrestricted,
         gestureRecognizers: Set()..add(Factory<WebViewGestureRecognizer>(() => WebViewGestureRecognizer())),
         onWebViewCreated: (controller) {
-          controller.loadHtml(syllabus, horizontalPadding: 10);
+          controller.loadHtml(widget.syllabus, horizontalPadding: 10);
         },
       ),
     );


### PR DESCRIPTION
This allows the screens to retain state (like scroll position) when moving between tabs