### PR TITLE
[Flutter Parent] Support dark mode in WebViews where possible

### DIFF
--- a/apps/flutter_parent/lib/l10n/app_localizations.dart
+++ b/apps/flutter_parent/lib/l10n/app_localizations.dart
@@ -908,6 +908,9 @@ class AppLocalizations {
   String get highContrastLabel =>
       Intl.message('High Contrast Mode', desc: 'Label for the switch that toggles high contrast mode');
 
+  String get webViewDarkModeLabel =>
+      Intl.message('Use Dark Theme in Web Content', desc: 'Label for the switch that toggles dark mode for webviews');
+
   String get appearance => Intl.message('Appearance', desc: 'Label for the appearance section in the settings page');
 
   /// Grade cell

--- a/apps/flutter_parent/lib/screens/help/terms_of_use_screen.dart
+++ b/apps/flutter_parent/lib/screens/help/terms_of_use_screen.dart
@@ -67,6 +67,7 @@ class _TermsOfUseScreenState extends State<TermsOfUseScreen> {
               onWebViewCreated: (controller) {
                 controller.loadHtml(snapshot.data.content, horizontalPadding: 16);
               },
+              darkMode: ParentTheme.of(context).isDarkMode,
             );
           },
         ),

--- a/apps/flutter_parent/lib/screens/help/terms_of_use_screen.dart
+++ b/apps/flutter_parent/lib/screens/help/terms_of_use_screen.dart
@@ -64,10 +64,10 @@ class _TermsOfUseScreenState extends State<TermsOfUseScreen> {
 
             // Content
             return WebView(
+              darkMode: ParentTheme.of(context).isWebViewDarkMode,
               onWebViewCreated: (controller) {
                 controller.loadHtml(snapshot.data.content, horizontalPadding: 16);
               },
-              darkMode: ParentTheme.of(context).isDarkMode,
             );
           },
         ),

--- a/apps/flutter_parent/lib/screens/settings/settings_screen.dart
+++ b/apps/flutter_parent/lib/screens/settings/settings_screen.dart
@@ -51,6 +51,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
               _themeButtons(context),
               SizedBox(height: 16),
+              if (ParentTheme.of(context).isDarkMode) _webViewDarkModeSwitch(context),
               _highContrastModeSwitch(context),
               if (_interactor.isDebugMode()) _themeViewer(context),
             ],
@@ -128,6 +129,24 @@ class _SettingsScreenState extends State<SettingsScreen> {
         ),
       ),
     );
