### PR TITLE
[Student][RemoteConfig][MBL-14172]: An E2E test for remote-config-settings

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/RemoteConfigSettingsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/RemoteConfigSettingsPage.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2019 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.instructure.student.ui.pages
+
+import android.widget.EditText
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.matcher.ViewMatchers
+import com.instructure.canvas.espresso.clearFocus
+import com.instructure.canvas.espresso.containsTextCaseInsensitive
+import com.instructure.canvas.espresso.scrollRecyclerView
+import com.instructure.canvasapi2.utils.RemoteConfigParam
+import com.instructure.espresso.click
+import com.instructure.espresso.page.BasePage
+import com.instructure.pandautils.R
+import org.hamcrest.Matchers
+
+class RemoteConfigSettingsPage : BasePage(R.id.remoteConfigSettingsFragment) {
+
+    fun clickRemoteConfigParamValue(param: RemoteConfigParam) {
+        val target = Matchers.allOf(
+                ViewMatchers.isAssignableFrom(EditText::class.java),
+                ViewMatchers.hasSibling(containsTextCaseInsensitive(param.rc_name))
+        )
+
+        scrollRecyclerView(R.id.recyclerView, target)
+
+        onView(target).click()
+    }
+
+    fun clearRemoteConfigParamValueFocus(param: RemoteConfigParam) {
+        val target = Matchers.allOf(
+                ViewMatchers.isAssignableFrom(EditText::class.java),
+                ViewMatchers.hasSibling(containsTextCaseInsensitive(param.rc_name))
+        )
+
+        scrollRecyclerView(R.id.recyclerView, target)
+
+        onView(target).perform(clearFocus())
+    }
+
+    fun verifyRemoteConfigParamValue(param: RemoteConfigParam, targetValue: String) {
+        val target = Matchers.allOf(
+                ViewMatchers.isAssignableFrom(EditText::class.java),
+                ViewMatchers.hasSibling(containsTextCaseInsensitive(param.rc_name))
+        )
+
+        scrollRecyclerView(R.id.recyclerView, target)
+        onView(target).check(ViewAssertions.matches((ViewMatchers.withText(targetValue))))
+    }
+}

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SettingsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SettingsPage.kt
@@ -17,6 +17,7 @@
 package com.instructure.student.ui.pages
 
 import com.instructure.espresso.OnViewWithId
+import com.instructure.espresso.assertHasContentDescription
 import com.instructure.espresso.click
 import com.instructure.espresso.page.BasePage
 import com.instructure.espresso.scrollTo
@@ -30,6 +31,7 @@ class SettingsPage : BasePage(R.id.settingsFragment) {
     private val aboutLabel by OnViewWithId(R.id.about)
     private val legalLabel by OnViewWithId(R.id.legal)
     private val helpLabel by OnViewWithId(R.id.help)
+    private val remoteConfigLabel by OnViewWithId(R.id.remoteConfigParams)
 
     fun launchAboutPage() {
         aboutLabel.click()
@@ -41,6 +43,10 @@ class SettingsPage : BasePage(R.id.settingsFragment) {
 
     fun launchHelpPage() {
         helpLabel.scrollTo().click()
+    }
+
+    fun launchRemoteConfigParams() {
+        remoteConfigLabel.scrollTo().click()
     }
 
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTest.kt
@@ -88,6 +88,7 @@ abstract class StudentTest : CanvasTest() {
     val fileUploadPage = FileUploadPage()
     val annotationCommentListPage = AnnotationCommentListPage()
     val pickerSubmissionUploadPage = PickerSubmissionUploadPage()
+    val remoteConfigSettingsPage = RemoteConfigSettingsPage()
 
     // A no-op interaction to afford us an easy, harmless way to get a11y checking to trigger.
     fun meaninglessSwipe() {

--- a/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/CustomActions.kt
+++ b/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/CustomActions.kt
@@ -187,6 +187,26 @@ fun explicitClick() : ViewAction {
 }
 
 /**
+ * Clear the focus of a view (i.e., remove focus from a view).
+ */
+fun clearFocus() : ViewAction {
+    return object : ViewAction {
+        override fun getDescription(): String {
+            return "Explicitly remove focus from a view"
+        }
+
+        override fun getConstraints(): Matcher<View> {
+            return  ViewMatchers.isAssignableFrom(View::class.java)
+        }
+
+        override fun perform(uiController: UiController?, view: View?) {
+            view?.clearFocus()
+        }
+
+    }
+}
+
+/**
  * Helper method that clicks on the coordinates of a view based the x/y percentages given
  */
 fun clickCoordinates(percentX: Float, percentY: Float) : ViewAction {

--- a/libs/pandautils/src/main/res/layout/adapter_remote_config_param.xml
+++ b/libs/pandautils/src/main/res/layout/adapter_remote_config_param.xml
@@ -25,12 +25,14 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:minHeight="48dp"
         android:id="@+id/param_name"/>
 
     <EditText
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
+        android:minHeight="48dp"
         android:id="@+id/param_value"/>
 
 </LinearLayout>

--- a/libs/pandautils/src/main/res/layout/fragment_remote_config_params.xml
+++ b/libs/pandautils/src/main/res/layout/fragment_remote_config_params.xml
@@ -19,6 +19,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/remoteConfigSettingsFragment"
     android:orientation="vertical">
 
     <androidx.appcompat.widget.Toolbar


### PR DESCRIPTION
Ensures that former bizarre behavior associated with interacting with soft keyboard from remote config settings page no longer occurs.

Why an E2E test?  It was easier to code than an interaction test, and also the dataseeding that takes place at the start of the test ensures that the remote config settings will be read successfully before the main test logic starts.