### PR TITLE
[Flutter-Parent] Update alert count when switching students

### DIFF
--- a/apps/flutter_parent/lib/screens/alerts/alerts_interactor.dart
+++ b/apps/flutter_parent/lib/screens/alerts/alerts_interactor.dart
@@ -15,6 +15,7 @@
 import 'package:flutter_parent/models/alert.dart';
 import 'package:flutter_parent/models/alert_threshold.dart';
 import 'package:flutter_parent/network/api/alert_api.dart';
+import 'package:flutter_parent/screens/dashboard/alert_notifier.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
 
 class AlertsInteractor {
@@ -29,6 +30,8 @@ class AlertsInteractor {
 
     final thresholdsFuture = _alertsApi().getAlertThresholds(studentId, forceRefresh);
 
+    // If forcing a refresh, also update the alert count
+    if (forceRefresh) locator<AlertCountNotifier>().update(studentId);
     return AlertsList(await alertsFuture, await thresholdsFuture);
   }
 

--- a/apps/flutter_parent/lib/screens/dashboard/selected_student_notifier.dart
+++ b/apps/flutter_parent/lib/screens/dashboard/selected_student_notifier.dart
@@ -14,11 +14,14 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_parent/models/user.dart';
+import 'package:flutter_parent/screens/dashboard/alert_notifier.dart';
+import 'package:flutter_parent/utils/service_locator.dart';
 
 class SelectedStudentNotifier extends ValueNotifier<User> {
   SelectedStudentNotifier() : super(null);
 
   update(User student) {
     value = student;
+    locator<AlertCountNotifier>().update(student.id);
   }
 }

--- a/apps/flutter_parent/lib/screens/dashboard/student_horizontal_list_view.dart
+++ b/apps/flutter_parent/lib/screens/dashboard/student_horizontal_list_view.dart
@@ -55,7 +55,7 @@ class StudentHorizontalListViewState extends State<StudentHorizontalListView> {
       onTap: () {
         var idx = widget._students.indexOf(student);
         ParentTheme.of(context).studentIndex = idx;
-        Provider.of<SelectedStudentNotifier>(context, listen: false).value = student;
+        Provider.of<SelectedStudentNotifier>(context, listen: false).update(student);
         ApiPrefs.setCurrentStudent(student);
         widget.onTap();
       },

--- a/apps/flutter_parent/test/screens/alerts/alerts_screen_test.dart
+++ b/apps/flutter_parent/test/screens/alerts/alerts_screen_test.dart
@@ -487,7 +487,7 @@ Widget _testableWidget({User student}) {
   return TestApp(
     ChangeNotifierProvider(
       create: (context) =>
-          SelectedStudentNotifier()..update(CanvasModelTestUtils.mockUser(id: _studentId, name: 'Trevor')),
+          SelectedStudentNotifier()..value = CanvasModelTestUtils.mockUser(id: _studentId, name: 'Trevor'),
       child: Consumer<SelectedStudentNotifier>(builder: (context, model, _) {
         return Scaffold(body: AlertsScreen());
       }),

--- a/apps/flutter_parent/test/screens/calendar/calendar_screen_test.dart
+++ b/apps/flutter_parent/test/screens/calendar/calendar_screen_test.dart
@@ -312,7 +312,7 @@ Widget _testableMaterialWidget({Widget widget, SelectedStudentNotifier notifier 
     TestApp(
       ChangeNotifierProvider<SelectedStudentNotifier>(
           create: (context) => notifier ?? SelectedStudentNotifier()
-            ..update(_mockStudent('1')),
+            ..value = _mockStudent('1'),
           child: Consumer<SelectedStudentNotifier>(
             builder: (context, model, _) {
               return Scaffold(body: widget ?? CalendarScreen());

--- a/apps/flutter_parent/test/screens/courses/courses_screen_test.dart
+++ b/apps/flutter_parent/test/screens/courses/courses_screen_test.dart
@@ -29,6 +29,7 @@ import 'package:flutter_parent/screens/courses/courses_interactor.dart';
 import 'package:flutter_parent/screens/courses/courses_screen.dart';
 import 'package:flutter_parent/screens/courses/details/course_details_interactor.dart';
 import 'package:flutter_parent/screens/courses/details/course_details_screen.dart';
+import 'package:flutter_parent/screens/dashboard/alert_notifier.dart';
 import 'package:flutter_parent/screens/dashboard/selected_student_notifier.dart';
 import 'package:flutter_parent/utils/common_widgets/empty_panda_widget.dart';
 import 'package:flutter_parent/utils/common_widgets/error_panda_widget.dart';
@@ -56,12 +57,13 @@ void main() {
     _locator.registerLazySingleton<Analytics>(() => Analytics());
 
     _locator.registerLazySingleton<SelectedStudentNotifier>(() => notifier ?? SelectedStudentNotifier());
+    _locator.registerLazySingleton<AlertCountNotifier>(() => _MockAlertCountNotifier());
   }
 
   Widget _testableMaterialWidget({Widget widget, SelectedStudentNotifier notifier = null}) => TestApp(
         ChangeNotifierProvider<SelectedStudentNotifier>(
             create: (context) => notifier ?? SelectedStudentNotifier()
-              ..update(_mockStudent('1')),
+              ..value = _mockStudent('1'),
             child: Consumer<SelectedStudentNotifier>(
               builder: (context, model, _) {
                 return Scaffold(body: widget ?? CoursesScreen());
@@ -325,6 +327,8 @@ class _MockCourseDetailsInteractor extends CourseDetailsInteractor {}
 class _MockAssignmentApi extends Mock implements AssignmentApi {}
 
 class _MockCourseApi extends Mock implements CourseApi {}
+
+class _MockAlertCountNotifier extends Mock implements AlertCountNotifier {}
 
 List<Course> generateCoursesForStudent(String userId, {int numberOfCourses = 1}) {
   var student = _mockStudent(userId);

--- a/apps/flutter_parent/test/screens/dashboard/student_horizontal_list_view_test.dart
+++ b/apps/flutter_parent/test/screens/dashboard/student_horizontal_list_view_test.dart
@@ -15,6 +15,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_parent/l10n/app_localizations.dart';
 import 'package:flutter_parent/network/utils/analytics.dart';
+import 'package:flutter_parent/screens/dashboard/alert_notifier.dart';
 import 'package:flutter_parent/screens/dashboard/selected_student_notifier.dart';
 import 'package:flutter_parent/screens/dashboard/student_horizontal_list_view.dart';
 import 'package:flutter_parent/screens/manage_students/add_student_dialog.dart';
@@ -62,9 +63,11 @@ void main() {
       };
 
       var notifier = SelectedStudentNotifier();
+      final alertNotifier = _MockAlertCountNotifier();
 
       setupTestLocator((locator) {
         locator.registerLazySingleton<SelectedStudentNotifier>(() => notifier);
+        locator.registerLazySingleton<AlertCountNotifier>(() => alertNotifier);
       });
 
       // Setup the widget
@@ -95,6 +98,7 @@ void main() {
 
       // Check to make sure we called the onTap function passed in
       expect(called, true);
+      verify(alertNotifier.update(student2.id)).called(1);
     });
 
     testWidgetsWithAccessibilityChecks('add student tap shows add student dialog', (tester) async {
@@ -219,3 +223,5 @@ class SelectedStudentNotifierTestApp extends StatelessWidget {
 class _MockManageStudentsInteractor extends Mock implements ManageStudentsInteractor {}
 
 class _MockAnalytics extends Mock implements Analytics {}
+
+class _MockAlertCountNotifier extends Mock implements AlertCountNotifier {}


### PR DESCRIPTION
To test:
Have two students under an observer, with different amounts of alerts (create an alert in the course for student 1, but no alerts for courses for student2).
Switch between the two students, make sue the alert count notifier updates properly.
Also, PTR on the alerts screen should now update the alert count as well.