### PR TITLE
[Flutter Parent][MBL-14236] Wire up notifications to router

### DIFF
--- a/apps/flutter_parent/lib/models/reminder.dart
+++ b/apps/flutter_parent/lib/models/reminder.dart
@@ -41,6 +41,8 @@ abstract class Reminder implements Built<Reminder, ReminderBuilder> {
 
   String get itemId;
 
+  String get courseId;
+
   DateTime get date;
 
   Reminder._();
@@ -53,5 +55,6 @@ abstract class Reminder implements Built<Reminder, ReminderBuilder> {
     ..userId = ''
     ..type = TYPE_EVENT
     ..itemId = ''
+    ..courseId = ''
     ..date = DateTime.now();
 }

--- a/apps/flutter_parent/lib/models/reminder.g.dart
+++ b/apps/flutter_parent/lib/models/reminder.g.dart
@@ -29,6 +29,9 @@ class _$ReminderSerializer implements StructuredSerializer<Reminder> {
       'itemId',
       serializers.serialize(object.itemId,
           specifiedType: const FullType(String)),
+      'courseId',
+      serializers.serialize(object.courseId,
+          specifiedType: const FullType(String)),
       'date',
       serializers.serialize(object.date,
           specifiedType: const FullType(DateTime)),
@@ -75,6 +78,10 @@ class _$ReminderSerializer implements StructuredSerializer<Reminder> {
           result.itemId = serializers.deserialize(value,
               specifiedType: const FullType(String)) as String;
           break;
+        case 'courseId':
+          result.courseId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
         case 'date':
           result.date = serializers.deserialize(value,
               specifiedType: const FullType(DateTime)) as DateTime;
@@ -98,6 +105,8 @@ class _$Reminder extends Reminder {
   @override
   final String itemId;
   @override
+  final String courseId;
+  @override
   final DateTime date;
 
   factory _$Reminder([void Function(ReminderBuilder) updates]) =>
@@ -109,6 +118,7 @@ class _$Reminder extends Reminder {
       this.userId,
       this.type,
       this.itemId,
+      this.courseId,
       this.date})
       : super._() {
     if (userDomain == null) {
@@ -122,6 +132,9 @@ class _$Reminder extends Reminder {
     }
     if (itemId == null) {
       throw new BuiltValueNullFieldError('Reminder', 'itemId');
+    }
+    if (courseId == null) {
+      throw new BuiltValueNullFieldError('Reminder', 'courseId');
     }
     if (date == null) {
       throw new BuiltValueNullFieldError('Reminder', 'date');
@@ -144,6 +157,7 @@ class _$Reminder extends Reminder {
         userId == other.userId &&
         type == other.type &&
         itemId == other.itemId &&
+        courseId == other.courseId &&
         date == other.date;
   }
 
@@ -152,10 +166,12 @@ class _$Reminder extends Reminder {
     return $jf($jc(
         $jc(
             $jc(
-                $jc($jc($jc(0, id.hashCode), userDomain.hashCode),
-                    userId.hashCode),
-                type.hashCode),
-            itemId.hashCode),
+                $jc(
+                    $jc($jc($jc(0, id.hashCode), userDomain.hashCode),
+                        userId.hashCode),
+                    type.hashCode),
+                itemId.hashCode),
+            courseId.hashCode),
         date.hashCode));
   }
 
@@ -167,6 +183,7 @@ class _$Reminder extends Reminder {
           ..add('userId', userId)
           ..add('type', type)
           ..add('itemId', itemId)
+          ..add('courseId', courseId)
           ..add('date', date))
         .toString();
   }
@@ -195,6 +212,10 @@ class ReminderBuilder implements Builder<Reminder, ReminderBuilder> {
   String get itemId => _$this._itemId;
   set itemId(String itemId) => _$this._itemId = itemId;
 
+  String _courseId;
+  String get courseId => _$this._courseId;
+  set courseId(String courseId) => _$this._courseId = courseId;
+
   DateTime _date;
   DateTime get date => _$this._date;
   set date(DateTime date) => _$this._date = date;
@@ -210,6 +231,7 @@ class ReminderBuilder implements Builder<Reminder, ReminderBuilder> {
       _userId = _$v.userId;
       _type = _$v.type;
       _itemId = _$v.itemId;
+      _courseId = _$v.courseId;
       _date = _$v.date;
       _$v = null;
     }
@@ -238,6 +260,7 @@ class ReminderBuilder implements Builder<Reminder, ReminderBuilder> {
             userId: userId,
             type: type,
             itemId: itemId,
+            courseId: courseId,
             date: date);
     replace(_$result);
     return _$result;

--- a/apps/flutter_parent/lib/screens/assignments/assignment_details_interactor.dart
+++ b/apps/flutter_parent/lib/screens/assignments/assignment_details_interactor.dart
@@ -76,6 +76,7 @@ class AssignmentDetailsInteractor {
     AppLocalizations l10n,
     DateTime date,
     String assignmentId,
+    String courseId,
     String title,
     String body,
   ) async {
@@ -84,6 +85,7 @@ class AssignmentDetailsInteractor {
           ..userId = ApiPrefs.getUser().id
           ..type = Reminder.TYPE_ASSIGNMENT
           ..itemId = assignmentId
+          ..courseId = courseId
           ..date = date.toUtc() // built_value complains about non-utc timestamps
         );
 

--- a/apps/flutter_parent/lib/screens/assignments/assignment_details_screen.dart
+++ b/apps/flutter_parent/lib/screens/assignments/assignment_details_screen.dart
@@ -313,7 +313,14 @@ class _AssignmentDetailsScreenState extends State<AssignmentDetailsScreen> {
       if (date != null && time != null) {
         DateTime reminderDate = DateTime(date.year, date.month, date.day, time.hour, time.minute);
         var body = assignment.dueAt.l10nFormat(L10n(context).dueDateAtTime) ?? L10n(context).noDueDate;
-        await _interactor.createReminder(L10n(context), reminderDate, assignment.id, assignment.name, body);
+        await _interactor.createReminder(
+          L10n(context),
+          reminderDate,
+          assignment.id,
+          assignment.courseId,
+          assignment.name,
+          body,
+        );
       }
     }
 

--- a/apps/flutter_parent/lib/screens/events/event_details_interactor.dart
+++ b/apps/flutter_parent/lib/screens/events/event_details_interactor.dart
@@ -44,12 +44,20 @@ class EventDetailsInteractor {
     return reminder;
   }
 
-  Future<void> createReminder(AppLocalizations l10n, DateTime date, String eventId, String title, String body) async {
+  Future<void> createReminder(
+    AppLocalizations l10n,
+    DateTime date,
+    String eventId,
+    String courseId,
+    String title,
+    String body,
+  ) async {
     var reminder = Reminder((b) => b
           ..userDomain = ApiPrefs.getDomain()
           ..userId = ApiPrefs.getUser().id
           ..type = Reminder.TYPE_EVENT
           ..itemId = eventId
+          ..courseId = courseId
           ..date = date.toUtc() // built_value complains about non-utc timestamps
         );
 

--- a/apps/flutter_parent/lib/screens/events/event_details_screen.dart
+++ b/apps/flutter_parent/lib/screens/events/event_details_screen.dart
@@ -107,7 +107,7 @@ class _EventDetailsScreenState extends State<EventDetailsScreen> {
     } else if (!snapshot.hasData) {
       return LoadingIndicator();
     } else {
-      return _EventDetails(snapshot.data);
+      return _EventDetails(snapshot.data, widget.courseId);
     }
   }
 
@@ -139,8 +139,9 @@ class _EventDetailsScreenState extends State<EventDetailsScreen> {
 
 class _EventDetails extends StatelessWidget {
   final ScheduleItem event;
+  final String courseId;
 
-  const _EventDetails(this.event, {Key key})
+  const _EventDetails(this.event, this.courseId, {Key key})
       : assert(event != null),
         super(key: key);
 
@@ -191,7 +192,7 @@ class _EventDetails extends StatelessWidget {
               _SimpleTile(label: l10n.eventLocationLabel, line1: locationLine1, line2: locationLine2),
               Divider(),
               _SimpleHeader(label: l10n.assignmentRemindMeLabel),
-              _RemindMe(event, [dateLine1, dateLine2].where((it) => it != null).join('\n')),
+              _RemindMe(event, courseId, [dateLine1, dateLine2].where((it) => it != null).join('\n')),
               Divider(),
               _SimpleHeader(label: l10n.assignmentDescriptionLabel),
             ],
@@ -218,9 +219,10 @@ class _EventDetails extends StatelessWidget {
 
 class _RemindMe extends StatefulWidget {
   final ScheduleItem event;
+  final String courseId;
   final String formattedDate;
 
-  const _RemindMe(this.event, this.formattedDate, {Key key}) : super(key: key);
+  const _RemindMe(this.event, this.courseId, this.formattedDate, {Key key}) : super(key: key);
 
   @override
   _RemindMeState createState() => _RemindMeState();
@@ -296,7 +298,14 @@ class _RemindMeState extends State<_RemindMe> {
 
       if (date != null && time != null) {
         DateTime reminderDate = DateTime(date.year, date.month, date.day, time.hour, time.minute);
-        await _interactor.createReminder(L10n(context), reminderDate, event.id, event.title, formattedDate);
+        await _interactor.createReminder(
+          L10n(context),
+          reminderDate,
+          event.id,
+          widget.courseId,
+          event.title,
+          formattedDate,
+        );
       }
     }
 

--- a/apps/flutter_parent/lib/utils/db/db_util.dart
+++ b/apps/flutter_parent/lib/utils/db/db_util.dart
@@ -23,10 +23,11 @@ List<OnDatabaseCreateFn> _creators = [
 
 List<OnDatabaseVersionChangeFn> _updaters = [
   CalendarFilterDb.updateTable,
+  ReminderDb.updateTable,
 ];
 
 class DbUtil {
-  static const dbVersion = 2;
+  static const dbVersion = 3;
   static const dbName = 'canvas_parent.db';
 
   static Database _db;

--- a/apps/flutter_parent/lib/utils/db/reminder_db.dart
+++ b/apps/flutter_parent/lib/utils/db/reminder_db.dart
@@ -24,6 +24,7 @@ class ReminderDb {
   static const String columnUserId = 'user_id';
   static const String columnType = 'type';
   static const String columnItemId = 'item_id';
+  static const String columnCourseId = 'course_id';
   static const String columnDate = 'date';
 
   static const allColumns = [
@@ -32,6 +33,7 @@ class ReminderDb {
     columnUserId,
     columnType,
     columnItemId,
+    columnCourseId,
     columnDate,
   ];
 
@@ -43,6 +45,7 @@ class ReminderDb {
         columnUserId: data.userId,
         columnType: data.type,
         columnItemId: data.itemId,
+        columnCourseId: data.courseId,
         columnDate: data.date.toIso8601String(),
       };
 
@@ -52,6 +55,7 @@ class ReminderDb {
     ..userId = map[columnUserId]
     ..type = map[columnType]
     ..itemId = map[columnItemId]
+    ..courseId = map[columnCourseId]
     ..date = DateTime.parse(map[columnDate]));
 
   static Future<void> createTable(Database db, int version) async {
@@ -62,8 +66,16 @@ class ReminderDb {
         $columnUserId text not null,
         $columnType text not null,
         $columnItemId text not null,
+        $columnCourseId text not null,
         $columnDate text not null )
       ''');
+  }
+
+  static Future<void> updateTable(Database db, int oldVersion, int newVersion) async {
+    if (oldVersion < 3) {
+      // Course ID column added in database version 3
+      await db.execute('alter table $tableName add column $columnCourseId text not null default \'\'');
+    }
   }
 
   Future<Reminder> insert(Reminder data) async {

--- a/apps/flutter_parent/test/screens/assignments/assignment_details_interactor_test.dart
+++ b/apps/flutter_parent/test/screens/assignments/assignment_details_interactor_test.dart
@@ -131,13 +131,21 @@ void main() {
         ..userId = login.user.id
         ..type = Reminder.TYPE_ASSIGNMENT
         ..itemId = assignment.id
+        ..courseId = courseId
         ..date = date.toUtc());
 
       final savedReminder = reminder.rebuild((b) => b..id = 123);
       when(reminderDb.insert(reminder)).thenAnswer((_) async => savedReminder);
 
       final l10n = AppLocalizations();
-      await AssignmentDetailsInteractor().createReminder(l10n, date, assignment.id, assignment.name, formattedDate);
+      await AssignmentDetailsInteractor().createReminder(
+        l10n,
+        date,
+        assignment.id,
+        courseId,
+        assignment.name,
+        formattedDate,
+      );
 
       verify(reminderDb.insert(reminder));
       verify(notificationUtil.scheduleReminder(l10n, assignment.name, formattedDate, savedReminder));

--- a/apps/flutter_parent/test/screens/assignments/assignment_details_screen_test.dart
+++ b/apps/flutter_parent/test/screens/assignments/assignment_details_screen_test.dart
@@ -515,7 +515,7 @@ void main() {
     await tester.tap(find.text(DefaultMaterialLocalizations().okButtonLabel));
     await tester.pumpAndSettle();
 
-    verify(interactor.createReminder(any, any, assignmentId, assignment.name, AppLocalizations().noDueDate));
+    verify(interactor.createReminder(any, any, assignmentId, courseId, assignment.name, AppLocalizations().noDueDate));
 
     expect(find.text(AppLocalizations().assignmentRemindMeSet), findsOneWidget);
     expect((tester.widget(find.byType(Switch)) as Switch).value, true);
@@ -557,7 +557,7 @@ void main() {
     await tester.pumpAndSettle();
 
     var expectedBody = date.l10nFormat(AppLocalizations().dueDateAtTime);
-    verify(interactor.createReminder(any, any, assignmentId, assignment.name, expectedBody));
+    verify(interactor.createReminder(any, any, assignmentId, courseId, assignment.name, expectedBody));
 
     expect(find.text(AppLocalizations().assignmentRemindMeSet), findsOneWidget);
     expect((tester.widget(find.byType(Switch)) as Switch).value, true);

--- a/apps/flutter_parent/test/screens/events/event_details_interactor_test.dart
+++ b/apps/flutter_parent/test/screens/events/event_details_interactor_test.dart
@@ -108,6 +108,7 @@ void main() {
   test('createReminder inserts reminder into database and schedules a notification', () async {
     final date = DateTime.now();
     final formattedDate = 'Febtember 34, 3031';
+    final courseId = 'course_123';
     final event = ScheduleItem((b) => b
       ..id = 'event-123'
       ..title = 'Event title');
@@ -117,13 +118,14 @@ void main() {
       ..userId = login.user.id
       ..type = Reminder.TYPE_EVENT
       ..itemId = event.id
+      ..courseId = courseId
       ..date = date.toUtc());
 
     final savedReminder = reminder.rebuild((b) => b..id = 123);
     when(reminderDb.insert(reminder)).thenAnswer((_) async => savedReminder);
 
     final l10n = AppLocalizations();
-    await EventDetailsInteractor().createReminder(l10n, date, event.id, event.title, formattedDate);
+    await EventDetailsInteractor().createReminder(l10n, date, event.id, courseId, event.title, formattedDate);
 
     verify(reminderDb.insert(reminder));
     verify(notificationUtil.scheduleReminder(l10n, event.title, formattedDate, savedReminder));

--- a/apps/flutter_parent/test/screens/events/event_details_screen_test.dart
+++ b/apps/flutter_parent/test/screens/events/event_details_screen_test.dart
@@ -46,6 +46,7 @@ void main() {
     ..name = studentName);
 
   final eventId = '123';
+  final courseId = 'course_123';
   final baseEvent = ScheduleItem((b) => b
     ..id = eventId
     ..type = ScheduleItem.typeCalendar);
@@ -54,6 +55,7 @@ void main() {
     ..userId = 'user-123'
     ..type = 'type'
     ..itemId = eventId
+    ..courseId = courseId
     ..date = DateTime(2100)
     ..userDomain = 'domain');
 
@@ -317,7 +319,7 @@ void main() {
 
       when(interactor.loadReminder(any)).thenAnswer((_) async => null);
 
-      await tester.pumpWidget(_testableWidget(EventDetailsScreen.withEvent(event: event)));
+      await tester.pumpWidget(_testableWidget(EventDetailsScreen.withEvent(event: event, courseId: courseId)));
       await tester.pump(); // Let the widget build
       await tester.pump(); // Let the event future finish
       await tester.pump(); // Let the reminder future finish
@@ -338,7 +340,7 @@ void main() {
       await tester.tap(find.text(DefaultMaterialLocalizations().okButtonLabel));
       await tester.pumpAndSettle();
 
-      verify(interactor.createReminder(any, any, eventId, event.title, 'Saturday Jan 1, 2000'));
+      verify(interactor.createReminder(any, any, eventId, courseId, event.title, 'Saturday Jan 1, 2000'));
 
       expect(find.text(AppLocalizations().eventRemindMeSet), findsOneWidget);
       expect((tester.widget(find.byType(Switch)) as Switch).value, true);
@@ -355,7 +357,7 @@ void main() {
 
       when(interactor.loadReminder(any)).thenAnswer((_) async => null);
 
-      await tester.pumpWidget(_testableWidget(EventDetailsScreen.withEvent(event: event)));
+      await tester.pumpWidget(_testableWidget(EventDetailsScreen.withEvent(event: event, courseId: courseId)));
       await tester.pump(); // Let the widget build
       await tester.pump(); // Let the event future finish
       await tester.pump(); // Let the reminder future finish
@@ -376,7 +378,14 @@ void main() {
       await tester.tap(find.text(DefaultMaterialLocalizations().okButtonLabel));
       await tester.pumpAndSettle();
 
-      verify(interactor.createReminder(any, any, eventId, event.title, 'Saturday Jan 1, 2000\n12:00 AM - 2:00 AM'));
+      verify(interactor.createReminder(
+        any,
+        any,
+        eventId,
+        courseId,
+        event.title,
+        'Saturday Jan 1, 2000\n12:00 AM - 2:00 AM',
+      ));
 
       expect(find.text(AppLocalizations().eventRemindMeSet), findsOneWidget);
       expect((tester.widget(find.byType(Switch)) as Switch).value, true);


### PR DESCRIPTION
To test:
 - Set up a reminder for an assignment or calendar event (~1 minute in the future to avoid waiting too long)
 - Wait for the notification to appear
 - Tap the notification and the app should route to the correct assignment/event.
 - Routing should succeed regardless of whether the the app is in the foreground, background, or not started.