### PR TITLE
[Flutter-Parent][MBL-14043] External routing

### DIFF
--- a/apps/flutter_parent/android/app/src/main/AndroidManifest.xml
+++ b/apps/flutter_parent/android/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
@@ -36,13 +36,34 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <intent-filter>
+                <data android:scheme="https" />
+                <data android:scheme="http" />
+                <data android:host="*.instructure.com" />
+                <data android:host="*.canvas.net" />
+
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+            </intent-filter>
+            <intent-filter>
+                <data android:host="*"/>
+                <data android:scheme="canvas-courses"/>
+                <data android:scheme="canvas-parent"/>
+
+                <action android:name="android.intent.action.VIEW"/>
+
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+            </intent-filter>
         </activity>
 
         <receiver android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver" />
 
         <receiver android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
             <intent-filter>
-                <action android:name="android.intent.action.BOOT_COMPLETED"></action>
+                <action android:name="android.intent.action.BOOT_COMPLETED"/>
             </intent-filter>
         </receiver>
 

--- a/apps/flutter_parent/android/app/src/main/kotlin/com/instructure/parentapp/MainActivity.kt
+++ b/apps/flutter_parent/android/app/src/main/kotlin/com/instructure/parentapp/MainActivity.kt
@@ -16,71 +16,39 @@
 
 package com.instructure.parentapp
 
-import android.os.AsyncTask
-import android.os.Bundle
+import android.content.Intent
+import android.net.Uri
 import androidx.annotation.NonNull
+import com.instructure.parentapp.plugins.DataSeedingPlugin
 import com.instructure.parentapp.plugins.OldAppMigrations
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
-import io.flutter.plugin.common.MethodCall
-import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugins.GeneratedPluginRegistrant
-import okhttp3.HttpUrl
-import org.jsoup.Connection
-import org.jsoup.Jsoup
-import org.jsoup.nodes.FormElement
 
 class MainActivity : FlutterActivity() {
-    private val AUTHCODE_CHANNEL = "GET_AUTH_CODE"
-
     override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
         GeneratedPluginRegistrant.registerWith(flutterEngine)
         OldAppMigrations.init(flutterEngine, applicationContext)
+        DataSeedingPlugin.init(flutterEngine)
 
-        // Implement getAuthCode / JSoup support via MethodChannel
-        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, AUTHCODE_CHANNEL).setMethodCallHandler { call, result ->
-            print("Got AuthCode method ${call.method}");
-
-            if (call.method.equals("getAuthCode")) {
-
-                object : AsyncTask<MethodCall, Void, Void>() {
-                    var authCode : String? = null
-                    override fun doInBackground(vararg methodCalls: MethodCall): Void? {
-                        val _call = methodCalls[0]
-
-                        val domain = _call.argument<String>("domain")
-                        val clientId = _call.argument<String>("clientId")
-                        val redirectUrl = _call.argument<String>("redirectUrl")
-                        val login = _call.argument<String>("login")
-                        val password = _call.argument<String>("password")
-
-                        val loginPageResponse = Jsoup.connect("https://$domain/login/oauth2/auth")
-                                .method(Connection.Method.GET)
-                                .data("client_id", clientId)
-                                .data("response_type", "code")
-                                .data("redirect_uri", redirectUrl)
-                                .execute()
-                        val loginForm = loginPageResponse.parse().select("form").first() as FormElement
-                        loginForm.getElementById("pseudonym_session_unique_id").`val`(login)
-                        loginForm.getElementById("pseudonym_session_password").`val`(password)
-                        val authFormResponse = loginForm.submit().cookies(loginPageResponse.cookies()).execute()
-                        val authForm = authFormResponse.parse().select("form").first() as FormElement
-                        val responseUrl = authForm.submit().cookies(authFormResponse.cookies()).execute().url().toString()
-                        authCode = HttpUrl.parse(responseUrl)?.queryParameter("code")
-                                ?: throw RuntimeException("/login/oauth2/auth failed!")
-
-                        return null
-                    }
-
-                    override fun onPostExecute(nullResult: Void?) : Unit {
-                        result.success(authCode)
-                    }
-                }.execute(call)
-            } else {
-                result.notImplemented(); // Unknown call
-            }
-        }
-
+        checkForLinkEvent(intent)
     }
 
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        checkForLinkEvent(intent, newIntent = true)
+    }
+
+    private fun checkForLinkEvent(intent: Intent, newIntent: Boolean = false) {
+        val data = intent.data
+        if (intent.action != Intent.ACTION_VIEW || data == null) return
+
+        // NOTE: The `url` query param has to match ParentRouter.dart in the flutter code
+        val route = "/external?url=${Uri.encode(data.toString())}"
+        if (newIntent) {
+            flutterEngine?.navigationChannel?.pushRoute(route)
+        } else {
+            this.intent = intent.putExtra("initial_route", route)
+        }
+    }
 }

