### PR TITLE
[Flutter-Parent] More analytics

### DIFF
--- a/apps/flutter_parent/lib/network/utils/analytics.dart
+++ b/apps/flutter_parent/lib/network/utils/analytics.dart
@@ -32,6 +32,14 @@ class AnalyticsEventConstants {
   static String get HELP_DOMAIN_SEARCH => 'help_domain_search';
   static String get ADD_STUDENT_MANAGE_STUDENTS => 'add_student_manage_students';
   static String get ADD_STUDENT_DASHBOARD => 'add_student_dashboard';
+  static String get REMINDER_ASSIGNMENT_CREATE => 'reminder_assignment';
+  static String get REMINDER_EVENT_CREATE => 'reminder_event';
+  static String get DARK_MODE_ON => 'dark_mode_on';
+  static String get DARK_MODE_OFF => 'dark_mode_off';
+  static String get HC_MODE_ON => 'hc_mode_on';
+  static String get HC_MODE_OFF => 'hc_mode_off';
+  static String get DARK_WEB_MODE_ON => 'dark_web_mode_on';
+  static String get DARK_WEB_MODE_OFF => 'dark_web_mode_off';
 }
 
 /// (Copied from canvas-api-2, make sure to stay in sync)

--- a/apps/flutter_parent/lib/network/utils/analytics.dart
+++ b/apps/flutter_parent/lib/network/utils/analytics.dart
@@ -20,26 +20,26 @@ import 'package:flutter_parent/utils/debug_flags.dart';
 /// The naming scheme for the majority of these is found in a google doc so that we can be consistent
 /// across the platforms.
 class AnalyticsEventConstants {
-  static String get LOGIN_FAILURE => 'login_failure';
-  static String get LOGIN_SUCCESS => 'login_success';
-  static String get TOKEN_REFRESH_FAILURE => 'token_refresh_failure';
-  static String get TOKEN_REFRESH_FAILURE_TOKEN_NOT_VALID => 'token_refresh_failure_token_not_valid';
-  static String get TOKEN_REFRESH_FAILURE_NO_SECRET => 'token_refresh_failure_no_secret';
+  static const LOGIN_FAILURE = 'login_failure';
+  static const LOGIN_SUCCESS = 'login_success';
+  static const TOKEN_REFRESH_FAILURE = 'token_refresh_failure';
+  static const TOKEN_REFRESH_FAILURE_TOKEN_NOT_VALID = 'token_refresh_failure_token_not_valid';
+  static const TOKEN_REFRESH_FAILURE_NO_SECRET = 'token_refresh_failure_no_secret';
 
-  static String get LOGOUT => 'logout';
-  static String get SWITCH_USERS => 'switch_users';
-  static String get HELP_LOGIN => 'help_login';
-  static String get HELP_DOMAIN_SEARCH => 'help_domain_search';
-  static String get ADD_STUDENT_MANAGE_STUDENTS => 'add_student_manage_students';
-  static String get ADD_STUDENT_DASHBOARD => 'add_student_dashboard';
-  static String get REMINDER_ASSIGNMENT_CREATE => 'reminder_assignment';
-  static String get REMINDER_EVENT_CREATE => 'reminder_event';
-  static String get DARK_MODE_ON => 'dark_mode_on';
-  static String get DARK_MODE_OFF => 'dark_mode_off';
-  static String get HC_MODE_ON => 'hc_mode_on';
-  static String get HC_MODE_OFF => 'hc_mode_off';
-  static String get DARK_WEB_MODE_ON => 'dark_web_mode_on';
-  static String get DARK_WEB_MODE_OFF => 'dark_web_mode_off';
+  static const LOGOUT = 'logout';
+  static const SWITCH_USERS = 'switch_users';
+  static const HELP_LOGIN = 'help_login';
+  static const HELP_DOMAIN_SEARCH = 'help_domain_search';
+  static const ADD_STUDENT_MANAGE_STUDENTS = 'add_student_manage_students';
+  static const ADD_STUDENT_DASHBOARD = 'add_student_dashboard';
+  static const REMINDER_ASSIGNMENT_CREATE = 'reminder_assignment';
+  static const REMINDER_EVENT_CREATE = 'reminder_event';
+  static const DARK_MODE_ON = 'dark_mode_on';
+  static const DARK_MODE_OFF = 'dark_mode_off';
+  static const HC_MODE_ON = 'hc_mode_on';
+  static const HC_MODE_OFF = 'hc_mode_off';
+  static const DARK_WEB_MODE_ON = 'dark_web_mode_on';
+  static const DARK_WEB_MODE_OFF = 'dark_web_mode_off';
 }
 
 /// (Copied from canvas-api-2, make sure to stay in sync)
