### PR TITLE
[Flutter-Parent][MBL-14269] Make RCE having a loading indicator while loading

### DIFF
--- a/apps/flutter_parent/lib/screens/assignments/assignment_details_screen.dart
+++ b/apps/flutter_parent/lib/screens/assignments/assignment_details_screen.dart
@@ -215,37 +215,7 @@ class _AssignmentDetailsScreenState extends State<AssignmentDetailsScreen> {
             ),
           ),
           Divider(),
-          FutureBuilder(
-            future: _animationFuture,
-            builder: (context, snapshot) {
-              if (snapshot.connectionState == ConnectionState.waiting)
-                return Padding(
-                  padding: const EdgeInsets.only(top: 16.0),
-                  child: LoadingIndicator(),
-                );
-
-              if (fullyLocked)
-                // no good way to center this image vertically in a scrollable view's remaining space. Settling for padding for now
-                return Padding(
-                  padding: const EdgeInsets.only(top: 32),
-                  child: Center(child: SvgPicture.asset('assets/svg/panda-locked.svg', excludeFromSemantics: true)),
-                );
-              else
-                return Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: _rowTile(
-                    title: assignment.submissionTypes?.contains(SubmissionTypes.onlineQuiz) == true
-                        ? l10n.assignmentInstructionsLabel
-                        : l10n.assignmentDescriptionLabel,
-                    child: CanvasWebView(
-                      content: assignment.description,
-                      emptyDescription: l10n.assignmentNoDescriptionBody,
-                      fullScreen: false,
-                    ),
-                  ),
-                );
-            },
-          ),
+          _descriptionContent(assignment, fullyLocked),
           // TODO: Add in 'Learn more' feature
 //        Divider(),
 //        ..._rowTile(
@@ -256,6 +226,44 @@ class _AssignmentDetailsScreenState extends State<AssignmentDetailsScreen> {
         ],
       ),
     );
+  }
+
+  Widget _descriptionContent(Assignment assignment, bool fullyLocked) {
+    final l10n = L10n(context);
+
+    if (fullyLocked)
+      // no good way to center this image vertically in a scrollable view's remaining space. Settling for padding for now
+      return FutureBuilder(
+        future: _animationFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return Padding(
+              padding: const EdgeInsets.only(top: 16.0),
+              child: LoadingIndicator(),
+            );
+          }
+
+          return Padding(
+            padding: const EdgeInsets.only(top: 32),
+            child: Center(child: SvgPicture.asset('assets/svg/panda-locked.svg', excludeFromSemantics: true)),
+          );
+        },
+      );
+    else {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: _rowTile(
+          title: assignment.submissionTypes?.contains(SubmissionTypes.onlineQuiz) == true
+              ? l10n.assignmentInstructionsLabel
+              : l10n.assignmentDescriptionLabel,
+          child: CanvasWebView(
+            content: assignment.description,
+            emptyDescription: l10n.assignmentNoDescriptionBody,
+            fullScreen: false,
+          ),
+        ),
+      );
+    }
   }
 
   Widget _statusIcon(bool submitted, Color submittedColor) {

--- a/apps/flutter_parent/test/screens/assignments/assignment_details_screen_test.dart
+++ b/apps/flutter_parent/test/screens/assignments/assignment_details_screen_test.dart
@@ -119,7 +119,8 @@ void main() {
       platformConfig: PlatformConfig(mockPrefs: {ApiPrefs.KEY_CURRENT_STUDENT: json.encode(serialize(student))}),
     ));
 
-    await tester.pumpAndSettle();
+    // Pump for a duration since we're delaying webview load for the animation
+    await tester.pumpAndSettle(Duration(seconds: 1));
 
     expect(find.text(courseName), findsOneWidget);
   });
@@ -218,7 +219,8 @@ void main() {
           PlatformConfig(initWebview: true, mockPrefs: {ApiPrefs.KEY_CURRENT_STUDENT: json.encode(serialize(student))}),
     ));
 
-    await tester.pumpAndSettle();
+    // Pump for a duration since we're delaying webview load for the animation
+    await tester.pumpAndSettle(Duration(seconds: 1));
 
     expect(find.text(assignmentName), findsOneWidget);
     expect(find.text(dueDate.l10nFormat(AppLocalizations().dateAtTime)), findsOneWidget);
@@ -260,7 +262,8 @@ void main() {
       platformConfig: PlatformConfig(mockPrefs: {ApiPrefs.KEY_CURRENT_STUDENT: json.encode(serialize(student))}),
     ));
 
-    await tester.pumpAndSettle();
+    // Pump for a duration since we're delaying webview load for the animation
+    await tester.pumpAndSettle(Duration(seconds: 1));
 
     expect(find.text('1 pts'), findsOneWidget);
 
@@ -297,7 +300,8 @@ void main() {
       platformConfig: PlatformConfig(mockPrefs: {ApiPrefs.KEY_CURRENT_STUDENT: json.encode(serialize(student))}),
     ));
 
-    await tester.pumpAndSettle();
+    // Pump for a duration since we're delaying webview load for the animation
+    await tester.pumpAndSettle(Duration(seconds: 1));
 
     expect(find.text(assignmentName), findsOneWidget);
     expect(find.text('1 pts'), findsOneWidget);
