### PR TITLE
[Flutter-Parent] Cleaned up tests a little for platform configuration

### DIFF
--- a/apps/flutter_parent/test/screens/assignments/assignment_details_screen_test.dart
+++ b/apps/flutter_parent/test/screens/assignments/assignment_details_screen_test.dart
@@ -196,8 +196,6 @@ void main() {
   });
 
   testWidgetsWithAccessibilityChecks('shows Assignment data', (tester) async {
-    setupPlatformChannels(config: PlatformConfig(initWebview: true));
-
     final assignmentName = 'Testing Assignment';
     final description = 'This is a description';
     final dueDate = DateTime.utc(2000);
@@ -219,6 +217,7 @@ void main() {
         studentName: '',
       ),
       highContrast: true,
+      platformConfig: PlatformConfig(initWebview: true),
     ));
 
     await tester.pumpAndSettle();

--- a/apps/flutter_parent/test/screens/splash/splash_screen_test.dart
+++ b/apps/flutter_parent/test/screens/splash/splash_screen_test.dart
@@ -66,11 +66,13 @@ void main() {
       locator.registerFactory<DashboardInteractor>(() => interactor);
     });
 
-    await setupPlatformChannels(config: PlatformConfig(initLoggedInUser: login));
-
     when(interactor.getStudents(forceRefresh: true)).thenAnswer((_) => Future.value([]));
 
-    await tester.pumpWidget(TestApp(SplashScreen(), highContrast: true));
+    await tester.pumpWidget(TestApp(
+      SplashScreen(),
+      highContrast: true,
+      platformConfig: PlatformConfig(initLoggedInUser: login),
+    ));
     await tester.pumpAndSettle();
 
     expect(find.byType(NotAParentScreen), findsOneWidget);
@@ -125,8 +127,6 @@ void main() {
       locator.registerFactory<DashboardInteractor>(() => interactor);
     });
 
-    await setupPlatformChannels(config: PlatformConfig(initLoggedInUser: login));
-
     final completer = Completer<List<User>>();
     when(interactor.getStudents(forceRefresh: anyNamed('forceRefresh'))).thenAnswer((_) => completer.future);
     when(interactor.getSelf()).thenAnswer((_) => Future.value(login.user));
@@ -137,6 +137,7 @@ void main() {
       SplashScreen(),
       highContrast: true,
       navigatorObservers: [observer],
+      platformConfig: PlatformConfig(initLoggedInUser: login),
     ));
     await tester.pump();
 

--- a/apps/flutter_parent/test/utils/test_app.dart
+++ b/apps/flutter_parent/test/utils/test_app.dart
@@ -155,7 +155,7 @@ class MockThemePrefs extends ThemePrefs {
 ///
 /// Returned is a future that completes when all async tasks spawned by this method call have completed. Waiting isn't
 /// required, though is probably good practice and results in more stable tests.
-Future<void> setupPlatformChannels({PlatformConfig config = const PlatformConfig()}) {
+Future<void> setupPlatformChannels({PlatformConfig config = const PlatformConfig()}) async {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   if (config.initPackageInfo) _initPackageInfo();
@@ -170,15 +170,14 @@ Future<void> setupPlatformChannels({PlatformConfig config = const PlatformConfig
 
   if (config.initWebview) _initPlatformWebView();
 
+  await Future.wait([
+    if (apiPrefsInitFuture != null) apiPrefsInitFuture,
+  ]);
+
   if (config.initLoggedInUser != null) {
     ApiPrefs.addLogin(config.initLoggedInUser);
     ApiPrefs.switchLogins(config.initLoggedInUser);
   }
-
-  // Return all the futures that were created
-  return Future.wait([
-    if (apiPrefsInitFuture != null) apiPrefsInitFuture,
-  ]);
 }
 
 /// WebView helpers. These are needed as web views tie into platform views. These are special though as the channel

--- a/apps/flutter_parent/test/utils/widgets/webview/canvas_web_view_test.dart
+++ b/apps/flutter_parent/test/utils/widgets/webview/canvas_web_view_test.dart
@@ -111,13 +111,16 @@ void main() {
   });
 
   group('auth content', () {
-    setupPlatformChannels(config: PlatformConfig(initWebview: true));
+    final config = PlatformConfig(initWebview: true);
 
     testWidgetsWithAccessibilityChecks('shows loading while waiting to authenticate content', (tester) async {
       final content = 'html_content';
       when(interactor.authContent(content, AppLocalizations().launchExternalTool)).thenAnswer((_) async => content);
 
-      await tester.pumpWidget(TestApp(CanvasWebView(content: content, authContentIfNecessary: true)));
+      await tester.pumpWidget(TestApp(
+        CanvasWebView(content: content, authContentIfNecessary: true),
+        platformConfig: config,
+      ));
       await tester.pump(); // Let the webview build
 
       expect(find.byType(WebView), findsNothing);
@@ -127,7 +130,10 @@ void main() {
 
     testWidgetsWithAccessibilityChecks('does not call to authenticate content', (tester) async {
       final content = 'html_content';
-      await tester.pumpWidget(TestApp(CanvasWebView(content: content, authContentIfNecessary: false)));
+      await tester.pumpWidget(TestApp(
+        CanvasWebView(content: content, authContentIfNecessary: false),
+        platformConfig: config,
+      ));
       await tester.pump(); // Let the webview build
       await tester.pump(); // Let the future finish
 
@@ -139,7 +145,7 @@ void main() {
       final content = 'html_content';
       when(interactor.authContent(content, AppLocalizations().launchExternalTool)).thenAnswer((_) async => content);
 
-      await tester.pumpWidget(TestApp(CanvasWebView(content: content)));
+      await tester.pumpWidget(TestApp(CanvasWebView(content: content), platformConfig: config));
       await tester.pump(); // Let the webview build
       await tester.pump(); // Let the future finish
 

--- a/apps/flutter_parent/test/utils/widgets/webview/simple_web_view_screen_test.dart
+++ b/apps/flutter_parent/test/utils/widgets/webview/simple_web_view_screen_test.dart
@@ -22,13 +22,13 @@ import '../../test_app.dart';
 
 void main() {
   setupTestLocator((locator) => locator.registerFactory<WebViewInteractor>(() => WebViewInteractor()));
-  setupPlatformChannels(config: PlatformConfig(initWebview: true));
+  final config = PlatformConfig(initWebview: true);
 
   testWidgetsWithAccessibilityChecks('shows title in app bar', (tester) async {
     final url = 'https://www.google.com';
     final title = 'title';
 
-    await tester.pumpWidget(TestApp(SimpleWebViewScreen(url, title)));
+    await tester.pumpWidget(TestApp(SimpleWebViewScreen(url, title), platformConfig: config));
     await tester.pump();
 
     expect(find.text(title), findsOneWidget);
@@ -38,7 +38,7 @@ void main() {
     final url = 'https://www.google.com';
     final title = 'title';
 
-    await tester.pumpWidget(TestApp(SimpleWebViewScreen(url, title)));
+    await tester.pumpWidget(TestApp(SimpleWebViewScreen(url, title), platformConfig: config));
     await tester.pump();
 
     expect(find.byType(WebView), findsOneWidget);


### PR DESCRIPTION
Makes use of the TestApp’s platforConfig field, rather than manually calling setupPlatformChannels, for widget tests that use test app.