@@ -57,11 +57,11 @@ class AnalyticsEventConstants {
 ///   Used when events can originate from multiple locations
 ///
 class AnalyticsParamConstants {
-  static String get DOMAIN_PARAM => 'affiliation';
-  static String get USER_CONTEXT_ID => 'character';
-  static String get CANVAS_CONTEXT_ID => 'group_id';
-  static String get ASSIGNMENT_ID => 'item_id';
-  static String get SCREEN_OF_ORIGIN => 'origin';
+  static const DOMAIN_PARAM = 'affiliation';
+  static const USER_CONTEXT_ID = 'character';
+  static const CANVAS_CONTEXT_ID = 'group_id';
+  static const ASSIGNMENT_ID = 'item_id';
+  static const SCREEN_OF_ORIGIN = 'origin';
 }
 
 class Analytics {

--- a/apps/flutter_parent/lib/screens/settings/settings_interactor.dart
+++ b/apps/flutter_parent/lib/screens/settings/settings_interactor.dart
@@ -13,7 +13,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import 'package:flutter/widgets.dart';
+import 'package:flutter_parent/network/utils/analytics.dart';
 import 'package:flutter_parent/utils/debug_flags.dart';
+import 'package:flutter_parent/utils/design/parent_theme.dart';
 import 'package:flutter_parent/utils/design/theme_transition/theme_transition_target.dart';
 import 'package:flutter_parent/utils/quick_nav.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
@@ -28,10 +30,20 @@ class SettingsInteractor {
   }
 
   void toggleDarkMode(context, anchorKey) {
+    if (ParentTheme.of(context).isDarkMode) {
+      locator<Analytics>().logEvent(AnalyticsEventConstants.DARK_MODE_OFF);
+    } else {
+      locator<Analytics>().logEvent(AnalyticsEventConstants.DARK_MODE_ON);
+    }
     ThemeTransitionTarget.toggleDarkMode(context, anchorKey);
   }
 
   void toggleHCMode(context, anchorKey) {
+    if (ParentTheme.of(context).isHC) {
+      locator<Analytics>().logEvent(AnalyticsEventConstants.HC_MODE_OFF);
+    } else {
+      locator<Analytics>().logEvent(AnalyticsEventConstants.HC_MODE_ON);
+    }
     ThemeTransitionTarget.toggleHCMode(context, anchorKey);
   }
 }

--- a/apps/flutter_parent/lib/screens/settings/settings_screen.dart
+++ b/apps/flutter_parent/lib/screens/settings/settings_screen.dart
@@ -15,6 +15,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_parent/l10n/app_localizations.dart';
+import 'package:flutter_parent/network/utils/analytics.dart';
 import 'package:flutter_parent/screens/settings/settings_interactor.dart';
 import 'package:flutter_parent/utils/design/parent_theme.dart';
 import 'package:flutter_parent/utils/design/theme_transition/theme_transition_target.dart';
@@ -153,6 +154,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   _toggleWebViewDarkMode(BuildContext context) {
+    if (ParentTheme.of(context).isWebViewDarkMode) {
+      locator<Analytics>().logEvent(AnalyticsEventConstants.DARK_WEB_MODE_OFF);
+    } else {
+      locator<Analytics>().logEvent(AnalyticsEventConstants.DARK_WEB_MODE_ON);
+    }
     ParentTheme.of(context).toggleWebViewDarkMode();
   }
 

--- a/apps/flutter_parent/lib/utils/design/theme_transition/theme_transition_target.dart
+++ b/apps/flutter_parent/lib/utils/design/theme_transition/theme_transition_target.dart
@@ -35,20 +35,26 @@ class ThemeTransitionTarget extends StatefulWidget {
   /// a [BuildContext] that contains a [ThemeTransitionTarget], and [anchorKey] must be a [GlobalKey] assigned
   /// to a widget from which the animation transition will originate.
   static void toggleDarkMode(BuildContext context, GlobalKey anchorKey) {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      ThemeTransitionOverlay.display(context, anchorKey, () {
-        ParentTheme.of(context).toggleDarkMode();
-      });
-    });
+    _toggleMode(context, anchorKey, () => ParentTheme.of(context).toggleDarkMode());
   }
 
   /// Toggles high-contrast mode and initiates an animated circular reveal transition to the new theme. [context] must
   /// be a [BuildContext] that contains a [ThemeTransitionTarget], and [anchorKey] must be a [GlobalKey] assigned
   /// to a widget from which the animation transition will originate.
   static void toggleHCMode(BuildContext context, GlobalKey anchorKey) {
+    _toggleMode(context, anchorKey, () => ParentTheme.of(context).toggleHC());
+  }
+
+  static void _toggleMode(BuildContext context, GlobalKey anchorKey, Function() toggle) {
+    // If testing, just toggle without doing the theme transition overlay
+    if (WidgetsBinding.instance.runtimeType != WidgetsFlutterBinding) {
+      toggle();
+      return;
+    }
+
     WidgetsBinding.instance.addPostFrameCallback((_) {
       ThemeTransitionOverlay.display(context, anchorKey, () {
-        ParentTheme.of(context).toggleHC();
+        toggle();
       });
     });
   }

