### PR TITLE
[Flutter-Parent] Fix opening iframe LTIs externally

### DIFF
--- a/apps/flutter_parent/lib/utils/common_widgets/web_view/canvas_web_view.dart
+++ b/apps/flutter_parent/lib/utils/common_widgets/web_view/canvas_web_view.dart
@@ -16,12 +16,12 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_parent/l10n/app_localizations.dart';
 import 'package:flutter_parent/network/utils/api_prefs.dart';
+import 'package:flutter_parent/router/panda_router.dart';
 import 'package:flutter_parent/utils/common_widgets/loading_indicator.dart';
 import 'package:flutter_parent/utils/common_widgets/web_view/web_content_interactor.dart';
 import 'package:flutter_parent/utils/design/parent_theme.dart';
 import 'package:flutter_parent/utils/quick_nav.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
-import 'package:flutter_parent/utils/url_launcher.dart';
 import 'package:flutter_parent/utils/web_view_utils.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
@@ -265,8 +265,7 @@ class _ResizingWebViewState extends State<_ResizingWebView> {
   Set<JavascriptChannel> _webViewChannels() {
     return Set()
       ..add(_interactor.ltiToolPressedChannel((JavascriptMessage message) {
-        // TODO: Create an LTI webview that handles this better, so we don't have to just launch them out to a browser
-        locator<UrlLauncher>().launch(message.message);
+        PandaRouter.routeInternally(context, message.message);
       }));
   }
 }


### PR DESCRIPTION
Wasn’t opening an authenticated link before, so the user would have to login again.

To test:
Open some rich content with an lti in an iframe and click on the ‘Launch External Tool’ button at the bottom of the page. Verify it opens a web view directly to the content (no login required)