### PR TITLE
[Teacher][MBL-13464] Simple fix for pdf annotation resize issue

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/view/SubmissionContentView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/view/SubmissionContentView.kt
@@ -492,7 +492,17 @@ class SubmissionContentView(
         }
 
         when (content) {
-            is PdfContent -> if(content.url.contains("canvadoc")) handlePdfContent(content.url) else showMessageFragment(R.string.pdfError)
+            is PdfContent -> {
+                if(content.url.contains("canvadoc")) {
+                    if(slidingUpPanelLayout?.panelState == SlidingUpPanelLayout.PanelState.ANCHORED) {
+                        // Attempt to reset the sliding panel to collapsed, so we don't render the pdf at anchored size
+                        slidingUpPanelLayout?.panelState = SlidingUpPanelLayout.PanelState.COLLAPSED
+                    }
+                    handlePdfContent(content.url)
+                } else {
+                    showMessageFragment(R.string.pdfError)
+                }
+            }
             is NoSubmissionContent -> when (mAssignee) {
                 is StudentAssignee -> showMessageFragment(R.string.noSubmission, R.string.noSubmissionTeacher)
                 is GroupAssignee -> showMessageFragment(R.string.speedgrader_group_no_submissions)


### PR DESCRIPTION
Not sure why I never thought of this before, super simple fix for the annotation resize issue, see [https://instructure.atlassian.net/browse/MBL-13464](ticket) for explanation.

This is probs our best option, at least from the various fixes I've tried before. I simply collapse the sliding panel layout before loading in new pdfs. That way, we never render a pdf into the half sized content pane. This way we don't have to compromise with either additional re-draws on the pdf view, removing the content scaling, or messing with any other content type. It might be slightly annoying to see the sliding panel collapse on a new pdf load though.



