### PR TITLE
[Parent] Cameras optional

### DIFF
--- a/apps/flutter_parent/android/app/src/main/AndroidManifest.xml
+++ b/apps/flutter_parent/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.CAMERA" android:required="false"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/> <!-- For notifications plugin -->
 

--- a/apps/flutter_parent/lib/network/utils/api_prefs.dart
+++ b/apps/flutter_parent/lib/network/utils/api_prefs.dart
@@ -39,6 +39,7 @@ class ApiPrefs {
   static const String KEY_LOGINS = 'logins';
   static const String KEY_CURRENT_LOGIN_UUID = 'current_login_uuid';
   static const String KEY_CURRENT_STUDENT = 'current_student';
+  static const String KEY_CAMERA_COUNT = 'camera_count';
 
   static EncryptedSharedPreferences _prefs;
   static PackageInfo _packageInfo;
@@ -258,6 +259,10 @@ class ApiPrefs {
 
   static Future<void> setHasCheckedOldReminders(bool checked) => _setPrefBool(KEY_HAS_CHECKED_OLD_REMINDERS, checked);
 
+  static int getCameraCount() => _getPrefInt(KEY_CAMERA_COUNT);
+
+  static Future<void> setCameraCount(int count) => _setPrefInt(KEY_CAMERA_COUNT, count);
+
   static Future<void> _setPrefBool(String key, bool value) async {
     _checkInit();
     await _prefs.setBool(key, value);
@@ -271,6 +276,16 @@ class ApiPrefs {
   static String _getPrefString(String key) {
     _checkInit();
     return _prefs.getString(key);
+  }
+
+  static int _getPrefInt(String key) {
+    _checkInit();
+    return _prefs.getInt(key);
+  }
+
+  static Future<void> _setPrefInt(String key, int value) async {
+    _checkInit();
+    return _prefs.setInt(key, value);
   }
 
   static Map<String, String> getHeaderMap({

--- a/apps/flutter_parent/lib/screens/login_landing_screen.dart
+++ b/apps/flutter_parent/lib/screens/login_landing_screen.dart
@@ -128,8 +128,7 @@ class LoginLandingScreen extends StatelessWidget {
             ),
           ),
           SizedBox(height: 8),
-          if (RemoteConfigUtils.getStringValue(RemoteConfigParams.QR_LOGIN_ENABLED_PARENT).toLowerCase() == 'true')
-            _qrLogin(context),
+          if (_isQRLoginEnabled()) _qrLogin(context),
         ],
       ),
     );
@@ -155,6 +154,11 @@ class LoginLandingScreen extends StatelessWidget {
                 ),
               ]),
         ));