--- a/apps/flutter_parent/android/app/src/main/kotlin/com/instructure/parentapp/plugins/DataSeedingPlugin.kt
+++ b/apps/flutter_parent/android/app/src/main/kotlin/com/instructure/parentapp/plugins/DataSeedingPlugin.kt
@@ -1,0 +1,76 @@
+package com.instructure.parentapp.plugins
+
+import android.os.AsyncTask
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import okhttp3.HttpUrl
+import org.jsoup.Connection
+import org.jsoup.Jsoup
+import org.jsoup.nodes.FormElement
+
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+object DataSeedingPlugin {
+    private const val AUTHCODE_CHANNEL = "GET_AUTH_CODE"
+
+    fun init(flutterEngine: FlutterEngine) {
+        // Implement getAuthCode / JSoup support via MethodChannel
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, AUTHCODE_CHANNEL).setMethodCallHandler(::handleCall)
+    }
+
+    private fun handleCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "getAuthCode" -> getAuthCode(call, result)
+            else -> result.notImplemented()
+        }
+    }
+
+    private fun getAuthCode(call: MethodCall, result: MethodChannel.Result) {
+        object : AsyncTask<MethodCall, Void, Void>() {
+            var authCode : String? = null
+            override fun doInBackground(vararg methodCalls: MethodCall): Void? {
+                val _call = methodCalls[0]
+
+                val domain = _call.argument<String>("domain")
+                val clientId = _call.argument<String>("clientId")
+                val redirectUrl = _call.argument<String>("redirectUrl")
+                val login = _call.argument<String>("login")
+                val password = _call.argument<String>("password")
+
+                val loginPageResponse = Jsoup.connect("https://$domain/login/oauth2/auth")
+                    .method(Connection.Method.GET)
+                    .data("client_id", clientId)
+                    .data("response_type", "code")
+                    .data("redirect_uri", redirectUrl)
+                    .execute()
+                val loginForm = loginPageResponse.parse().select("form").first() as FormElement
+                loginForm.getElementById("pseudonym_session_unique_id").`val`(login)
+                loginForm.getElementById("pseudonym_session_password").`val`(password)
+                val authFormResponse = loginForm.submit().cookies(loginPageResponse.cookies()).execute()
+                val authForm = authFormResponse.parse().select("form").first() as FormElement
+                val responseUrl = authForm.submit().cookies(authFormResponse.cookies()).execute().url().toString()
+                authCode = HttpUrl.parse(responseUrl)?.queryParameter("code")
+                    ?: throw RuntimeException("/login/oauth2/auth failed!")
+
+                return null
+            }
+
+            override fun onPostExecute(nullResult: Void?) : Unit {
+                result.success(authCode)
+            }
+        }.execute(call)
+    }
+}

--- a/apps/flutter_parent/lib/parent_app.dart
+++ b/apps/flutter_parent/lib/parent_app.dart
@@ -57,7 +57,6 @@ class _ParentAppState extends State<ParentApp> {
           supportedLocales: AppLocalizations.delegate.supportedLocales,
           localeResolutionCallback: _localeCallback(),
           theme: themeData,
-          initialRoute: ParentRouter.rootSplash(),
           onGenerateRoute: ParentRouter.router.generator,
         ),
       ),


### PR DESCRIPTION
Also moved data seeding logic to it's own plugin to keep MainActivity a little more clean.

Also fixes a new bug from SplashScreen, where _navigate was getting called multiple times for already logged in users (can't control how many times build is called in a widget). This was causing multiple animation listeners to be added. Instead, just add the animation listener once at when creating the animation.