### PR TITLE
[Flutter Parent][MBL-13916] Dashboard Tab Routing

### DIFF
--- a/apps/flutter_parent/android/app/src/main/kotlin/com/instructure/parentapp/MainActivity.kt
+++ b/apps/flutter_parent/android/app/src/main/kotlin/com/instructure/parentapp/MainActivity.kt
@@ -43,8 +43,9 @@ class MainActivity : FlutterActivity() {
         val data = intent.data
         if (intent.action != Intent.ACTION_VIEW || data == null) return
 
-        // NOTE: The `url` query param has to match ParentRouter.dart in the flutter code
-        val route = "/external?url=${Uri.encode(data.toString())}"
+        // NOTE: The `url` query param has to match the result of one of the static string methods in
+        // panda_router.dart in the flutter code
+        val route = "external?url=${Uri.encode(data.toString())}"
         if (newIntent) {
             flutterEngine?.navigationChannel?.pushRoute(route)
         } else {

--- a/apps/flutter_parent/lib/network/api/user_api.dart
+++ b/apps/flutter_parent/lib/network/api/user_api.dart
@@ -17,5 +17,5 @@ import 'package:flutter_parent/network/utils/dio_config.dart';
 import 'package:flutter_parent/network/utils/fetch.dart';
 
 class UserApi {
-  static Future<User> getSelf() => fetch(canvasDio(forceDeviceLanguage: true).get('users/self/profile'));
+  Future<User> getSelf() => fetch(canvasDio(forceDeviceLanguage: true).get('users/self/profile'));
 }

--- a/apps/flutter_parent/lib/router/panda_router.dart
+++ b/apps/flutter_parent/lib/router/panda_router.dart
@@ -24,6 +24,7 @@ import 'package:flutter_parent/network/utils/api_prefs.dart';
 import 'package:flutter_parent/router/router_error_screen.dart';
 import 'package:flutter_parent/screens/announcements/announcement_details_screen.dart';
 import 'package:flutter_parent/screens/assignments/assignment_details_screen.dart';
+import 'package:flutter_parent/screens/calendar/calendar_widget/calendar_widget.dart';
 import 'package:flutter_parent/screens/courses/details/course_details_screen.dart';
 import 'package:flutter_parent/screens/dashboard/dashboard_screen.dart';
 import 'package:flutter_parent/screens/domain_search/domain_search_screen.dart';
@@ -55,8 +56,12 @@ class PandaRouter {
 
   static bool _isInitialized = false;
 
+  static final String alerts = '/alerts';
+
   static String assignmentDetails(String courseId, String assignmentId) =>
       '/courses/$courseId/assignments/$assignmentId';
+
+  static final String calendar = '/calendar';
 
   static String conversations() => '/conversations';
 
@@ -64,6 +69,8 @@ class PandaRouter {
       '/courses/$courseId/discussion_topics/$announcementId';
 
   static String courseDetails(String courseId) => '/courses/$courseId';
+
+  static String courses() => '/courses';
 
   static String dashboard() => '/dashboard';
 
@@ -81,6 +88,7 @@ class PandaRouter {
   static String legal() => '/legal';
 
   static String login() => '/login';
+
   static final String _loginWeb = '/loginWeb';
 
   static String loginWeb(String domain, {String authenticationProvider = null}) =>
@@ -91,12 +99,15 @@ class PandaRouter {
   static String notParent() => '/not_parent';
 
   static String quizAssignmentDetails(String courseId, String quizId) => assignmentDetails(courseId, quizId);
-  static final String _rootWithExternalUrl = '/external';
+
+  static final String _rootWithExternalUrl = 'external';
+
   static final String _routerError = '/error';
 
   static String _routerErrorRoute(String url) => '/error?${_RouterKeys.url}=${Uri.encodeQueryComponent(url)}';
 
   static String rootSplash() => '/';
+
   static final String _simpleWebView = '/internal';
 
   static String _simpleWebViewRoute(String url) => '/internal?${_RouterKeys.url}=${Uri.encodeQueryComponent(url)}';
@@ -108,31 +119,34 @@ class PandaRouter {
   static void init() {
     if (!_isInitialized) {
       _isInitialized = true;
-      router.define(rootSplash(), handler: _rootSplashHandler);
       router.define(conversations(), handler: _conversationsHandler);
       router.define(dashboard(), handler: _dashboardHandler);
-      router.define(login(), handler: _loginHandler);
-      router.define(_loginWeb, handler: _loginWebHandler);
       router.define(domainSearch(), handler: _domainSearchHandler);
+      router.define(_loginWeb, handler: _loginWebHandler);
+      router.define(login(), handler: _loginHandler);
       router.define(notParent(), handler: _notParentHandler);
+      router.define(rootSplash(), handler: _rootSplashHandler);
 
       // INTERNAL
-      router.define(courseDetails(':${_RouterKeys.courseId}'), handler: _courseDetailsHandler);
+      router.define(alerts, handler: _alertHandler);
       router.define(assignmentDetails(':${_RouterKeys.courseId}', ':${_RouterKeys.assignmentId}'),
           handler: _assignmentDetailsHandler);
-      router.define(quizAssignmentDetails(':${_RouterKeys.courseId}', ':${_RouterKeys.quizId}'),
-          handler: _assignmentDetailsHandler);
-      router.define(eventDetails(':${_RouterKeys.courseId}', ':${_RouterKeys.eventId}'), handler: _eventDetailsHandler);
-      router.define(help(), handler: _helpHandler);
-      router.define(legal(), handler: _legalHandler);
-      router.define(termsOfUse(), handler: _termsOfUseHandler);
-      router.define(settings(), handler: _settingsHandler);
+      router.define(calendar, handler: _calendarHandler);
       router.define(courseAnnouncementDetails(':${_RouterKeys.courseId}', ':${_RouterKeys.announcementId}'),
           handler: _courseAnnouncementDetailsHandler);
+      router.define(courseDetails(':${_RouterKeys.courseId}'), handler: _courseDetailsHandler);
+      router.define(courses(), handler: _coursesHandler);
+      router.define(eventDetails(':${_RouterKeys.courseId}', ':${_RouterKeys.eventId}'), handler: _eventDetailsHandler);
+      router.define(help(), handler: _helpHandler);
       router.define(institutionAnnouncementDetails(':${_RouterKeys.accountNotificationId}'),
           handler: _institutionAnnouncementDetailsHandler);
-      router.define(_simpleWebView, handler: _simpleWebViewHandler);
+      router.define(legal(), handler: _legalHandler);
+      router.define(quizAssignmentDetails(':${_RouterKeys.courseId}', ':${_RouterKeys.quizId}'),
+          handler: _assignmentDetailsHandler);
       router.define(_routerError, handler: _routerErrorHandler);
+      router.define(_simpleWebView, handler: _simpleWebViewHandler);
+      router.define(settings(), handler: _settingsHandler);
+      router.define(termsOfUse(), handler: _termsOfUseHandler);
 
       // EXTERNAL
       router.define(_rootWithExternalUrl, handler: _rootWithExternalUrlHandler);
@@ -140,42 +154,10 @@ class PandaRouter {
   }
 
   // Handlers
-  static Handler _rootSplashHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
-    return SplashScreen();
-  });
-
-  static Handler _conversationsHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
-    return ConversationListScreen();
-  });
-
-  static Handler _dashboardHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
-    return DashboardScreen();
-  });
-
-  static Handler _loginHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
-    return LoginLandingScreen();
-  });
-
-  static Handler _loginWebHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
-    var authProvider = params[_RouterKeys.authenticationProvider]?.elementAt(0);
-    return (authProvider == null || authProvider == 'null')
-        ? WebLoginScreen(params[_RouterKeys.domain][0])
-        : WebLoginScreen(
-            params[_RouterKeys.domain][0],
-            authenticationProvider: authProvider,
-          );
-  });
-
-  static Handler _domainSearchHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
-    return DomainSearchScreen();
-  });
-
-  static Handler _notParentHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
-    return NotAParentScreen();
-  });
-
-  static Handler _courseDetailsHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
-    return CourseDetailsScreen(params[_RouterKeys.courseId][0]);
+  static Handler _alertHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
+    return DashboardScreen(
+      startingPage: DashboardContentScreens.Alerts,
+    );
   });
 
   static Handler _assignmentDetailsHandler =
