### PR TITLE
[Teacher] Add remote config flag for Student View and also check for old student app

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/CourseBrowserFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/CourseBrowserFragment.kt
@@ -17,7 +17,6 @@
 package com.instructure.teacher.fragments
 
 import android.animation.ObjectAnimator
-import android.content.DialogInterface
 import android.content.Intent
 import android.graphics.Color
 import android.net.Uri
@@ -361,8 +360,14 @@ class CourseBrowserFragment : BaseSyncFragment<
             flags = Intent.FLAG_ACTIVITY_NEW_TASK
         }
 
-        // Send bundle to the student app
-        startActivity(studentViewIntent)
+        val pm = requireActivity().packageManager
+        val canHandleIntent = pm.queryIntentActivities(studentViewIntent, 0).any()
+        if (canHandleIntent)
+            // Send bundle to the student app
+            startActivity(studentViewIntent)
+        // If there is no activity that can handle the intent, then the Student app is not up to date - take them
+        // to the student app listing for them to update it
+        else gotoStudentPlayStoreListing()
     }
 }
 

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/RemoteConfigUtils.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/RemoteConfigUtils.kt
@@ -17,7 +17,8 @@ enum class RemoteConfigParam(val rc_name: String, val safeValueAsString: String)
     USE_NEW_RELIC("all_new_relic_enabled", "false"),
     MOBILE_VERIFY_BETA_ENABLED("mobile_verify_beta_enabled", "true"),
     QR_LOGIN_ENABLED("qr_login_enabled", "true"),
-    QR_LOGIN_ENABLED_TEACHER("qr_login_enabled_teacher", "false")
+    QR_LOGIN_ENABLED_TEACHER("qr_login_enabled_teacher", "false"),
+    STUDENT_VIEW_ENABLED_TEACHER("student_view_enabled_teacher", "false")
 }
 
 /**


### PR DESCRIPTION
The remote config flag is set to false for now. Student View api work is still beta, and we'll want to flip that flag once we're 100% rolled out for the student and teacher release that has the student view feature.