### PR TITLE
[Flutter Parent][MBL-13925] Calendar RTL fixes

### DIFF
--- a/apps/flutter_parent/lib/screens/calendar/calendar_widget/calendar_day_of_week_headers.dart
+++ b/apps/flutter_parent/lib/screens/calendar/calendar_widget/calendar_day_of_week_headers.dart
@@ -31,7 +31,6 @@ class DayOfWeekHeaders extends StatelessWidget {
       child: Container(
         height: headerHeight,
         child: Row(
-          textDirection: TextDirection.ltr,
           mainAxisSize: MainAxisSize.max,
           children: List.generate(7, (index) {
             final day = (firstDayOfWeek + index + 1) % 7;

--- a/apps/flutter_parent/lib/screens/calendar/calendar_widget/calendar_week.dart
+++ b/apps/flutter_parent/lib/screens/calendar/calendar_widget/calendar_week.dart
@@ -47,7 +47,6 @@ class CalendarWeek extends StatelessWidget {
         Container(
           height: CalendarDay.dayHeight,
           child: Row(
-            textDirection: TextDirection.ltr,
             mainAxisSize: MainAxisSize.max,
             children: [
               for (DateTime day in days)

--- a/apps/flutter_parent/lib/screens/calendar/calendar_widget/calendar_widget.dart
+++ b/apps/flutter_parent/lib/screens/calendar/calendar_widget/calendar_widget.dart
@@ -390,7 +390,6 @@ class CalendarWidgetState extends State<CalendarWidget> with TickerProviderState
       key: _monthKey,
       itemCount: _maxMonthIndex,
       controller: _monthController,
-      reverse: Directionality.of(context) == TextDirection.rtl,
       itemBuilder: (context, index) {
         final yearMonth = _yearAndMonthForIndex(index);
         return CalendarMonth(
@@ -488,7 +487,6 @@ class CalendarWidgetState extends State<CalendarWidget> with TickerProviderState
       key: _weekKey,
       itemCount: _maxWeekIndex,
       controller: _weekController,
-      reverse: Directionality.of(context) == TextDirection.rtl,
       itemBuilder: (context, index) {
         final weekStart = _weekStartForIndex(index);
         return CalendarWeek(

--- a/apps/flutter_parent/test/screens/calendar/calendar_widget/calendar_day_of_week_headers_test.dart
+++ b/apps/flutter_parent/test/screens/calendar/calendar_widget/calendar_day_of_week_headers_test.dart
@@ -123,31 +123,31 @@ void main() {
     });
   });
 
-  testWidgetsWithAccessibilityChecks('Displays correctly for Arabic locale', (tester) async {
-    // Weekday names in expected display order
+  testWidgetsWithAccessibilityChecks('Displays correctly for Arabic locale - RTL', (tester) async {
+    // Weekday names in expected display order (RTL)
     final allDays = [
-      find.text('السبت'),
-      find.text('الأحد'),
-      find.text('الاثنين'),
-      find.text('الثلاثاء'),
-      find.text('الأربعاء'),
-      find.text('الخميس'),
       find.text('الجمعة'),
+      find.text('الخميس'),
+      find.text('الأربعاء'),
+      find.text('الثلاثاء'),
+      find.text('الاثنين'),
+      find.text('الأحد'),
+      find.text('السبت'),
     ];
 
     // Weekdays
     final weekdays = [
-      find.text('الأحد'),
-      find.text('الاثنين'),
-      find.text('الثلاثاء'),
-      find.text('الأربعاء'),
       find.text('الخميس'),
+      find.text('الأربعاء'),
+      find.text('الثلاثاء'),
+      find.text('الاثنين'),
+      find.text('الأحد'),
     ];
 
     // Weekend days
     final weekends = [
-      find.text('السبت'),
       find.text('الجمعة'),
+      find.text('السبت'),
     ];
 
     await tester.pumpWidget(TestApp(DayOfWeekHeaders(), locale: Locale('ar')));

--- a/apps/flutter_parent/test/screens/calendar/calendar_widget/calendar_week_test.dart
+++ b/apps/flutter_parent/test/screens/calendar/calendar_widget/calendar_week_test.dart
@@ -18,6 +18,7 @@ import 'package:flutter_parent/screens/calendar/calendar_widget/calendar_day.dar
 import 'package:flutter_parent/screens/calendar/calendar_widget/calendar_day_of_week_headers.dart';
 import 'package:flutter_parent/screens/calendar/calendar_widget/calendar_week.dart';
 import 'package:flutter_parent/screens/calendar/planner_fetcher.dart';
+import 'package:flutter_parent/utils/core_extensions/list_extensions.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 
@@ -145,14 +146,68 @@ void main() {
       expect(widgetSize.width, moreOrLessEquals(expectedWidgetWidth));
     }
   });
+
+  testWidgetsWithAccessibilityChecks('Correctly displays days LTR order', (tester) async {
+    final weekWidget = CalendarWeek(
+      firstDay: weekStart,
+      selectedDay: selectedDate,
+      onDaySelected: (_) {},
+      displayDayOfWeekHeader: false,
+    );
+    await tester.pumpWidget(
+      _appWithFetcher(
+        weekWidget,
+      ),
+    );
+    await tester.pump();
+
+    // Get X position of day widget centers
+    final List<double> centers = weekWidget.days.map((it) {
+      var finder = find.text(it.day.toString());
+      return tester.getCenter(finder).dx;
+    }).toList();
+
+    // We expect X positions to be in ascending order
+    final List<double> expectedCenters = List<double>.from(centers).sortBy([(it) => it]);
+
+    expect(centers, expectedCenters);
+  });
+
+  testWidgetsWithAccessibilityChecks('Correctly displays days RTL order', (tester) async {
+    final weekWidget = CalendarWeek(
+      firstDay: weekStart,
+      selectedDay: selectedDate,
+      onDaySelected: (_) {},
+      displayDayOfWeekHeader: false,
+    );
+    await tester.pumpWidget(
+      _appWithFetcher(
+        weekWidget,
+        locale: Locale('ar'),
+      ),
+    );
+    await tester.pump();
+
+    // Get X position of day widget centers
+    final List<double> centers = weekWidget.days.map((it) {
+      var finder = find.text(it.day.toString());
+      return tester.getCenter(finder).dx;
+    }).toList();
+
+    // We expect X positions to be in descending order
+    final List<double> expectedCenters = List<double>.from(centers).sortBy([(it) => it], descending: true);
+
+    expect(centers, expectedCenters);
+  });
 }
 
-Widget _appWithFetcher(Widget child, {PlannerFetcher fetcher}) {
+Widget _appWithFetcher(Widget child, {PlannerFetcher fetcher, Locale locale}) {
   return TestApp(
     ChangeNotifierProvider<PlannerFetcher>(
       create: (BuildContext context) => fetcher ?? _FakeFetcher(),
       child: child,
     ),
+    locale: locale,
     highContrast: true,
   );
 }

--- a/apps/flutter_parent/test/screens/calendar/calendar_widget/calendar_widget_test.dart
+++ b/apps/flutter_parent/test/screens/calendar/calendar_widget/calendar_widget_test.dart
@@ -54,731 +54,15 @@ void main() {
     expect(find.byType(CalendarMonth), findsNothing);
   });
 
-  testWidgetsWithAccessibilityChecks('Expand button expands and collapses month', (tester) async {
-    final calendar = CalendarWidget(
-      dayBuilder: (_, __) => Container(),
-      fetcher: _FakeFetcher(),
-    );
-    await tester.pumpWidget(
-      TestApp(
-        calendar,
-        highContrast: true,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    // Tap expand button
-    await tester.tap(find.byKey(Key('expand-button')));
-    await tester.pumpAndSettle();
-
-    // Should show month w/ multiple weeks
-    expect(find.byType(CalendarMonth), findsOneWidget);
-    expect(find.byType(CalendarWeek).evaluate().length, greaterThan(1));
-
-    // Tap expand button again
-    await tester.tap(find.byKey(Key('expand-button')));
-    await tester.pumpAndSettle();
-
-    // Should should one week view and no month
-    expect(find.byType(CalendarWeek), findsOneWidget);
-    expect(find.byType(CalendarMonth), findsNothing);
-  });
-
-  testWidgetsWithAccessibilityChecks('Can drag to expand and collapse month', (tester) async {
-    final calendar = CalendarWidget(
-      dayBuilder: (_, __) => Container(),
-      fetcher: _FakeFetcher(),
-    );
-    await tester.pumpWidget(
-      TestApp(
-        calendar,
-        highContrast: true,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    // Drag down on week to expand
-    await tester.drag(find.byType(CalendarWeek), Offset(0, 400));
-    await tester.pumpAndSettle();
-
-    // Should show month w/ multiple weeks
-    expect(find.byType(CalendarMonth), findsOneWidget);
-    expect(find.byType(CalendarWeek).evaluate().length, greaterThan(1));
-
-    // Drag up on month to collapse
-    await tester.drag(find.byType(CalendarMonth), Offset(0, -400));
-    await tester.pumpAndSettle();
-
-    // Should should one week view and no month
-    expect(find.byType(CalendarWeek), findsOneWidget);
-    expect(find.byType(CalendarMonth), findsNothing);
-  });
-
-  testWidgetsWithAccessibilityChecks('Can fling to expand and collapse month', (tester) async {
-    final calendar = CalendarWidget(
-      dayBuilder: (_, __) => Container(),
-      fetcher: _FakeFetcher(),
-    );
-    await tester.pumpWidget(
-      TestApp(
-        calendar,
-        highContrast: true,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    // Fling down on week to expand
-    await tester.fling(find.byType(CalendarWeek), Offset(0, 50), 300);
-    await tester.pumpAndSettle();
-
-    // Should show month w/ multiple weeks
-    expect(find.byType(CalendarMonth), findsOneWidget);
-    expect(find.byType(CalendarWeek).evaluate().length, greaterThan(1));
-
-    // Fling up on month to collapse
-    await tester.fling(find.byType(CalendarMonth), Offset(0, -50), 300);
-    await tester.pumpAndSettle();
-
-    // Should should one week view and no month
-    expect(find.byType(CalendarWeek), findsOneWidget);
-    expect(find.byType(CalendarMonth), findsNothing);
-  });
-
-  testWidgetsWithAccessibilityChecks('Can fling day content to collapse month', (tester) async {
-    final dayContentKey = Key('day-content');
-    final calendar = CalendarWidget(
-      dayBuilder: (_, __) => Container(key: dayContentKey),
-      fetcher: _FakeFetcher(),
-    );
-    await tester.pumpWidget(
-      TestApp(
-        calendar,
-        highContrast: true,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    // Tap expand button
-    await tester.tap(find.byKey(Key('expand-button')));
-    await tester.pumpAndSettle();
-
-    // Should show month now
-    expect(find.byType(CalendarMonth), findsOneWidget);
-
-    // Fling up on day content to collapse
-    await tester.fling(find.byKey(dayContentKey), Offset(0, -50), 300);
-    await tester.pumpAndSettle();
-
-    // Should should one week view and no month
-    expect(find.byType(CalendarWeek), findsOneWidget);
-    expect(find.byType(CalendarMonth), findsNothing);
-  });
-
-  testWidgetsWithAccessibilityChecks('Jumps to selected date', (tester) async {
-    DateTime dateForDayBuilder = null;
-    await tester.pumpWidget(
-      TestApp(
-        CalendarWidget(
-          dayBuilder: (_, day) {
-            dateForDayBuilder = day;
-            return Container();
-          },
-          fetcher: _FakeFetcher(),
-        ),
-        highContrast: true,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    DateTime targetDate = DateTime(2000, 1, 1);
-    await goToDate(tester, targetDate);
-
-    // Day should have built using target date
-    expect(dateForDayBuilder, targetDate);
-
-    // Week should start on Dec 26, 1999
-    DateTime weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
-    expect(weekStart, DateTime(1999, 12, 26));
-
-    // Month should be Jan 2000
-    final monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth, skipOffstage: false));
-    expect(monthWidget.year, 2000);
-    expect(monthWidget.month, 1);
-  });
-
-  testWidgetsWithAccessibilityChecks('Animates to selected date', (tester) async {
-    DateTime dateForDayBuilder = null;
-    await tester.pumpWidget(
-      TestApp(
-        CalendarWidget(
-          dayBuilder: (_, day) {
-            dateForDayBuilder = day;
-            return Container();
-          },
-          fetcher: _FakeFetcher(),
-        ),
-        highContrast: true,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    CalendarWidgetState state = await goToDate(tester, DateTime(2000, 1, 1));
-
-    DateTime targetDate = DateTime(1999, 12, 23);
-    state.selectDay(
-      targetDate,
-      dayPagerBehavior: CalendarPageChangeBehavior.animate,
-      weekPagerBehavior: CalendarPageChangeBehavior.animate,
-      monthPagerBehavior: CalendarPageChangeBehavior.animate,
-    );
-    await tester.pumpAndSettle();
-
-    // Day should have built using target date
-    expect(dateForDayBuilder, targetDate);
-
-    // Week should start on Dec 19, 1999
-    DateTime weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
-    expect(weekStart, DateTime(1999, 12, 19));
-
-    // Month should be Dec 1999
-    final monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth, skipOffstage: false));
-    expect(monthWidget.year, 1999);
-    expect(monthWidget.month, 12);
-  });
-
-  testWidgetsWithAccessibilityChecks('Swipes to previous week', (tester) async {
-    await tester.pumpWidget(
-      TestApp(
-        CalendarWidget(
-          dayBuilder: (_, day) => Container(),
-          fetcher: _FakeFetcher(),
-        ),
-        highContrast: true,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    DateTime targetDate = DateTime(2000, 1, 1);
-    CalendarWidgetState state = await goToDate(tester, targetDate);
-
-    // Week should start on Dec 26, 1999
-    DateTime weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
-    expect(weekStart, DateTime(1999, 12, 26));
-
-    // Selected day should be Saturday (Jan 1 2000)
-    expect(state.selectedDay, targetDate);
-
-    // Fling to previous week
-    await tester.fling(find.byType(CalendarWeek), Offset(50, 0), 300);
-    await tester.pumpAndSettle();
-
-    // Week should now start on Dec 19, 1999
-    weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
-    expect(weekStart, DateTime(1999, 12, 19));
-
-    // Selected day should be the same day of the week, Saturday (Dec 25, 1999)
-    expect(state.selectedDay, DateTime(1999, 12, 25));
-  });
-
-  testWidgetsWithAccessibilityChecks('Swipes to next week', (tester) async {
-    await tester.pumpWidget(
-      TestApp(
-        CalendarWidget(
-          dayBuilder: (_, day) => Container(),
-          fetcher: _FakeFetcher(),
-        ),
-        highContrast: true,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    DateTime targetDate = DateTime(2000, 1, 1);
-    CalendarWidgetState state = await goToDate(tester, targetDate);
-
-    // Week should start on Dec 26, 1999
-    DateTime weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
-    expect(weekStart, DateTime(1999, 12, 26));
-
-    // Selected day should be Saturday (Jan 1 2000)
-    expect(state.selectedDay, targetDate);
-
-    // Fling to previous month
-    await tester.fling(find.byType(CalendarWeek), Offset(-50, 0), 300);
-    await tester.pumpAndSettle();
-
-    // Week should now start on Jan 2, 2000
-    weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
-    expect(weekStart, DateTime(2000, 1, 2));
-
-    // Selected day should be the same day of the week, Saturday (Jan 8, 2000)
-    expect(state.selectedDay, DateTime(2000, 1, 8));
-  });
-
-  testWidgetsWithAccessibilityChecks('Swipes to previous month', (tester) async {
-    await tester.pumpWidget(
-      TestApp(
-        CalendarWidget(
-          dayBuilder: (_, day) => Container(),
-          fetcher: _FakeFetcher(),
-        ),
-        highContrast: true,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    DateTime targetDate = DateTime(2000, 1, 1);
-    CalendarWidgetState state = await goToDate(tester, targetDate);
-
-    // Tap expand button
-    await tester.tap(find.byKey(Key('expand-button')));
-    await tester.pumpAndSettle();
-
-    // Month should be January 2000
-    CalendarMonth monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth));
-    expect(monthWidget.year, 2000);
-    expect(monthWidget.month, 1);
-
-    // Selected day should be Jan 1 2000
-    expect(state.selectedDay, targetDate);
-
-    // Fling to previous month
-    await tester.fling(find.byType(CalendarMonth), Offset(50, 0), 300);
-    await tester.pumpAndSettle();
-
-    // Month should be December 1999
-    monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth));
-    expect(monthWidget.year, 1999);
-    expect(monthWidget.month, 12);
-
-    // Selected day should be Same day of the month (Dec 1, 1999)
-    expect(state.selectedDay, DateTime(1999, 12, 1));
-  });
-
-  testWidgetsWithAccessibilityChecks('Swipes to next month', (tester) async {
-    await tester.pumpWidget(
-      TestApp(
-        CalendarWidget(
-          dayBuilder: (_, day) => Container(),
-          fetcher: _FakeFetcher(),
-        ),
-        highContrast: true,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    DateTime targetDate = DateTime(2000, 1, 1);
-    CalendarWidgetState state = await goToDate(tester, targetDate);
-
-    // Tap expand button
-    await tester.tap(find.byKey(Key('expand-button')));
-    await tester.pumpAndSettle();
-
-    // Month should be January 2000
-    CalendarMonth monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth));
-    expect(monthWidget.year, 2000);
-    expect(monthWidget.month, 1);
-
-    // Selected day should be Jan 1 2000
-    expect(state.selectedDay, targetDate);
-
-    // Fling to next month
-    await tester.fling(find.byType(CalendarMonth), Offset(-50, 0), 300);
-    await tester.pumpAndSettle();
-
-    // Month should be February 2000
-    monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth));
-    expect(monthWidget.year, 2000);
-    expect(monthWidget.month, 2);
-
-    // Selected day should be same day of the month (Feb 1, 2000)
-    expect(state.selectedDay, DateTime(2000, 2, 1));
-  });
-
-  testWidgetsWithAccessibilityChecks('Displays a11y arrows for week view', (tester) async {
-    await tester.pumpWidget(
-      TestApp(
-        MediaQuery(
-          child: CalendarWidget(
-            dayBuilder: (_, __) => Container(),
-            fetcher: _FakeFetcher(),
-          ),
-          data: MediaQueryData(accessibleNavigation: true),
-        ),
-        highContrast: true,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    // Jump to Jan 1 2000
-    await goToDate(tester, DateTime(2000, 1, 1));
-
-    // Should show week a11y arrows
-    expect(find.byKey(Key('calendar-a11y-previous-week')), findsOneWidget);
-    expect(find.byKey(Key('calendar-a11y-next-week')), findsOneWidget);
-  });
-
-  testWidgetsWithAccessibilityChecks('A11y arrow moves to previous week', (tester) async {
-    await tester.pumpWidget(
-      TestApp(
-        MediaQuery(
-          child: CalendarWidget(
-            dayBuilder: (_, __) => Container(),
-            fetcher: _FakeFetcher(),
-          ),
-          data: MediaQueryData(accessibleNavigation: true),
-        ),
-        highContrast: true,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    DateTime targetDate = DateTime(2000, 1, 1);
-    CalendarWidgetState state = await goToDate(tester, targetDate);
-
-    // Tap previous arrow
-    await tester.tap(find.byKey(Key('calendar-a11y-previous-week')));
-    await tester.pumpAndSettle();
-
-    // Week should start on Dec 19, 1999
-    DateTime weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
-    expect(weekStart, DateTime(1999, 12, 19));
-
-    // Selected day should be the same day of the week, Saturday (Dec 25, 1999)
-    expect(state.selectedDay, DateTime(1999, 12, 25));
-  });
-
-  testWidgetsWithAccessibilityChecks('A11y arrow moves to next week', (tester) async {
-    await tester.pumpWidget(
-      TestApp(
-        MediaQuery(
-          child: CalendarWidget(
-            dayBuilder: (_, __) => Container(),
-            fetcher: _FakeFetcher(),
-          ),
-          data: MediaQueryData(accessibleNavigation: true),
-        ),
-        highContrast: true,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    DateTime targetDate = DateTime(2000, 1, 1);
-    CalendarWidgetState state = await goToDate(tester, targetDate);
-
-    // Tap next arrow
-    await tester.tap(find.byKey(Key('calendar-a11y-next-week')));
-    await tester.pumpAndSettle();
-
-    // Week should now start on Jan 2, 2000
-    DateTime weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
-    expect(weekStart, DateTime(2000, 1, 2));
-
-    // Selected day should be the same day of the week, Saturday (Jan 8, 2000)
-    expect(state.selectedDay, DateTime(2000, 1, 8));
-  });
-
-  testWidgetsWithAccessibilityChecks('Displays a11y arrows for month view', (tester) async {
-    await tester.pumpWidget(
-      TestApp(
-        MediaQuery(
-          child: CalendarWidget(
-            dayBuilder: (_, __) => Container(),
-            fetcher: _FakeFetcher(),
-          ),
-          data: MediaQueryData(accessibleNavigation: true),
-        ),
-        highContrast: true,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    // Jump to Jan 1 2000
-    await goToDate(tester, DateTime(2000, 1, 1));
-
-    // Tap to expand month view
-    await tester.tap(find.byKey(Key('expand-button')));
-    await tester.pumpAndSettle();
-
-    // Should show week a11y arrows
-    expect(find.byKey(Key('calendar-a11y-previous-month')), findsOneWidget);
-    expect(find.byKey(Key('calendar-a11y-next-month')), findsOneWidget);
-  });
-  testWidgetsWithAccessibilityChecks('A11y arrow moves to previous month', (tester) async {
-    await tester.pumpWidget(
-      TestApp(
-        MediaQuery(
-          child: CalendarWidget(
-            dayBuilder: (_, __) => Container(),
-            fetcher: _FakeFetcher(),
-          ),
-          data: MediaQueryData(accessibleNavigation: true),
-        ),
-        highContrast: true,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    DateTime targetDate = DateTime(2000, 1, 1);
-    CalendarWidgetState state = await goToDate(tester, targetDate);
-
-    // Tap to expand month view
-    await tester.tap(find.byKey(Key('expand-button')));
-    await tester.pumpAndSettle();
-
-    // Tap previous arrow
-    await tester.tap(find.byKey(Key('calendar-a11y-previous-month')));
-    await tester.pumpAndSettle();
-
-    // Month should be December 1999
-    var monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth));
-    expect(monthWidget.year, 1999);
-    expect(monthWidget.month, 12);
-
-    // Selected day should be Same day of the month (Dec 1, 1999)
-    expect(state.selectedDay, DateTime(1999, 12, 1));
-  });
-
-  testWidgetsWithAccessibilityChecks('A11y arrow moves to next month', (tester) async {
-    await tester.pumpWidget(
-      TestApp(
-        MediaQuery(
-          child: CalendarWidget(
-            dayBuilder: (_, __) => Container(),
-            fetcher: _FakeFetcher(),
-          ),
-          data: MediaQueryData(accessibleNavigation: true),
-        ),
-        highContrast: true,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    DateTime targetDate = DateTime(2000, 1, 1);
-    CalendarWidgetState state = await goToDate(tester, targetDate);
-
-    // Tap to expand month view
-    await tester.tap(find.byKey(Key('expand-button')));
-    await tester.pumpAndSettle();
-
-    // Tap next arrow
-    await tester.tap(find.byKey(Key('calendar-a11y-next-month')));
-    await tester.pumpAndSettle();
-
-    // Month should be February 2000
-    var monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth));
-    expect(monthWidget.year, 2000);
-    expect(monthWidget.month, 2);
-
-    // Selected day should be same day of the month (Feb 1, 2000)
-    expect(state.selectedDay, DateTime(2000, 2, 1));
-  });
-
-  testWidgetsWithAccessibilityChecks('Selects date from week view', (tester) async {
-    DateTime dateForDayBuilder = null;
-    await tester.pumpWidget(
-      TestApp(
-        CalendarWidget(
-          dayBuilder: (_, day) {
-            dateForDayBuilder = day;
-            return Container();
-          },
-          fetcher: _FakeFetcher(),
-        ),
-        highContrast: true,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    await goToDate(tester, DateTime(2000, 1, 1));
-
-    await tester.tap(find.text('31'));
-    await tester.pumpAndSettle();
-
-    // Day should have built Dec 31 1999
-    expect(dateForDayBuilder, DateTime(1999, 12, 31));
-
-    // Week should start Dec 26, 1999
-    DateTime weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
-    expect(weekStart, DateTime(1999, 12, 26));
-
-    // Month should be December 1999
-    final monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth, skipOffstage: false));
-    expect(monthWidget.year, 1999);
-    expect(monthWidget.month, 12);
-  });
-
-  testWidgetsWithAccessibilityChecks('Selects date from month view', (tester) async {
-    DateTime dateForDayBuilder = null;
-    await tester.pumpWidget(
-      TestApp(
-        CalendarWidget(
-          dayBuilder: (_, day) {
-            dateForDayBuilder = day;
-            return Container();
-          },
-          fetcher: _FakeFetcher(),
-        ),
-        highContrast: true,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    await goToDate(tester, DateTime(2000, 1, 1));
-    await tester.tap(find.byKey(Key('expand-button')));
-    await tester.pumpAndSettle();
-
-    // Tap the last '1', which should be February 1 2000
-    await tester.tap(find.text('1').last);
-    await tester.pumpAndSettle();
-
-    // Day should have built Feb 1 2000
-    expect(dateForDayBuilder, DateTime(2000, 2, 1));
-
-    // Week should start Jan 30 2000
-    DateTime weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek, skipOffstage: false).first).firstDay;
-    expect(weekStart, DateTime(2000, 1, 30));
-
-    // Month should be Feb 2000
-    final monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth));
-    expect(monthWidget.year, 2000);
-    expect(monthWidget.month, 2);
-  });
-
-  testWidgetsWithAccessibilityChecks('Swipes to select adjacent day', (tester) async {
-    DateTime dateForDayBuilder = null;
-    final dayContentKey = Key('day-content');
-
-    await tester.pumpWidget(
-      TestApp(
-        CalendarWidget(
-          dayBuilder: (_, day) {
-            dateForDayBuilder = day;
-            return Container(key: dayContentKey);
-          },
-          fetcher: _FakeFetcher(),
-        ),
-        highContrast: true,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    await goToDate(tester, DateTime(2000, 1, 1));
-
-    // Swipe to next day, which should be Jan 2 2000
-    await tester.fling(find.byKey(dayContentKey), Offset(-50, 0), 300);
-    await tester.pumpAndSettle();
-
-    // Day should have built Jan 2 2000
-    expect(dateForDayBuilder, DateTime(2000, 1, 2));
-
-    // Week should start Jan 2 2000
-    DateTime weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
-    expect(weekStart, DateTime(2000, 1, 2));
-
-    // Month should be Jan 2000
-    final monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth, skipOffstage: false));
-    expect(monthWidget.year, 2000);
-    expect(monthWidget.month, 1);
-  });
-
-  testWidgetsWithAccessibilityChecks('disables expand/collapse button for insufficient height', (tester) async {
-    final calendarHeight = 200;
-    final screenHeight = tester.binding.window.physicalSize.height / tester.binding.window.devicePixelRatio;
-    final calendar = CalendarWidget(
-      dayBuilder: (_, __) => Container(),
-      fetcher: _FakeFetcher(),
-    );
-    await tester.pumpWidget(
-      TestApp(
-        Column(
-          children: <Widget>[
-            SizedBox(height: screenHeight - calendarHeight),
-            Expanded(child: calendar),
-          ],
-        ),
-        highContrast: true,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    // Should not show dropdown arrow
-    expect(find.byType(DropdownArrow), findsNothing);
-
-    // Tap expand button
-    await tester.tap(find.byKey(Key('expand-button')));
-    await tester.pumpAndSettle();
-
-    // Should not show month
-    expect(find.byType(CalendarMonth), findsNothing);
-  });
-
-  testWidgetsWithAccessibilityChecks('disables swipe-to-expand for insufficient height', (tester) async {
-    final calendarHeight = 200;
-    final screenHeight = tester.binding.window.physicalSize.height / tester.binding.window.devicePixelRatio;
-    final calendar = CalendarWidget(
-      dayBuilder: (_, __) => Container(),
-      fetcher: _FakeFetcher(),
-    );
-    await tester.pumpWidget(
-      TestApp(
-        Column(
-          children: <Widget>[
-            SizedBox(height: screenHeight - calendarHeight),
-            Expanded(child: calendar),
-          ],
-        ),
-        highContrast: true,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    // Fling down on week to try expand
-    await tester.fling(find.byType(CalendarWeek), Offset(0, 50), 300);
-    await tester.pumpAndSettle();
-
-    // Should not show month
-    expect(find.byType(CalendarMonth), findsNothing);
-  });
-
-  testWidgetsWithAccessibilityChecks('collapses month if height becomes insufficient', (tester) async {
-    // Due to how we must capture height changes, when the month view is open and the height becomes insufficient
-    // there will be at least one build pass where the month layout overflows its parent. This is acceptable while the
-    // month view is animating its collapse into the week view. However, because such overflows will fail the test,
-    // we must intercept and ignore those specific errors
-    FlutterExceptionHandler onError = FlutterError.onError;
-    FlutterError.onError = (details) {
-      var exception = details.exception;
-      if (exception is FlutterError && exception?.message?.startsWith('A RenderFlex overflowed') == true) {
-        // Intentionally left blank
-      } else {
-        onError(details);
-      }
-    };
-
-    try {
-      double calendarHeight = 600;
-      final screenHeight = tester.binding.window.physicalSize.height / tester.binding.window.devicePixelRatio;
-
+  group('Month Expand/Collapse', () {
+    testWidgetsWithAccessibilityChecks('Expand button expands and collapses month', (tester) async {
       final calendar = CalendarWidget(
         dayBuilder: (_, __) => Container(),
         fetcher: _FakeFetcher(),
       );
-
-      StateSetter stateSetter;
-
       await tester.pumpWidget(
         TestApp(
-          StatefulBuilder(
-            builder: (context, setState) {
-              stateSetter = setState;
-              return Column(
-                children: <Widget>[
-                  SizedBox(height: screenHeight - calendarHeight),
-                  Expanded(child: OverflowBox(maxHeight: calendarHeight, child: calendar)),
-                ],
-              );
-            },
-          ),
+          calendar,
           highContrast: true,
         ),
       );
@@ -788,20 +72,940 @@ void main() {
       await tester.tap(find.byKey(Key('expand-button')));
       await tester.pumpAndSettle();
 
-      // Should show month
+      // Should show month w/ multiple weeks
       expect(find.byType(CalendarMonth), findsOneWidget);
+      expect(find.byType(CalendarWeek).evaluate().length, greaterThan(1));
 
-      // Shrink calendar height and rebuild
-      calendarHeight = 200;
-      stateSetter(() {});
+      // Tap expand button again
+      await tester.tap(find.byKey(Key('expand-button')));
       await tester.pumpAndSettle();
 
-      // Should no longer show month
+      // Should should one week view and no month
+      expect(find.byType(CalendarWeek), findsOneWidget);
       expect(find.byType(CalendarMonth), findsNothing);
-    } finally {
-      // Restore exception handler
-      FlutterError.onError = onError;
-    }
+    });
+
+    testWidgetsWithAccessibilityChecks('Can drag to expand and collapse month', (tester) async {
+      final calendar = CalendarWidget(
+        dayBuilder: (_, __) => Container(),
+        fetcher: _FakeFetcher(),
+      );
+      await tester.pumpWidget(
+        TestApp(
+          calendar,
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Drag down on week to expand
+      await tester.drag(find.byType(CalendarWeek), Offset(0, 400));
+      await tester.pumpAndSettle();
+
+      // Should show month w/ multiple weeks
+      expect(find.byType(CalendarMonth), findsOneWidget);
+      expect(find.byType(CalendarWeek).evaluate().length, greaterThan(1));
+
+      // Drag up on month to collapse
+      await tester.drag(find.byType(CalendarMonth), Offset(0, -400));
+      await tester.pumpAndSettle();
+
+      // Should should one week view and no month
+      expect(find.byType(CalendarWeek), findsOneWidget);
+      expect(find.byType(CalendarMonth), findsNothing);
+    });
+
+    testWidgetsWithAccessibilityChecks('Can fling to expand and collapse month', (tester) async {
+      final calendar = CalendarWidget(
+        dayBuilder: (_, __) => Container(),
+        fetcher: _FakeFetcher(),
+      );
+      await tester.pumpWidget(
+        TestApp(
+          calendar,
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Fling down on week to expand
+      await tester.fling(find.byType(CalendarWeek), Offset(0, 50), 300);
+      await tester.pumpAndSettle();
+
+      // Should show month w/ multiple weeks
+      expect(find.byType(CalendarMonth), findsOneWidget);
+      expect(find.byType(CalendarWeek).evaluate().length, greaterThan(1));
+
+      // Fling up on month to collapse
+      await tester.fling(find.byType(CalendarMonth), Offset(0, -50), 300);
+      await tester.pumpAndSettle();
+
+      // Should should one week view and no month
+      expect(find.byType(CalendarWeek), findsOneWidget);
+      expect(find.byType(CalendarMonth), findsNothing);
+    });
+
+    testWidgetsWithAccessibilityChecks('Can fling day content to collapse month', (tester) async {
+      final dayContentKey = Key('day-content');
+      final calendar = CalendarWidget(
+        dayBuilder: (_, __) => Container(key: dayContentKey),
+        fetcher: _FakeFetcher(),
+      );
+      await tester.pumpWidget(
+        TestApp(
+          calendar,
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Tap expand button
+      await tester.tap(find.byKey(Key('expand-button')));
+      await tester.pumpAndSettle();
+
+      // Should show month now
+      expect(find.byType(CalendarMonth), findsOneWidget);
+
+      // Fling up on day content to collapse
+      await tester.fling(find.byKey(dayContentKey), Offset(0, -50), 300);
+      await tester.pumpAndSettle();
+
+      // Should should one week view and no month
+      expect(find.byType(CalendarWeek), findsOneWidget);
+      expect(find.byType(CalendarMonth), findsNothing);
+    });
+  });
+
+  group('Set day/week/month', () {
+    testWidgetsWithAccessibilityChecks('Jumps to selected date', (tester) async {
+      DateTime dateForDayBuilder = null;
+      await tester.pumpWidget(
+        TestApp(
+          CalendarWidget(
+            dayBuilder: (_, day) {
+              dateForDayBuilder = day;
+              return Container();
+            },
+            fetcher: _FakeFetcher(),
+          ),
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      DateTime targetDate = DateTime(2000, 1, 1);
+      await goToDate(tester, targetDate);
+
+      // Day should have built using target date
+      expect(dateForDayBuilder, targetDate);
+
+      // Week should start on Dec 26, 1999
+      DateTime weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
+      expect(weekStart, DateTime(1999, 12, 26));
+
+      // Month should be Jan 2000
+      final monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth, skipOffstage: false));
+      expect(monthWidget.year, 2000);
+      expect(monthWidget.month, 1);
+    });
+
+    testWidgetsWithAccessibilityChecks('Animates to selected date', (tester) async {
+      DateTime dateForDayBuilder = null;
+      await tester.pumpWidget(
+        TestApp(
+          CalendarWidget(
+            dayBuilder: (_, day) {
+              dateForDayBuilder = day;
+              return Container();
+            },
+            fetcher: _FakeFetcher(),
+          ),
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      CalendarWidgetState state = await goToDate(tester, DateTime(2000, 1, 1));
+
+      DateTime targetDate = DateTime(1999, 12, 23);
+      state.selectDay(
+        targetDate,
+        dayPagerBehavior: CalendarPageChangeBehavior.animate,
+        weekPagerBehavior: CalendarPageChangeBehavior.animate,
+        monthPagerBehavior: CalendarPageChangeBehavior.animate,
+      );
+      await tester.pumpAndSettle();
+
+      // Day should have built using target date
+      expect(dateForDayBuilder, targetDate);
+
+      // Week should start on Dec 19, 1999
+      DateTime weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
+      expect(weekStart, DateTime(1999, 12, 19));
+
+      // Month should be Dec 1999
+      final monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth, skipOffstage: false));
+      expect(monthWidget.year, 1999);
+      expect(monthWidget.month, 12);
+    });
+  });
+
+  group('Week and Month Swipe', () {
+    testWidgetsWithAccessibilityChecks('Swipes to previous week', (tester) async {
+      await tester.pumpWidget(
+        TestApp(
+          CalendarWidget(
+            dayBuilder: (_, day) => Container(),
+            fetcher: _FakeFetcher(),
+          ),
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      DateTime targetDate = DateTime(2000, 1, 1);
+      CalendarWidgetState state = await goToDate(tester, targetDate);
+
+      // Week should start on Dec 26, 1999
+      DateTime weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
+      expect(weekStart, DateTime(1999, 12, 26));
+
+      // Selected day should be Saturday (Jan 1 2000)
+      expect(state.selectedDay, targetDate);
+
+      // Fling to previous week
+      await tester.fling(find.byType(CalendarWeek), Offset(50, 0), 300);
+      await tester.pumpAndSettle();
+
+      // Week should now start on Dec 19, 1999
+      weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
+      expect(weekStart, DateTime(1999, 12, 19));
+
+      // Selected day should be the same day of the week, Saturday (Dec 25, 1999)
+      expect(state.selectedDay, DateTime(1999, 12, 25));
+    });
+
+    testWidgetsWithAccessibilityChecks('Swipes to next week', (tester) async {
+      await tester.pumpWidget(
+        TestApp(
+          CalendarWidget(
+            dayBuilder: (_, day) => Container(),
+            fetcher: _FakeFetcher(),
+          ),
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      DateTime targetDate = DateTime(2000, 1, 1);
+      CalendarWidgetState state = await goToDate(tester, targetDate);
+
+      // Week should start on Dec 26, 1999
+      DateTime weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
+      expect(weekStart, DateTime(1999, 12, 26));
+
+      // Selected day should be Saturday (Jan 1 2000)
+      expect(state.selectedDay, targetDate);
+
+      // Fling to previous month
+      await tester.fling(find.byType(CalendarWeek), Offset(-50, 0), 300);
+      await tester.pumpAndSettle();
+
+      // Week should now start on Jan 2, 2000
+      weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
+      expect(weekStart, DateTime(2000, 1, 2));
+
+      // Selected day should be the same day of the week, Saturday (Jan 8, 2000)
+      expect(state.selectedDay, DateTime(2000, 1, 8));
+    });
+
+    testWidgetsWithAccessibilityChecks('Swipes to previous month', (tester) async {
+      await tester.pumpWidget(
+        TestApp(
+          CalendarWidget(
+            dayBuilder: (_, day) => Container(),
+            fetcher: _FakeFetcher(),
+          ),
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      DateTime targetDate = DateTime(2000, 1, 1);
+      CalendarWidgetState state = await goToDate(tester, targetDate);
+
+      // Tap expand button
+      await tester.tap(find.byKey(Key('expand-button')));
+      await tester.pumpAndSettle();
+
+      // Month should be January 2000
+      CalendarMonth monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth));
+      expect(monthWidget.year, 2000);
+      expect(monthWidget.month, 1);
+
+      // Selected day should be Jan 1 2000
+      expect(state.selectedDay, targetDate);
+
+      // Fling to previous month
+      await tester.fling(find.byType(CalendarMonth), Offset(50, 0), 300);
+      await tester.pumpAndSettle();
+
+      // Month should be December 1999
+      monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth));
+      expect(monthWidget.year, 1999);
+      expect(monthWidget.month, 12);
+
+      // Selected day should be Same day of the month (Dec 1, 1999)
+      expect(state.selectedDay, DateTime(1999, 12, 1));
+    });
+    testWidgetsWithAccessibilityChecks('Swipes to next month', (tester) async {
+      await tester.pumpWidget(
+        TestApp(
+          CalendarWidget(
+            dayBuilder: (_, day) => Container(),
+            fetcher: _FakeFetcher(),
+          ),
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      DateTime targetDate = DateTime(2000, 1, 1);
+      CalendarWidgetState state = await goToDate(tester, targetDate);
+
+      // Tap expand button
+      await tester.tap(find.byKey(Key('expand-button')));
+      await tester.pumpAndSettle();
+
+      // Month should be January 2000
+      CalendarMonth monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth));
+      expect(monthWidget.year, 2000);
+      expect(monthWidget.month, 1);
+
+      // Selected day should be Jan 1 2000
+      expect(state.selectedDay, targetDate);
+
+      // Fling to next month
+      await tester.fling(find.byType(CalendarMonth), Offset(-50, 0), 300);
+      await tester.pumpAndSettle();
+
+      // Month should be February 2000
+      monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth));
+      expect(monthWidget.year, 2000);
+      expect(monthWidget.month, 2);
+
+      // Selected day should be same day of the month (Feb 1, 2000)
+      expect(state.selectedDay, DateTime(2000, 2, 1));
+    });
+  });
+
+  group('Accessibility', () {
+    testWidgetsWithAccessibilityChecks('Displays a11y arrows for week view', (tester) async {
+      await tester.pumpWidget(
+        TestApp(
+          MediaQuery(
+            child: CalendarWidget(
+              dayBuilder: (_, __) => Container(),
+              fetcher: _FakeFetcher(),
+            ),
+            data: MediaQueryData(accessibleNavigation: true),
+          ),
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Jump to Jan 1 2000
+      await goToDate(tester, DateTime(2000, 1, 1));
+
+      // Should show week a11y arrows
+      expect(find.byKey(Key('calendar-a11y-previous-week')), findsOneWidget);
+      expect(find.byKey(Key('calendar-a11y-next-week')), findsOneWidget);
+    });
+
+    testWidgetsWithAccessibilityChecks('A11y arrow moves to previous week', (tester) async {
+      await tester.pumpWidget(
+        TestApp(
+          MediaQuery(
+            child: CalendarWidget(
+              dayBuilder: (_, __) => Container(),
+              fetcher: _FakeFetcher(),
+            ),
+            data: MediaQueryData(accessibleNavigation: true),
+          ),
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      DateTime targetDate = DateTime(2000, 1, 1);
+      CalendarWidgetState state = await goToDate(tester, targetDate);
+
+      // Tap previous arrow
+      await tester.tap(find.byKey(Key('calendar-a11y-previous-week')));
+      await tester.pumpAndSettle();
+
+      // Week should start on Dec 19, 1999
+      DateTime weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
+      expect(weekStart, DateTime(1999, 12, 19));
+
+      // Selected day should be the same day of the week, Saturday (Dec 25, 1999)
+      expect(state.selectedDay, DateTime(1999, 12, 25));
+    });
+
+    testWidgetsWithAccessibilityChecks('A11y arrow moves to next week', (tester) async {
+      await tester.pumpWidget(
+        TestApp(
+          MediaQuery(
+            child: CalendarWidget(
+              dayBuilder: (_, __) => Container(),
+              fetcher: _FakeFetcher(),
+            ),
+            data: MediaQueryData(accessibleNavigation: true),
+          ),
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      DateTime targetDate = DateTime(2000, 1, 1);
+      CalendarWidgetState state = await goToDate(tester, targetDate);
+
+      // Tap next arrow
+      await tester.tap(find.byKey(Key('calendar-a11y-next-week')));
+      await tester.pumpAndSettle();
+
+      // Week should now start on Jan 2, 2000
+      DateTime weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
+      expect(weekStart, DateTime(2000, 1, 2));
+
+      // Selected day should be the same day of the week, Saturday (Jan 8, 2000)
+      expect(state.selectedDay, DateTime(2000, 1, 8));
+    });
+
+    testWidgetsWithAccessibilityChecks('Displays a11y arrows for month view', (tester) async {
+      await tester.pumpWidget(
+        TestApp(
+          MediaQuery(
+            child: CalendarWidget(
+              dayBuilder: (_, __) => Container(),
+              fetcher: _FakeFetcher(),
+            ),
+            data: MediaQueryData(accessibleNavigation: true),
+          ),
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Jump to Jan 1 2000
+      await goToDate(tester, DateTime(2000, 1, 1));
+
+      // Tap to expand month view
+      await tester.tap(find.byKey(Key('expand-button')));
+      await tester.pumpAndSettle();
+
+      // Should show week a11y arrows
+      expect(find.byKey(Key('calendar-a11y-previous-month')), findsOneWidget);
+      expect(find.byKey(Key('calendar-a11y-next-month')), findsOneWidget);
+    });
+
+    testWidgetsWithAccessibilityChecks('A11y arrow moves to previous month', (tester) async {
+      await tester.pumpWidget(
+        TestApp(
+          MediaQuery(
+            child: CalendarWidget(
+              dayBuilder: (_, __) => Container(),
+              fetcher: _FakeFetcher(),
+            ),
+            data: MediaQueryData(accessibleNavigation: true),
+          ),
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      DateTime targetDate = DateTime(2000, 1, 1);
+      CalendarWidgetState state = await goToDate(tester, targetDate);
+
+      // Tap to expand month view
+      await tester.tap(find.byKey(Key('expand-button')));
+      await tester.pumpAndSettle();
+
+      // Tap previous arrow
+      await tester.tap(find.byKey(Key('calendar-a11y-previous-month')));
+      await tester.pumpAndSettle();
+
+      // Month should be December 1999
+      var monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth));
+      expect(monthWidget.year, 1999);
+      expect(monthWidget.month, 12);
+
+      // Selected day should be Same day of the month (Dec 1, 1999)
+      expect(state.selectedDay, DateTime(1999, 12, 1));
+    });
+
+    testWidgetsWithAccessibilityChecks('A11y arrow moves to next month', (tester) async {
+      await tester.pumpWidget(
+        TestApp(
+          MediaQuery(
+            child: CalendarWidget(
+              dayBuilder: (_, __) => Container(),
+              fetcher: _FakeFetcher(),
+            ),
+            data: MediaQueryData(accessibleNavigation: true),
+          ),
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      DateTime targetDate = DateTime(2000, 1, 1);
+      CalendarWidgetState state = await goToDate(tester, targetDate);
+
+      // Tap to expand month view
+      await tester.tap(find.byKey(Key('expand-button')));
+      await tester.pumpAndSettle();
+
+      // Tap next arrow
+      await tester.tap(find.byKey(Key('calendar-a11y-next-month')));
+      await tester.pumpAndSettle();
+
+      // Month should be February 2000
+      var monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth));
+      expect(monthWidget.year, 2000);
+      expect(monthWidget.month, 2);
+
+      // Selected day should be same day of the month (Feb 1, 2000)
+      expect(state.selectedDay, DateTime(2000, 2, 1));
+    });
+  });
+
+  group('Date Selection', () {
+    testWidgetsWithAccessibilityChecks('Selects date from week view', (tester) async {
+      DateTime dateForDayBuilder = null;
+      await tester.pumpWidget(
+        TestApp(
+          CalendarWidget(
+            dayBuilder: (_, day) {
+              dateForDayBuilder = day;
+              return Container();
+            },
+            fetcher: _FakeFetcher(),
+          ),
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await goToDate(tester, DateTime(2000, 1, 1));
+
+      await tester.tap(find.text('31'));
+      await tester.pumpAndSettle();
+
+      // Day should have built Dec 31 1999
+      expect(dateForDayBuilder, DateTime(1999, 12, 31));
+
+      // Week should start Dec 26, 1999
+      DateTime weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
+      expect(weekStart, DateTime(1999, 12, 26));
+
+      // Month should be December 1999
+      final monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth, skipOffstage: false));
+      expect(monthWidget.year, 1999);
+      expect(monthWidget.month, 12);
+    });
+
+    testWidgetsWithAccessibilityChecks('Selects date from month view', (tester) async {
+      DateTime dateForDayBuilder = null;
+      await tester.pumpWidget(
+        TestApp(
+          CalendarWidget(
+            dayBuilder: (_, day) {
+              dateForDayBuilder = day;
+              return Container();
+            },
+            fetcher: _FakeFetcher(),
+          ),
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await goToDate(tester, DateTime(2000, 1, 1));
+      await tester.tap(find.byKey(Key('expand-button')));
+      await tester.pumpAndSettle();
+
+      // Tap the last '1', which should be February 1 2000
+      await tester.tap(find.text('1').last);
+      await tester.pumpAndSettle();
+
+      // Day should have built Feb 1 2000
+      expect(dateForDayBuilder, DateTime(2000, 2, 1));
+
+      // Week should start Jan 30 2000
+      DateTime weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek, skipOffstage: false).first).firstDay;
+      expect(weekStart, DateTime(2000, 1, 30));
+
+      // Month should be Feb 2000
+      final monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth));
+      expect(monthWidget.year, 2000);
+      expect(monthWidget.month, 2);
+    });
+
+    testWidgetsWithAccessibilityChecks('Swipes to select adjacent day', (tester) async {
+      DateTime dateForDayBuilder = null;
+      final dayContentKey = Key('day-content');
+
+      await tester.pumpWidget(
+        TestApp(
+          CalendarWidget(
+            dayBuilder: (_, day) {
+              dateForDayBuilder = day;
+              return Container(key: dayContentKey);
+            },
+            fetcher: _FakeFetcher(),
+          ),
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await goToDate(tester, DateTime(2000, 1, 1));
+
+      // Swipe to next day, which should be Jan 2 2000
+      await tester.fling(find.byKey(dayContentKey), Offset(-50, 0), 300);
+      await tester.pumpAndSettle();
+
+      // Day should have built Jan 2 2000
+      expect(dateForDayBuilder, DateTime(2000, 1, 2));
+
+      // Week should start Jan 2 2000
+      DateTime weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
+      expect(weekStart, DateTime(2000, 1, 2));
+
+      // Month should be Jan 2000
+      final monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth, skipOffstage: false));
+      expect(monthWidget.year, 2000);
+      expect(monthWidget.month, 1);
+    });
+  });
+
+  group('Insufficient Height', () {
+    testWidgetsWithAccessibilityChecks('disables expand/collapse button for insufficient height', (tester) async {
+      final calendarHeight = 200;
+      final screenHeight = tester.binding.window.physicalSize.height / tester.binding.window.devicePixelRatio;
+      final calendar = CalendarWidget(
+        dayBuilder: (_, __) => Container(),
+        fetcher: _FakeFetcher(),
+      );
+      await tester.pumpWidget(
+        TestApp(
+          Column(
+            children: <Widget>[
+              SizedBox(height: screenHeight - calendarHeight),
+              Expanded(child: calendar),
+            ],
+          ),
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Should not show dropdown arrow
+      expect(find.byType(DropdownArrow), findsNothing);
+
+      // Tap expand button
+      await tester.tap(find.byKey(Key('expand-button')));
+      await tester.pumpAndSettle();
+
+      // Should not show month
+      expect(find.byType(CalendarMonth), findsNothing);
+    });
+
+    testWidgetsWithAccessibilityChecks('disables swipe-to-expand for insufficient height', (tester) async {
+      final calendarHeight = 200;
+      final screenHeight = tester.binding.window.physicalSize.height / tester.binding.window.devicePixelRatio;
+      final calendar = CalendarWidget(
+        dayBuilder: (_, __) => Container(),
+        fetcher: _FakeFetcher(),
+      );
+      await tester.pumpWidget(
+        TestApp(
+          Column(
+            children: <Widget>[
+              SizedBox(height: screenHeight - calendarHeight),
+              Expanded(child: calendar),
+            ],
+          ),
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Fling down on week to try expand
+      await tester.fling(find.byType(CalendarWeek), Offset(0, 50), 300);
+      await tester.pumpAndSettle();
+
+      // Should not show month
+      expect(find.byType(CalendarMonth), findsNothing);
+    });
+
+    testWidgetsWithAccessibilityChecks('collapses month if height becomes insufficient', (tester) async {
+      // Due to how we must capture height changes, when the month view is open and the height becomes insufficient
+      // there will be at least one build pass where the month layout overflows its parent. This is acceptable while the
+      // month view is animating its collapse into the week view. However, because such overflows will fail the test,
+      // we must intercept and ignore those specific errors
+      FlutterExceptionHandler onError = FlutterError.onError;
+      FlutterError.onError = (details) {
+        var exception = details.exception;
+        if (exception is FlutterError && exception?.message?.startsWith('A RenderFlex overflowed') == true) {
+          // Intentionally left blank
+        } else {
+          onError(details);
+        }
+      };
+
+      try {
+        double calendarHeight = 600;
+        final screenHeight = tester.binding.window.physicalSize.height / tester.binding.window.devicePixelRatio;
+
+        final calendar = CalendarWidget(
+          dayBuilder: (_, __) => Container(),
+          fetcher: _FakeFetcher(),
+        );
+
+        StateSetter stateSetter;
+
+        await tester.pumpWidget(
+          TestApp(
+            StatefulBuilder(
+              builder: (context, setState) {
+                stateSetter = setState;
+                return Column(
+                  children: <Widget>[
+                    SizedBox(height: screenHeight - calendarHeight),
+                    Expanded(child: OverflowBox(maxHeight: calendarHeight, child: calendar)),
+                  ],
+                );
+              },
+            ),
+            highContrast: true,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Tap expand button
+        await tester.tap(find.byKey(Key('expand-button')));
+        await tester.pumpAndSettle();
+
+        // Should show month
+        expect(find.byType(CalendarMonth), findsOneWidget);
+
+        // Shrink calendar height and rebuild
+        calendarHeight = 200;
+        stateSetter(() {});
+        await tester.pumpAndSettle();
+
+        // Should no longer show month
+        expect(find.byType(CalendarMonth), findsNothing);
+      } finally {
+        // Restore exception handler
+        FlutterError.onError = onError;
+      }
+    });
+  });
+
+  group('Right-to-Left', () {
+    testWidgetsWithAccessibilityChecks('Swipes to previous week in RTL', (tester) async {
+      await tester.pumpWidget(
+        TestApp(
+          CalendarWidget(
+            dayBuilder: (_, day) => Container(),
+            fetcher: _FakeFetcher(),
+          ),
+          locale: Locale('ar'),
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      DateTime targetDate = DateTime(2000, 1, 1);
+      CalendarWidgetState state = await goToDate(tester, targetDate);
+
+      // 'ar' week should start on Jan 1, 2000
+      DateTime weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
+      expect(weekStart, DateTime(2000, 1, 1));
+
+      // Selected day should be Saturday (Jan 1 2000)
+      expect(state.selectedDay, targetDate);
+
+      // Fling to previous week
+      await tester.fling(find.byType(CalendarWeek), Offset(-50, 0), 300);
+      await tester.pumpAndSettle();
+
+      // Week should now start on Dec 25, 1999
+      weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
+      expect(weekStart, DateTime(1999, 12, 25));
+
+      // Selected day should be the same day of the week, Saturday (Dec 25, 1999)
+      expect(state.selectedDay, DateTime(1999, 12, 25));
+    });
+
+    testWidgetsWithAccessibilityChecks('Swipes to next week in RTL', (tester) async {
+      await tester.pumpWidget(
+        TestApp(
+          CalendarWidget(
+            dayBuilder: (_, day) => Container(),
+            fetcher: _FakeFetcher(),
+          ),
+          locale: Locale('ar'),
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      DateTime targetDate = DateTime(2000, 1, 1);
+      CalendarWidgetState state = await goToDate(tester, targetDate);
+
+      // 'ar' week should start on Jan 1, 2000
+      DateTime weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
+      expect(weekStart, DateTime(2000, 1, 1));
+
+      // Selected day should be Saturday (Jan 1 2000)
+      expect(state.selectedDay, targetDate);
+
+      // Fling to next week
+      await tester.fling(find.byType(CalendarWeek), Offset(50, 0), 300);
+      await tester.pumpAndSettle();
+
+      // Week should now start on Jan 8, 2000
+      weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
+      expect(weekStart, DateTime(2000, 1, 8));
+
+      // Selected day should be the same day of the week, Saturday (Jan 8, 2000)
+      expect(state.selectedDay, DateTime(2000, 1, 8));
+    });
+
+    testWidgetsWithAccessibilityChecks('Swipes to previous month in RTL', (tester) async {
+      await tester.pumpWidget(
+        TestApp(
+          CalendarWidget(
+            dayBuilder: (_, day) => Container(),
+            fetcher: _FakeFetcher(),
+          ),
+          locale: Locale('ar'),
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      DateTime targetDate = DateTime(2000, 1, 1);
+      CalendarWidgetState state = await goToDate(tester, targetDate);
+
+      // Tap expand button
+      await tester.tap(find.byKey(Key('expand-button')));
+      await tester.pumpAndSettle();
+
+      // Month should be January 2000
+      CalendarMonth monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth));
+      expect(monthWidget.year, 2000);
+      expect(monthWidget.month, 1);
+
+      // Selected day should be Jan 1 2000
+      expect(state.selectedDay, targetDate);
+
+      // Fling to previous month
+      await tester.fling(find.byType(CalendarMonth), Offset(-50, 0), 300);
+      await tester.pumpAndSettle();
+
+      // Month should be December 1999
+      monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth));
+      expect(monthWidget.year, 1999);
+      expect(monthWidget.month, 12);
+
+      // Selected day should be Same day of the month (Dec 1, 1999)
+      expect(state.selectedDay, DateTime(1999, 12, 1));
+    });
+
+    testWidgetsWithAccessibilityChecks('Swipes to next month in RTL', (tester) async {
+      await tester.pumpWidget(
+        TestApp(
+          CalendarWidget(
+            dayBuilder: (_, day) => Container(),
+            fetcher: _FakeFetcher(),
+          ),
+          locale: Locale('ar'),
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      DateTime targetDate = DateTime(2000, 1, 1);
+      CalendarWidgetState state = await goToDate(tester, targetDate);
+
+      // Tap expand button
+      await tester.tap(find.byKey(Key('expand-button')));
+      await tester.pumpAndSettle();
+
+      // Month should be January 2000
+      CalendarMonth monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth));
+      expect(monthWidget.year, 2000);
+      expect(monthWidget.month, 1);
+
+      // Selected day should be Jan 1 2000
+      expect(state.selectedDay, targetDate);
+
+      // Fling to next month
+      await tester.fling(find.byType(CalendarMonth), Offset(50, 0), 300);
+      await tester.pumpAndSettle();
+
+      // Month should be February 2000
+      monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth));
+      expect(monthWidget.year, 2000);
+      expect(monthWidget.month, 2);
+
+      // Selected day should be same day of the month (Feb 1, 2000)
+      expect(state.selectedDay, DateTime(2000, 2, 1));
+    });
+
+    testWidgetsWithAccessibilityChecks('Swipes to select adjacent day in RTL', (tester) async {
+      DateTime dateForDayBuilder = null;
+      final dayContentKey = Key('day-content');
+
+      await tester.pumpWidget(
+        TestApp(
+          CalendarWidget(
+            dayBuilder: (_, day) {
+              dateForDayBuilder = day;
+              return Container(key: dayContentKey);
+            },
+            fetcher: _FakeFetcher(),
+          ),
+          locale: Locale('ar'),
+          highContrast: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await goToDate(tester, DateTime(2000, 1, 1));
+
+      // Swipe to next day, which should be Jan 2 2000
+      await tester.fling(find.byKey(dayContentKey), Offset(50, 0), 300);
+      await tester.pumpAndSettle();
+
+      // Day should have built Jan 2 2000
+      expect(dateForDayBuilder, DateTime(2000, 1, 2));
+
+      // Week should start Jan 1 2000
+      DateTime weekStart = tester.widget<CalendarWeek>(find.byType(CalendarWeek)).firstDay;
+      expect(weekStart, DateTime(2000, 1, 1));
+
+      // Month should be Jan 2000
+      final monthWidget = tester.widget<CalendarMonth>(find.byType(CalendarMonth, skipOffstage: false));
+      expect(monthWidget.year, 2000);
+      expect(monthWidget.month, 1);
+    });
   });
 }
 


### PR DESCRIPTION
It turns out that PageView automatically reverses for RTL locales, so we don't need to handle that ourselves.
Also, this commit moves most calendar tests into groups, so make sure to enable 'Hide whitespace changes'