### PR TITLE
[Student][Teacher] Quick fix for studio vids embedded in pages

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/PageDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/PageDetailsFragment.kt
@@ -91,14 +91,14 @@ class PageDetailsFragment : InternalWebviewFragment(), Bookmarkable {
 
     override fun onPause() {
         super.onPause()
-        getCanvasWebView()?.onPause()
+        canvasWebView?.onPause()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         fetchDataJob?.cancel()
         loadHtmlJob?.cancel()
-        getCanvasWebView()?.destroy()
+        canvasWebView?.destroy()
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/PageDetailsFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/PageDetailsFragment.kt
@@ -170,16 +170,11 @@ class PageDetailsFragment : BasePresenterFragment<
     override fun populatePageDetails(page: Page) {
         mPage = page
         if (CanvasWebView.containsLTI(page.body.orEmpty(), "UTF-8")) {
-            if (page.body.orEmpty().contains("arc_media")) {
-                // For embedded Studio videos, we just want to load the HTML we get back from the server
-                loadPageHtml(page.body.orEmpty())
-            } else {
-                canvasWebView.addJavascriptInterface(JsExternalToolInterface {
-                    val args = LTIWebViewFragment.makeLTIBundle(URLDecoder.decode(it, "utf-8"), "LTI Launch", true)
-                    RouteMatcher.route(requireContext(), Route(LTIWebViewFragment::class.java, canvasContext, args))
-                }, "accessor")
-                loadHtmlJob = canvasWebView.loadHtmlWithLTIs(requireContext(), isTablet, page.body.orEmpty(), ::loadPageHtml)
-            }
+            canvasWebView.addJavascriptInterface(JsExternalToolInterface {
+                val args = LTIWebViewFragment.makeLTIBundle(URLDecoder.decode(it, "utf-8"), "LTI Launch", true)
+                RouteMatcher.route(requireContext(), Route(LTIWebViewFragment::class.java, canvasContext, args))
+            }, "accessor")
+            loadHtmlJob = canvasWebView.loadHtmlWithLTIs(requireContext(), isTablet, page.body.orEmpty(), ::loadPageHtml)
         } else {
             loadPageHtml(page.body.orEmpty())
         }


### PR DESCRIPTION
For some reason, we were at one time excluding studio from the authentication of iframe src urls. Calvin and I noticed this while testing earlier today. Perhaps studio has changed, but this is now necessary to get these videos to not require the user to login. Also, videos weren't pausing upon hitting the back arrow from student page details, hence the lifecycle pass throughs to canvas webview in student.