--- a/apps/flutter_parent/lib/utils/notification_util.dart
+++ b/apps/flutter_parent/lib/utils/notification_util.dart
@@ -20,6 +20,7 @@ import 'package:flutter_parent/l10n/app_localizations.dart';
 import 'package:flutter_parent/models/notification_payload.dart';
 import 'package:flutter_parent/models/reminder.dart';
 import 'package:flutter_parent/models/serializers.dart';
+import 'package:flutter_parent/network/utils/analytics.dart';
 import 'package:flutter_parent/utils/db/reminder_db.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
 
@@ -104,6 +105,12 @@ class NotificationUtil {
       ),
       null,
     );
+
+    if (reminder.type == Reminder.TYPE_ASSIGNMENT) {
+      locator<Analytics>().logEvent(AnalyticsEventConstants.REMINDER_ASSIGNMENT_CREATE);
+    } else {
+      locator<Analytics>().logEvent(AnalyticsEventConstants.REMINDER_EVENT_CREATE);
+    }
 
     return _plugin.schedule(
       reminder.id,

--- a/apps/flutter_parent/test/screens/settings/settings_interactor_test.dart
+++ b/apps/flutter_parent/test/screens/settings/settings_interactor_test.dart
@@ -12,13 +12,17 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_parent/network/utils/analytics.dart';
 import 'package:flutter_parent/screens/settings/settings_interactor.dart';
 import 'package:flutter_parent/screens/theme_viewer_screen.dart';
+import 'package:flutter_parent/utils/design/parent_theme.dart';
 import 'package:flutter_parent/utils/quick_nav.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:test/test.dart';
 
+import '../../utils/accessibility_utils.dart';
 import '../../utils/test_app.dart';
 
 void main() {
@@ -39,8 +43,54 @@ void main() {
     var screen = verify(nav.push(context, captureAny)).captured[0];
     expect(screen, isA<ThemeViewerScreen>());
   });
+
+  testNonWidgetsWithContext('toggle dark mode sets dark mode to true', (tester) async {
+    await setupPlatformChannels();
+    final analytics = _MockAnalytics();
+
+    setupTestLocator((locator) => locator.registerLazySingleton<Analytics>(() => analytics));
+
+    await tester.pumpWidget(TestApp(Container()));
+    await tester.pumpAndSettle();
+
+    final context = tester.state(find.byType(MaterialApp)).context;
+    expect(ParentTheme.of(context).isDarkMode, false);
+
+    SettingsInteractor().toggleDarkMode(context, null);
+    expect(ParentTheme.of(context).isDarkMode, true);
+
+    SettingsInteractor().toggleDarkMode(context, null);
+    expect(ParentTheme.of(context).isDarkMode, false);
+
+    verify(analytics.logEvent(AnalyticsEventConstants.DARK_MODE_OFF)).called(1);
+    verify(analytics.logEvent(AnalyticsEventConstants.DARK_MODE_ON)).called(1);
+  });
+
+  testNonWidgetsWithContext('toggle hc mode sets hc mode to true', (tester) async {
+    await setupPlatformChannels();
+    final analytics = _MockAnalytics();
+
+    setupTestLocator((locator) => locator.registerLazySingleton<Analytics>(() => analytics));
+
+    await tester.pumpWidget(TestApp(Container()));
+    await tester.pumpAndSettle();
+
+    final context = tester.state(find.byType(MaterialApp)).context;
+    expect(ParentTheme.of(context).isHC, false);
+
+    SettingsInteractor().toggleHCMode(context, null);
+    expect(ParentTheme.of(context).isHC, true);
+
+    SettingsInteractor().toggleHCMode(context, null);
+    expect(ParentTheme.of(context).isHC, false);
+
+    verify(analytics.logEvent(AnalyticsEventConstants.HC_MODE_OFF)).called(1);
+    verify(analytics.logEvent(AnalyticsEventConstants.HC_MODE_ON)).called(1);
+  });
 }
 
 class _MockNav extends Mock implements QuickNav {}
 
 class _MockContext extends Mock implements BuildContext {}
