### PR TITLE
[Student][MBL-14248] Show submission when observer

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsEffectHandler.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsEffectHandler.kt
@@ -75,8 +75,8 @@ class SubmissionDetailsEffectHandler : EffectHandler<SubmissionDetailsView, Subm
         launch {
             // If the user is an observer, get the id of the first observee that comes back, otherwise use the user's id
             val enrollmentsResult = EnrollmentManager.getObserveeEnrollmentsAsync(true).await()
-            val observee = enrollmentsResult.dataOrNull?.firstOrNull { it.isObserver && it.courseId == effect.courseId }
-            val userId = observee?.associatedUserId ?: ApiPrefs.user!!.id
+            val observeeId = enrollmentsResult.dataOrNull?.firstOrNull { it.isObserver && it.courseId == effect.courseId }?.associatedUserId
+            val userId = observeeId ?: ApiPrefs.user!!.id
 
             val submissionResult = SubmissionManager.getSingleSubmissionAsync(effect.courseId, effect.assignmentId, userId, true).await()
             val assignmentResult = AssignmentManager.getAssignmentAsync(effect.assignmentId, effect.courseId, true).await()

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsEffectHandler.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsEffectHandler.kt
@@ -18,21 +18,23 @@
 package com.instructure.student.mobius.assignmentDetails.submissionDetails
 
 import com.instructure.canvasapi2.managers.AssignmentManager
+import com.instructure.canvasapi2.managers.EnrollmentManager
 import com.instructure.canvasapi2.managers.QuizManager
 import com.instructure.canvasapi2.managers.SubmissionManager
 import com.instructure.canvasapi2.models.Assignment
+import com.instructure.canvasapi2.models.Enrollment
 import com.instructure.canvasapi2.models.LTITool
 import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.canvasapi2.utils.DataResult
 import com.instructure.canvasapi2.utils.Failure
 import com.instructure.canvasapi2.utils.exhaustive
 import com.instructure.canvasapi2.utils.weave.StatusCallbackError
+import com.instructure.canvasapi2.utils.weave.awaitApi
 import com.instructure.student.mobius.assignmentDetails.submissionDetails.drawer.comments.SubmissionCommentsSharedEvent
 import com.instructure.student.mobius.assignmentDetails.submissionDetails.ui.SubmissionDetailsView
 import com.instructure.student.mobius.common.ChannelSource
 import com.instructure.student.mobius.common.ui.EffectHandler
 import com.instructure.student.util.getStudioLTITool
-import com.instructure.student.util.isStudioEnabled
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import java.io.File
@@ -71,7 +73,12 @@ class SubmissionDetailsEffectHandler : EffectHandler<SubmissionDetailsView, Subm
 
     private fun loadData(effect: SubmissionDetailsEffect.LoadData) {
         launch {
-            val submissionResult = SubmissionManager.getSingleSubmissionAsync(effect.courseId, effect.assignmentId, ApiPrefs.user!!.id, true).await()
+            // If the user is an observer, get the id of the first observee that comes back, otherwise use the user's id
+            val enrollmentsResult = EnrollmentManager.getObserveeEnrollmentsAsync(true).await()
+            val observee = enrollmentsResult.dataOrNull?.firstOrNull { it.isObserver && it.courseId == effect.courseId }
+            val userId = observee?.associatedUserId ?: ApiPrefs.user!!.id
+
+            val submissionResult = SubmissionManager.getSingleSubmissionAsync(effect.courseId, effect.assignmentId, userId, true).await()
             val assignmentResult = AssignmentManager.getAssignmentAsync(effect.assignmentId, effect.courseId, true).await()
 
             val studioLTIToolResult: DataResult<LTITool> = if (assignmentResult.isSuccess && assignmentResult.dataOrThrow.getSubmissionTypes().contains(Assignment.SubmissionType.ONLINE_UPLOAD)) {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/EnrollmentManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/EnrollmentManager.kt
@@ -22,6 +22,7 @@ import com.instructure.canvasapi2.builders.RestBuilder
 import com.instructure.canvasapi2.builders.RestParams
 import com.instructure.canvasapi2.models.Enrollment
 import com.instructure.canvasapi2.utils.ExhaustiveListCallback
+import com.instructure.canvasapi2.utils.weave.apiAsync
 
 object EnrollmentManager {
 
@@ -92,6 +93,10 @@ object EnrollmentManager {
         adapter.statusCallback = depaginatedCallback
         EnrollmentAPI.getObserveeEnrollments(adapter, params, depaginatedCallback)
     }
+
+    fun getObserveeEnrollmentsAsync(forceNetwork: Boolean)
+            = apiAsync<List<Enrollment>> { getObserveeEnrollments(forceNetwork, it) }
+
 
     @JvmStatic
     fun handleInvite(courseId: Long, enrollmentId: Long, acceptInvite: Boolean, callback: StatusCallback<Void>) {


### PR DESCRIPTION
Submission details page would error out because we were using the observer's ID instead of the observee's ID when retrieving submissions.

If the user is an observer, we use the ID of the first observee we retrieve that is in that course.