### PR TITLE
[Flutter-Parent] Fix getting self when no permissions are present

### DIFF
--- a/apps/flutter_parent/lib/screens/dashboard/dashboard_interactor.dart
+++ b/apps/flutter_parent/lib/screens/dashboard/dashboard_interactor.dart
@@ -31,7 +31,7 @@ class DashboardInteractor {
 
   Future<User> getSelf({app}) async => locator<UserApi>().getSelf().then((user) async {
         final permissions = (await locator<UserApi>().getSelfPermissions().catchError((_) => null));
-        user = user.rebuild((b) => b..permissions = permissions.toBuilder());
+        user = user.rebuild((b) => b..permissions = permissions?.toBuilder());
         ApiPrefs.setUser(user, app: app);
         return user;
       });


### PR DESCRIPTION
To test:

The app should now show data in the nav drawer again for users that don't have any permissions defined.