### PR TITLE
[Flutter-Parent] Fix student switcher in RTL

### DIFF
--- a/apps/flutter_parent/lib/screens/dashboard/student_horizontal_list_view.dart
+++ b/apps/flutter_parent/lib/screens/dashboard/student_horizontal_list_view.dart
@@ -81,7 +81,6 @@ class StudentHorizontalListViewState extends State<StudentHorizontalListView> {
                   key: Key("${student.shortName}_text"),
                   style: Theme.of(context).textTheme.subtitle.copyWith(color: ParentTheme.of(context).onSurfaceColor),
                   overflow: TextOverflow.ellipsis,
-                  textWidthBasis: TextWidthBasis.longestLine,
                 ),
               ],
             ),


### PR DESCRIPTION
To test:
Student names should be centered, even when in an RTL language