### PR TITLE
[Flutter-Parent][MBL-13924] Limit web access

### DIFF
--- a/apps/flutter_parent/lib/l10n/app_localizations.dart
+++ b/apps/flutter_parent/lib/l10n/app_localizations.dart
@@ -1133,6 +1133,7 @@ class AppLocalizations {
         'Missing',
         desc: 'Description for when a student has not turned anything in for an assignment',
       );
+
   String get notGraded => Intl.message(
         'Not Graded',
         desc: 'Description for an assignment has not been graded.',
@@ -1171,6 +1172,11 @@ class AppLocalizations {
   String get launchExternalTool => Intl.message(
         'Launch External Tool',
         desc: 'Button text added to webviews to let users open external tools in their browser',
+      );
+
+  String get webAccessLimitedMessage => Intl.message(
+        'Interactions on this page are limited by your institution.',
+        desc: 'Message describing how the webview has limited access due to an instution setting',
       );
 
   String dateAtTime(String date, String time) => Intl.message(

--- a/apps/flutter_parent/lib/models/serializers.g.dart
+++ b/apps/flutter_parent/lib/models/serializers.g.dart
@@ -74,6 +74,7 @@ Serializers _$_serializers = (new Serializers().toBuilder()
       ..add(UnreadCount.serializer)
       ..add(User.serializer)
       ..add(UserNameData.serializer)
+      ..add(UserPermission.serializer)
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(Assignment)]),
           () => new ListBuilder<Assignment>())

--- a/apps/flutter_parent/lib/models/user.dart
+++ b/apps/flutter_parent/lib/models/user.dart
@@ -57,7 +57,33 @@ abstract class User implements Built<User, UserBuilder> {
   @BuiltValueField(wireName: 'effective_locale')
   String get effectiveLocale;
 
+  @nullable
+  UserPermission get permissions;
+
   static void _initializeBuilder(UserBuilder b) => b
     ..id = ''
     ..name = '';
+}
+
+abstract class UserPermission implements Built<UserPermission, UserPermissionBuilder> {
+  @BuiltValueSerializer(serializeNulls: true)
+  static Serializer<UserPermission> get serializer => _$userPermissionSerializer;
+
+  UserPermission._();
+  factory UserPermission([void Function(UserPermissionBuilder) updates]) = _$UserPermission;
+
+  @BuiltValueField(wireName: 'become_user')
+  bool get become_user;
+  @BuiltValueField(wireName: 'can_update_name')
+  bool get canUpdateName;
+  @BuiltValueField(wireName: 'can_update_avatar')
+  bool get canUpdateAvatar;
+  @BuiltValueField(wireName: 'limit_parent_app_web_access')
+  bool get limitParentAppWebAccess;
+
+  static void _initializeBuilder(UserPermissionBuilder b) => b
+    ..become_user = false
+    ..canUpdateName = false
+    ..canUpdateAvatar = false
+    ..limitParentAppWebAccess = false;
 }

--- a/apps/flutter_parent/lib/models/user.g.dart
+++ b/apps/flutter_parent/lib/models/user.g.dart
@@ -7,6 +7,8 @@ part of user;
 // **************************************************************************
 
 Serializer<User> _$userSerializer = new _$UserSerializer();
+Serializer<UserPermission> _$userPermissionSerializer =
+    new _$UserPermissionSerializer();
 
 class _$UserSerializer implements StructuredSerializer<User> {
   @override
@@ -72,6 +74,13 @@ class _$UserSerializer implements StructuredSerializer<User> {
       result.add(serializers.serialize(object.effectiveLocale,
           specifiedType: const FullType(String)));
     }
+    result.add('permissions');
+    if (object.permissions == null) {
+      result.add(null);
+    } else {
+      result.add(serializers.serialize(object.permissions,
+          specifiedType: const FullType(UserPermission)));
+    }
     return result;
   }
 
@@ -123,6 +132,74 @@ class _$UserSerializer implements StructuredSerializer<User> {
           result.effectiveLocale = serializers.deserialize(value,
               specifiedType: const FullType(String)) as String;
           break;
+        case 'permissions':
+          result.permissions.replace(serializers.deserialize(value,
+              specifiedType: const FullType(UserPermission)) as UserPermission);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$UserPermissionSerializer
+    implements StructuredSerializer<UserPermission> {
+  @override
+  final Iterable<Type> types = const [UserPermission, _$UserPermission];
+  @override
+  final String wireName = 'UserPermission';
+
+  @override
+  Iterable<Object> serialize(Serializers serializers, UserPermission object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object>[
+      'become_user',
+      serializers.serialize(object.become_user,
+          specifiedType: const FullType(bool)),
+      'can_update_name',
+      serializers.serialize(object.canUpdateName,
+          specifiedType: const FullType(bool)),
+      'can_update_avatar',
+      serializers.serialize(object.canUpdateAvatar,
+          specifiedType: const FullType(bool)),
+      'limit_parent_app_web_access',
+      serializers.serialize(object.limitParentAppWebAccess,
+          specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  UserPermission deserialize(
+      Serializers serializers, Iterable<Object> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new UserPermissionBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final dynamic value = iterator.current;
+      if (value == null) continue;
+      switch (key) {
+        case 'become_user':
+          result.become_user = serializers.deserialize(value,
+              specifiedType: const FullType(bool)) as bool;
+          break;
+        case 'can_update_name':
+          result.canUpdateName = serializers.deserialize(value,
+              specifiedType: const FullType(bool)) as bool;
+          break;
+        case 'can_update_avatar':
+          result.canUpdateAvatar = serializers.deserialize(value,
+              specifiedType: const FullType(bool)) as bool;
+          break;
+        case 'limit_parent_app_web_access':
+          result.limitParentAppWebAccess = serializers.deserialize(value,
+              specifiedType: const FullType(bool)) as bool;
+          break;
       }
     }
 
@@ -149,6 +226,8 @@ class _$User extends User {
   final String locale;
   @override
   final String effectiveLocale;
+  @override
+  final UserPermission permissions;
 
   factory _$User([void Function(UserBuilder) updates]) =>
       (new UserBuilder()..update(updates)).build();
@@ -162,7 +241,8 @@ class _$User extends User {
       this.avatarUrl,
       this.primaryEmail,
       this.locale,
-      this.effectiveLocale})
+      this.effectiveLocale,
+      this.permissions})
       : super._() {
     if (id == null) {
       throw new BuiltValueNullFieldError('User', 'id');
@@ -191,7 +271,8 @@ class _$User extends User {
         avatarUrl == other.avatarUrl &&
         primaryEmail == other.primaryEmail &&
         locale == other.locale &&
-        effectiveLocale == other.effectiveLocale;
+        effectiveLocale == other.effectiveLocale &&
+        permissions == other.permissions;
   }
 
   @override
@@ -202,14 +283,16 @@ class _$User extends User {
                 $jc(
                     $jc(
                         $jc(
-                            $jc($jc($jc(0, id.hashCode), name.hashCode),
-                                sortableName.hashCode),
-                            shortName.hashCode),
-                        pronouns.hashCode),
-                    avatarUrl.hashCode),
-                primaryEmail.hashCode),
-            locale.hashCode),
-        effectiveLocale.hashCode));
+                            $jc(
+                                $jc($jc($jc(0, id.hashCode), name.hashCode),
+                                    sortableName.hashCode),
+                                shortName.hashCode),
+                            pronouns.hashCode),
+                        avatarUrl.hashCode),
+                    primaryEmail.hashCode),
+                locale.hashCode),
+            effectiveLocale.hashCode),
+        permissions.hashCode));
   }
 
   @override
