### PR TITLE
[Student][MBL-14108] Fix crash for media uploads without file extension

### DIFF
--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/FileUtils.java
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/FileUtils.java
@@ -189,11 +189,14 @@ public class FileUtils {
     }
 
     public static String getMimeType(String url) {
-        String type = null;
+        String type = "";
         String extension = MimeTypeMap.getFileExtensionFromUrl(url);
         if (extension != null) {
             MimeTypeMap mime = MimeTypeMap.getSingleton();
             type = mime.getMimeTypeFromExtension(extension);
+            if (type == null) {
+                type = "";
+            }
         }
         return type;
     }


### PR DESCRIPTION
To test:

I don't remember the exact case I got to this, but I have a downloaded video in Photos on my emulator. It has a valid filename and extension, but mime type of "*/*".
Trying to submit this file as a media upload for an assignment crashes.

Normal media files should also still upload without issue.