### PR TITLE
[Student][MBL-14023] Always use gray for pdf toolbar

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/activity/CandroidPSPDFActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/CandroidPSPDFActivity.kt
@@ -83,11 +83,6 @@ class CandroidPSPDFActivity : PdfActivity(), ToolbarCoordinatorLayout.OnContextu
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setOnContextualToolbarLifecycleListener(this)
-
-        ViewStyler.themeActionBar(this, supportActionBar, ThemePrefs.primaryColor)
-
-        findViewById<View>(R.id.pspdf__activity_thumbnail_bar)?.setBackgroundColor(ThemePrefs.brandColor)
-        findViewById<View>(R.id.pspdf__activity_title_overlay)?.setBackgroundColor(ThemePrefs.brandColor)
     }
 
     override fun onPrepareOptionsMenu(menu: Menu): Boolean {

--- a/apps/student/src/main/res/values/styles.xml
+++ b/apps/student/src/main/res/values/styles.xml
@@ -38,9 +38,9 @@
     </style>
 
     <style name="PSPDFKitTheme" parent="Theme.AppCompat.Light.NoActionBar">
-        <item name="colorPrimary">@color/canvasRed</item>
-        <item name="colorAccent">@color/canvasRed</item>
-        <item name="colorPrimaryDark">@color/canvasRed</item>
+        <item name="colorPrimary">@color/annotationToolbarBackground</item>
+        <item name="colorAccent">@color/annotationToolbarBackground</item>
+        <item name="colorPrimaryDark">@color/annotationToolbarBackground</item>
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="windowActionModeOverlay">true</item>


### PR DESCRIPTION
There are issues with theming the toolbar to the institution color when it is white. Rather than hack our way into a way to customize all the toolbar colors, just default to gray with white icons.