### PR TITLE
[Flutter-Parent][RC 3.2.0] Fix error screen in convo course list

### DIFF
--- a/apps/flutter_parent/lib/screens/inbox/conversation_list/conversation_list_interactor.dart
+++ b/apps/flutter_parent/lib/screens/inbox/conversation_list/conversation_list_interactor.dart
@@ -64,8 +64,14 @@ class ConversationListInteractor {
     // Create tuple list
     // Remove enrollments where the user is not observing anyone
     enrollments.retainWhere((e) => e.observedUser != null);
-    List<Tuple2<User, Course>> thing =
-        enrollments.map((e) => Tuple2(e.observedUser, courses.firstWhere((c) => c.id == e.courseId))).toList();
+    List<Tuple2<User, Course>> thing = enrollments
+        .map((e) {
+          final course = courses.firstWhere((c) => c.id == e.courseId, orElse: () => null);
+          if (course == null) return null;
+          return Tuple2(e.observedUser, course);
+        })
+        .where((e) => e != null)
+        .toList();
 
     // Sort users in alphabetical order and sort their courses alphabetically
     thing.sortBy(

--- a/apps/flutter_parent/test/screens/inbox/conversation_list/conversation_list_interactor_test.dart
+++ b/apps/flutter_parent/test/screens/inbox/conversation_list/conversation_list_interactor_test.dart
@@ -211,8 +211,53 @@ void main() {
       Tuple2(chericeEnrollments[0].observedUser, choirCourse),
     ];
 
-    List<Tuple2<User, Course>> actual = ConversationListInteractor().combineEnrollmentsAndCourses(
-        [choirCourse, boxingCourse, arithmeticCourse], [...billEnrollments, ...andyEnrollments, ...chericeEnrollments]);
+    List<Tuple2<User, Course>> actual = ConversationListInteractor()
+        .combineEnrollmentsAndCourses([choirCourse, boxingCourse, arithmeticCourse], enrollments);
+
+    for (var i = 0; i < expectedResult.length; i++) {
+      expect(actual[i].item1, expectedResult[i].item1);
+      expect(actual[i].item2, expectedResult[i].item2);
+    }
+  });
+
+  // This test simulates a 'pending' enrollment situation, where we get the enrollment but not the course
+  test('combineEnrollmentsAndCourses handles enrollments without matching courses', () {
+    String arithmetic = 'Arithmetic';
+    String boxing = 'Boxing';
+    String choir = 'Choir';
+
+    List<Enrollment> andyEnrollments = _createEnrollments('Andy', [boxing, choir]);
+    List<Enrollment> billEnrollments = _createEnrollments('Bill', [choir, arithmetic]);
+    List<Enrollment> chericeEnrollments = _createEnrollments('Cherice', [choir, arithmetic, boxing]);
+    List<Enrollment> pendingEnrollments = _createEnrollments('pending', ['pending']);
+
+    var enrollments = [...andyEnrollments, ...billEnrollments, ...chericeEnrollments, ...pendingEnrollments];
+
+    Course arithmeticCourse = Course((b) => b
+      ..id = arithmetic
+      ..name = arithmetic
+      ..enrollments = ListBuilder(enrollments.where((e) => e.courseId == arithmetic)));
+    Course boxingCourse = Course((b) => b
+      ..id = boxing
+      ..name = boxing
+      ..enrollments = ListBuilder(enrollments.where((e) => e.courseId == boxing)));
+    Course choirCourse = Course((b) => b
+      ..id = choir
+      ..name = choir
+      ..enrollments = ListBuilder(enrollments.where((e) => e.courseId == choir)));
+
+    List<Tuple2<User, Course>> expectedResult = [
+      Tuple2(andyEnrollments[0].observedUser, boxingCourse),
+      Tuple2(andyEnrollments[1].observedUser, choirCourse),
+      Tuple2(billEnrollments[1].observedUser, arithmeticCourse),
+      Tuple2(billEnrollments[0].observedUser, choirCourse),
+      Tuple2(chericeEnrollments[1].observedUser, arithmeticCourse),
+      Tuple2(chericeEnrollments[2].observedUser, boxingCourse),
+      Tuple2(chericeEnrollments[0].observedUser, choirCourse),
+    ];
+
+    List<Tuple2<User, Course>> actual = ConversationListInteractor()
+        .combineEnrollmentsAndCourses([choirCourse, boxingCourse, arithmeticCourse], enrollments);
 
     for (var i = 0; i < expectedResult.length; i++) {
       expect(actual[i].item1, expectedResult[i].item1);


### PR DESCRIPTION
When no matching course can be found for an enrollment provided to the convo list when creating a message, we get an error screen. This happens for me when I have a pending invite to a course, but could happen for many cases (concluded perhaps?)