### PR TITLE
[Flutter-Parent][MBL-13598] Login improvements

### DIFF
--- a/apps/flutter_parent/lib/l10n/app_localizations.dart
+++ b/apps/flutter_parent/lib/l10n/app_localizations.dart
@@ -750,6 +750,48 @@ class AppLocalizations {
         desc: 'The generic error shown when we are unable to verify with Canvas',
       );
 
+  // Skip non translatable (support only)
+  String get skipMobileVerifyTitle => Intl.message(
+        'Skipping Mobile Verify…',
+        skip: true,
+      );
+
+  // Skip non translatable (support only)
+  String get skipMobileVerifyProtocol => Intl.message(
+        'https',
+        skip: true,
+      );
+
+  // Skip non translatable (support only)
+  String get skipMobileVerifyProtocolMissing => Intl.message(
+        'Must provide a protocol',
+        skip: true,
+      );
+
+  // Skip non translatable (support only)
+  String get skipMobileVerifyClientId => Intl.message(
+        'Client Id',
+        skip: true,
+      );
+
+  // Skip non translatable (support only)
+  String get skipMobileVerifyClientIdMissing => Intl.message(
+        'Must provide a client id',
+        skip: true,
+      );
+
+  // Skip non translatable (support only)
+  String get skipMobileVerifyClientSecret => Intl.message(
+        'Client Secret',
+        skip: true,
+      );
+
+  // Skip non translatable (support only)
+  String get skipMobileVerifyClientSecretMissing => Intl.message(
+        'Must provide a client secret',
+        skip: true,
+      );
+
   /// Reminders
 
   String get remindersNotificationChannelName => Intl.message(

--- a/apps/flutter_parent/lib/screens/domain_search/domain_search_screen.dart
+++ b/apps/flutter_parent/lib/screens/domain_search/domain_search_screen.dart
@@ -271,7 +271,8 @@ class _DomainSearchScreenState extends State<DomainSearchScreen> {
 
   void _next(BuildContext context) {
     var domain = _query;
-    if (domain.indexOf('.') == -1) domain += '.instructure.com';
+    if (domain.startsWith('www.')) domain = domain.substring(4); // Strip off www. if they typed it
+    if (!domain.contains('.') || domain.endsWith('.beta')) domain += '.instructure.com';
     locator<QuickNav>().pushRoute(context, PandaRouter.loginWeb(domain, loginFlow: widget.loginFlow));
   }
 }

--- a/apps/flutter_parent/test/screens/login/domain_search_screen_test.dart
+++ b/apps/flutter_parent/test/screens/login/domain_search_screen_test.dart
@@ -338,7 +338,7 @@ void main() {
     var interactor = MockInteractor();
     when(interactor.performSearch(any)).thenAnswer((_) => Future.value([
           SchoolDomain((sd) => sd
-            ..domain = 'mobileqa.instructure.com'
+            ..domain = 'mobileqa'
             ..name = 'Result')
         ]));
     final webInteractor = _MockWebLoginInteractor();
@@ -354,7 +354,10 @@ void main() {
     await tester.tap(find.text(l10n.next));
     await tester.pumpAndSettle();
 
-    expect(find.byType(WebLoginScreen), findsOneWidget);
+    final webLogin = find.byType(WebLoginScreen);
+    expect(webLogin, findsOneWidget);
+    // Should also append .instructure.com to single word queries
+    expect(tester.widget<WebLoginScreen>(webLogin).domain, "mobileqa.instructure.com");
   });
 
   testWidgets('Navigates to Login page from keyboard submit button', (WidgetTester tester) async {
@@ -384,7 +387,7 @@ void main() {
     var interactor = MockInteractor();
     when(interactor.performSearch(any)).thenAnswer((_) => Future.value([
           SchoolDomain((sd) => sd
-            ..domain = 'mobileqa.instructure.com'
+            ..domain = 'mobileqa'
             ..name = 'Result')
         ]));
     final webInteractor = _MockWebLoginInteractor();
@@ -405,6 +408,50 @@ void main() {
 
     WebLoginScreen webLogin = tester.widget(find.byType(WebLoginScreen));
     expect(webLogin.loginFlow, flow);
+  });
+
+  testWidgets('Adds .instructure.com to .beta search text', (WidgetTester tester) async {
+    var interactor = MockInteractor();
+    when(interactor.performSearch(any)).thenAnswer((_) => Future.value([]));
+    final webInteractor = _MockWebLoginInteractor();
+    when(webInteractor.mobileVerify(any)).thenAnswer((_) => Future.value(MobileVerifyResult()));
+    _setupLocator(interactor, webInteractor: webInteractor);
+
+    await tester.pumpWidget(TestApp(DomainSearchScreen()));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'mobileqa.beta');
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text(l10n.next));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(WebLoginScreen), findsOneWidget);
+
+    WebLoginScreen webLogin = tester.widget(find.byType(WebLoginScreen));
+    expect(webLogin.domain, 'mobileqa.beta.instructure.com');
+  });
+
+  testWidgets('clears leading www. from search text', (WidgetTester tester) async {
+    var interactor = MockInteractor();
+    when(interactor.performSearch(any)).thenAnswer((_) => Future.value([]));
+    final webInteractor = _MockWebLoginInteractor();
+    when(webInteractor.mobileVerify(any)).thenAnswer((_) => Future.value(MobileVerifyResult()));
+    _setupLocator(interactor, webInteractor: webInteractor);
+
+    await tester.pumpWidget(TestApp(DomainSearchScreen()));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'www.mobileqa.beta');
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text(l10n.next));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(WebLoginScreen), findsOneWidget);
+
+    WebLoginScreen webLogin = tester.widget(find.byType(WebLoginScreen));
+    expect(webLogin.domain, 'mobileqa.beta.instructure.com');
   });
 }
 

