### PR TITLE
[Flutter-Parent] Add log if we catch a ‘widget crash’

### DIFF
--- a/apps/flutter_parent/lib/utils/crash_utils.dart
+++ b/apps/flutter_parent/lib/utils/crash_utils.dart
@@ -25,7 +25,11 @@ class CrashUtils {
     // Set up custom crash screen
     ErrorWidget.builder = (error) {
       // Only need to dump errors in debug, release builds call onError
-      if (!kReleaseMode) FlutterError.dumpErrorToConsole(error);
+      if (!kReleaseMode) {
+        FlutterError.dumpErrorToConsole(error);
+      } else {
+        FlutterCrashlytics().log('Widget Crash');
+      }
       return CrashScreen(error);
     };
 


### PR DESCRIPTION
This is to help us differentiate between widget crashes and dart crashes.