### PR TITLE
[Flutter-Parent][MBL-14102] Simplify debug flag

### DIFF
--- a/apps/flutter_parent/lib/network/utils/api_prefs.dart
+++ b/apps/flutter_parent/lib/network/utils/api_prefs.dart
@@ -15,6 +15,7 @@
 import 'dart:convert';
 import 'dart:ui' as ui;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_parent/models/login.dart';
 import 'package:flutter_parent/models/serializers.dart';
@@ -38,6 +39,10 @@ class ApiPrefs {
   static SharedPreferences _prefs;
   static PackageInfo _packageInfo;
   static Login _currentLogin;
+
+  // A static bool rather than a persisted pref, change this as desired during release testing
+  static bool _debugMode = kDebugMode;
+  static bool get isDebug => !kReleaseMode || _debugMode;
 
   static Future<void> init() async {
     if (_prefs == null) _prefs = await SharedPreferences.getInstance();

--- a/apps/flutter_parent/lib/network/utils/api_prefs.dart
+++ b/apps/flutter_parent/lib/network/utils/api_prefs.dart
@@ -15,7 +15,6 @@
 import 'dart:convert';
 import 'dart:ui' as ui;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_parent/models/login.dart';
 import 'package:flutter_parent/models/serializers.dart';
@@ -39,10 +38,6 @@ class ApiPrefs {
   static SharedPreferences _prefs;
   static PackageInfo _packageInfo;
   static Login _currentLogin;
-
-  // A static bool rather than a persisted pref, change this as desired during release testing
-  static bool _debugMode = kDebugMode;
-  static bool get isDebug => !kReleaseMode || _debugMode;
 
   static Future<void> init() async {
     if (_prefs == null) _prefs = await SharedPreferences.getInstance();

--- a/apps/flutter_parent/lib/network/utils/dio_config.dart
+++ b/apps/flutter_parent/lib/network/utils/dio_config.dart
@@ -19,6 +19,7 @@ import 'package:dio_http_cache/dio_http_cache.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_parent/network/utils/api_prefs.dart';
 import 'package:flutter_parent/network/utils/authentication_interceptor.dart';
+import 'package:flutter_parent/utils/debug_flags.dart';
 
 import 'private_consts.dart';
 
@@ -87,7 +88,7 @@ class DioConfig {
       dio.interceptors.add(_cacheInterceptor());
     }
 
-    bool debug = false;
+    bool debug = DebugFlags.isDebugApi;
 
     // Log interceptor
     dio.interceptors.add(LogInterceptor(

--- a/apps/flutter_parent/lib/screens/login_landing_screen.dart
+++ b/apps/flutter_parent/lib/screens/login_landing_screen.dart
@@ -39,7 +39,7 @@ class LoginLandingScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return DefaultParentTheme(
       builder: (context) => Scaffold(
-        endDrawer: kReleaseMode
+        endDrawer: !ApiPrefs.isDebug
             ? null // Don't show snickers in release mode
             : Drawer(
                 child: SafeArea(

--- a/apps/flutter_parent/lib/screens/login_landing_screen.dart
+++ b/apps/flutter_parent/lib/screens/login_landing_screen.dart
@@ -14,7 +14,6 @@
 
 import 'dart:math';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_parent/l10n/app_localizations.dart';
 import 'package:flutter_parent/network/utils/api_prefs.dart';
@@ -25,6 +24,7 @@ import 'package:flutter_parent/utils/common_widgets/error_report/error_report_di
 import 'package:flutter_parent/utils/common_widgets/error_report/error_report_interactor.dart';
 import 'package:flutter_parent/utils/common_widgets/full_screen_scroll_container.dart';
 import 'package:flutter_parent/utils/common_widgets/user_name.dart';
+import 'package:flutter_parent/utils/debug_flags.dart';
 import 'package:flutter_parent/utils/design/canvas_icons_solid.dart';
 import 'package:flutter_parent/utils/design/parent_colors.dart';
 import 'package:flutter_parent/utils/design/parent_theme.dart';
@@ -39,7 +39,7 @@ class LoginLandingScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return DefaultParentTheme(
       builder: (context) => Scaffold(
-        endDrawer: !ApiPrefs.isDebug
+        endDrawer: !DebugFlags.isDebug
             ? null // Don't show snickers in release mode
             : Drawer(
                 child: SafeArea(

--- a/apps/flutter_parent/lib/screens/settings/settings_interactor.dart
+++ b/apps/flutter_parent/lib/screens/settings/settings_interactor.dart
@@ -12,8 +12,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_parent/network/utils/api_prefs.dart';
 import 'package:flutter_parent/utils/design/theme_transition/theme_transition_target.dart';
 import 'package:flutter_parent/utils/quick_nav.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
@@ -21,7 +21,7 @@ import 'package:flutter_parent/utils/service_locator.dart';
 import '../theme_viewer_screen.dart';
 
 class SettingsInteractor {
-  bool isDebugMode() => kDebugMode;
+  bool isDebugMode() => ApiPrefs.isDebug;
 
   void routeToThemeViewer(BuildContext context) {
     locator<QuickNav>().push(context, ThemeViewerScreen());

--- a/apps/flutter_parent/lib/screens/settings/settings_interactor.dart
+++ b/apps/flutter_parent/lib/screens/settings/settings_interactor.dart
@@ -13,7 +13,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import 'package:flutter/widgets.dart';
-import 'package:flutter_parent/network/utils/api_prefs.dart';
+import 'package:flutter_parent/utils/debug_flags.dart';
 import 'package:flutter_parent/utils/design/theme_transition/theme_transition_target.dart';
 import 'package:flutter_parent/utils/quick_nav.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
@@ -21,7 +21,7 @@ import 'package:flutter_parent/utils/service_locator.dart';
 import '../theme_viewer_screen.dart';
 
 class SettingsInteractor {
-  bool isDebugMode() => ApiPrefs.isDebug;
+  bool isDebugMode() => DebugFlags.isDebug;
 
   void routeToThemeViewer(BuildContext context) {
     locator<QuickNav>().push(context, ThemeViewerScreen());

--- a/apps/flutter_parent/lib/utils/crash_utils.dart
+++ b/apps/flutter_parent/lib/utils/crash_utils.dart
@@ -20,12 +20,12 @@ import 'package:flutter_parent/screens/crash_screen.dart';
 
 class CrashUtils {
   static Future<void> init() async {
-    if (kReleaseMode) await FlutterCrashlytics().initialize();
+    if (!ApiPrefs.isDebug) await FlutterCrashlytics().initialize();
 
     // Set up custom crash screen
     ErrorWidget.builder = (error) {
       // Only need to dump errors in debug, release builds call onError
-      if (!kReleaseMode) {
+      if (ApiPrefs.isDebug) {
         FlutterError.dumpErrorToConsole(error);
       } else {
         FlutterCrashlytics().log('Widget Crash');
@@ -35,11 +35,11 @@ class CrashUtils {
 
     // Set up error handling
     FlutterError.onError = (error) {
-      if (kReleaseMode) {
-        reportCrash(error.exception, error.stack);
-      } else {
+      if (ApiPrefs.isDebug) {
         // Manually handle debug reporting here, as this console formatting is nicer than simple print(stacktrace)
         FlutterError.dumpErrorToConsole(error);
+      } else {
+        reportCrash(error.exception, error.stack);
       }
     };
   }
@@ -49,7 +49,7 @@ class CrashUtils {
     print('Caught exception: $exception');
     debugPrintStack(stackTrace: stacktrace);
 
-    if (kReleaseMode) {
+    if (!ApiPrefs.isDebug) {
       // Set any user info that will help to debug the issue
       await Future.wait([
         FlutterCrashlytics().setInfo('domain', ApiPrefs.getDomain()),

--- a/apps/flutter_parent/lib/utils/debug_flags.dart
+++ b/apps/flutter_parent/lib/utils/debug_flags.dart
@@ -11,18 +11,17 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import 'package:flutter/foundation.dart';
-import 'package:flutter_crashlytics/flutter_crashlytics.dart';
-import 'package:flutter_parent/utils/debug_flags.dart';
 
-class Logger {
-  void log(String message) {
-    if (kReleaseMode) {
-      FlutterCrashlytics().log(message);
-    }
-
-    if (DebugFlags.isDebug) {
-      print(message);
-    }
-  }
+/// A collection of boolean flags that will control when debug features are used
+///
+/// To edit this file and have git ignore your local changes, run this command:
+/// git update-index --skip-worktree apps/flutter_parent/lib/utils/debug_flags.dart
+///
+/// To start tracking local changes again, run this command:
+/// git update-index --no-skip-worktree apps/flutter_parent/lib/utils/debug_flags.dart
+class DebugFlags {
+  static bool isDebug = kDebugMode; // Defaults to kDebugMode, can set to true to have debug features in release builds
+  static bool isDebugApi = false;
 }

--- a/apps/flutter_parent/lib/utils/logger.dart
+++ b/apps/flutter_parent/lib/utils/logger.dart
@@ -11,15 +11,15 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import 'package:flutter/foundation.dart';
 import 'package:flutter_crashlytics/flutter_crashlytics.dart';
+import 'package:flutter_parent/network/utils/api_prefs.dart';
 
 class Logger {
   void log(String message) {
-    if (kReleaseMode) {
-      FlutterCrashlytics().log(message);
-    } else {
+    if (ApiPrefs.isDebug) {
       print(message);
+    } else {
+      FlutterCrashlytics().log(message);
     }
   }
 }


### PR DESCRIPTION
All release/debug checks now key off of `ApiPrefs.isDebug`. This is to simplify logic for debug related features to one place, and making it easy to enable debug features in a release build.

Feel free to request any other changes/features with this. Kept is very simple so we could modify as needed, but would be nice to have a way to change this at runtime (without leaking into actual release builds)