### PR TITLE
[Student][MBL-12196] Handle links in iframes

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
@@ -99,6 +99,7 @@ open class InternalWebviewFragment : ParentFragment() {
             originalUserAgentString = canvasWebView.settings.userAgentString
             canvasWebView.settings.userAgentString = ApiPrefs.userAgent
             canvasWebView.setInitialScale(100)
+            canvasWebView.settings.setSupportMultipleWindows(true) // Required to allow iFrames with links that have a target of '_blank' - see CanvasWebChromeClient#onCreateWindow()
 
             canvasWebView.canvasWebChromeClientCallback = CanvasWebView.CanvasWebChromeClientCallback { _, newProgress ->
                 if (newProgress == 100) {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/views/CanvasWebView.java
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/views/CanvasWebView.java
@@ -46,6 +46,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.Message;
 import android.os.Parcelable;
 import android.provider.MediaStore;
 import androidx.annotation.NonNull;
@@ -460,6 +461,21 @@ public class CanvasWebView extends WebView implements NestedScrollingChild {
             PermissionUtilsKt.requestWebPermissions((Activity) getContext(), request);
         }
 
+        @Override
+        public boolean onCreateWindow(WebView view, boolean isDialog, boolean isUserGesture, Message resultMsg) {
+            // This allows us to handle links in an iFrame when they have a target of '_blank', which tells the WebView
+            // to launch the URL in a new window.
+            //
+            // Without this, Chrome will launch, but doesn't appear to get the URL. This launches the browser and
+            // explicitly sends it the URL.
+            String url = view.getHitTestResult().getExtra();
+            if (url != null && !url.isEmpty()) {
+                Context context = view.getContext();
+                Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                context.startActivity(browserIntent);
+                return false;
+            } else return super.onCreateWindow(view, isDialog, isUserGesture, resultMsg);
+        }
     }
 
     public class CanvasWebViewClient extends WebViewClient {


### PR DESCRIPTION
See ticket for testing creds. Clicking the Google doc link in the main page on the (only) course in the test account will launch the mobile browser, but not load the link. This explicitly launches an intent with the url in it.

Web will load the link inside the iFrame, but we have no way of doing that on our end (security features won't let us modify links in iFrames to change the target away from '_blank'). This is our next best bet, and on par with iOS.