@@ -184,6 +166,48 @@ class PandaRouter {
       courseId: params[_RouterKeys.courseId][0],
       assignmentId: params[_RouterKeys.assignmentId][0],
     );
+  });
+
+  static Handler _calendarHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
+    var calendarParams = {
+      'startDate': DateTime.tryParse(params[_RouterKeys.calendarStart]?.elementAt(0) ?? '') ?? DateTime.now(),
+      'startView': params[_RouterKeys.calendarView]?.elementAt(0) == 'month' ? CalendarView.Month : CalendarView.Week,
+    };
+
+    var widget = DashboardScreen(
+      startingPage: DashboardContentScreens.Calendar,
+      deepLinkParams: calendarParams,
+    );
+
+    return widget;
+  });
+
+  static Handler _conversationsHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
+    return ConversationListScreen();
+  });
+
+  static Handler _courseAnnouncementDetailsHandler =
+      Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
+    return AnnouncementDetailScreen(
+        params[_RouterKeys.announcementId][0], AnnouncementType.COURSE, params[_RouterKeys.courseId][0], context);
+  });
+
+  static Handler _courseDetailsHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
+    return CourseDetailsScreen(params[_RouterKeys.courseId][0]);
+  });
+
+  static Handler _coursesHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
+    return DashboardScreen(
+      startingPage: DashboardContentScreens.Courses,
+    );
+  });
+
+  static Handler _dashboardHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
+    return DashboardScreen();
+  });
+
+  static Handler _domainSearchHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
+    return DomainSearchScreen();
   });
 
   static Handler _eventDetailsHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
@@ -197,36 +221,37 @@ class PandaRouter {
     return HelpScreen();
   });
 
+  static Handler _institutionAnnouncementDetailsHandler =
+      Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
+    return AnnouncementDetailScreen(
+        params[_RouterKeys.accountNotificationId][0], AnnouncementType.INSTITUTION, '', context);
+  });
+
   static Handler _legalHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
     return LegalScreen();
   });
 
-  static Handler _termsOfUseHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
-    return TermsOfUseScreen();
+  static Handler _loginHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
+    return LoginLandingScreen();
   });
 
-  static Handler _settingsHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
-    return SettingsScreen();
+  static Handler _loginWebHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
+    var authProvider = params[_RouterKeys.authenticationProvider]?.elementAt(0);
+    var widget = (authProvider == null || authProvider == 'null')
+        ? WebLoginScreen(params[_RouterKeys.domain][0])
+        : WebLoginScreen(
+            params[_RouterKeys.domain][0],
+            authenticationProvider: authProvider,
+          );
+    return widget;
   });
 
-  static Handler _courseAnnouncementDetailsHandler =
-      Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
-    return AnnouncementDetailScreen(
-      params[_RouterKeys.announcementId][0],
-      AnnouncementType.COURSE,
-      params[_RouterKeys.courseId][0],
-      context,
-    );
+  static Handler _notParentHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
+    return NotAParentScreen();
   });
 
-  static Handler _institutionAnnouncementDetailsHandler =
-      Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
-    return AnnouncementDetailScreen(
-      params[_RouterKeys.accountNotificationId][0],
-      AnnouncementType.INSTITUTION,
-      '',
-      context,
-    );
+  static Handler _rootSplashHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
+    return SplashScreen();
   });
 
   static Handler _routerErrorHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
