### PR TITLE
[Parent][E2E][MBL-14233]: Added retry capability to e2e test script

### DIFF
--- a/apps/flutter_parent/lib/network/api/auth_api.dart
+++ b/apps/flutter_parent/lib/network/api/auth_api.dart
@@ -44,12 +44,14 @@ class AuthApi {
     return fetch(dio.post('${verifyResult.baseUrl}/login/oauth2/token', queryParameters: params));
   }
 
-  Future<MobileVerifyResult> mobileVerify(String domain) async {
-    // We only want to switch over to the beta mobile verify domain if the remote firebase config is true
-    // and we are trying to use a beta domain
-    var mobileVerifyBetaEnabled =
-        RemoteConfigUtils.getStringValue(RemoteConfigParams.MOBILE_VERIFY_BETA_ENABLED)?.toLowerCase() == 'true' &&
-            domain.contains('.beta.');
+  Future<MobileVerifyResult> mobileVerify(String domain, {bool forceBetaDomain = false}) async {
+    // We only want to switch over to the beta mobile verify domain if either:
+    //   (1) we are forcing the beta domain (typically in UI tests) OR
+    //   (2) the remote firebase config setting for MOBILE_VERIFY_BETA_ENABLED is true
+    // AND we are trying to use a beta domain
+    var mobileVerifyBetaEnabled = (forceBetaDomain ||
+            RemoteConfigUtils.getStringValue(RemoteConfigParams.MOBILE_VERIFY_BETA_ENABLED)?.toLowerCase() == 'true') &&
+        domain.contains('.beta.');
 
     Dio dio = DioConfig.core(useBetaDomain: mobileVerifyBetaEnabled).dio;
 

--- a/apps/flutter_parent/run_all_ui_tests.bash
+++ b/apps/flutter_parent/run_all_ui_tests.bash
@@ -12,21 +12,30 @@ failed=0
 failures=()
 for driver in test_driver/*_test.dart
 do
-	echo "Aggregator: driver = $driver"
+        echo "Aggregator: driver = $driver"
 
-	target=${driver/_test}
-	echo "Aggregator: target = $target"
+        target=${driver/_test}
+        echo "Aggregator: target = $target"
 	
-	flutter drive --target=$target
-	if [ $? -eq 0 ]
-	then
-	  echo Aggregator: $driver Passed
-	  ((passed=passed+1))
-	else
-	  echo Aggregator: $driver FAILED
-	  ((failed=failed+1))
-	  failures=("${failures[@]}" $driver)
-	fi
+        # Run the test
+        flutter drive --target=$target
+
+        # Allow for a single retry for a failed test
+        if [ $? -ne 0 ]
+        then
+          echo "Aggregator: $driver failed; retrying..."
+          flutter drive --target=$target
+        fi
+
+        # Record test result
+        if [ $? -eq 0 ]
+        then
+          echo Aggregator: $driver Passed
+          ((passed=passed+1))
+        else
+          ((failed=failed+1))
+          failures=("${failures[@]}" $driver)
+        fi
 done
 
 if [ $failed -eq 0 ]

--- a/apps/flutter_parent/test_driver/apis/user_seed_api.dart
+++ b/apps/flutter_parent/test_driver/apis/user_seed_api.dart
@@ -65,7 +65,7 @@ class UserSeedApi {
         ..password = userData.pseudonym.password
         ..domain = response.request.uri.host);
 
-      var verifyResult = await AuthApi().mobileVerify(result.domain);
+      var verifyResult = await AuthApi().mobileVerify(result.domain, forceBetaDomain: true);
       var authCode = await _getAuthCode(result, verifyResult);
       var token = await _getToken(result, verifyResult, authCode);
 


### PR DESCRIPTION
Also MBL-14242: Suppressed a RemoteConfigUtils call that was messing up the tests.

(I also tried to convert all tabs to 8-spaces in the script file, leading to some insignificant diffs.)