### PR TITLE
[Parent][Architecture][MBL-14173] | added remote config support to flutter-parent

### DIFF
--- a/apps/flutter_parent/lib/main.dart
+++ b/apps/flutter_parent/lib/main.dart
@@ -24,6 +24,7 @@ import 'package:flutter_parent/utils/db/db_util.dart';
 import 'package:flutter_parent/utils/design/theme_prefs.dart';
 import 'package:flutter_parent/utils/notification_util.dart';
 import 'package:flutter_parent/utils/old_app_migration.dart';
+import 'package:flutter_parent/utils/remote_config_utils.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
 
 void main() {
@@ -36,6 +37,7 @@ void main() {
       CrashUtils.init(),
       FlutterDownloader.initialize(),
       DbUtil.init(),
+      RemoteConfigUtils.initialize()
     ]);
     setupLocator();
     PandaRouter.init();

--- a/apps/flutter_parent/lib/utils/remote_config_utils.dart
+++ b/apps/flutter_parent/lib/utils/remote_config_utils.dart
@@ -1,0 +1,101 @@
+import 'package:firebase_remote_config/firebase_remote_config.dart';
+import 'package:flutter/widgets.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+enum RemoteConfigParams { TEST_STRING, QR_LOGIN_ENABLED_PARENT }
+
+class RemoteConfigUtils {
+  static RemoteConfig _remoteConfig = null;
+  static SharedPreferences _prefs;
+  static final _RC_PREFS_PREFIX = "rc_";
+
+  // I bifurcated initialize() into initialize() and initializeExplicit() to allow for
+  // tests to pass in a mocked RemoteConfig object.
+  // This is the normal initializer that should be used from production code.
+  static Future<void> initialize() async {
+    RemoteConfig freshRemoteConfig = await RemoteConfig.instance;
+    await initializeExplicit(freshRemoteConfig);
+  }
+
+  @visibleForTesting
+  static void clean() {
+    _remoteConfig = null;
+    _prefs = null;
+  }
+
+  @visibleForTesting
+  static Future<void> initializeExplicit(RemoteConfig remoteConfig) async {
+    if (_remoteConfig != null) throw StateError('double-initialization of RemoteConfigUtils');
+
+    _remoteConfig = remoteConfig;
+
+    // fetch data from Firebase
+    await _remoteConfig.fetch(expiration: const Duration(hours: 1));
+    var updated = await _remoteConfig.activateFetched();
+
+    // Grab a SharedPreferences instance
+    _prefs = await SharedPreferences.getInstance();
+
+    if (updated) {
+      // If we actually fetched something, then store the fetched info into _prefs
+      RemoteConfigParams.values.forEach((rc) {
+        String rcParamName = _getRemoteConfigName(rc);
+        String rcParamValue = _remoteConfig.getString(rcParamName);
+        print(
+            "RemoteConfigUtils.initialize(): fetched $rcParamName=${rcParamValue == null ? "null" : "\"$rcParamValue\""}");
+        _prefs.setString("$_RC_PREFS_PREFIX$rcParamName", rcParamValue);
+      });
+    } else {
+      // Otherwise, some log info.  The log info here and above will serve as a substitute for
+      // a local remote-config settings page, which is not supported at this time.
+      print("RemoteConfigUtils.initialize(): No update");
+      RemoteConfigParams.values.forEach((rc) {
+        String rcParamName = _getRemoteConfigName(rc);
+        String rcParamValue = _prefs.getString("$_RC_PREFS_PREFIX$rcParamName");
+        print(
+            "RemoteConfigUtils.initialize(): cached $rcParamName value = ${rcParamValue == null ? "null" : "\"$rcParamValue\""}");
+      });
+    }
+  }
+
+  static String getStringValue(RemoteConfigParams rcParam) {
+    if (_remoteConfig == null) throw StateError('RemoteConfigUtils not yet initialized');
+
+    var rcName = _getRemoteConfigName(rcParam);
+    var rcDefault = _getRemoteConfigDefaultValue(rcParam);
+    var result = _prefs.getString("$_RC_PREFS_PREFIX$rcName");
+    if (result == null) {
+      result = rcDefault;
+      _prefs.setString("$_RC_PREFS_PREFIX$rcName", rcDefault);
+    }
+    return result;
+  }
+
+  // TODO: Get bool, double, int
+
+  // Utility method to fetch the remote config variable name associated with rcParam.
+  // Switch statements are required to cover all possible cases, so if we add
+  // a new element in RemoveConfigParams, we'll be forced to add handling for
+  // it here.
+  static String _getRemoteConfigName(RemoteConfigParams rcParam) {
+    switch (rcParam) {
+      case RemoteConfigParams.TEST_STRING:
+        return "test_string";
+      case RemoteConfigParams.QR_LOGIN_ENABLED_PARENT:
+        return "qr_login_enabled_parent";
+    }
+  }
+
+  // Utility method to fetch the default (string) value associated with rcParam.
+  // Switch statements are required to cover all possible cases, so if we add
+  // a new element in RemoveConfigParams, we'll be forced to add handling for
+  // it here.
+  static String _getRemoteConfigDefaultValue(RemoteConfigParams rcParam) {
+    switch (rcParam) {
+      case RemoteConfigParams.TEST_STRING:
+        return "hey there";
+      case RemoteConfigParams.QR_LOGIN_ENABLED_PARENT:
+        return "false";
+    }
+  }
+}

