### PR TITLE
[Parent-Flutter] Take off extra padding on alert dismiss button

### DIFF
--- a/apps/flutter_parent/lib/screens/alerts/alerts_screen.dart
+++ b/apps/flutter_parent/lib/screens/alerts/alerts_screen.dart
@@ -172,7 +172,6 @@ class __AlertsListState extends State<_AlertsList> {
             icon: Icon(Icons.clear, size: 20),
             onPressed: () => _dismissAlert(alert),
           ),
-          SizedBox(width: 16),
         ],
       ),
     );


### PR DESCRIPTION
Since the dismiss button needs to be 48x48 min, the padding at the end is unnecessary.