### PR TITLE
[Student][Automation][MBL-14238] | fix splunk reporting for individual test results

### DIFF
--- a/apps/postProcessTestRun.bash
+++ b/apps/postProcessTestRun.bash
@@ -84,6 +84,7 @@ do
         then
             successReport="$successReport $payload"
             ((successCount=successCount+1))
+            # Emit successful test data to Splunk every 100 tests
             if [ $successCount -eq 100 ]
             then
               emitSuccessfulTestData

--- a/apps/postProcessTestRun.bash
+++ b/apps/postProcessTestRun.bash
@@ -84,25 +84,16 @@ do
         then
             successReport="$successReport $payload"
             ((successCount=successCount+1))
-            if [ successCount -eq 100 ]
+            if [ $successCount -eq 100 ]
             then
               emitSuccessfulTestData
             fi    
         fi
     fi
-
-    # Emit success report after each testsuite/device.  For multi-device runs, the report gets
-    # too large to emit if you aggregate the results of all testsuites.
-    if [[ $line =~ "</testsuite>" ]]
-    then
-        #echo -e "\nSuccess payload: $successReport\n"
-        curl -k "https://http-inputs-inst.splunkcloud.com:443/services/collector" -H "Authorization: Splunk $SPLUNK_MOBILE_TOKEN" -d "$successReport"
-        successReport="" # Reset the successReport after emitting it
-    fi
 done < "$reportFile"
 
 # Take care of any straggling successful test reports
-if [ successCount -gt 0 ]
+if [ $successCount -gt 0 ]
 then
     emitSuccessfulTestData
 fi

--- a/apps/postProcessTestRun.bash
+++ b/apps/postProcessTestRun.bash
@@ -28,6 +28,15 @@ commonData="\"workflow\" : \"$BITRISE_TRIGGERED_WORKFLOW_ID\", \"app\" : \"$appN
 
 # A running collection of info for all passed tests.  JSON object strings are just concatenated together.
 successReport=""
+successCount=0
+
+# Emits collected successful test data to splunk, and zeroes out the running trackers.
+emitSuccessfulTestData () {
+        #echo -e "\nSuccess payload: $successReport\n"
+        curl -k "https://http-inputs-inst.splunkcloud.com:443/services/collector" -H "Authorization: Splunk $SPLUNK_MOBILE_TOKEN" -d "$successReport"
+        successReport="" # Reset the successReport after emitting it
+        successCount=0
+}
 
 # Process the test report (JUnitReport.xml)
 while IFS= read -r line
@@ -74,6 +83,11 @@ do
         if [[ $failureEncountered = false ]]
         then
             successReport="$successReport $payload"
+            ((successCount=successCount+1))
+            if [ successCount -eq 100 ]
+            then
+              emitSuccessfulTestData
+            fi    
         fi
     fi
 
@@ -86,6 +100,12 @@ do
         successReport="" # Reset the successReport after emitting it
     fi
 done < "$reportFile"
+
+# Take care of any straggling successful test reports
+if [ successCount -gt 0 ]
+then
+    emitSuccessfulTestData
+fi
 
 # Globals for parsing time/cost info
 cost=0


### PR DESCRIPTION
We were emitting one big message for all successful tests in a run.  As we approached 300 tests, we began observing that that message was getting too large for curl to send.  So now we emit the message every 100 tests.