--- a/apps/flutter_parent/lib/utils/remote_config_utils.dart
+++ b/apps/flutter_parent/lib/utils/remote_config_utils.dart
@@ -17,7 +17,10 @@ import 'package:flutter/widgets.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 // All of the Remote Config params that we choose to care about.
-enum RemoteConfigParams { TEST_STRING, QR_LOGIN_ENABLED_PARENT }
+enum RemoteConfigParams {
+  QR_LOGIN_ENABLED_PARENT,
+  TEST_STRING,
+}
 
 class RemoteConfigUtils {
   static RemoteConfig _remoteConfig = null;
@@ -65,19 +68,19 @@ class RemoteConfigUtils {
         String rcParamValue = _remoteConfig.getString(rcParamName);
         String rcPreferencesName = _getSharedPreferencesName(rc);
         print(
-            "RemoteConfigUtils.initialize(): fetched $rcParamName=${rcParamValue == null ? "null" : "\"$rcParamValue\""}");
+            'RemoteConfigUtils.initialize(): fetched $rcParamName=${rcParamValue == null ? 'null' : '\"$rcParamValue\"'}');
         _prefs.setString(rcPreferencesName, rcParamValue);
       });
     } else {
       // Otherwise, some log info.  The log info here and above will serve as a substitute for
       // a local remote-config settings page, which is not supported at this time.
-      print("RemoteConfigUtils.initialize(): No update");
+      print('RemoteConfigUtils.initialize(): No update');
       RemoteConfigParams.values.forEach((rc) {
         String rcParamName = _getRemoteConfigName(rc);
         String rcPreferencesName = _getSharedPreferencesName(rc);
         String rcParamValue = _prefs.getString(rcPreferencesName);
         print(
-            "RemoteConfigUtils.initialize(): cached $rcParamName value = ${rcParamValue == null ? "null" : "\"$rcParamValue\""}");
+            'RemoteConfigUtils.initialize(): cached $rcParamName value = ${rcParamValue == null ? 'null' : '\"$rcParamValue\"'}');
       });
     }
   }