+
+class _MockAnalytics extends Mock implements Analytics {}

--- a/apps/flutter_parent/test/utils/accessibility_utils.dart
+++ b/apps/flutter_parent/test/utils/accessibility_utils.dart
@@ -54,7 +54,18 @@ extension A11yExclusionExtension on A11yExclusion {
   }
 }
 
-// A testWidgets() wrapper that runs accessibility checks
+/// A testWidgets() wrapper that does not run accessibility checks. This should not be used by things that are actually
+/// rendering widgets for a meaningful purpose. This should only be used by non widget tests that need access to a
+/// context and a WidgetTester. (example, interactors that need a context as a parameter)
+@isTest
+void testNonWidgetsWithContext(
+  String description,
+  WidgetTesterCallback callback,
+) {
+  testWidgets(description, (tester) async => await callback(tester));
+}
+
+/// A testWidgets() wrapper that runs accessibility checks
 @isTest
 void testWidgetsWithAccessibilityChecks(
   String description,

--- a/apps/flutter_parent/test/utils/notification_util_test.dart
+++ b/apps/flutter_parent/test/utils/notification_util_test.dart
@@ -118,7 +118,7 @@ void main() {
     verify(plugin.cancel(notificationIds[2]));
   });
 
-  test('scheduleReminder calls plugin with expected parameters', () async {
+  test('scheduleReminder calls plugin with expected parameters for an event', () async {
     await setupPlatformChannels();
 
     final reminder = Reminder((b) => b
@@ -148,7 +148,7 @@ void main() {
     verify(analytics.logEvent(AnalyticsEventConstants.REMINDER_EVENT_CREATE));
   });
 
-  test('scheduleReminder calls plugin with expected parameters', () async {
+  test('scheduleReminder calls plugin with expected parameters for an assignment', () async {
     await setupPlatformChannels();
 
     final reminder = Reminder((b) => b


### PR DESCRIPTION
Added events for toggling dark/hc modes, as well as for creating reminders. Creating different events for each as we only get 25 parameters across all events, so saving those for more important things.

Also created a new `testNonWidgetsWithContext` test wrapper for testing NON widgets that need a BuildContext (there’s interactors that have contexts as parameters, using this test method and the widget tester you can achieve testing those functions).