### PR TITLE
[Flutter Parent] Fix building in release mode from IDE

### DIFF
--- a/apps/flutter_parent/android/app/proguard-rules.pro
+++ b/apps/flutter_parent/android/app/proguard-rules.pro
@@ -1,2 +1,6 @@
 # Local notifications plugin
 -keep class com.dexterous.** { *; }
+
+# Crashlytics
+-keep class com.crashlytics.** { *; }
+-dontwarn com.crashlytics.**


### PR DESCRIPTION
To test, pull this branch locally and build in release mode from Android Studio. The app should no longer crash on launch.