@@ -106,9 +109,9 @@ class RemoteConfigUtils {
   static String _getRemoteConfigName(RemoteConfigParams rcParam) {
     switch (rcParam) {
       case RemoteConfigParams.TEST_STRING:
-        return "test_string";
+        return 'test_string';
       case RemoteConfigParams.QR_LOGIN_ENABLED_PARENT:
-        return "qr_login_enabled_parent";
+        return 'qr_login_enabled_parent';
     }
   }
 
@@ -119,16 +122,16 @@ class RemoteConfigUtils {
   static String _getRemoteConfigDefaultValue(RemoteConfigParams rcParam) {
     switch (rcParam) {
       case RemoteConfigParams.TEST_STRING:
-        return "hey there";
+        return 'hey there';
       case RemoteConfigParams.QR_LOGIN_ENABLED_PARENT:
-        return "false";
+        return 'false';
     }
   }
 
   // Utility method to fetch the name of the SharedPreferences entry
-  // that corresponds to rcParam.  Just prepends an "rc_" to the
+  // that corresponds to rcParam.  Just prepends an 'rc_' to the
   // remote config name for rcParam.
   static String _getSharedPreferencesName(RemoteConfigParams rcParam) {
-    return "rc_${_getRemoteConfigName(rcParam)}";
+    return 'rc_${_getRemoteConfigName(rcParam)}';
   }
 }

--- a/apps/flutter_parent/lib/utils/remote_config_utils.dart
+++ b/apps/flutter_parent/lib/utils/remote_config_utils.dart
@@ -25,18 +25,26 @@ class RemoteConfigUtils {
 
   // I bifurcated initialize() into initialize() and initializeExplicit() to allow for
   // tests to pass in a mocked RemoteConfig object.
-  // This is the normal initializer that should be used from production code.
+  /**
+   * Initialize RemoteConfigUtils.  Should only be called once.
+   * This is the normal initializer that should be called from production code.
+   **/
   static Future<void> initialize() async {
     RemoteConfig freshRemoteConfig = await RemoteConfig.instance;
     await initializeExplicit(freshRemoteConfig);
   }
 
+  /** Only intended for use in test code.  Should not be called from production code. */
   @visibleForTesting
   static void clean() {
     _remoteConfig = null;
     _prefs = null;
   }
 
+  /**
+   * Initialize RemoteConfigUtils with a pre-built RemoteConfig object.
+   * Only intended for use in test code.  Should not be called from production code.
+   */
   @visibleForTesting
   static Future<void> initializeExplicit(RemoteConfig remoteConfig) async {
     if (_remoteConfig != null) throw StateError('double-initialization of RemoteConfigUtils');
@@ -74,6 +82,7 @@ class RemoteConfigUtils {
     }
   }
 
+  /** Fetch the value (in string form) of the specified RemoteConfigParams element. */
   static String getStringValue(RemoteConfigParams rcParam) {
     if (_remoteConfig == null) throw StateError('RemoteConfigUtils not yet initialized');
 

--- a/apps/flutter_parent/pubspec.lock
+++ b/apps/flutter_parent/pubspec.lock
@@ -267,6 +267,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.1+2"
+  firebase_remote_config:
+    dependency: "direct main"
+    description:
+      name: firebase_remote_config
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0+3"
   fixnum:
     dependency: transitive
     description:

--- a/apps/flutter_parent/pubspec.yaml
+++ b/apps/flutter_parent/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   firebase_analytics: ^5.0.2
+  firebase_remote_config: ^0.3.0+3
   firebase_core: ^0.4.0+9
   flutter_crashlytics: ^1.0.0
   get_it: ^3.0.1

--- a/apps/flutter_parent/test/utils/remote_config_utils_test.dart
+++ b/apps/flutter_parent/test/utils/remote_config_utils_test.dart
@@ -44,43 +44,43 @@ void main() {
     final mockRemoteConfig = _setupMockRemoteConfig();
     await RemoteConfigUtils.initializeExplicit(mockRemoteConfig);
 
-    // default value = "hey there"
-    expect(RemoteConfigUtils.getStringValue(RemoteConfigParams.TEST_STRING), "hey there");
+    // default value = 'hey there'
+    expect(RemoteConfigUtils.getStringValue(RemoteConfigParams.TEST_STRING), 'hey there');
   });
 
   test('fetched value trumps default value', () async {
     // Start up with no cached values
     await setupPlatformChannels();
 
-    // Create a mocked RemoteConfig object that will fetch a "test_string" value
-    final mockRemoteConfig = _setupMockRemoteConfig(valueSettings: {"test_string": "fetched value"});
+    // Create a mocked RemoteConfig object that will fetch a 'test_string' value
+    final mockRemoteConfig = _setupMockRemoteConfig(valueSettings: {'test_string': 'fetched value'});
     await RemoteConfigUtils.initializeExplicit(mockRemoteConfig);
 
-    expect(RemoteConfigUtils.getStringValue(RemoteConfigParams.TEST_STRING), "fetched value");
+    expect(RemoteConfigUtils.getStringValue(RemoteConfigParams.TEST_STRING), 'fetched value');
   });
 
   test('cached value trumps default value', () async {
-    // Create a cached value for the "test string" flag.
-    var platformConfig = PlatformConfig(mockPrefs: {"rc_test_string": "cached value"});
+    // Create a cached value for the 'test string' flag.
+    var platformConfig = PlatformConfig(mockPrefs: {'rc_test_string': 'cached value'});
     await setupPlatformChannels(config: platformConfig);
 
     // Create a mocked RemoteConfig object that does not refresh its data.
     final mockRemoteConfig = _setupMockRemoteConfig();
     await RemoteConfigUtils.initializeExplicit(mockRemoteConfig);
 
-    expect(RemoteConfigUtils.getStringValue(RemoteConfigParams.TEST_STRING), "cached value");
+    expect(RemoteConfigUtils.getStringValue(RemoteConfigParams.TEST_STRING), 'cached value');
   });
 
   test('fetched value trumps cached value', () async {
-    // Create a cached value for the "test string" flag.
-    var platformConfig = PlatformConfig(mockPrefs: {"rc_test_string": "cached value"});
+    // Create a cached value for the 'test string' flag.
+    var platformConfig = PlatformConfig(mockPrefs: {'rc_test_string': 'cached value'});
     await setupPlatformChannels(config: platformConfig);
 
     // Create a mocked RemoteConfig object that refreshes with new data.
-    final mockRemoteConfig = _setupMockRemoteConfig(valueSettings: {"test_string": "fetched value"});
+    final mockRemoteConfig = _setupMockRemoteConfig(valueSettings: {'test_string': 'fetched value'});
     await RemoteConfigUtils.initializeExplicit(mockRemoteConfig);
 
-    expect(RemoteConfigUtils.getStringValue(RemoteConfigParams.TEST_STRING), "fetched value");
+    expect(RemoteConfigUtils.getStringValue(RemoteConfigParams.TEST_STRING), 'fetched value');
   });
 }
 

--- a/apps/flutter_parent/test/utils/remote_config_utils_test.dart
+++ b/apps/flutter_parent/test/utils/remote_config_utils_test.dart
@@ -1,0 +1,78 @@
+import 'package:firebase_remote_config/firebase_remote_config.dart';
+import 'package:flutter_parent/utils/remote_config_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import 'platform_config.dart';
+import 'test_app.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  RemoteConfig mockRemoteConfig;
+
+  tearDown(() {
+    RemoteConfigUtils.clean();
+  });
+
+  test('retrieval without initialization throws', () {
+    expect(() => RemoteConfigUtils.getStringValue(RemoteConfigParams.TEST_STRING), throwsStateError);
+  });
+
+  test('double initialization throws', () async {
+    await setupPlatformChannels();
+    final mockRemoteConfig = _setupMockRemoteConfig();
+    await RemoteConfigUtils.initializeExplicit(mockRemoteConfig);
+    expect(() async => await RemoteConfigUtils.initializeExplicit(mockRemoteConfig), throwsStateError);
+  });
+
+  test('unfetched variable yields default', () async {
+    // No cached values, no fetched values
+    await setupPlatformChannels();
+    final mockRemoteConfig = _setupMockRemoteConfig();
+    await RemoteConfigUtils.initializeExplicit(mockRemoteConfig);
+
+    // default value = "hey there"
+    expect(RemoteConfigUtils.getStringValue(RemoteConfigParams.TEST_STRING), "hey there");
+  });
+
+  test('fetched variable trumps default value', () async {
+    // Start up with no cached values
+    await setupPlatformChannels();
+
+    // Create a mocked RemoteConfig object that will fetch a "test_string" value
+    final mockRemoteConfig = _setupMockRemoteConfig(valueSettings: {"test_string": "fetched value"});
+    await RemoteConfigUtils.initializeExplicit(mockRemoteConfig);
+
+    expect(RemoteConfigUtils.getStringValue(RemoteConfigParams.TEST_STRING), "fetched value");
+  });
+
+  test('cached value trumps default value', () async {
+    // Create a cached value for the "test string" flag.
+    var platformConfig = PlatformConfig(mockPrefs: {"rc_test_string": "cached value"});
+    await setupPlatformChannels(config: platformConfig);
+
+    // Create a mocked RemoteConfig object that does not refresh its data.
+    final mockRemoteConfig = _setupMockRemoteConfig();
+    await RemoteConfigUtils.initializeExplicit(mockRemoteConfig);
+
+    expect(RemoteConfigUtils.getStringValue(RemoteConfigParams.TEST_STRING), "cached value");
+  });
+}
+
+// Create a mocked RemoteConfig object.
+// If valueSettings != null, then (1) a mocked settings fetch will occur, and (2) the retrieved
+// settings will correspond the specified values.
+_MockRemoteConfig _setupMockRemoteConfig({Map<String, String> valueSettings = null}) {
+  final mockRemoteConfig = _MockRemoteConfig();
+  when(mockRemoteConfig.fetch()).thenAnswer((_) => Future.value());
+  when(mockRemoteConfig.activateFetched()).thenAnswer((_) => Future.value(valueSettings != null));
+  if (valueSettings != null) {
+    valueSettings.forEach((key, value) {
+      when(mockRemoteConfig.getString(key)).thenAnswer((_) => value);
+    });
+  }
+
+  return mockRemoteConfig;
+}
+
+class _MockRemoteConfig extends Mock implements RemoteConfig {}

