### PR TITLE
[Student][Teacher][MBL-14122] Support opening LTI links that are intents

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/SettingsInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/SettingsInteractionTest.kt
@@ -233,7 +233,7 @@ class SettingsInteractionTest : StudentTest() {
         legalPage.openPrivacyPolicy()
         canvasWebViewPage.runTextChecks(
                 // Potentially brittle, as this content could be changed by another team.
-                WebViewTextCheck(Locator.CLASS_NAME, "subnav-wrapper", "POLICIES HOME", 20)
+                WebViewTextCheck(Locator.CLASS_NAME, "subnav-wrapper", "Policies Home", 20)
         )
     }
 


### PR DESCRIPTION
To test:
Use my sandbox and go to course 1.
* Google Meet -> Opens our LTIWebView momentarily, then goes straight to the play store page (or opens the app if already downloaded)
* Google Meet (new tab) -> Opens our LTIWebView, once you click "open in new tab" it behaves like "Google Meet"
* Goog intent -> Opens our LTIWebView, once you click "open in new tab" it loads googles search page as a fallback for a non-supported intent.