+  }
+
+  Widget _webViewDarkModeSwitch(BuildContext context) {
+    return MergeSemantics(
+      child: ListTile(
+        title: Text(L10n(context).webViewDarkModeLabel),
+        trailing: Switch(
+          value: ParentTheme.of(context).isWebViewDarkMode,
+          onChanged: (_) => _toggleWebViewDarkMode(context),
+          materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        ),
+        onTap: () => _toggleWebViewDarkMode(context),
+      ),
+    );
+  }
+
+  _toggleWebViewDarkMode(BuildContext context) {
+    ParentTheme.of(context).toggleWebViewDarkMode();
   }
 
   Widget _highContrastModeSwitch(BuildContext context) {

--- a/apps/flutter_parent/lib/screens/web_login/web_login_screen.dart
+++ b/apps/flutter_parent/lib/screens/web_login/web_login_screen.dart
@@ -121,7 +121,7 @@ class _WebLoginScreenState extends State<WebLoginScreen> {
     return WebView(
       navigationDelegate: (request) => _navigate(context, request, verifyResult),
       javascriptMode: JavascriptMode.unrestricted,
-      darkMode: ParentTheme.of(context).isDarkMode,
+      darkMode: ParentTheme.of(context).isWebViewDarkMode,
       userAgent: ApiPrefs.getUserAgent(),
       onPageFinished: (url) => _pageFinished(url, verifyResult),
       onWebViewCreated: (controller) => _webViewCreated(controller, verifyResult),

--- a/apps/flutter_parent/lib/screens/web_login/web_login_screen.dart
+++ b/apps/flutter_parent/lib/screens/web_login/web_login_screen.dart
@@ -121,6 +121,7 @@ class _WebLoginScreenState extends State<WebLoginScreen> {
     return WebView(
       navigationDelegate: (request) => _navigate(context, request, verifyResult),
       javascriptMode: JavascriptMode.unrestricted,
+      darkMode: ParentTheme.of(context).isDarkMode,
       userAgent: ApiPrefs.getUserAgent(),
       onPageFinished: (url) => _pageFinished(url, verifyResult),
       onWebViewCreated: (controller) => _webViewCreated(controller, verifyResult),

--- a/apps/flutter_parent/lib/utils/common_widgets/web_view/canvas_web_view.dart
+++ b/apps/flutter_parent/lib/utils/common_widgets/web_view/canvas_web_view.dart
@@ -175,7 +175,7 @@ class _ResizingWebViewState extends State<_ResizingWebView> {
       javascriptMode: JavascriptMode.unrestricted,
       onPageFinished: _handlePageLoaded,
       onWebViewCreated: _handleWebViewCreated,
-      darkMode: ParentTheme.of(context).isDarkMode,
+      darkMode: ParentTheme.of(context).isWebViewDarkMode,
       navigationDelegate: _handleNavigation,
       gestureRecognizers: _webViewGestures(),
       javascriptChannels: _webViewChannels(),

--- a/apps/flutter_parent/lib/utils/common_widgets/web_view/canvas_web_view.dart
+++ b/apps/flutter_parent/lib/utils/common_widgets/web_view/canvas_web_view.dart
@@ -18,6 +18,7 @@ import 'package:flutter_parent/l10n/app_localizations.dart';
 import 'package:flutter_parent/network/utils/api_prefs.dart';
 import 'package:flutter_parent/utils/common_widgets/loading_indicator.dart';
 import 'package:flutter_parent/utils/common_widgets/web_view/web_content_interactor.dart';
+import 'package:flutter_parent/utils/design/parent_theme.dart';
 import 'package:flutter_parent/utils/quick_nav.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
 import 'package:flutter_parent/utils/url_launcher.dart';
@@ -174,6 +175,7 @@ class _ResizingWebViewState extends State<_ResizingWebView> {
       javascriptMode: JavascriptMode.unrestricted,
       onPageFinished: _handlePageLoaded,
       onWebViewCreated: _handleWebViewCreated,
+      darkMode: ParentTheme.of(context).isDarkMode,
       navigationDelegate: _handleNavigation,
       gestureRecognizers: _webViewGestures(),
       javascriptChannels: _webViewChannels(),

--- a/apps/flutter_parent/lib/utils/common_widgets/web_view/simple_web_view_screen.dart
+++ b/apps/flutter_parent/lib/utils/common_widgets/web_view/simple_web_view_screen.dart
@@ -49,6 +49,7 @@ class _SimpleWebViewScreenState extends State<SimpleWebViewScreen> {
         body: WebView(
           javascriptMode: JavascriptMode.unrestricted,
           userAgent: ApiPrefs.getUserAgent(),
+          darkMode: ParentTheme.of(context).isDarkMode,
           gestureRecognizers: Set()..add(Factory<WebViewGestureRecognizer>(() => WebViewGestureRecognizer())),
           navigationDelegate: _handleNavigation,
           onWebViewCreated: (controller) {

--- a/apps/flutter_parent/lib/utils/common_widgets/web_view/simple_web_view_screen.dart
+++ b/apps/flutter_parent/lib/utils/common_widgets/web_view/simple_web_view_screen.dart
@@ -49,7 +49,7 @@ class _SimpleWebViewScreenState extends State<SimpleWebViewScreen> {
         body: WebView(
           javascriptMode: JavascriptMode.unrestricted,
           userAgent: ApiPrefs.getUserAgent(),
-          darkMode: ParentTheme.of(context).isDarkMode,
+          darkMode: ParentTheme.of(context).isWebViewDarkMode,
           gestureRecognizers: Set()..add(Factory<WebViewGestureRecognizer>(() => WebViewGestureRecognizer())),
           navigationDelegate: _handleNavigation,
           onWebViewCreated: (controller) {

--- a/apps/flutter_parent/lib/utils/design/parent_theme.dart
+++ b/apps/flutter_parent/lib/utils/design/parent_theme.dart
@@ -93,8 +93,18 @@ class _ParentThemeState extends State<ParentTheme> {
     });
   }
 
+  /// Sets whether the current theme should use dark mode for WebViews
+  set isWebViewDarkMode(bool isDark) {
+    setState(() {
+      widget.themePrefs.webViewDarkMode = isDark;
+    });
+  }
+
   /// Toggles dark mode for the current theme
   toggleDarkMode() => isDarkMode = !isDarkMode;
+
+  /// Toggles WebView dark mode for the current theme
+  toggleWebViewDarkMode() => isWebViewDarkMode = !isWebViewDarkMode;
 
   /// Sets whether the current theme should use high-contrast mode
   set isHC(bool isHC) {
@@ -108,6 +118,9 @@ class _ParentThemeState extends State<ParentTheme> {
 
   /// Returns true if dark mode is enabled for the current theme
   bool get isDarkMode => widget.themePrefs.darkMode;
+
+  /// Returns true if dark mode for WebViews is enabled for the current theme
+  bool get isWebViewDarkMode => widget.themePrefs.darkMode && widget.themePrefs.webViewDarkMode;
 
   /// Returns true if high-contrast mode is enabled for the current theme
   bool get isHC => widget.themePrefs.hcMode;

--- a/apps/flutter_parent/lib/utils/design/theme_prefs.dart
+++ b/apps/flutter_parent/lib/utils/design/theme_prefs.dart
@@ -17,6 +17,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 class ThemePrefs {
   static String PREF_KEY_DARK_MODE = 'dark_mode';
 
+  static String PREF_KEY_WEB_VIEW_DARK_MODE = 'web_view_dark_mode';
+
   static String PREF_KEY_HC_MODE = 'high_contrast_mode';
 
   static SharedPreferences _prefs;
@@ -33,6 +35,14 @@ class ThemePrefs {
   /// Sets the dark mode value. Note that calling this only changes the stored preference. To update the theme in use,
   /// prefer setting ParentTheme.of(context).isDarkMode
   set darkMode(bool value) => _prefs.setBool(PREF_KEY_DARK_MODE, value);
+
+  /// Returns the stored preference for dark mode for WebViews. The get the value for the theme in use,
+  /// call ParentTheme.of(context).isWebViewDarkMode
+  bool get webViewDarkMode => _prefs.getBool(PREF_KEY_WEB_VIEW_DARK_MODE) ?? false;
+
+  /// Sets the dark mode value for WebViews. Note that calling this only changes the stored preference. To update the
+  /// theme in use, prefer setting ParentTheme.of(context).isWebViewDarkMode
+  set webViewDarkMode(bool value) => _prefs.setBool(PREF_KEY_WEB_VIEW_DARK_MODE, value);
 
   /// Returns the stored preference for high-contrast mode. To get the value for the theme in use, call ParentTheme.of(context).isHC
   bool get hcMode => _prefs.getBool(PREF_KEY_HC_MODE) ?? false;

--- a/apps/flutter_parent/plugins/webview_flutter/android/build.gradle
+++ b/apps/flutter_parent/plugins/webview_flutter/android/build.gradle
@@ -34,6 +34,6 @@ android {
 
     dependencies {
         implementation 'androidx.annotation:annotation:1.0.0'
-        implementation 'androidx.webkit:webkit:1.0.0'
+        implementation 'androidx.webkit:webkit:1.2.0'
     }
 }

--- a/apps/flutter_parent/plugins/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/apps/flutter_parent/plugins/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -23,6 +23,8 @@ import android.view.View;
 import android.webkit.WebStorage;
 import android.webkit.WebViewClient;
 import android.webkit.CookieManager;
+import androidx.webkit.WebSettingsCompat;
+import androidx.webkit.WebViewFeature;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -330,9 +332,21 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
         case "userAgent":
           updateUserAgent((String) settings.get(key));
           break;
+        case "darkMode":
+          setDarkMode((boolean) settings.get(key));
+          break;
         default:
           throw new IllegalArgumentException("Unknown WebView setting: " + key);
       }
+    }
+  }
+
+  private void setDarkMode(boolean darkMode) {
+    if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
+      int forceDarkMode = darkMode ? WebSettingsCompat.FORCE_DARK_ON : WebSettingsCompat.FORCE_DARK_OFF;
+      WebSettingsCompat.setForceDark(webView.getSettings(), forceDarkMode);
+    } else {
+      Log.d("FlutterWebView", "FORCE_DARK feature is not supported by this WebView");
     }
   }
 

--- a/apps/flutter_parent/plugins/webview_flutter/lib/platform_interface.dart
+++ b/apps/flutter_parent/plugins/webview_flutter/lib/platform_interface.dart
@@ -248,6 +248,7 @@ class WebSettings {
   WebSettings({
     this.javascriptMode,
     this.hasNavigationDelegate,
+    this.darkMode,
     this.debuggingEnabled,
     this.gestureNavigationEnabled,
     @required this.userAgent,
@@ -258,6 +259,8 @@ class WebSettings {
 
   /// Whether the [WebView] has a [NavigationDelegate] set.
   final bool hasNavigationDelegate;
+
+  final bool darkMode;
 
   /// Whether to enable the platform's webview content debugging tools.
   ///

--- a/apps/flutter_parent/plugins/webview_flutter/lib/src/webview_method_channel.dart
+++ b/apps/flutter_parent/plugins/webview_flutter/lib/src/webview_method_channel.dart
@@ -155,6 +155,7 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
 
     _addIfNonNull('jsMode', settings.javascriptMode?.index);
     _addIfNonNull('hasNavigationDelegate', settings.hasNavigationDelegate);
+    _addIfNonNull('darkMode', settings.darkMode);
     _addIfNonNull('debuggingEnabled', settings.debuggingEnabled);
     _addIfNonNull('gestureNavigationEnabled', settings.gestureNavigationEnabled);
     _addSettingIfPresent('userAgent', settings.userAgent);

--- a/apps/flutter_parent/plugins/webview_flutter/lib/webview_flutter.dart
+++ b/apps/flutter_parent/plugins/webview_flutter/lib/webview_flutter.dart
@@ -147,6 +147,7 @@ class WebView extends StatefulWidget {
     this.gestureRecognizers,
     this.onPageStarted,
     this.onPageFinished,
+    this.darkMode = false,
     this.debuggingEnabled = false,
     this.gestureNavigationEnabled = false,
     this.userAgent,
@@ -277,6 +278,8 @@ class WebView extends StatefulWidget {
   /// [WebViewController.evaluateJavascript] can assume this.
   final PageFinishedCallback onPageFinished;
 
+  final bool darkMode;
+
   /// Controls whether WebView debugging is enabled.
   ///
   /// Setting this to true enables [WebView debugging on Android](https://developers.google.com/web/tools/chrome-devtools/remote-debugging/).
@@ -390,6 +393,7 @@ WebSettings _webSettingsFromWidget(WebView widget) {
   return WebSettings(
     javascriptMode: widget.javascriptMode,
     hasNavigationDelegate: widget.navigationDelegate != null,
+    darkMode: widget.darkMode,
     debuggingEnabled: widget.debuggingEnabled,
     gestureNavigationEnabled: widget.gestureNavigationEnabled,
     userAgent: WebSetting<String>.of(widget.userAgent),
@@ -401,15 +405,18 @@ WebSettings _clearUnchangedWebSettings(
     WebSettings currentValue, WebSettings newValue) {
   assert(currentValue.javascriptMode != null);
   assert(currentValue.hasNavigationDelegate != null);
+  assert(currentValue.darkMode != null);
   assert(currentValue.debuggingEnabled != null);
   assert(currentValue.userAgent.isPresent);
   assert(newValue.javascriptMode != null);
   assert(newValue.hasNavigationDelegate != null);
+  assert(newValue.darkMode != null);
   assert(newValue.debuggingEnabled != null);
   assert(newValue.userAgent.isPresent);
 
   JavascriptMode javascriptMode;
   bool hasNavigationDelegate;
+  bool darkMode;
   bool debuggingEnabled;
   WebSetting<String> userAgent = WebSetting<String>.absent();
   if (currentValue.javascriptMode != newValue.javascriptMode) {
@@ -417,6 +424,9 @@ WebSettings _clearUnchangedWebSettings(
   }
   if (currentValue.hasNavigationDelegate != newValue.hasNavigationDelegate) {
     hasNavigationDelegate = newValue.hasNavigationDelegate;
+  }
+  if (currentValue.darkMode != newValue.darkMode) {
+    darkMode = newValue.darkMode;
   }
   if (currentValue.debuggingEnabled != newValue.debuggingEnabled) {
     debuggingEnabled = newValue.debuggingEnabled;
@@ -428,6 +438,7 @@ WebSettings _clearUnchangedWebSettings(
   return WebSettings(
     javascriptMode: javascriptMode,
     hasNavigationDelegate: hasNavigationDelegate,
+    darkMode: darkMode,
     debuggingEnabled: debuggingEnabled,
     userAgent: userAgent,
   );

--- a/apps/flutter_parent/test/screens/settings/settings_screen_test.dart
+++ b/apps/flutter_parent/test/screens/settings/settings_screen_test.dart
@@ -33,6 +33,7 @@ void main() {
   darkModeButton() => find.byKey(Key('dark-mode-button'));
   lightModeButton() => find.byKey(Key('light-mode-button'));
   hcToggle() => find.text(l10n.highContrastLabel);
+  webViewDarkModeToggle() => find.text(l10n.webViewDarkModeLabel);
 
   setUpAll(() {
     interactor = _MockInteractor();
@@ -131,6 +132,34 @@ void main() {
 
     state = tester.state(find.byType(SettingsScreen));
     expect(ParentTheme.of(state.context).isHC, isTrue);
+  });
+
+  testWidgetsWithAccessibilityChecks('Hides WebView dark mode toggle in light mode', (tester) async {
+    await tester.pumpWidget(TestApp(SettingsScreen()));
+    await tester.pumpAndSettle();
+
+    expect(webViewDarkModeToggle(), findsNothing);
+  });
+
+  testWidgetsWithAccessibilityChecks('Shows WebView dark mode toggle in dark mode', (tester) async {
+    await tester.pumpWidget(TestApp(SettingsScreen(), darkMode: true));
+    await tester.pumpAndSettle();
+
+    expect(webViewDarkModeToggle(), findsOneWidget);
+  });
+
+  testWidgetsWithAccessibilityChecks('Enables WebView dark mode', (tester) async {
+    await tester.pumpWidget(TestApp(SettingsScreen(), darkMode: true));
+    await tester.pumpAndSettle();
+
+    var state = tester.state(find.byType(SettingsScreen));
+    expect(ParentTheme.of(state.context).isWebViewDarkMode, isFalse);
+
+    await tester.tap(webViewDarkModeToggle());
+    await tester.pumpAndSettle();
+
+    state = tester.state(find.byType(SettingsScreen));
+    expect(ParentTheme.of(state.context).isWebViewDarkMode, isTrue);
   });
 }
 

--- a/apps/flutter_parent/test/utils/test_app.dart
+++ b/apps/flutter_parent/test/utils/test_app.dart
@@ -148,6 +148,7 @@ class MockThemePrefs extends ThemePrefs {
   MockThemePrefs(this._darkMode, this._hcMode);
 
   bool _darkMode;
+  bool _webViewDarkMode = false;
   bool _hcMode;
 
   @override
@@ -155,6 +156,12 @@ class MockThemePrefs extends ThemePrefs {
 
   @override
   set darkMode(bool value) => _darkMode = value;
+
+  @override
+  bool get webViewDarkMode => _webViewDarkMode;
+
+  @override
+  set webViewDarkMode(bool value) => _webViewDarkMode = value;
 
   @override
   bool get hcMode => _hcMode;


### PR DESCRIPTION
This change updates the androidx webkit dependency to add support for dark mode in WebViews. This requires a recent version of the native WebView to test, so it may not work on emulators without Google Play. Tested working on an Android 7 emulator w/ Google Play and an up-to-date physical device running Lollipop. 

Note that the background of WebViews in dark mode is a very dark gray, which doesn't fully match the app's completely black background. Cursory research on this issue did not reveal an easy fix, so we may just have to live with it.