### PR TITLE
[Flutter Parent] Calendar week DST fix

### DIFF
--- a/apps/flutter_parent/lib/screens/calendar/calendar_widget/calendar_widget.dart
+++ b/apps/flutter_parent/lib/screens/calendar/calendar_widget/calendar_widget.dart
@@ -169,7 +169,7 @@ class CalendarWidgetState extends State<CalendarWidget> with TickerProviderState
     final weekStart = day.withFirstDayOfWeek();
     final thisWeekStart = DateTime.now().withFirstDayOfWeek();
     double weeksDiff = thisWeekStart.difference(weekStart).inDays / 7;
-    return _todayWeekIndex - weeksDiff.floor();
+    return _todayWeekIndex - weeksDiff.round();
   }
 
   // Returns the day pager index associated with the specified day


### PR DESCRIPTION
Fixes an issue where the selected week can be off by one if the current date is a week or more past a DST change. This is related to [another fix](https://github.com/instructure/canvas-android/pull/612) where the selected day could be off by one after a DST change. Note that the month view _should_ be immune to this category of issue.