@@ -234,9 +259,17 @@ class PandaRouter {
     return RouterErrorScreen(url);
   });
 
+  static Handler _settingsHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
+    return SettingsScreen();
+  });
+
   static Handler _simpleWebViewHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
     final url = params[_RouterKeys.url][0];
     return SimpleWebViewScreen(url, url);
+  });
+
+  static Handler _termsOfUseHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
+    return TermsOfUseScreen();
   });
 
   /// Used to handled external urls routed by the intent-filter -> MainActivity.kt
@@ -250,9 +283,15 @@ class PandaRouter {
     // We only care about valid app routes if they are already signed in
     if (urlRouteWrapper.appRouteMatch != null && ApiPrefs.isLoggedIn()) {
       if (urlRouteWrapper.validHost) {
+        Map<String, List<String>> params = {};
+        // Add any fragment parameters, e.g. '/...#view=month&start=12-12-2020'
+        var frags = Uri.parse(link).fragment;
+        Uri.splitQueryString(frags).forEach((k, v) => params[k] = [v]);
+
+        params.addAll(urlRouteWrapper.appRouteMatch.parameters);
+
         // If its a link we can handle natively and within our domain, route
-        return (urlRouteWrapper.appRouteMatch.route.handler as Handler)
-            .handlerFunc(context, urlRouteWrapper.appRouteMatch.parameters);
+        return (urlRouteWrapper.appRouteMatch.route.handler as Handler).handlerFunc(context, params);
       } else {
         // Otherwise, we want to route to the error page if they are already logged in
         return _routerErrorHandler.handlerFunc(context, params);
@@ -318,6 +357,8 @@ class _RouterKeys {
   static final announcementId = 'announcementId';
   static final assignmentId = 'assignmentId';
   static final authenticationProvider = 'authenticationProvider';
+  static final calendarStart = 'view_start';
+  static final calendarView = 'view_name';
   static final courseId = 'courseId';
   static final domain = 'domain';
   static final eventId = 'eventId';

--- a/apps/flutter_parent/lib/screens/calendar/calendar_screen.dart
+++ b/apps/flutter_parent/lib/screens/calendar/calendar_screen.dart
@@ -29,6 +29,11 @@ import 'package:provider/provider.dart';
 class CalendarScreen extends StatefulWidget {
   final DateTime startDate;
   final CalendarView startView;
+
+  // Keys for the deep link parameter map passed in via DashboardScreen
+  static final startDateKey = 'startDate';
+  static final startViewKey = 'startView';
+
   CalendarScreen({Key key, this.startDate, this.startView = CalendarView.Week}) : super(key: key);
 
   @override

--- a/apps/flutter_parent/lib/screens/calendar/calendar_screen.dart
+++ b/apps/flutter_parent/lib/screens/calendar/calendar_screen.dart
@@ -27,7 +27,9 @@ import 'package:flutter_parent/utils/service_locator.dart';
 import 'package:provider/provider.dart';
 
 class CalendarScreen extends StatefulWidget {
-  CalendarScreen({Key key}) : super(key: key);
+  final DateTime startDate;
+  final CalendarView startView;
+  CalendarScreen({Key key, this.startDate, this.startView = CalendarView.Week}) : super(key: key);
 
   @override
   State<StatefulWidget> createState() => CalendarScreenState();
@@ -60,6 +62,8 @@ class CalendarScreenState extends State<CalendarScreen> {
   Widget build(BuildContext context) {
     return CalendarWidget(
       fetcher: _fetcher,
+      startingDate: widget.startDate,
+      startingView: widget.startView,
       onFilterTap: () async {
         Set<String> currentContexts = await _fetcher.getContexts();
         Set<String> updatedContexts = await locator.get<QuickNav>().push(

--- a/apps/flutter_parent/lib/screens/calendar/calendar_widget/calendar_widget.dart
+++ b/apps/flutter_parent/lib/screens/calendar/calendar_widget/calendar_widget.dart
@@ -62,7 +62,7 @@ class CalendarWidget extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  CalendarWidgetState createState() => CalendarWidgetState(startingDate, startingView);
+  CalendarWidgetState createState() => CalendarWidgetState();
 }
 
 @visibleForTesting
@@ -70,12 +70,6 @@ enum CalendarPageChangeBehavior { none, jump, animate }
 
 @visibleForTesting
 class CalendarWidgetState extends State<CalendarWidget> with TickerProviderStateMixin {
-  CalendarWidgetState(this.startingDate, this.startingView);
-
-  // Initial starting date and starting view (month/week). Used for deep linking into the calendar.
-  DateTime startingDate;
-  CalendarView startingView;
-
   // Day, week, and month page indices for 'today'.
   //
   // Rather than track dates from the beginning of time/unix epoch/whatever, they are tracked
@@ -210,7 +204,7 @@ class CalendarWidgetState extends State<CalendarWidget> with TickerProviderState
     });
 
     if (_canExpandMonth) {
-      if (startingView == CalendarView.Month) {
+      if (widget.startingView == CalendarView.Month) {
         _isMonthExpanded = true;
         _monthExpansionNotifier.value = 1.0;
       } else
@@ -461,7 +455,7 @@ class CalendarWidgetState extends State<CalendarWidget> with TickerProviderState
     );
   }
 
-//  @visibleForTesting
+  @visibleForTesting
   void selectDay(
     DateTime day, {
     CalendarPageChangeBehavior dayPagerBehavior: CalendarPageChangeBehavior.jump,

--- a/apps/flutter_parent/lib/screens/dashboard/dashboard_interactor.dart
+++ b/apps/flutter_parent/lib/screens/dashboard/dashboard_interactor.dart
@@ -29,7 +29,7 @@ class DashboardInteractor {
         return users;
       });
 
-  Future<User> getSelf({app}) async => UserApi.getSelf().then((user) {
+  Future<User> getSelf({app}) async => locator<UserApi>().getSelf().then((user) {
         ApiPrefs.setUser(user, app: app);
         return user;
       });

--- a/apps/flutter_parent/lib/screens/dashboard/dashboard_screen.dart
+++ b/apps/flutter_parent/lib/screens/dashboard/dashboard_screen.dart
@@ -356,11 +356,13 @@ class DashboardState extends State<DashboardScreen> {
       case DashboardContentScreens.Calendar:
         _page = CalendarScreen(
           startDate: currentDeepLinkParams != null
-              ? (currentDeepLinkParams.containsKey('startDate') ? currentDeepLinkParams['startDate'] as DateTime : null)
+              ? (currentDeepLinkParams.containsKey(CalendarScreen.startDateKey)
+                  ? currentDeepLinkParams[CalendarScreen.startDateKey] as DateTime
+                  : null)
               : null,
           startView: currentDeepLinkParams != null
-              ? (currentDeepLinkParams.containsKey('startView')
-                  ? currentDeepLinkParams['startView'] as CalendarView
+              ? (currentDeepLinkParams.containsKey(CalendarScreen.startViewKey)
+                  ? currentDeepLinkParams[CalendarScreen.startViewKey] as CalendarView
                   : null)
               : null,
         );

--- a/apps/flutter_parent/lib/screens/dashboard/student_expansion_widget.dart
+++ b/apps/flutter_parent/lib/screens/dashboard/student_expansion_widget.dart
@@ -18,8 +18,6 @@ class StudentExpansionWidget extends StatefulWidget {
   final Widget child;
   final bool expand;
 
-  static final GlobalKey<StudentExpansionWidgetState> expansionWidgetKey = GlobalKey<StudentExpansionWidgetState>();
-
   StudentExpansionWidget({this.expand = false, this.child});
 
   @override
@@ -27,6 +25,7 @@ class StudentExpansionWidget extends StatefulWidget {
 }
 
 class StudentExpansionWidgetState extends State<StudentExpansionWidget> with SingleTickerProviderStateMixin {
+  GlobalKey<StudentExpansionWidgetState> expansionWidgetKey = GlobalKey<StudentExpansionWidgetState>();
   AnimationController expandController;
   Animation<double> animation;
 
@@ -40,7 +39,7 @@ class StudentExpansionWidgetState extends State<StudentExpansionWidget> with Sin
   @override
   Widget build(BuildContext context) {
     return SizeTransition(
-      key: StudentExpansionWidget.expansionWidgetKey,
+      key: expansionWidgetKey,
       axisAlignment: 1.0,
       sizeFactor: animation,
       child: widget.child,

--- a/apps/flutter_parent/lib/screens/dashboard/student_expansion_widget.dart
+++ b/apps/flutter_parent/lib/screens/dashboard/student_expansion_widget.dart
@@ -25,7 +25,6 @@ class StudentExpansionWidget extends StatefulWidget {
 }
 
 class StudentExpansionWidgetState extends State<StudentExpansionWidget> with SingleTickerProviderStateMixin {
-  GlobalKey<StudentExpansionWidgetState> expansionWidgetKey = GlobalKey<StudentExpansionWidgetState>();
   AnimationController expandController;
   Animation<double> animation;
 
@@ -39,7 +38,6 @@ class StudentExpansionWidgetState extends State<StudentExpansionWidget> with Sin
   @override
   Widget build(BuildContext context) {
     return SizeTransition(
-      key: expansionWidgetKey,
       axisAlignment: 1.0,
       sizeFactor: animation,
       child: widget.child,

--- a/apps/flutter_parent/lib/utils/service_locator.dart
+++ b/apps/flutter_parent/lib/utils/service_locator.dart
@@ -27,6 +27,7 @@ import 'package:flutter_parent/network/api/inbox_api.dart';
 import 'package:flutter_parent/network/api/oauth_api.dart';
 import 'package:flutter_parent/network/api/page_api.dart';
 import 'package:flutter_parent/network/api/planner_api.dart';
+import 'package:flutter_parent/network/api/user_api.dart';
 import 'package:flutter_parent/network/utils/analytics.dart';
 import 'package:flutter_parent/screens/alert_thresholds/alert_thresholds_interactor.dart';
 import 'package:flutter_parent/screens/alerts/alerts_interactor.dart';
@@ -87,6 +88,7 @@ void setupLocator() {
   locator.registerLazySingleton<OAuthApi>(() => OAuthApi());
   locator.registerLazySingleton<PageApi>(() => PageApi());
   locator.registerLazySingleton<PlannerApi>(() => PlannerApi());
+  locator.registerLazySingleton<UserApi>(() => UserApi());
 
   // DB helpers
   locator.registerLazySingleton<Database>(() => DbUtil.instance);

--- a/apps/flutter_parent/test/router/panda_router_test.dart
+++ b/apps/flutter_parent/test/router/panda_router_test.dart
@@ -244,16 +244,19 @@ void main() {
         'view_start': ['12-12-2020'],
         'view_name': ['month']
       });
+      expect((widget as DashboardScreen).startingPage, DashboardContentScreens.Calendar);
       expect(widget, isA<DashboardScreen>());
     });
 
     test('courses returns Dashboard screen', () {
       final widget = _getWidgetFromRoute(PandaRouter.courses());
+      expect((widget as DashboardScreen).startingPage, DashboardContentScreens.Courses);
       expect(widget, isA<DashboardScreen>());
     });
 
     test('alerts returns Dashboard screen', () {
       final widget = _getWidgetFromRoute(PandaRouter.alerts);
+      expect((widget as DashboardScreen).startingPage, DashboardContentScreens.Alerts);
       expect(widget, isA<DashboardScreen>());
     });
   });
@@ -263,7 +266,6 @@ void main() {
       final url = 'https://test.instructure.com/not-supported';
       final widget = _getWidgetFromRoute(
         _rootWithUrl(url),
-        logCount: 2, // Once for root url handling, another for splash handler
       );
 
       expect(widget, isA<SplashScreen>());
@@ -273,7 +275,6 @@ void main() {
       final url = 'https://test.instructure.com/conversations';
       final widget = _getWidgetFromRoute(
         _rootWithUrl(url),
-        logCount: 2, // Once for root url handling, another for conversations handler
       );
 
       expect(widget, isA<ConversationListScreen>());
@@ -283,7 +284,6 @@ void main() {
       final url = 'http://test.instructure.com/conversations';
       final widget = _getWidgetFromRoute(
         _rootWithUrl(url),
-        logCount: 2, // Once for root url handling, another for conversations handler
       );
 
       expect(widget, isA<ConversationListScreen>());
@@ -293,7 +293,6 @@ void main() {
       final url = 'canvas-parent://test.instructure.com/conversations';
       final widget = _getWidgetFromRoute(
         _rootWithUrl(url),
-        logCount: 2, // Once for root url handling, another for conversations handler
       );
 
       expect(widget, isA<ConversationListScreen>());
@@ -303,7 +302,6 @@ void main() {
       final url = 'canvas-courses://test.instructure.com/conversations';
       final widget = _getWidgetFromRoute(
         _rootWithUrl(url),
-        logCount: 2, // Once for root url handling, another for conversations handler
       );
 
       expect(widget, isA<ConversationListScreen>());
@@ -313,7 +311,6 @@ void main() {
       final url = 'https://test.instructure.com/courses/123';
       final widget = _getWidgetFromRoute(
         _rootWithUrl(url),
-        logCount: 2, // Once for root url handling, another for course details handler
       );
 
       expect(widget, isA<CourseDetailsScreen>());
@@ -325,7 +322,6 @@ void main() {
       final url = 'https://test.instructure.com/courses/$courseId/assignments/$assignmentId';
       final widget = _getWidgetFromRoute(
         _rootWithUrl(url),
-        logCount: 2, // Once for root url handling, another for assignment details handler
       ) as AssignmentDetailsScreen;
 
       expect(widget, isA<AssignmentDetailsScreen>());
@@ -339,7 +335,6 @@ void main() {
       final url = 'https://fakedomain.instructure.com/courses/$courseId/assignments/$assignmentId';
       final widget = _getWidgetFromRoute(
         _rootWithUrl(url),
-        logCount: 2,
       ) as RouterErrorScreen;
 
       expect(widget, isA<RouterErrorScreen>());
@@ -450,7 +445,7 @@ String _routerErrorRoute(String url) => '/error?url=${Uri.encodeQueryComponent(u
 
 String _simpleWebViewRoute(String url) => '/internal?url=${Uri.encodeQueryComponent(url)}';
 
-Widget _getWidgetFromRoute(String route, {int logCount = 1, Map<String, List<String>> extraParams}) {
+Widget _getWidgetFromRoute(String route, {Map<String, List<String>> extraParams}) {
   final match = PandaRouter.router.match(route);
 
   if (extraParams != null) match.parameters.addAll(extraParams);

--- a/apps/flutter_parent/test/router/panda_router_test.dart
+++ b/apps/flutter_parent/test/router/panda_router_test.dart
@@ -238,6 +238,24 @@ void main() {
 
       expect(widget, isA<SimpleWebViewScreen>());
     });
+
+    test('calendar returns Dashboard screen', () {
+      final widget = _getWidgetFromRoute(PandaRouter.calendar, extraParams: {
+        'view_start': ['12-12-2020'],
+        'view_name': ['month']
+      });
+      expect(widget, isA<DashboardScreen>());
+    });
+
+    test('courses returns Dashboard screen', () {
+      final widget = _getWidgetFromRoute(PandaRouter.courses());
+      expect(widget, isA<DashboardScreen>());
+    });
+
+    test('alerts returns Dashboard screen', () {
+      final widget = _getWidgetFromRoute(PandaRouter.alerts);
+      expect(widget, isA<DashboardScreen>());
+    });
   });
 
   group('external url handler', () {
@@ -390,12 +408,6 @@ void main() {
       verify(_mockSnackbar.showSnackBar(any, 'An error occurred when trying to display this link'));
     });
 
-//     Todo once MBL-13924 is done
-//    testWidgetsWithAccessibilityChecks('launches simpleWebView for limitAccessFlag without match', (tester) async {
-//    });
-  });
-
-  group('internal url handler', () {
     test('returns valid UrlRouteWrapper', () {
       final path = '/courses/1567973';
       final url = '$_domain$path';
@@ -425,18 +437,26 @@ void main() {
       assert(routeWrapper.validHost == true);
       assert(routeWrapper.appRouteMatch == null);
     });
+
+//     Todo once MBL-13924 is done
+//    testWidgetsWithAccessibilityChecks('launches simpleWebView for limitAccessFlag without match', (tester) async {
+//    });
   });
 }
 
-String _rootWithUrl(String url) => '/external?url=${Uri.encodeQueryComponent(url)}';
+String _rootWithUrl(String url) => 'external?url=${Uri.encodeQueryComponent(url)}';
 
 String _routerErrorRoute(String url) => '/error?url=${Uri.encodeQueryComponent(url)}';
 
 String _simpleWebViewRoute(String url) => '/internal?url=${Uri.encodeQueryComponent(url)}';
 
-Widget _getWidgetFromRoute(String route, {int logCount = 1}) {
+Widget _getWidgetFromRoute(String route, {int logCount = 1, Map<String, List<String>> extraParams}) {
   final match = PandaRouter.router.match(route);
-  return (match.route.handler as Handler).handlerFunc(null, match.parameters);
+
+  if (extraParams != null) match.parameters.addAll(extraParams);
+  final widget = (match.route.handler as Handler).handlerFunc(null, match.parameters);
+
+  return widget;
 }
 
 class _MockAnalytics extends Mock implements Analytics {}

--- a/apps/flutter_parent/test/screens/calendar/calendar_widget/calendar_widget_test.dart
+++ b/apps/flutter_parent/test/screens/calendar/calendar_widget/calendar_widget_test.dart
@@ -61,7 +61,6 @@ void main() {
           fetcher: _FakeFetcher(),
           startingView: CalendarView.Month,
         ),
-        highContrast: true,
       ),
     );
     await tester.pumpAndSettle();

--- a/apps/flutter_parent/test/screens/calendar/calendar_widget/calendar_widget_test.dart
+++ b/apps/flutter_parent/test/screens/calendar/calendar_widget/calendar_widget_test.dart
@@ -54,6 +54,23 @@ void main() {
     expect(find.byType(CalendarMonth), findsNothing);
   });
 
+  testWidgetsWithAccessibilityChecks('Displays month view when passed in', (tester) async {
+    await tester.pumpWidget(
+      TestApp(
+        CalendarWidget(
+          dayBuilder: (_, __) => Container(),
+          fetcher: _FakeFetcher(),
+          startingView: CalendarView.Month,
+        ),
+        highContrast: true,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(CalendarWeek), findsNWidgets(5));
+    expect(find.byType(CalendarMonth), findsOneWidget);
+  });
+
   group('Month Expand/Collapse', () {
     testWidgetsWithAccessibilityChecks('Expand button expands and collapses month', (tester) async {
       final calendar = CalendarWidget(

--- a/apps/flutter_parent/test/screens/dashboard/dashboard_interactor_test.dart
+++ b/apps/flutter_parent/test/screens/dashboard/dashboard_interactor_test.dart
@@ -51,8 +51,8 @@ void main() {
 
     // Setup ApiPrefs
     final login = Login((b) => b..user = initialUser.toBuilder());
-    await setupPlatformChannels(config: PlatformConfig(mockPrefs: {ApiPrefs.KEY_CURRENT_LOGIN_UUID: login.uuid}));
-    await ApiPrefs.addLogin(login);
+    await setupPlatformChannels(
+        config: PlatformConfig(mockPrefs: {ApiPrefs.KEY_CURRENT_LOGIN_UUID: login.uuid}, initLoggedInUser: login));
 
     var interactor = DashboardInteractor();
     interactor.getSelf();

--- a/apps/flutter_parent/test/screens/dashboard/dashboard_interactor_test.dart
+++ b/apps/flutter_parent/test/screens/dashboard/dashboard_interactor_test.dart
@@ -15,14 +15,50 @@
 import 'dart:math';
 
 import 'package:flutter_parent/models/enrollment.dart';
+import 'package:flutter_parent/models/login.dart';
 import 'package:flutter_parent/models/user.dart';
+import 'package:flutter_parent/network/api/enrollments_api.dart';
+import 'package:flutter_parent/network/api/user_api.dart';
+import 'package:flutter_parent/network/utils/api_prefs.dart';
 import 'package:flutter_parent/screens/dashboard/dashboard_interactor.dart';
 import 'package:flutter_parent/screens/dashboard/inbox_notifier.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
 
+import '../../utils/canvas_model_utils.dart';
+import '../../utils/platform_config.dart';
 import '../../utils/test_app.dart';
 
 void main() {
+  test('getStudents calls getObserveeEnrollments from EnrollmentsApi', () {
+    var api = MockEnrollmentsApi();
+    setupTestLocator((l) => l.registerLazySingleton<EnrollmentsApi>(() => api));
+    when(api.getObserveeEnrollments(forceRefresh: anyNamed('forceRefresh')))
+        .thenAnswer((_) => Future.value(<Enrollment>[]));
+
+    var interactor = DashboardInteractor();
+    interactor.getStudents();
+    verify(api.getObserveeEnrollments(forceRefresh: anyNamed('forceRefresh'))).called(1);
+  });
+
+  test('getSelf calls getSelf from UserApi', () async {
+    var api = MockUserApi();
+    final initialUser = CanvasModelTestUtils.mockUser();
+    final updatedUser = CanvasModelTestUtils.mockUser(name: 'Inst Panda');
+
+    setupTestLocator((l) => l.registerLazySingleton<UserApi>(() => api));
+    when(api.getSelf()).thenAnswer((_) => Future.value(updatedUser));
+
+    // Setup ApiPrefs
+    final login = Login((b) => b..user = initialUser.toBuilder());
+    await setupPlatformChannels(config: PlatformConfig(mockPrefs: {ApiPrefs.KEY_CURRENT_LOGIN_UUID: login.uuid}));
+    await ApiPrefs.addLogin(login);
+
+    var interactor = DashboardInteractor();
+    interactor.getSelf();
+    verify(api.getSelf()).called(1);
+  });
+
   test('Sort users in descending order', () {
     // Create lists
     var startingList = [_mockStudent('Zed'), _mockStudent('Alex'), _mockStudent('Billy')];
@@ -84,3 +120,7 @@ Enrollment _mockEnrollment(UserBuilder observedUser) => Enrollment((b) => b
   ..enrollmentState = ''
   ..observedUser = observedUser
   ..build());
+
+class MockEnrollmentsApi extends Mock implements EnrollmentsApi {}
+
+class MockUserApi extends Mock implements UserApi {}

--- a/apps/flutter_parent/test/screens/dashboard/dashboard_screen_test.dart
+++ b/apps/flutter_parent/test/screens/dashboard/dashboard_screen_test.dart
@@ -86,8 +86,17 @@ void main() {
     reset(analyticsMock);
   });
 
-  Widget _testableMaterialWidget({Login initLogin}) => TestApp(
-        Scaffold(body: DashboardScreen()),
+  Widget _testableMaterialWidget({
+    Login initLogin,
+    Map<String, Object> deepLinkParams,
+    DashboardContentScreens startingPage,
+  }) =>
+      TestApp(
+        Scaffold(
+            body: DashboardScreen(
+          deepLinkParams: deepLinkParams,
+          startingPage: startingPage,
+        )),
         highContrast: true,
         platformConfig: PlatformConfig(initLoggedInUser: initLogin),
       );
@@ -147,7 +156,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Open the drawer
-      DashboardScreen.scaffoldKey.currentState.openDrawer();
+      dashboardState(tester).scaffoldKey.currentState.openDrawer();
       await tester.pumpAndSettle();
 
       expect(find.text('${observer.name} (${observer.pronouns})'), findsOneWidget);
@@ -169,7 +178,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Open the drawer
-      DashboardScreen.scaffoldKey.currentState.openDrawer();
+      dashboardState(tester).scaffoldKey.currentState.openDrawer();
       await tester.pumpAndSettle();
 
       expect(find.text('${observer.name}'), findsOneWidget);
@@ -200,7 +209,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Open the nav drawer
-      DashboardScreen.scaffoldKey.currentState.openDrawer();
+      dashboardState(tester).scaffoldKey.currentState.openDrawer();
       await tester.pumpAndSettle();
 
       // Assert there's no text in the inbox-count
@@ -218,7 +227,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Open the nav drawer
-      DashboardScreen.scaffoldKey.currentState.openDrawer();
+      dashboardState(tester).scaffoldKey.currentState.openDrawer();
       await tester.pumpAndSettle();
 
       expect(find.text('12321'), findsOneWidget);
@@ -252,6 +261,44 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.descendant(of: find.byType(AppBar), matching: find.byKey(NumberBadge.backgroundKey)), findsNothing);
+    });
+
+    testWidgetsWithAccessibilityChecks('displays course when passed in as starting page', (tester) async {
+      _setupLocator();
+
+      await tester.pumpWidget(_testableMaterialWidget(startingPage: DashboardContentScreens.Courses));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CoursesScreen), findsOneWidget);
+    });
+
+    testWidgetsWithAccessibilityChecks('displays calendar when passed in as starting page', (tester) async {
+      _setupLocator();
+
+      var login = Login((b) => b
+        ..domain = 'domain'
+        ..accessToken = 'token'
+        ..user = CanvasModelTestUtils.mockUser().toBuilder());
+
+      await tester.pumpWidget(_testableMaterialWidget(
+        initLogin: login,
+        startingPage: DashboardContentScreens.Calendar,
+      ));
+
+      // Wait for day activity dot animation delay to settle
+      await tester.pumpAndSettle(Duration(seconds: 1));
+
+      expect(find.byType(CalendarScreen), findsOneWidget);
+    });
+
+    testWidgetsWithAccessibilityChecks('displays alerts when passed in as starting page', (tester) async {
+      _setupLocator();
+
+      await tester.pumpWidget(_testableMaterialWidget(startingPage: DashboardContentScreens.Alerts));
+      await tester.pumpAndSettle();
+
+      // Check for the alerts screen
+      expect(find.byType(AlertsScreen), findsOneWidget);
     });
   });
 
@@ -316,7 +363,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Open the nav drawer
-      DashboardScreen.scaffoldKey.currentState.openDrawer();
+      dashboardState(tester).scaffoldKey.currentState.openDrawer();
       await tester.pumpAndSettle();
 
       // Click on Inbox
@@ -331,7 +378,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Open the nav drawer
-      DashboardScreen.scaffoldKey.currentState.openDrawer();
+      dashboardState(tester).scaffoldKey.currentState.openDrawer();
       await tester.pumpAndSettle();
 
       // Click on Manage Students
@@ -349,7 +396,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Open the nav drawer
-      DashboardScreen.scaffoldKey.currentState.openDrawer();
+      dashboardState(tester).scaffoldKey.currentState.openDrawer();
       await tester.pumpAndSettle();
 
       // Click on Settings
@@ -370,7 +417,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Open the nav drawer
-      DashboardScreen.scaffoldKey.currentState.openDrawer();
+      dashboardState(tester).scaffoldKey.currentState.openDrawer();
       await tester.pumpAndSettle();
 
       // Click on Help
@@ -408,7 +455,7 @@ void main() {
         expect(ApiPrefs.isLoggedIn(), true);
 
         // Open the nav drawer
-        DashboardScreen.scaffoldKey.currentState.openDrawer();
+        dashboardState(tester).scaffoldKey.currentState.openDrawer();
         await tester.pumpAndSettle();
 
         // Click on Sign Out
@@ -461,7 +508,7 @@ void main() {
       expect(ApiPrefs.isLoggedIn(), true);
 
       // Open the nav drawer
-      DashboardScreen.scaffoldKey.currentState.openDrawer();
+      dashboardState(tester).scaffoldKey.currentState.openDrawer();
       await tester.pumpAndSettle();
 
       // Click on Sign Out
@@ -509,7 +556,7 @@ void main() {
       expect(ApiPrefs.isLoggedIn(), true);
 
       // Open the nav drawer
-      DashboardScreen.scaffoldKey.currentState.openDrawer();
+      dashboardState(tester).scaffoldKey.currentState.openDrawer();
       await tester.pumpAndSettle();
 
       // Click on Sign Out
@@ -544,9 +591,9 @@ void main() {
       await tester.pumpAndSettle();
 
       // Widget tree is built, we should have access to what we need to check the state of the expandable widget animation now
-      var slideAnimation =
-          ((StudentExpansionWidget.expansionWidgetKey.currentWidget as SizeTransition).listenable as CurvedAnimation)
-              .parent;
+      var slideAnimation = ((studentExpansionState(tester).expansionWidgetKey.currentWidget as SizeTransition)
+              .listenable as CurvedAnimation)
+          .parent;
 
       // Make sure the expansion widget exists and is initially retracted
       expect(find.byType(StudentExpansionWidget), findsOneWidget);
@@ -588,9 +635,9 @@ void main() {
       await tester.pumpAndSettle();
 
       // Widget tree is built, we should have access to what we need to check the state of the expandable widget animation now
-      var slideAnimation =
-          ((StudentExpansionWidget.expansionWidgetKey.currentWidget as SizeTransition).listenable as CurvedAnimation)
-              .parent;
+      var slideAnimation = ((studentExpansionState(tester).expansionWidgetKey.currentWidget as SizeTransition)
+              .listenable as CurvedAnimation)
+          .parent;
 
       // Make sure the expansion widget exists and is initially retracted
       expect(find.byType(StudentExpansionWidget), findsOneWidget);
@@ -609,6 +656,24 @@ void main() {
 
       expect(slideAnimation.value, retracted);
     });
+
+    testWidgetsWithAccessibilityChecks('deep link params is cleared after first screen is shown', (tester) async {
+      _setupLocator();
+
+      Map<String, Object> params = {'test': 'Instructure Pandas'};
+
+      await tester.pumpWidget(_testableMaterialWidget(deepLinkParams: params));
+      await tester.pump();
+
+      // Make sure our params made it into DashboardScreen
+      expect(dashboardState(tester).currentDeepLinkParams, params);
+
+      // Finish loading the screen
+      await tester.pumpAndSettle();
+
+      // Check that the deep link params are null
+      expect(dashboardState(tester).currentDeepLinkParams, null);
+    });
   });
 
   group('Loading', () {
@@ -621,7 +686,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Open the nav drawer
-      DashboardScreen.scaffoldKey.currentState.openDrawer();
+      dashboardState(tester).scaffoldKey.currentState.openDrawer();
       await tester.pumpAndSettle();
 
       verify(inboxApi.getUnreadCount()).called(1);
@@ -638,7 +703,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Open the nav drawer
-      DashboardScreen.scaffoldKey.currentState.openDrawer();
+      dashboardState(tester).scaffoldKey.currentState.openDrawer();
       await tester.pumpAndSettle();
 
       when(inboxApi.getUnreadCount())
@@ -661,7 +726,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Open the nav drawer
-      DashboardScreen.scaffoldKey.currentState.openDrawer();
+      dashboardState(tester).scaffoldKey.currentState.openDrawer();
       await tester.pumpAndSettle();
 
       verify(alertsApi.getUnreadCount(any)).called(1);
@@ -677,7 +742,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Open the nav drawer
-      DashboardScreen.scaffoldKey.currentState.openDrawer();
+      dashboardState(tester).scaffoldKey.currentState.openDrawer();
       await tester.pumpAndSettle();
 
       // Assert there's no text in the alerts-count
@@ -695,7 +760,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Open the nav drawer
-      DashboardScreen.scaffoldKey.currentState.openDrawer();
+      dashboardState(tester).scaffoldKey.currentState.openDrawer();
       await tester.pumpAndSettle();
 
       expect(find.text('88'), findsOneWidget);
@@ -712,7 +777,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Open the nav drawer
-      DashboardScreen.scaffoldKey.currentState.openDrawer();
+      dashboardState(tester).scaffoldKey.currentState.openDrawer();
       await tester.pumpAndSettle();
 
       when(alertsApi.getUnreadCount(any))
@@ -725,6 +790,11 @@ void main() {
     });
   });
 }
+
+DashboardState dashboardState(WidgetTester tester) => tester.state(find.byType(DashboardScreen));
+
+StudentExpansionWidgetState studentExpansionState(WidgetTester tester) =>
+    tester.state(find.byType(StudentExpansionWidget));
 
 class MockHelpScreenInteractor extends HelpScreenInteractor {
   @override

--- a/apps/flutter_parent/test/screens/dashboard/dashboard_screen_test.dart
+++ b/apps/flutter_parent/test/screens/dashboard/dashboard_screen_test.dart
@@ -93,11 +93,11 @@ void main() {
   }) =>
       TestApp(
         Scaffold(
-            body: DashboardScreen(
-          deepLinkParams: deepLinkParams,
-          startingPage: startingPage,
-        )),
-        highContrast: true,
+          body: DashboardScreen(
+            deepLinkParams: deepLinkParams,
+            startingPage: startingPage,
+          ),
+        ),
         platformConfig: PlatformConfig(initLoggedInUser: initLogin),
       );
 
@@ -591,9 +591,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Widget tree is built, we should have access to what we need to check the state of the expandable widget animation now
-      var slideAnimation = ((studentExpansionState(tester).expansionWidgetKey.currentWidget as SizeTransition)
-              .listenable as CurvedAnimation)
-          .parent;
+      var slideAnimation = ((studentExpansionState(tester).animation));
 
       // Make sure the expansion widget exists and is initially retracted
       expect(find.byType(StudentExpansionWidget), findsOneWidget);
@@ -635,9 +633,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Widget tree is built, we should have access to what we need to check the state of the expandable widget animation now
-      var slideAnimation = ((studentExpansionState(tester).expansionWidgetKey.currentWidget as SizeTransition)
-              .listenable as CurvedAnimation)
-          .parent;
+      var slideAnimation = ((studentExpansionState(tester).animation));
 
       // Make sure the expansion widget exists and is initially retracted
       expect(find.byType(StudentExpansionWidget), findsOneWidget);


### PR DESCRIPTION
There's some behavior we might want to tweak, mainly that when deep linking to one of the bottom nav screens a new Dashboard is loaded. The user can navigate in that new Dashboard like normal, but when they hit back enough times, that Dashboard screen is popped and the previous Dashboard screen is shown. Might not be a big deal, but it might seem kind of weird if the user navigates a lot in the new Dashboard screen.