### PR TITLE
[Flutter Parent] Avatar tweaks

### DIFF
--- a/apps/flutter_parent/lib/screens/dashboard/dashboard_screen.dart
+++ b/apps/flutter_parent/lib/screens/dashboard/dashboard_screen.dart
@@ -423,7 +423,9 @@ class DashboardState extends State<DashboardScreen> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
           Padding(
-              padding: const EdgeInsets.fromLTRB(16, 16, 0, 12), child: Avatar(user.avatarUrl, name: user.shortName)),
+            padding: const EdgeInsets.fromLTRB(16, 16, 0, 12),
+            child: Avatar(user.avatarUrl, name: user.shortName, radius: 28),
+          ),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: UserName.fromUser(user, style: TextStyle(fontSize: 20.0, fontWeight: FontWeight.bold)),

--- a/apps/flutter_parent/lib/screens/inbox/create_conversation/create_conversation_screen.dart
+++ b/apps/flutter_parent/lib/screens/inbox/create_conversation/create_conversation_screen.dart
@@ -517,6 +517,7 @@ class _CreateConversationScreenState extends State<CreateConversationScreen> wit
                         subtitle: Text(_enrollmentType(context, user)),
                         leading: Avatar(
                           user.avatarUrl,
+                          name: user.name,
                           overlay: selected
                               ? Container(
                                   color: Theme.of(context).accentColor.withOpacity(0.8),

--- a/apps/flutter_parent/lib/utils/common_widgets/avatar.dart
+++ b/apps/flutter_parent/lib/utils/common_widgets/avatar.dart
@@ -15,7 +15,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_parent/models/user.dart';
-import 'package:flutter_parent/utils/design/parent_theme.dart';
+import 'package:flutter_parent/utils/design/parent_colors.dart';
 
 class Avatar extends StatelessWidget {
   final Color backgroundColor;
@@ -49,7 +49,7 @@ class Avatar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Color bgColor = backgroundColor ?? ParentTheme.of(context).nearSurfaceColor;
+    Color bgColor = backgroundColor ?? Theme.of(context).canvasColor;
 
     // We avoid using CachedNetworkImage in tests due to the complexity of mocking its dependencies.
     // We determine if we're in a test by checking the runtime type of WidgetsBinding. In prod it's an instance of
@@ -93,14 +93,21 @@ class Avatar extends StatelessWidget {
     );
   }
 
-  CircleAvatar _initialsWidget(BuildContext context, Color bgColor) {
-    return CircleAvatar(
-      child: Text(
-        getUserInitials(name),
-        style: TextStyle(fontSize: radius * 0.8, fontWeight: FontWeight.bold),
+  Widget _initialsWidget(BuildContext context, Color bgColor) {
+    return Container(
+      padding: EdgeInsets.all(0.5),
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: Theme.of(context).dividerColor,
       ),
-      backgroundColor: bgColor,
-      radius: radius,
+      child: CircleAvatar(
+        child: Text(
+          getUserInitials(name),
+          style: TextStyle(fontSize: radius * 0.8, fontWeight: FontWeight.bold, color: ParentColors.ash),
+        ),
+        backgroundColor: bgColor,
+        radius: radius,
+      ),
     );
   }
 

--- a/apps/flutter_parent/lib/utils/design/parent_theme.dart
+++ b/apps/flutter_parent/lib/utils/design/parent_theme.dart
@@ -224,7 +224,7 @@ class _ParentThemeState extends State<ParentTheme> {
       iconTheme: IconThemeData(color: onSurfaceColor),
       primaryIconTheme: IconThemeData(color: isDarkMode ? ParentColors.tiara : Colors.white),
       accentIconTheme: IconThemeData(color: isDarkMode ? Colors.black : Colors.white),
-      dividerColor: isHC ? onSurfaceColor : isDarkMode ? nearSurfaceColor : ParentColors.tiara,
+      dividerColor: isHC ? onSurfaceColor : isDarkMode ? ParentColors.oxford : ParentColors.tiara,
       buttonTheme: ButtonThemeData(height: 48, minWidth: 120),
     );
   }


### PR DESCRIPTION
- Updates the Avatar widget style to match existing apps (white background, gray text, thin gray border)
 - Fixes recipient list avatars not showing user initials
 - Changes dark mode divider color to a slightly lighter value
 - Increases nav drawer avatar size to match designs

Before/after
![output](https://user-images.githubusercontent.com/6033874/79258118-e7812600-7e47-11ea-8cf4-f7d2fd807831.png)

