### PR TITLE
[Flutter Parent][MBL-14193] A11y fix for light/dark mode buttons

### DIFF
--- a/apps/flutter_parent/lib/screens/settings/settings_screen.dart
+++ b/apps/flutter_parent/lib/screens/settings/settings_screen.dart
@@ -63,28 +63,32 @@ class _SettingsScreenState extends State<SettingsScreen> {
   Widget _themeButtons(BuildContext context) {
     return Padding(
       padding: EdgeInsets.zero,
-      child: Container(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: <Widget>[
-            _themeOption(
-              anchorKey: _lightModeKey,
-              buttonKey: Key('light-mode-button'),
-              context: context,
-              selected: !ParentTheme.of(context).isDarkMode,
-              semanticsLabel: L10n(context).lightModeLabel,
-              child: SvgPicture.asset('assets/svg/panda-light-mode.svg'),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: <Widget>[
+          _themeOption(
+            anchorKey: _lightModeKey,
+            buttonKey: Key('light-mode-button'),
+            context: context,
+            selected: !ParentTheme.of(context).isDarkMode,
+            semanticsLabel: L10n(context).lightModeLabel,
+            child: SvgPicture.asset(
+              'assets/svg/panda-light-mode.svg',
+              excludeFromSemantics: true, // Semantic label is set in _themeOption()
             ),
-            _themeOption(
-              anchorKey: _darkModeKey,
-              buttonKey: Key('dark-mode-button'),
-              context: context,
-              selected: ParentTheme.of(context).isDarkMode,
-              semanticsLabel: L10n(context).darkModeLabel,
-              child: SvgPicture.asset('assets/svg/panda-dark-mode.svg'),
+          ),
+          _themeOption(
+            anchorKey: _darkModeKey,
+            buttonKey: Key('dark-mode-button'),
+            context: context,
+            selected: ParentTheme.of(context).isDarkMode,
+            semanticsLabel: L10n(context).darkModeLabel,
+            child: SvgPicture.asset(
+              'assets/svg/panda-dark-mode.svg',
+              excludeFromSemantics: true, // Semantic label is set in _themeOption()
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
@@ -98,33 +102,36 @@ class _SettingsScreenState extends State<SettingsScreen> {
     Widget child,
   }) {
     double size = 140;
-    return Container(
-      key: anchorKey,
-      width: size,
-      height: size,
-      padding: EdgeInsets.all(5),
-      foregroundDecoration: selected
-          ? BoxDecoration(
-              borderRadius: BorderRadius.circular(100),
-              border: Border.all(color: Theme.of(context).accentColor, width: 2),
-            )
-          : null,
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(100),
-        child: Stack(
-          children: <Widget>[
-            child,
-            Material(
-              type: MaterialType.transparency,
-              child: Semantics(
-                label: semanticsLabel,
+    return Semantics(
+      selected: selected,
+      label: semanticsLabel,
+      inMutuallyExclusiveGroup: true,
+      button: true,
+      child: Container(
+        key: anchorKey,
+        width: size,
+        height: size,
+        padding: EdgeInsets.all(5),
+        foregroundDecoration: selected
+            ? BoxDecoration(
+                borderRadius: BorderRadius.circular(100),
+                border: Border.all(color: Theme.of(context).accentColor, width: 2),
+              )
+            : null,
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(100),
+          child: Stack(
+            children: <Widget>[
+              child,
+              Material(
+                type: MaterialType.transparency,
                 child: InkWell(
                   key: buttonKey,
                   onTap: selected ? null : () => _interactor.toggleDarkMode(context, anchorKey),
                 ),
-              ),
-            )
-          ],
+              )
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
This fixes an issues where light/dark mode buttons were missing semantic labels and did not indicate the selected state when using a screen reader