--- a/apps/flutter_parent/test/utils/remote_config_utils_test.dart
+++ b/apps/flutter_parent/test/utils/remote_config_utils_test.dart
@@ -1,3 +1,17 @@
+// Copyright (C) 2019 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import 'package:firebase_remote_config/firebase_remote_config.dart';
 import 'package:flutter_parent/utils/remote_config_utils.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -8,7 +22,6 @@ import 'test_app.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  RemoteConfig mockRemoteConfig;
 
   tearDown(() {
     RemoteConfigUtils.clean();
@@ -25,7 +38,7 @@ void main() {
     expect(() async => await RemoteConfigUtils.initializeExplicit(mockRemoteConfig), throwsStateError);
   });
 
-  test('unfetched variable yields default', () async {
+  test('unfetched, uncached value yields default', () async {
     // No cached values, no fetched values
     await setupPlatformChannels();
     final mockRemoteConfig = _setupMockRemoteConfig();
@@ -35,7 +48,7 @@ void main() {
     expect(RemoteConfigUtils.getStringValue(RemoteConfigParams.TEST_STRING), "hey there");
   });
 
-  test('fetched variable trumps default value', () async {
+  test('fetched value trumps default value', () async {
     // Start up with no cached values
     await setupPlatformChannels();
 
@@ -56,6 +69,18 @@ void main() {
     await RemoteConfigUtils.initializeExplicit(mockRemoteConfig);
 
     expect(RemoteConfigUtils.getStringValue(RemoteConfigParams.TEST_STRING), "cached value");
+  });
+
+  test('fetched value trumps cached value', () async {
+    // Create a cached value for the "test string" flag.
+    var platformConfig = PlatformConfig(mockPrefs: {"rc_test_string": "cached value"});
+    await setupPlatformChannels(config: platformConfig);
+
+    // Create a mocked RemoteConfig object that refreshes with new data.
+    final mockRemoteConfig = _setupMockRemoteConfig(valueSettings: {"test_string": "fetched value"});
+    await RemoteConfigUtils.initializeExplicit(mockRemoteConfig);
+
+    expect(RemoteConfigUtils.getStringValue(RemoteConfigParams.TEST_STRING), "fetched value");
   });
 }
 


### PR DESCRIPTION
For now, this does not include an rc-settings page where you can enforce local overrides.  That will need to be a separate ticket.

Works very similar to native Android RemoteConfigUtils: remote config values are stored in shared preferences.  When we fetch updates from Firebase, we store them in shared preferences.  All reads are fetched from shared preferences.  Internal defaults are in effect until the initial Firebase read completes.