--- a/apps/flutter_parent/test/screens/login/web_login_screen_test.dart
+++ b/apps/flutter_parent/test/screens/login/web_login_screen_test.dart
@@ -191,6 +191,66 @@ void main() {
 
     expect(find.byType(Dialog), findsNothing);
   });
+
+  testWidgetsWithAccessibilityChecks('Shows a skip verify dialog when that is the login type', (tester) async {
+    final domain = 'domain';
+    final interactor = _MockWebLoginInteractor();
+    when(interactor.mobileVerify(domain)).thenAnswer((_) => Future.value());
+    when(interactor.performLogin(any, any)).thenAnswer((_) => Future.value());
+    _setupLocator(webInteractor: interactor);
+
+    await tester.pumpWidget(TestApp(
+      WebLoginScreen(domain, loginFlow: LoginFlow.skipMobileVerify),
+      platformConfig: PlatformConfig(initWebview: true),
+    ));
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(Duration(milliseconds: 1000));
+
+    expect(find.byType(Dialog), findsOneWidget);
+    expect(find.text(AppLocalizations().skipMobileVerifyTitle), findsOneWidget);
+
+    // Tap ok, verify we still have a dialog when id/secret are empty
+    await tester.tap(find.text(AppLocalizations().ok));
+    await tester.pump();
+    expect(find.byType(Dialog), findsOneWidget);
+
+    await tester.enterText(find.byKey(Key(WebLoginScreen.ID_SKIP_VERIFY_KEY)), 'id');
+    await tester.enterText(find.byKey(Key(WebLoginScreen.SECRET_SKIP_VERIFY_KEY)), 'secret');
+
+    // Tap ok, verify the dialog is gone now
+    await tester.tap(find.text(AppLocalizations().ok.toUpperCase()));
+    await tester.pump();
+    await tester.pump();
+    expect(find.byType(Dialog), findsNothing);
+
+    verifyNever(interactor.mobileVerify(any));
+  });
+
+  testWidgetsWithAccessibilityChecks('Can cancel a skip verify dialog when that is the login type', (tester) async {
+    final domain = 'domain';
+    final interactor = _MockWebLoginInteractor();
+    when(interactor.mobileVerify(domain)).thenAnswer((_) => Future.value());
+    when(interactor.performLogin(any, any)).thenAnswer((_) => Future.value());
+    _setupLocator(webInteractor: interactor);
+
+    await tester.pumpWidget(TestApp(
+      WebLoginScreen(domain, loginFlow: LoginFlow.skipMobileVerify),
+      platformConfig: PlatformConfig(initWebview: true),
+    ));
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(Duration(milliseconds: 1000));
+
+    expect(find.byType(Dialog), findsOneWidget);
+    expect(find.text(AppLocalizations().skipMobileVerifyTitle), findsOneWidget);
+
+    await tester.tap(find.text(AppLocalizations().cancel.toUpperCase()));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Dialog), findsNothing);
+    verify(interactor.mobileVerify(any));
+  });
 }
 
 class _MockWebLoginInteractor extends Mock implements WebLoginInteractor {}


### PR DESCRIPTION
To test:
* Try entering in the domain search www.<sandbox> and make sure it still works (strips out www.)
* Try skipping mobile verify and using the expiring refresh token key in mobile dev (manually input client id/secret from the key)
* Special test: Pull down the code, change the user-agent header in AuthApi to ‘candroid’ -> Try loading canvas.sfu.ca and verify you get redirected (doesn’t allow ‘canvasParent’ normally)