### PR TITLE
[Flutter-Parent] Fix course grade having no padding

### DIFF
--- a/apps/flutter_parent/lib/screens/courses/details/course_grades_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_grades_screen.dart
@@ -178,6 +178,7 @@ class _CourseGradeHeader extends StatelessWidget {
 
     return Column(
       children: [
+        if (gradingPeriodHeader != null || gradeTotalHeader != null) SizedBox(height: 16),
         if (gradingPeriodHeader != null) gradingPeriodHeader,
         if (gradingPeriodHeader != null && gradeTotalHeader != null) SizedBox(height: 4),
         if (gradeTotalHeader != null) gradeTotalHeader,
@@ -202,10 +203,7 @@ class _CourseGradeHeader extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.baseline,
         textBaseline: TextBaseline.ideographic,
         children: <Widget>[
-          Padding(
-            padding: const EdgeInsets.only(top: 16),
-            child: Text(gradingPeriod.title, style: Theme.of(context).textTheme.display1),
-          ),
+          Text(gradingPeriod.title, style: Theme.of(context).textTheme.display1),
           InkWell(
             child: ConstrainedBox(
               constraints: BoxConstraints(minHeight: 48, minWidth: 48), // For a11y


### PR DESCRIPTION
To test:
The course Android Dev on our mobiledev sandbox fits the criteria for only showing the grade, without showing the grading period header. Before, the grade was right against the top of the screen. Now there is padding whether there is just the grade, just the grading period header, or both.