### PR TITLE
[Flutter-Parent][MBL-13938] Refresh token interceptor

### DIFF
--- a/apps/flutter_parent/lib/network/utils/analytics.dart
+++ b/apps/flutter_parent/lib/network/utils/analytics.dart
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+class AnalyticsEventConstants {
+  static String get REFRESH_TOKEN => 'refresh_token';
+  static String get FOREVER_TOKEN => 'forever_token';
+  static String get LOGIN_FAILURE => 'login_failure';
+  static String get LOGIN_SUCCESS => 'login_success';
+  static String get TOKEN_REFRESH_FAILURE => 'token_refresh_failure';
+  static String get TOKEN_REFRESH_FAILURE_TOKEN_NOT_VALID => 'token_refresh_failure_token_not_valid';
+  static String get TOKEN_REFRESH_FAILURE_NO_SECRET => 'token_refresh_failure_no_secret';
+}

--- a/apps/flutter_parent/lib/network/utils/authentication_interceptor.dart
+++ b/apps/flutter_parent/lib/network/utils/authentication_interceptor.dart
@@ -24,9 +24,9 @@ import 'api_prefs.dart';
 class AuthenticationInterceptor extends InterceptorsWrapper {
   final String _RETRY_HEADER = 'mobile_refresh';
 
-  final Dio dio;
+  final Dio _dio;
 
-  AuthenticationInterceptor(this.dio);
+  AuthenticationInterceptor(this._dio);
 
   @override
   Future onError(DioError error) async {
@@ -47,8 +47,8 @@ class AuthenticationInterceptor extends InterceptorsWrapper {
     }
 
     // Lock new requests from being processed while refreshing the token
-    dio.interceptors?.requestLock?.lock();
-    dio.interceptors?.responseLock?.lock();
+    _dio.interceptors?.requestLock?.lock();
+    _dio.interceptors?.responseLock?.lock();
 
     // Refresh the token and update the login
     dynamic result = error;
@@ -68,11 +68,11 @@ class AuthenticationInterceptor extends InterceptorsWrapper {
       options.headers['Authorization'] = 'Bearer ${tokens.accessToken}';
       options.headers[_RETRY_HEADER] = _RETRY_HEADER; // Mark retry to prevent infinite recursion
 
-      result = dio.request(options.path, options: options);
+      result = _dio.request(options.path, options: options);
     }
 
-    dio.interceptors?.requestLock?.unlock();
-    dio.interceptors?.responseLock?.unlock();
+    _dio.interceptors?.requestLock?.unlock();
+    _dio.interceptors?.responseLock?.unlock();
 
     return result;
   }

--- a/apps/flutter_parent/lib/network/utils/authentication_interceptor.dart
+++ b/apps/flutter_parent/lib/network/utils/authentication_interceptor.dart
@@ -1,0 +1,88 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import 'package:dio/dio.dart';
+import 'package:flutter_parent/models/canvas_token.dart';
+import 'package:flutter_parent/models/login.dart';
+import 'package:flutter_parent/network/api/auth_api.dart';
+import 'package:flutter_parent/network/utils/analytics.dart';
+import 'package:flutter_parent/utils/service_locator.dart';
+
+import 'api_prefs.dart';
+
+class AuthenticationInterceptor extends InterceptorsWrapper {
+  final String _RETRY_HEADER = 'mobile_refresh';
+
+  final Dio dio;
+
+  AuthenticationInterceptor(this.dio);
+
+  @override
+  Future onError(DioError error) async {
+    final currentLogin = ApiPrefs.getCurrentLogin();
+
+    // Check for any errors
+    if (error.request?.path?.contains('accounts/self') == true) {
+      // We are likely just checking if the user can masquerade or not, which happens on login - don't try to re-auth here
+      return error;
+    } else if (error.request.headers[_RETRY_HEADER] != null) {
+      _logAuthAnalytics(AnalyticsEventConstants.TOKEN_REFRESH_FAILURE);
+      return error;
+    } else if (currentLogin == null ||
+        (currentLogin.clientId?.isEmpty ?? true) ||
+        (currentLogin.clientSecret?.isEmpty ?? true)) {
+      _logAuthAnalytics(AnalyticsEventConstants.TOKEN_REFRESH_FAILURE_NO_SECRET);
+      return error;
+    }
+
+    // Lock new requests from being processed while refreshing the token
+    dio.interceptors?.requestLock?.lock();
+    dio.interceptors?.responseLock?.lock();
+
+    // Refresh the token and update the login
+    dynamic result = error;
+    CanvasToken tokens;
+
+    tokens = await locator<AuthApi>().refreshToken().catchError((e) => null);
+
+    if (tokens == null) {
+      _logAuthAnalytics(AnalyticsEventConstants.TOKEN_REFRESH_FAILURE_TOKEN_NOT_VALID);
+    } else {
+      Login login = currentLogin.rebuild((b) => b..accessToken = tokens.accessToken);
+      ApiPrefs.addLogin(login);
+      ApiPrefs.switchLogins(login);
+
+      // Update the header and make the request again
+      RequestOptions options = error.request;
+      options.headers['Authorization'] = 'Bearer ${tokens.accessToken}';
+      options.headers[_RETRY_HEADER] = _RETRY_HEADER; // Mark retry to prevent infinite recursion
+
+      result = dio.request(options.path, options: options);
+    }
+
+    dio.interceptors?.requestLock?.unlock();
+    dio.interceptors?.responseLock?.unlock();
+
+    return result;
+  }
+
+  // TODO: Finish implementing with analytics
+  _logAuthAnalytics(String eventString) {
+//    final bundle = {
+//      AnalyticsParamConstants.DOMAIN_PARAM: ApiPrefs.domain,
+//      AnalyticsParamConstants.USER_CONTEXT_ID: ApiPrefs.user?.contextId
+//    }
+//    Analytics.logEvent(eventString, bundle)
+  }
+}

--- a/apps/flutter_parent/lib/network/utils/dio_config.dart
+++ b/apps/flutter_parent/lib/network/utils/dio_config.dart
@@ -18,6 +18,7 @@ import 'package:dio/dio.dart';
 import 'package:dio_http_cache/dio_http_cache.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_parent/network/utils/api_prefs.dart';
+import 'package:flutter_parent/network/utils/authentication_interceptor.dart';
 
 import 'private_consts.dart';
 
@@ -77,6 +78,9 @@ class DioConfig {
 
     // Create Dio instance and add interceptors
     final dio = Dio(options);
+
+    // Authentication refresh interceptor
+    dio.interceptors.add(AuthenticationInterceptor(dio));
 
     // Cache manager
     if (cacheMaxAge != Duration.zero) {

--- a/apps/flutter_parent/lib/screens/web_login/web_login_screen.dart
+++ b/apps/flutter_parent/lib/screens/web_login/web_login_screen.dart
@@ -139,11 +139,12 @@ class WebLoginScreen extends StatelessWidget {
     var clientId = verifyResult != null ? Uri.encodeQueryComponent(verifyResult?.clientId) : '';
     var redirect = Uri.encodeQueryComponent('https://canvas.instructure.com/login/oauth2/auth');
 
-    // TODO: Support skipping mobile verify
-//    if (forceAuthRedirect || || mCanvasLogin == MOBILE_VERIFY_FLOW || (domain.contains(".test."))) {
+    // TODO: Support skipping mobile verify better
+    // forceAuthRedirect || mCanvasLogin == MOBILE_VERIFY_FLOW || domain.contains(".test.")
+    if (domain.contains(".test.")) {
 //      //Skip mobile verify
-//      redirect = Uri.encodeQueryComponent("urn:ietf:wg:oauth:2.0:oob");
-//    }
+      redirect = Uri.encodeQueryComponent("urn:ietf:wg:oauth:2.0:oob");
+    }
 
     var result =
         '$baseUrl/login/oauth2/auth?client_id=$clientId&response_type=code&mobile=1&purpose=$purpose&redirect_uri=$redirect';

--- a/apps/flutter_parent/test/network/authentication_interceptor_test.dart
+++ b/apps/flutter_parent/test/network/authentication_interceptor_test.dart
@@ -1,0 +1,130 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import 'package:dio/dio.dart';
+import 'package:flutter_parent/models/canvas_token.dart';
+import 'package:flutter_parent/models/login.dart';
+import 'package:flutter_parent/network/api/auth_api.dart';
+import 'package:flutter_parent/network/utils/api_prefs.dart';
+import 'package:flutter_parent/network/utils/authentication_interceptor.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../utils/platform_config.dart';
+import '../utils/test_app.dart';
+
+void main() {
+  final login = Login((b) => b
+    ..clientSecret = 'client_secret'
+    ..clientId = 'client_id');
+
+  final dio = _MockDio();
+  final authApi = _MockAuthApi();
+
+  final interceptor = AuthenticationInterceptor(dio);
+
+  setupTestLocator((locator) {
+    locator.registerLazySingleton<AuthApi>(() => authApi);
+  });
+
+  setUp(() {
+    reset(dio);
+    reset(authApi);
+  });
+
+  test('returns error if path is accounts/self', () async {
+    await setupPlatformChannels();
+    final error = DioError(request: RequestOptions(path: 'accounts/self'));
+
+    // Test the error response
+    expect(await interceptor.onError(error), error);
+  });
+
+  test('returns error if headers have the retry header', () async {
+    await setupPlatformChannels();
+    final error = DioError(request: RequestOptions(headers: {'mobile_refresh': 'mobile_refresh'}));
+
+    // Test the error response
+    expect(await interceptor.onError(error), error);
+    // TODO: verify log event called
+  });
+
+  test('returns error if login is null', () async {
+    await setupPlatformChannels();
+    final error = DioError(request: RequestOptions());
+
+    // Test the error response
+    expect(await interceptor.onError(error), error);
+    // TODO: verify log event called
+  });
+
+  test('returns error if login client id is null', () async {
+    await setupPlatformChannels(config: PlatformConfig(initLoggedInUser: login.rebuild((b) => b..clientId = null)));
+    final error = DioError(request: RequestOptions());
+
+    // Test the error response
+    expect(await interceptor.onError(error), error);
+    // TODO: verify log event called
+  });
+
+  test('returns error if login client secret is null', () async {
+    await setupPlatformChannels(config: PlatformConfig(initLoggedInUser: login.rebuild((b) => b..clientSecret = null)));
+    final error = DioError(request: RequestOptions());
+
+    // Test the error response
+    expect(await interceptor.onError(error), error);
+    // TODO: verify log event called
+  });
+
+  test('returns error if the refresh api call failed', () async {
+    await setupPlatformChannels(config: PlatformConfig(initLoggedInUser: login));
+    final error = DioError(request: RequestOptions());
+
+    when(authApi.refreshToken()).thenAnswer((_) => Future.error('Failed to refresh'));
+
+    // Test the error response
+    expect(await interceptor.onError(error), error);
+
+    // TODO: verify log event called
+    verify(authApi.refreshToken()).called(1);
+  });
+
+  test('returns a newly authenticated api call', () async {
+    await setupPlatformChannels(config: PlatformConfig(initLoggedInUser: login));
+
+    final tokens = CanvasToken((b) => b..accessToken = 'token');
+    final path = 'test/path/stuff';
+    final error = DioError(request: RequestOptions(path: path));
+    final expectedOptions = RequestOptions(path: path, headers: {
+      'Authorization': 'Bearer ${tokens.accessToken}',
+      'mobile_refresh': 'mobile_refresh',
+    });
+    final expectedAnswer = Response(data: 'data');
+
+    when(authApi.refreshToken()).thenAnswer((_) async => tokens);
+    when(dio.request(any, options: anyNamed('options'))).thenAnswer((_) async => expectedAnswer);
+
+    // Do the onError call
+    expect(await interceptor.onError(error), expectedAnswer);
+
+    // TODO: verify log event called
+    verify(authApi.refreshToken()).called(1);
+    final actualOptions = verify(dio.request(path, options: captureAnyNamed('options'))).captured[0] as RequestOptions;
+    expect(actualOptions.headers, expectedOptions.headers);
+    expect(ApiPrefs.getCurrentLogin().accessToken, tokens.accessToken);
+  });
+}
+
+class _MockDio extends Mock implements Dio {}
+
+class _MockAuthApi extends Mock implements AuthApi {}


### PR DESCRIPTION
Unfortunately, testing this is a little complicated, and requires pulling the branch down to make a small change before running.

* Check mobile dev developer key for the one created by Nate (login as site admin, click on Developer Keys in the menu)
* Set the client id/secret using the number above the 'Show Key' button, and the string shown after pressing the 'Show Key' button respectively
  * This requires a small change in `WebLoginScreen#_webView`
  * This line `final verifyResult = snapshot.data;`
  * Becomes `final verifyResult = snapshot.data.rebuild((b) => b..clientId = 'id'..clientSecret = 'secret');` with the hid/secret obtained from the dev key page
* Then, build the app and sign in to mobiledev.test (to bypass mobile verify).
* Log into web as that user, check for a token that has an expiration time on it (on the api keys for the user)
* Wait 1 hour
* See if the app still works for that user (navigate around the app)
* Check on web if that tokens expiration date has been updated