### PR TITLE
[Flutter-Parent] Fix edge case for grading period header

### DIFF
--- a/apps/flutter_parent/lib/screens/courses/details/course_grades_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_grades_screen.dart
@@ -83,10 +83,12 @@ class _CourseGradesScreenState extends State<CourseGradesScreen> with AutomaticK
   }
 
   Widget _body(AsyncSnapshot<GradeDetails> snapshot, CourseDetailsModel model) {
-    final header = _CourseGradeHeader(context, snapshot.data?.gradingPeriods ?? [], snapshot.data?.termEnrollment);
     if (snapshot.connectionState == ConnectionState.waiting && !snapshot.hasData) {
       return LoadingIndicator();
     }
+
+    final gradingPeriods = snapshot.data?.gradingPeriods ?? [];
+    final header = _CourseGradeHeader(context, gradingPeriods, snapshot.data?.termEnrollment);
 
     if (snapshot.hasError) {
       return ErrorPandaWidget(
@@ -97,13 +99,14 @@ class _CourseGradesScreenState extends State<CourseGradesScreen> with AutomaticK
       );
     } else if (!snapshot.hasData ||
         snapshot.data.assignmentGroups == null ||
+        snapshot.data.assignmentGroups.isEmpty ||
         snapshot.data.assignmentGroups.every((group) => group.assignments.isEmpty) == true) {
       return EmptyPandaWidget(
         svgPath: 'assets/svg/panda-space-no-assignments.svg',
         title: L10n(context).noAssignmentsTitle,
         subtitle: L10n(context).noAssignmentsMessage,
         // Don't show the header if we have no assignments at all (null grading period id corresponds to all grading periods)
-        header: (model.currentGradingPeriod()?.id == null) ? null : header,
+        header: (model.currentGradingPeriod()?.id == null && gradingPeriods.isEmpty) ? null : header,
       );
     }
 


### PR DESCRIPTION
If a course has no assignments with a current grading period, filtering to ‘All Grading Periods’ removes the period header and requires users to back out and in to filter by period again.

To test:
Use Wilsons sandbox and view the course `Better Chat`, ensure you can change the grading period to "All Grading Periods" and then change again without having to reload the screen.