@@ -223,7 +306,8 @@ class _$User extends User {
           ..add('avatarUrl', avatarUrl)
           ..add('primaryEmail', primaryEmail)
           ..add('locale', locale)
-          ..add('effectiveLocale', effectiveLocale))
+          ..add('effectiveLocale', effectiveLocale)
+          ..add('permissions', permissions))
         .toString();
   }
 }
@@ -268,6 +352,12 @@ class UserBuilder implements Builder<User, UserBuilder> {
   set effectiveLocale(String effectiveLocale) =>
       _$this._effectiveLocale = effectiveLocale;
 
+  UserPermissionBuilder _permissions;
+  UserPermissionBuilder get permissions =>
+      _$this._permissions ??= new UserPermissionBuilder();
+  set permissions(UserPermissionBuilder permissions) =>
+      _$this._permissions = permissions;
+
   UserBuilder() {
     User._initializeBuilder(this);
   }
@@ -283,6 +373,7 @@ class UserBuilder implements Builder<User, UserBuilder> {
       _primaryEmail = _$v.primaryEmail;
       _locale = _$v.locale;
       _effectiveLocale = _$v.effectiveLocale;
+      _permissions = _$v.permissions?.toBuilder();
       _$v = null;
     }
     return this;
@@ -303,17 +394,166 @@ class UserBuilder implements Builder<User, UserBuilder> {
 
   @override
   _$User build() {
+    _$User _$result;
+    try {
+      _$result = _$v ??
+          new _$User._(
+              id: id,
+              name: name,
+              sortableName: sortableName,
+              shortName: shortName,
+              pronouns: pronouns,
+              avatarUrl: avatarUrl,
+              primaryEmail: primaryEmail,
+              locale: locale,
+              effectiveLocale: effectiveLocale,
+              permissions: _permissions?.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'permissions';
+        _permissions?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'User', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$UserPermission extends UserPermission {
+  @override
+  final bool become_user;
+  @override
+  final bool canUpdateName;
+  @override
+  final bool canUpdateAvatar;
+  @override
+  final bool limitParentAppWebAccess;
+
+  factory _$UserPermission([void Function(UserPermissionBuilder) updates]) =>
+      (new UserPermissionBuilder()..update(updates)).build();
+
+  _$UserPermission._(
+      {this.become_user,
+      this.canUpdateName,
+      this.canUpdateAvatar,
+      this.limitParentAppWebAccess})
+      : super._() {
+    if (become_user == null) {
+      throw new BuiltValueNullFieldError('UserPermission', 'become_user');
+    }
+    if (canUpdateName == null) {
+      throw new BuiltValueNullFieldError('UserPermission', 'canUpdateName');
+    }
+    if (canUpdateAvatar == null) {
+      throw new BuiltValueNullFieldError('UserPermission', 'canUpdateAvatar');
+    }
+    if (limitParentAppWebAccess == null) {
+      throw new BuiltValueNullFieldError(
+          'UserPermission', 'limitParentAppWebAccess');
+    }
+  }
+
+  @override
+  UserPermission rebuild(void Function(UserPermissionBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UserPermissionBuilder toBuilder() =>
+      new UserPermissionBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UserPermission &&
+        become_user == other.become_user &&
+        canUpdateName == other.canUpdateName &&
+        canUpdateAvatar == other.canUpdateAvatar &&
+        limitParentAppWebAccess == other.limitParentAppWebAccess;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(
+        $jc($jc($jc(0, become_user.hashCode), canUpdateName.hashCode),
+            canUpdateAvatar.hashCode),
+        limitParentAppWebAccess.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('UserPermission')
+          ..add('become_user', become_user)
+          ..add('canUpdateName', canUpdateName)
+          ..add('canUpdateAvatar', canUpdateAvatar)
+          ..add('limitParentAppWebAccess', limitParentAppWebAccess))
+        .toString();
+  }
+}
+
+class UserPermissionBuilder
+    implements Builder<UserPermission, UserPermissionBuilder> {
+  _$UserPermission _$v;
+
+  bool _become_user;
+  bool get become_user => _$this._become_user;
+  set become_user(bool become_user) => _$this._become_user = become_user;
+
+  bool _canUpdateName;
+  bool get canUpdateName => _$this._canUpdateName;
+  set canUpdateName(bool canUpdateName) =>
+      _$this._canUpdateName = canUpdateName;
+
+  bool _canUpdateAvatar;
+  bool get canUpdateAvatar => _$this._canUpdateAvatar;
+  set canUpdateAvatar(bool canUpdateAvatar) =>
+      _$this._canUpdateAvatar = canUpdateAvatar;
+
+  bool _limitParentAppWebAccess;
+  bool get limitParentAppWebAccess => _$this._limitParentAppWebAccess;
+  set limitParentAppWebAccess(bool limitParentAppWebAccess) =>
+      _$this._limitParentAppWebAccess = limitParentAppWebAccess;
+
+  UserPermissionBuilder() {
+    UserPermission._initializeBuilder(this);
+  }
+
+  UserPermissionBuilder get _$this {
+    if (_$v != null) {
+      _become_user = _$v.become_user;
+      _canUpdateName = _$v.canUpdateName;
+      _canUpdateAvatar = _$v.canUpdateAvatar;
+      _limitParentAppWebAccess = _$v.limitParentAppWebAccess;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(UserPermission other) {
+    if (other == null) {
+      throw new ArgumentError.notNull('other');
+    }
+    _$v = other as _$UserPermission;
+  }
+
+  @override
+  void update(void Function(UserPermissionBuilder) updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$UserPermission build() {
     final _$result = _$v ??
-        new _$User._(
-            id: id,
-            name: name,
-            sortableName: sortableName,
-            shortName: shortName,
-            pronouns: pronouns,
-            avatarUrl: avatarUrl,
-            primaryEmail: primaryEmail,
-            locale: locale,
-            effectiveLocale: effectiveLocale);
+        new _$UserPermission._(
+            become_user: become_user,
+            canUpdateName: canUpdateName,
+            canUpdateAvatar: canUpdateAvatar,
+            limitParentAppWebAccess: limitParentAppWebAccess);
     replace(_$result);
     return _$result;
   }

--- a/apps/flutter_parent/lib/network/api/user_api.dart
+++ b/apps/flutter_parent/lib/network/api/user_api.dart
@@ -18,4 +18,6 @@ import 'package:flutter_parent/network/utils/fetch.dart';
 
 class UserApi {
   Future<User> getSelf() => fetch(canvasDio(forceDeviceLanguage: true).get('users/self/profile'));
+
+  Future<User> getSelfPermissions() => fetch(canvasDio(forceRefresh: true).get('users/self'));
 }

--- a/apps/flutter_parent/lib/network/api/user_api.dart
+++ b/apps/flutter_parent/lib/network/api/user_api.dart
@@ -19,5 +19,6 @@ import 'package:flutter_parent/network/utils/fetch.dart';
 class UserApi {
   Future<User> getSelf() => fetch(canvasDio(forceDeviceLanguage: true).get('users/self/profile'));
 
-  Future<User> getSelfPermissions() => fetch(canvasDio(forceRefresh: true).get('users/self'));
+  Future<UserPermission> getSelfPermissions() =>
+      fetch(canvasDio(forceRefresh: true).get<User>('users/self')).then((user) => user.permissions);
 }

--- a/apps/flutter_parent/lib/router/panda_router.dart
+++ b/apps/flutter_parent/lib/router/panda_router.dart
@@ -111,7 +111,8 @@ class PandaRouter {
 
   static final String _simpleWebView = '/internal';
 
-  static String _simpleWebViewRoute(String url) => '/internal?${_RouterKeys.url}=${Uri.encodeQueryComponent(url)}';
+  static String simpleWebViewRoute(String url, String infoText) =>
+      '/internal?${_RouterKeys.url}=${Uri.encodeQueryComponent(url)}&${_RouterKeys.infoText}=$infoText';
 
   static String settings() => '/settings';
 
@@ -268,7 +269,8 @@ class PandaRouter {
 
   static Handler _simpleWebViewHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
     final url = params[_RouterKeys.url][0];
-    return SimpleWebViewScreen(url, url);
+    final infoText = params[_RouterKeys.infoText]?.elementAt(0);
+    return SimpleWebViewScreen(url, url, infoText: infoText);
   });
 
   static Handler _termsOfUseHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
@@ -316,22 +318,20 @@ class PandaRouter {
         locator<QuickNav>().pushRoute(context, _routerErrorRoute(link));
       }
     } else {
-      // No native route found, let's launch the url if possible, or show an error toast
-      if (await canLaunch(link)) {
-        String authUrl = await _interactor.getAuthUrl(link);
-        if (limitWebAccess) {
-          // Special case for limit webview access flag (We don't want them to be able to navigate within the webview)
-          locator<QuickNav>().pushRoute(context, _simpleWebViewRoute(link));
-        } else {
-          launch(authUrl);
-        }
+      final url = await _interactor.getAuthUrl(link);
+      if (limitWebAccess) {
+        // Special case for limit webview access flag (We don't want them to be able to navigate within the webview)
+        locator<QuickNav>().pushRoute(context, simpleWebViewRoute(url, L10n(context).webAccessLimitedMessage));
+      } else if (await canLaunch(link) ?? false) {
+        // No native route found, let's launch the url if possible, or show an error toast
+        launch(url);
       } else {
         locator<FlutterSnackbarVeneer>().showSnackBar(context, L10n(context).routerLaunchErrorMessage);
       }
     }
   }
 
-  static final bool limitWebAccess = false; // TODO - replace after MBL-13924 is implemented
+  static bool get limitWebAccess => ApiPrefs.getUser()?.permissions?.limitParentAppWebAccess ?? false;
 
   /// Simple helper method to determine if the router can handle a url
   /// returns a RouteWrapper
@@ -371,6 +371,7 @@ class _RouterKeys {
   static final eventId = 'eventId';
   static final quizId = 'quizId';
   static final topicId = 'topicId';
+  static final infoText = 'infoText';
   static final url = 'url'; // NOTE: This has to match MainActivity.kt in the Android code
 }
 

--- a/apps/flutter_parent/lib/router/panda_router.dart
+++ b/apps/flutter_parent/lib/router/panda_router.dart
@@ -270,7 +270,7 @@ class PandaRouter {
   static Handler _simpleWebViewHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
     final url = params[_RouterKeys.url][0];
     final infoText = params[_RouterKeys.infoText]?.elementAt(0);
-    return SimpleWebViewScreen(url, url, infoText: infoText);
+    return SimpleWebViewScreen(url, url, infoText: infoText == null || infoText == 'null' ? null : infoText);
   });
 
   static Handler _termsOfUseHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
@@ -364,15 +364,15 @@ class _RouterKeys {
   static final announcementId = 'announcementId';
   static final assignmentId = 'assignmentId';
   static final authenticationProvider = 'authenticationProvider';
-  static final calendarStart = 'view_start';
-  static final calendarView = 'view_name';
   static final courseId = 'courseId';
   static final domain = 'domain';
   static final eventId = 'eventId';
+  static final infoText = 'infoText';
   static final quizId = 'quizId';
   static final topicId = 'topicId';
-  static final infoText = 'infoText';
   static final url = 'url'; // NOTE: This has to match MainActivity.kt in the Android code
+  static final calendarStart = 'view_start';
+  static final calendarView = 'view_name';
 }
 
 /// Simple helper class to manage the repeated data extracted from a link to be routed

--- a/apps/flutter_parent/lib/screens/dashboard/dashboard_interactor.dart
+++ b/apps/flutter_parent/lib/screens/dashboard/dashboard_interactor.dart
@@ -29,7 +29,9 @@ class DashboardInteractor {
         return users;
       });
 
-  Future<User> getSelf({app}) async => locator<UserApi>().getSelf().then((user) {
+  Future<User> getSelf({app}) async => locator<UserApi>().getSelf().then((user) async {
+        final permissions = (await locator<UserApi>().getSelfPermissions().catchError((_) => null))?.permissions;
+        user = user.rebuild((b) => b..permissions = permissions.toBuilder());
         ApiPrefs.setUser(user, app: app);
         return user;
       });

--- a/apps/flutter_parent/lib/screens/dashboard/dashboard_interactor.dart
+++ b/apps/flutter_parent/lib/screens/dashboard/dashboard_interactor.dart
@@ -30,7 +30,7 @@ class DashboardInteractor {
       });
 
   Future<User> getSelf({app}) async => locator<UserApi>().getSelf().then((user) async {
-        final permissions = (await locator<UserApi>().getSelfPermissions().catchError((_) => null))?.permissions;
+        final permissions = (await locator<UserApi>().getSelfPermissions().catchError((_) => null));
         user = user.rebuild((b) => b..permissions = permissions.toBuilder());
         ApiPrefs.setUser(user, app: app);
         return user;

--- a/apps/flutter_parent/test/router/panda_router_test.dart
+++ b/apps/flutter_parent/test/router/panda_router_test.dart
@@ -14,7 +14,9 @@
 
 import 'package:fluro/fluro.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_parent/l10n/app_localizations.dart';
 import 'package:flutter_parent/models/login.dart';
+import 'package:flutter_parent/models/user.dart';
 import 'package:flutter_parent/network/utils/analytics.dart';
 import 'package:flutter_parent/router/panda_router.dart';
 import 'package:flutter_parent/router/router_error_screen.dart';
@@ -403,6 +405,26 @@ void main() {
       verify(_mockSnackbar.showSnackBar(any, 'An error occurred when trying to display this link'));
     });
 
+    testWidgetsWithAccessibilityChecks('launches simpleWebView for limitAccessFlag without match', (tester) async {
+      final newLogin = login.rebuild((b) => b.user = login.user
+          .rebuild((user) => user.permissions = UserPermissionBuilder()..limitParentAppWebAccess = true)
+          .toBuilder());
+
+      final url = 'https://test.instructure.com/commons/1234';
+      when(_mockWebContentInteractor.getAuthUrl(url)).thenAnswer((_) async => url);
+
+      await TestApp.showWidgetFromTap(
+        tester,
+        (context) => PandaRouter.routeInternally(context, url),
+        config: PlatformConfig(initLoggedInUser: newLogin),
+      );
+
+      verify(_analytics.logMessage('Attempting to route INTERNAL url: $url')).called(1);
+      verify(_mockNav.pushRoute(any, PandaRouter.simpleWebViewRoute(url, AppLocalizations().webAccessLimitedMessage)));
+    });
+  });
+
+  group('url route wrapper', () {
     test('returns valid UrlRouteWrapper', () {
       final path = '/courses/1567973';
       final url = '$_domain$path';
@@ -432,10 +454,6 @@ void main() {
       assert(routeWrapper.validHost == true);
       assert(routeWrapper.appRouteMatch == null);
     });
-
-//     Todo once MBL-13924 is done
-//    testWidgetsWithAccessibilityChecks('launches simpleWebView for limitAccessFlag without match', (tester) async {
-//    });
   });
 }
 

--- a/apps/flutter_parent/test/screens/dashboard/dashboard_interactor_test.dart
+++ b/apps/flutter_parent/test/screens/dashboard/dashboard_interactor_test.dart
@@ -51,7 +51,7 @@ void main() {
 
     setupTestLocator((l) => l.registerLazySingleton<UserApi>(() => api));
     when(api.getSelf()).thenAnswer((_) => Future.value(updatedUser));
-    when(api.getSelfPermissions()).thenAnswer((_) => Future.value(permittedUser));
+    when(api.getSelfPermissions()).thenAnswer((_) => Future.value(permittedUser.permissions));
 
     // Setup ApiPrefs
     final login = Login((b) => b..user = initialUser.toBuilder());

--- a/apps/flutter_parent/test/screens/dashboard/dashboard_interactor_test.dart
+++ b/apps/flutter_parent/test/screens/dashboard/dashboard_interactor_test.dart
@@ -45,9 +45,13 @@ void main() {
     var api = MockUserApi();
     final initialUser = CanvasModelTestUtils.mockUser();
     final updatedUser = CanvasModelTestUtils.mockUser(name: 'Inst Panda');
+    final permittedUser = updatedUser.rebuild((b) {
+      return b..permissions = UserPermission((p) => p..limitParentAppWebAccess = true).toBuilder();
+    });
 
     setupTestLocator((l) => l.registerLazySingleton<UserApi>(() => api));
     when(api.getSelf()).thenAnswer((_) => Future.value(updatedUser));
+    when(api.getSelfPermissions()).thenAnswer((_) => Future.value(permittedUser));
 
     // Setup ApiPrefs
     final login = Login((b) => b..user = initialUser.toBuilder());
@@ -55,8 +59,11 @@ void main() {
         config: PlatformConfig(mockPrefs: {ApiPrefs.KEY_CURRENT_LOGIN_UUID: login.uuid}, initLoggedInUser: login));
 
     var interactor = DashboardInteractor();
-    interactor.getSelf();
+    final actual = await interactor.getSelf();
+
+    expect(actual, permittedUser);
     verify(api.getSelf()).called(1);
+    verify(api.getSelfPermissions()).called(1);
   });
 
   test('Sort users in descending order', () {


### PR DESCRIPTION
To test:
Change the account settings at the institution level to limit web access to parents using the mobile app.
Open the app and go to an assignment with some links to places we don't handle in the app (my sandbox, course1 -> link assignment). Things like modules, files, groups, pages.
When the checkbox is not enabled, the links should open out to the browser (or show the action sheet to choose between apps, always pick browser).
When the checkbox is enabled (to limit web access), then links should open to our simple web view that doesn't allow any further page loads, also displaying an alert that only disappears when clicked.