### PR TITLE
[Flutter Parent][MBL-14088] Fix calendar month height overflow

### DIFF
--- a/apps/flutter_parent/lib/screens/calendar/calendar_widget/calendar_month.dart
+++ b/apps/flutter_parent/lib/screens/calendar/calendar_widget/calendar_month.dart
@@ -36,6 +36,9 @@ class CalendarMonth extends StatefulWidget {
     @required this.monthExpansionListener,
   }) : super(key: key);
 
+  /// The maximum possible height of this widget
+  static double maxHeight = DayOfWeekHeaders.headerHeight + (6 * CalendarDay.dayHeight);
+
   static List<DateTime> generateWeekStarts(int year, int month) {
     DateTime firstDayOfMonth = DateTime(year, month);
     DateTime firstDayOfWeek = firstDayOfMonth.withFirstDayOfWeek();


### PR DESCRIPTION
On most screens in landscape, and even on very small screens in portrait, the expanded month view in the calendar will overflow vertically. Shinking the height of the calendar elements is not an option, as that would reduce the tap target size below the acceptable a11y threshold. We also can't wrap the month view in a scrollable widget as that would interfere with swipe-to-expand. As such, the month view needs to be disabled entirely in these cases.

With this change, the height available to the calendar widget is now monitored. If the height ever becomes insufficient to display the full-height month view then the month view will be disabled entirely, and re-enabled when the height becomes sufficient again. If the month view is disabled while expanded, it will trigger a collapse animation.