+  }
+
+  bool _isQRLoginEnabled() {
+    return RemoteConfigUtils.getStringValue(RemoteConfigParams.QR_LOGIN_ENABLED_PARENT).toLowerCase() == 'true' &&
+        ApiPrefs.getCameraCount() != 0;
   }
 
   Widget _previousLogins(BuildContext context) {

--- a/apps/flutter_parent/lib/screens/login_landing_screen.dart
+++ b/apps/flutter_parent/lib/screens/login_landing_screen.dart
@@ -158,7 +158,7 @@ class LoginLandingScreen extends StatelessWidget {
 
   bool _isQRLoginEnabled() {
     return RemoteConfigUtils.getStringValue(RemoteConfigParams.QR_LOGIN_ENABLED_PARENT).toLowerCase() == 'true' &&
-        ApiPrefs.getCameraCount() != 0;
+        (ApiPrefs.getCameraCount() != null && ApiPrefs.getCameraCount() != 0);
   }
 
   Widget _previousLogins(BuildContext context) {

--- a/apps/flutter_parent/lib/screens/splash/splash_screen.dart
+++ b/apps/flutter_parent/lib/screens/splash/splash_screen.dart
@@ -26,7 +26,6 @@ import 'package:flutter_parent/utils/quick_nav.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
 
 class SplashScreen extends StatefulWidget {
-
   final String qrLoginUrl;
 
   SplashScreen({this.qrLoginUrl, Key key}) : super(key: key);
@@ -37,6 +36,7 @@ class SplashScreen extends StatefulWidget {
 
 class _SplashScreenState extends State<SplashScreen> with SingleTickerProviderStateMixin {
   Future<SplashScreenData> _dataFuture;
+  Future<int> _cameraFuture;
 
   // Controller and animation used on the loading indicator for the 'zoom out' effect immediately before routing
   AnimationController _controller;
@@ -55,8 +55,19 @@ class _SplashScreenState extends State<SplashScreen> with SingleTickerProviderSt
   Widget build(BuildContext context) {
     if (!ApiPrefs.isLoggedIn() && widget.qrLoginUrl == null) {
       // If they aren't logged in or logging in with QR, route to login screen
-      _navigate(PandaRouter.login());
-      return _defaultBody(context);
+      if (_cameraFuture == null) {
+        _cameraFuture = locator<SplashScreenInteractor>().getCameraCount();
+      }
+
+      return FutureBuilder(
+          future: _cameraFuture,
+          builder: (BuildContext context, AsyncSnapshot<int> snapshot) {
+            if (snapshot.hasData) {
+              _navigate(PandaRouter.login());
+            }
+
+            return _defaultBody(context);
+          });
     } else {
       if (_dataFuture == null) {
         _dataFuture = locator<SplashScreenInteractor>().getData(qrLoginUrl: widget.qrLoginUrl);
@@ -75,7 +86,7 @@ class _SplashScreenState extends State<SplashScreen> with SingleTickerProviderSt
                 _navigate(PandaRouter.notParent());
               }
             } else if (snapshot.hasError) {
-              if(snapshot.error is QRLoginError) {
+              if (snapshot.error is QRLoginError) {
                 Scaffold.of(context).showSnackBar(SnackBar(content: Text(L10n(context).loginWithQRCodeError)));
                 Navigator.pop(context);
               } else {

--- a/apps/flutter_parent/lib/screens/splash/splash_screen.dart
+++ b/apps/flutter_parent/lib/screens/splash/splash_screen.dart
@@ -62,7 +62,8 @@ class _SplashScreenState extends State<SplashScreen> with SingleTickerProviderSt
       return FutureBuilder(
           future: _cameraFuture,
           builder: (BuildContext context, AsyncSnapshot<int> snapshot) {
-            if (snapshot.hasData) {
+            if (snapshot.hasData || snapshot.hasError) {
+              // Even if the camera count fails, we don't want to trap the user on splash
               _navigate(PandaRouter.login());
             }
 

--- a/apps/flutter_parent/lib/screens/splash/splash_screen_interactor.dart
+++ b/apps/flutter_parent/lib/screens/splash/splash_screen_interactor.dart
@@ -23,6 +23,7 @@ import 'package:flutter_parent/screens/dashboard/dashboard_interactor.dart';
 import 'package:flutter_parent/screens/masquerade/masquerade_screen_interactor.dart';
 import 'package:flutter_parent/utils/qr_utils.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
+import 'package:flutter_parent/utils/veneers/barcode_scan_veneer.dart';
 
 class SplashScreenInteractor {
   Future<SplashScreenData> getData({String qrLoginUrl}) async {
@@ -69,6 +70,16 @@ class SplashScreenInteractor {
     }
 
     return SplashScreenData(isObserver, ApiPrefs.getCurrentLogin().canMasquerade);
+  }
+
+  Future<int> getCameraCount() async {
+    if (ApiPrefs.getCameraCount() == null) {
+      int cameraCount = await locator<BarcodeScanVeneer>().getNumberOfCameras();
+      await ApiPrefs.setCameraCount(cameraCount);
+      return cameraCount;
+    } else {
+      return ApiPrefs.getCameraCount();
+    }
   }
 
   Future<bool> _performSSOLogin(Uri qrLoginUri) async {

--- a/apps/flutter_parent/lib/utils/veneers/barcode_scan_veneer.dart
+++ b/apps/flutter_parent/lib/utils/veneers/barcode_scan_veneer.dart
@@ -20,4 +20,8 @@ class BarcodeScanVeneer {
   Future<ScanResult> scanBarcode() {
     return BarcodeScanner.scan();
   }
+
+  Future<int> getNumberOfCameras() {
+    return BarcodeScanner.numberOfCameras;
+  }
 }

--- a/apps/flutter_parent/test/network/api_prefs_test.dart
+++ b/apps/flutter_parent/test/network/api_prefs_test.dart
@@ -404,6 +404,14 @@ void main() {
     expect(ApiPrefs.getCurrentStudent(), user);
   });
 
+  test('gets and sets camera count', () async {
+    await setupPlatformChannels();
+    final count = 2;
+    await ApiPrefs.setCameraCount(count);
+
+    expect(ApiPrefs.getCameraCount(), count);
+  });
+
   test('migrates old prefs to encrypted prefs', () async {
     // Setup platform channels with minimal configuration
     setupPlatformChannels(config: PlatformConfig(mockApiPrefs: null));

--- a/apps/flutter_parent/test/screens/login/login_landing_screen_test.dart
+++ b/apps/flutter_parent/test/screens/login/login_landing_screen_test.dart
@@ -290,12 +290,21 @@ void main() {
 
   testWidgetsWithAccessibilityChecks('Tapping QR login shows QR Login Tutorial screen', (tester) async {
     await tester.pumpWidget(TestApp(LoginLandingScreen()));
+    await ApiPrefs.setCameraCount(2);
     await tester.pumpAndSettle();
 
     await tester.tap(find.text(AppLocalizations().qrCode));
     await tester.pumpAndSettle();
 
     expect(find.byType(QRLoginTutorialScreen), findsOneWidget);
+  });
+
+  testWidgetsWithAccessibilityChecks('QR login does not display when camera count is 0', (tester) async {
+    await tester.pumpWidget(TestApp(LoginLandingScreen()));
+    await ApiPrefs.setCameraCount(0);
+    await tester.pumpAndSettle();
+
+    expect(find.text(AppLocalizations().qrCode), findsNothing);
   });
 }
 

--- a/apps/flutter_parent/test/screens/login/qr_login_tutorial_screen_interactor_test.dart
+++ b/apps/flutter_parent/test/screens/login/qr_login_tutorial_screen_interactor_test.dart
@@ -23,9 +23,10 @@ import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import '../../utils/test_app.dart';
+import '../../utils/test_helpers/mock_helpers.dart';
 
 void main() {
-  final mockScanner = _MockScanner();
+  final mockScanner = MockBarcodeScanner();
 
   setupTestLocator((locator) {
     locator.registerLazySingleton<BarcodeScanVeneer>(() => mockScanner);
@@ -119,5 +120,3 @@ void main() {
     expect(result.result, isNull);
   });
 }
-
-class _MockScanner extends Mock implements BarcodeScanVeneer {}

--- a/apps/flutter_parent/test/screens/login/qr_login_tutorial_screen_interactor_test.dart
+++ b/apps/flutter_parent/test/screens/login/qr_login_tutorial_screen_interactor_test.dart
@@ -107,6 +107,17 @@ void main() {
     expect(result.errorType, QRError.invalidQR);
     expect(result.result, isNull);
   });
+
+  test('returns error when given generic Exception', () async {
+    when(mockScanner.scanBarcode()).thenAnswer((_) => throw Exception('ErRoR'));
+
+    var interactor = QRLoginTutorialScreenInteractor();
+
+    final result = await interactor.scan();
+    expect(result.isSuccess, isFalse);
+    expect(result.errorType, QRError.invalidQR);
+    expect(result.result, isNull);
+  });
 }
 
 class _MockScanner extends Mock implements BarcodeScanVeneer {}

--- a/apps/flutter_parent/test/screens/splash/splash_screen_interactor_test.dart
+++ b/apps/flutter_parent/test/screens/splash/splash_screen_interactor_test.dart
@@ -21,16 +21,19 @@ import 'package:flutter_parent/network/api/auth_api.dart';
 import 'package:flutter_parent/network/utils/api_prefs.dart';
 import 'package:flutter_parent/screens/dashboard/dashboard_interactor.dart';
 import 'package:flutter_parent/screens/splash/splash_screen_interactor.dart';
+import 'package:flutter_parent/utils/veneers/barcode_scan_veneer.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import '../../utils/canvas_model_utils.dart';
 import '../../utils/test_app.dart';
+import '../../utils/test_helpers/mock_helpers.dart';
 
 void main() {
   _MockDashboardInteractor dashboardInteractor = _MockDashboardInteractor();
   _MockAccountsApi accountsApi = _MockAccountsApi();
   _MockAuthApi authApi = _MockAuthApi();
+  final mockScanner = MockBarcodeScanner();
 
   Login login = Login((b) => b
     ..domain = 'domain'
@@ -54,6 +57,7 @@ void main() {
     locator.registerFactory<DashboardInteractor>(() => dashboardInteractor);
     locator.registerLazySingleton<AccountsApi>(() => accountsApi);
     locator.registerLazySingleton<AuthApi>(() => authApi);
+    locator.registerLazySingleton<BarcodeScanVeneer>(() => mockScanner);
   });
 
   setUp(() async {
@@ -204,6 +208,16 @@ void main() {
     var data = await SplashScreenInteractor().getData(qrLoginUrl: url);
     expect(data.isObserver, isTrue);
     expect(data.canMasquerade, isTrue);
+  });
+
+  test('getCameraCount returns valid camera count and sets ApiPrefs', () async {
+    when(mockScanner.getNumberOfCameras()).thenAnswer((_) => Future.value(2));
+
+    final count = await SplashScreenInteractor().getCameraCount();
+
+    final prefCount = await ApiPrefs.getCameraCount();
+
+    expect(count, prefCount);
   });
 }
 

--- a/apps/flutter_parent/test/screens/splash/splash_screen_test.dart
+++ b/apps/flutter_parent/test/screens/splash/splash_screen_test.dart
@@ -144,6 +144,22 @@ void main() {
     expect(find.byType(LoginLandingScreen), findsOneWidget);
   });
 
+  testWidgetsWithAccessibilityChecks(
+      'Routes to login screen when the user is not logged in and camera count throws error', (tester) async {
+    var interactor = _MockInteractor();
+    setupTestLocator((locator) {
+      locator.registerFactory<SplashScreenInteractor>(() => interactor);
+      locator.registerLazySingleton<QuickNav>(() => QuickNav());
+    });
+
+    when(interactor.getCameraCount()).thenAnswer((_) => Future.error('error'));
+
+    await tester.pumpWidget(TestApp(SplashScreen()));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(LoginLandingScreen), findsOneWidget);
+  });
+
   /* - TODO - fix this up if this route starts to pre-fetch students again
   testWidgetsWithAccessibilityChecks('Routes to dashboard when there are students', (tester) async {
     var interactor = _MockInteractor();

--- a/apps/flutter_parent/test/screens/splash/splash_screen_test.dart
+++ b/apps/flutter_parent/test/screens/splash/splash_screen_test.dart
@@ -136,6 +136,8 @@ void main() {
       locator.registerLazySingleton<QuickNav>(() => QuickNav());
     });
 
+    when(interactor.getCameraCount()).thenAnswer((_) => Future.value(2));
+
     await tester.pumpWidget(TestApp(SplashScreen()));
     await tester.pumpAndSettle();
 

--- a/apps/flutter_parent/test/utils/test_helpers/mock_helpers.dart
+++ b/apps/flutter_parent/test/utils/test_helpers/mock_helpers.dart
@@ -40,6 +40,7 @@ import 'package:flutter_parent/utils/db/calendar_filter_db.dart';
 import 'package:flutter_parent/utils/db/reminder_db.dart';
 import 'package:flutter_parent/utils/notification_util.dart';
 import 'package:flutter_parent/utils/url_launcher.dart';
+import 'package:flutter_parent/utils/veneers/barcode_scan_veneer.dart';
 import 'package:mockito/mockito.dart';
 import 'package:sqflite/sqflite.dart';
 
@@ -107,3 +108,5 @@ class MockPageApi extends Mock implements PageApi {}
 class MockCourseRoutingShellInteractor extends Mock implements CourseRoutingShellInteractor {}
 
 class MockWebViewInteractor extends Mock implements WebContentInteractor {}
+
+class MockBarcodeScanner extends Mock implements BarcodeScanVeneer {}


### PR DESCRIPTION
To Test:
I don't have a real device without a camera, but using an emulator with 0 cameras did the trick. The splash screen does the check/awaiting, and the login landing page should show/hide the qr code button. We can just re-use the ApiPrefs value for QR scanning pairing codes in the future.