### PR TITLE
[Flutter Parent] Login landing page UI tweaks

### DIFF
--- a/apps/flutter_parent/lib/screens/login_landing_screen.dart
+++ b/apps/flutter_parent/lib/screens/login_landing_screen.dart
@@ -28,6 +28,7 @@ import 'package:flutter_parent/utils/common_widgets/full_screen_scroll_container
 import 'package:flutter_parent/utils/common_widgets/two_finger_double_tap_gesture_detector.dart';
 import 'package:flutter_parent/utils/common_widgets/user_name.dart';
 import 'package:flutter_parent/utils/debug_flags.dart';
+import 'package:flutter_parent/utils/design/canvas_icons.dart';
 import 'package:flutter_parent/utils/design/canvas_icons_solid.dart';
 import 'package:flutter_parent/utils/design/parent_colors.dart';
 import 'package:flutter_parent/utils/design/parent_theme.dart';
@@ -81,6 +82,7 @@ class LoginLandingScreen extends StatelessWidget {
               children: <Widget>[
                 Expanded(
                   child: FullScreenScrollContainer(
+                    horizontalPadding: 0,
                     children: <Widget>[
                       _helpRequestButton(context),
                       Expanded(child: _body(context)),
@@ -107,23 +109,27 @@ class LoginLandingScreen extends StatelessWidget {
             semanticsLabel: L10n(context).canvasLogoLabel,
           ),
           SizedBox(height: 64),
-          RaisedButton(
-            child: Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: Text(
-                L10n(context).findSchool,
-                style: TextStyle(fontSize: 16),
+          ButtonTheme(
+            minWidth: 260,
+            child: RaisedButton(
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Text(
+                  L10n(context).findSchool,
+                  style: TextStyle(fontSize: 16),
+                ),
               ),
+              color: Theme.of(context).accentColor,
+              textColor: Colors.white,
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4))),
+              onPressed: () {
+                onFindSchoolPressed(context);
+              },
             ),
-            color: Theme.of(context).accentColor,
-            textColor: Colors.white,
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4))),
-            onPressed: () {
-              onFindSchoolPressed(context);
-            },
           ),
-          SizedBox(height: 16),
-          if(RemoteConfigUtils.getStringValue(RemoteConfigParams.QR_LOGIN_ENABLED_PARENT).toLowerCase() == 'true') _qrLogin(context),
+          SizedBox(height: 8),
+          if (RemoteConfigUtils.getStringValue(RemoteConfigParams.QR_LOGIN_ENABLED_PARENT).toLowerCase() == 'true')
+            _qrLogin(context),
         ],
       ),
     );
@@ -240,7 +246,7 @@ class LoginLandingScreen extends StatelessWidget {
           padding: const EdgeInsets.all(16.0),
           child: Align(
             child: Icon(
-              CanvasIconsSolid.question,
+              CanvasIcons.question,
               color: ParentColors.tiara,
             ),
             alignment: Alignment.topRight,

--- a/apps/flutter_parent/test/screens/login/login_landing_screen_test.dart
+++ b/apps/flutter_parent/test/screens/login/login_landing_screen_test.dart
@@ -29,6 +29,7 @@ import 'package:flutter_parent/screens/web_login/web_login_screen.dart';
 import 'package:flutter_parent/utils/common_widgets/avatar.dart';
 import 'package:flutter_parent/utils/common_widgets/error_report/error_report_dialog.dart';
 import 'package:flutter_parent/utils/common_widgets/two_finger_double_tap_gesture_detector.dart';
+import 'package:flutter_parent/utils/design/canvas_icons.dart';
 import 'package:flutter_parent/utils/design/canvas_icons_solid.dart';
 import 'package:flutter_parent/utils/quick_nav.dart';
 import 'package:flutter_parent/utils/remote_config_utils.dart';
@@ -235,7 +236,7 @@ void main() {
     await tester.pumpWidget(TestApp(LoginLandingScreen()));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byIcon(CanvasIconsSolid.question));
+    await tester.tap(find.byIcon(CanvasIcons.question));
     await tester.pumpAndSettle();
 
     expect(find.byType(ErrorReportDialog), findsOneWidget);


### PR DESCRIPTION
- Increases login button width to 260
 - Uses outline style instead of solid style for help button icon
 - Removes extra horizontal padding around help icon
 - Adjusts space between login button and QR code button

Before/after:
![output](https://user-images.githubusercontent.com/6033874/79155501-6fa2f500-7d8e-11ea-9886-8c578ffffcbe.png)

