### PR TITLE
[Student][Teacher] Add route support for new rce files

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/router/RouteMatcher.kt
+++ b/apps/student/src/main/java/com/instructure/student/router/RouteMatcher.kt
@@ -176,8 +176,8 @@ object RouteMatcher : BaseRouteMatcher() {
 
         routes.add(Route("/files", FileListFragment::class.java).apply{ canvasContext = ApiPrefs.user }) // validRoute for FileListFragment checks for a canvasContext, which is null on deep links
         routes.add(Route("/files/folder/:${RouterParams.FOLDER_NAME}", RouteContext.FILE))
-        routes.add(Route("/files/:${RouterParams.FILE_ID}", FileListFragment::class.java)) // TODO TEST
         routes.add(Route("/files/:${RouterParams.FILE_ID}/download", RouteContext.FILE)) // trigger webview's download listener
+        routes.add(Route("/files/:${RouterParams.FILE_ID}", RouteContext.FILE)) // Triggered by new RCE content file links
 
         //Notification Preferences
         routes.add(Route("/profile/communication", RouteContext.NOTIFICATION_PREFERENCES))

--- a/apps/student/src/test/java/com/instructure/student/test/util/RouterUtilsTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/util/RouterUtilsTest.kt
@@ -167,7 +167,7 @@ class RouterUtilsTest : TestCase() {
 
         route = callGetInternalRoute("https://mobiledev.instructure.com/files/63383591")
         assertNotNull(route)
-        assertEquals(FileListFragment::class.java, route!!.primaryClass)
+        assertEquals(RouteContext.FILE, route!!.routeContext)
 
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/833052/files/63383591/download?verifier=12344556")
         assertNotNull(route)

--- a/apps/teacher/src/main/java/com/instructure/teacher/router/RouteMatcher.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/router/RouteMatcher.kt
@@ -93,6 +93,7 @@ object RouteMatcher : BaseRouteMatcher() {
         routes.add(Route(courseOrGroup("/:course_id/files/folder(\\/.*)*"), FileListFragment::class.java))
         // Same as above, but if they access nested user files instead of course files
         routes.add(Route("/files/folder(\\/.*)*", RouteContext.FILE))
+        routes.add(Route("/files/:${RouterParams.FILE_ID}", RouteContext.FILE)) // Triggered by new RCE content file links
 
         routes.add(Route(courseOrGroup("/:course_id/files"), FileListFragment::class.java))
 


### PR DESCRIPTION
See ticket for more deets. We had a route in place in student that was perhaps intended for a similar case, but wasn't functioning. The new RCE content creates a route with no canvas context id, even for course files.