@@ -315,7 +319,8 @@ void main() {
       platformConfig: PlatformConfig(mockPrefs: {ApiPrefs.KEY_CURRENT_STUDENT: json.encode(serialize(student))}),
     ));
 
-    await tester.pumpAndSettle();
+    // Pump for a duration since we're delaying webview load for the animation
+    await tester.pumpAndSettle(Duration(seconds: 1));
 
     expect(find.text(AppLocalizations().noDueDate), findsOneWidget);
   });
@@ -396,7 +401,8 @@ void main() {
       platformConfig: PlatformConfig(mockPrefs: {ApiPrefs.KEY_CURRENT_STUDENT: json.encode(serialize(student))}),
     ));
 
-    await tester.pumpAndSettle();
+    // Pump for a duration since we're delaying webview load for the animation
+    await tester.pumpAndSettle(Duration(seconds: 1));
 
     expect(find.text(AppLocalizations().assignmentLockLabel), findsOneWidget);
     expect(find.text(explanation), findsOneWidget);
@@ -423,7 +429,8 @@ void main() {
       platformConfig: PlatformConfig(mockPrefs: {ApiPrefs.KEY_CURRENT_STUDENT: json.encode(serialize(student))}),
     ));
 
-    await tester.pumpAndSettle();
+    // Pump for a duration since we're delaying webview load for the animation
+    await tester.pumpAndSettle(Duration(seconds: 1));
 
     // Should not show locked info since it is not yet locked
     expect(find.text(AppLocalizations().assignmentLockLabel), findsNothing);
@@ -442,7 +449,8 @@ void main() {
       platformConfig: PlatformConfig(mockPrefs: {ApiPrefs.KEY_CURRENT_STUDENT: json.encode(serialize(student))}),
     ));
 
-    await tester.pumpAndSettle();
+    // Pump for a duration since we're delaying webview load for the animation
+    await tester.pumpAndSettle(Duration(seconds: 1));
 
     expect(find.text(AppLocalizations().assignmentNoDescriptionBody), findsOneWidget);
   });
@@ -462,7 +470,8 @@ void main() {
       platformConfig: PlatformConfig(mockPrefs: {ApiPrefs.KEY_CURRENT_STUDENT: json.encode(serialize(student))}),
     ));
 
-    await tester.pumpAndSettle();
+    // Pump for a duration since we're delaying webview load for the animation
+    await tester.pumpAndSettle(Duration(seconds: 1));
 
     expect(find.text(AppLocalizations().assignmentInstructionsLabel), findsOneWidget);
   });
@@ -481,7 +490,8 @@ void main() {
       platformConfig: PlatformConfig(mockPrefs: {ApiPrefs.KEY_CURRENT_STUDENT: json.encode(serialize(student))}),
     ));
 
-    await tester.pumpAndSettle();
+    // Pump for a duration since we're delaying webview load for the animation
+    await tester.pumpAndSettle(Duration(seconds: 1));
 
     expect(find.text(AppLocalizations().assignmentRemindMeSet), findsOneWidget);
     expect((tester.widget(find.byType(Switch)) as Switch).value, true);
@@ -584,7 +594,8 @@ void main() {
       platformConfig: PlatformConfig(mockPrefs: {ApiPrefs.KEY_CURRENT_STUDENT: json.encode(serialize(student))}),
     ));
 
-    await tester.pumpAndSettle();
+    // Pump for a duration since we're delaying webview load for the animation
+    await tester.pumpAndSettle(Duration(seconds: 1));
 
     expect(find.text(AppLocalizations().assignmentRemindMeSet), findsOneWidget);
     expect((tester.widget(find.byType(Switch)) as Switch).value, true);

--- a/apps/flutter_parent/test/utils/widgets/webview/canvas_web_view_test.dart
+++ b/apps/flutter_parent/test/utils/widgets/webview/canvas_web_view_test.dart
@@ -56,7 +56,7 @@ void main() {
       await tester.pumpWidget(TestApp(CanvasWebView(content: null)));
       await tester.pump();
 
-      expect(find.descendant(of: find.byType(CanvasWebView), matching: find.byType(Container)), findsOneWidget);
+      expect(find.descendant(of: find.byType(CanvasWebView), matching: find.byType(Container)), findsWidgets);
       expect(find.byType(WebView), findsNothing);
     });
 
@@ -64,7 +64,7 @@ void main() {
       await tester.pumpWidget(TestApp(CanvasWebView(content: '', emptyDescription: '')));
       await tester.pump();
 
-      expect(find.descendant(of: find.byType(CanvasWebView), matching: find.byType(Container)), findsOneWidget);
+      expect(find.descendant(of: find.byType(CanvasWebView), matching: find.byType(Container)), findsWidgets);
       expect(find.byType(WebView), findsNothing);
     });
   });


### PR DESCRIPTION
Shows loading before web views finish page load, also consolidates loading indicators for assignment details, since web view was showing two different loaders which felt icky.

To test:
Navigate to all the different screens that have webviews: Assignment Details (most important), Home Page, Syllabus, Event Details, and Announcement Details.
Verify that all content still loads.
Verify loading indicators are more consolidated and look better.