### PR TITLE
[Parent] Beef up QR error handling

### DIFF
--- a/apps/flutter_parent/lib/screens/qr_login/qr_login_tutorial_screen.dart
+++ b/apps/flutter_parent/lib/screens/qr_login/qr_login_tutorial_screen.dart
@@ -55,7 +55,13 @@ class _QRLoginTutorialScreenState extends State<QRLoginTutorialScreen> {
       onPressed: () async {
         var barcodeResult = await locator<QRLoginTutorialScreenInteractor>().scan();
         if (barcodeResult.isSuccess) {
-          locator<QuickNav>().pushRoute(context, PandaRouter.qrLogin(barcodeResult.result));
+          final result = await locator<QuickNav>().pushRoute(context, PandaRouter.qrLogin(barcodeResult.result));
+
+          // Await this result so we can show an error message if the splash screen has to pop after a login issue
+          // (This is typically in the case of the same QR code being scanned twice)
+          if (result != null) {
+            _showSnackBarError(context, result);
+          }
         } else {
           _showSnackBarError(
               context,

--- a/apps/flutter_parent/lib/screens/qr_login/qr_login_tutorial_screen.dart
+++ b/apps/flutter_parent/lib/screens/qr_login/qr_login_tutorial_screen.dart
@@ -63,7 +63,8 @@ class _QRLoginTutorialScreenState extends State<QRLoginTutorialScreen> {
           if (result != null) {
             _showSnackBarError(context, result);
           }
-        } else {
+        } else if (barcodeResult.errorType == QRError.invalidQR || barcodeResult.errorType == QRError.cameraError) {
+          // We only want to display an error for invalid and camera denied, the other case is the user cancelled
           locator<Analytics>().logMessage(barcodeResult?.errorType?.toString() ?? 'No barcode result');
           _showSnackBarError(
               context,

--- a/apps/flutter_parent/lib/screens/qr_login/qr_login_tutorial_screen_interactor.dart
+++ b/apps/flutter_parent/lib/screens/qr_login/qr_login_tutorial_screen_interactor.dart
@@ -22,7 +22,7 @@ import 'package:flutter_parent/utils/veneers/barcode_scan_veneer.dart';
 
 class QRLoginTutorialScreenInteractor {
   Future<BarcodeScanResult> scan() async {
-    BarcodeScanResult result;
+    BarcodeScanResult result = BarcodeScanResult(false, errorType: QRError.invalidQR);
     try {
       ScanResult scanResult = await locator<BarcodeScanVeneer>().scanBarcode();
       String barcodeResult = scanResult.rawContent;
@@ -39,6 +39,7 @@ class QRLoginTutorialScreenInteractor {
           break;
         case ResultType.Cancelled:
           // Do nothing
+          result = BarcodeScanResult(false, errorType: QRError.cancelled);
           break;
       }
     } on PlatformException catch (e) {
@@ -65,4 +66,4 @@ class BarcodeScanResult {
   BarcodeScanResult(this.isSuccess, {this.errorType = null, this.result = null});
 }
 
-enum QRError { invalidQR, cameraError }
+enum QRError { invalidQR, cameraError, cancelled }

--- a/apps/flutter_parent/lib/screens/splash/splash_screen.dart
+++ b/apps/flutter_parent/lib/screens/splash/splash_screen.dart
@@ -35,8 +35,6 @@ class SplashScreen extends StatefulWidget {
 }
 
 class _SplashScreenState extends State<SplashScreen> with SingleTickerProviderStateMixin {
-  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
-
   Future<SplashScreenData> _dataFuture;
 
   // Controller and animation used on the loading indicator for the 'zoom out' effect immediately before routing
@@ -64,7 +62,6 @@ class _SplashScreenState extends State<SplashScreen> with SingleTickerProviderSt
       }
 
       return Scaffold(
-        key: _scaffoldKey,
         backgroundColor: Theme.of(context).primaryColor,
         body: FutureBuilder(
           future: _dataFuture,

--- a/apps/flutter_parent/lib/screens/splash/splash_screen.dart
+++ b/apps/flutter_parent/lib/screens/splash/splash_screen.dart
@@ -26,7 +26,6 @@ import 'package:flutter_parent/utils/quick_nav.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
 
 class SplashScreen extends StatefulWidget {
-
   final String qrLoginUrl;
 
   SplashScreen({this.qrLoginUrl, Key key}) : super(key: key);
@@ -36,6 +35,8 @@ class SplashScreen extends StatefulWidget {
 }
 
 class _SplashScreenState extends State<SplashScreen> with SingleTickerProviderStateMixin {
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+
   Future<SplashScreenData> _dataFuture;
 
   // Controller and animation used on the loading indicator for the 'zoom out' effect immediately before routing
@@ -63,6 +64,7 @@ class _SplashScreenState extends State<SplashScreen> with SingleTickerProviderSt
       }
 
       return Scaffold(
+        key: _scaffoldKey,
         backgroundColor: Theme.of(context).primaryColor,
         body: FutureBuilder(
           future: _dataFuture,
@@ -75,9 +77,9 @@ class _SplashScreenState extends State<SplashScreen> with SingleTickerProviderSt
                 _navigate(PandaRouter.notParent());
               }
             } else if (snapshot.hasError) {
-              if(snapshot.error is QRLoginError) {
-                Scaffold.of(context).showSnackBar(SnackBar(content: Text(L10n(context).loginWithQRCodeError)));
-                Navigator.pop(context);
+              if (snapshot.error is QRLoginError) {
+                WidgetsBinding.instance
+                    .addPostFrameCallback((_) => Navigator.pop(context, L10n(context).loginWithQRCodeError));
               } else {
                 // On error, proceed without pre-fetched student list
                 _navigate(PandaRouter.dashboard());

--- a/apps/flutter_parent/lib/screens/splash/splash_screen_interactor.dart
+++ b/apps/flutter_parent/lib/screens/splash/splash_screen_interactor.dart
@@ -12,6 +12,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import 'package:flutter_parent/models/canvas_token.dart';
 import 'package:flutter_parent/models/login.dart';
 import 'package:flutter_parent/models/mobile_verify_result.dart';
 import 'package:flutter_parent/network/api/accounts_api.dart';
@@ -31,7 +32,7 @@ class SplashScreenInteractor {
       final qrLoginUri = QRUtils.verifySSOLogin(qrLoginUrl);
       if (qrLoginUrl == null) {
         locator<Analytics>().logEvent(AnalyticsEventConstants.QR_LOGIN_FAILURE);
-        return Future.error(QRLoginError);
+        return Future.error(QRLoginError());
       } else {
         final qrSuccess = await _performSSOLogin(qrLoginUri);
         // Error out if the login fails, otherwise continue
@@ -40,7 +41,7 @@ class SplashScreenInteractor {
             AnalyticsEventConstants.QR_LOGIN_FAILURE,
             extras: {AnalyticsParamConstants.DOMAIN_PARAM: qrLoginUri.host},
           );
-          return Future.error(QRLoginError);
+          return Future.error(QRLoginError());
         } else {
           locator<Analytics>().logEvent(
             AnalyticsEventConstants.QR_LOGIN_SUCCESS,
@@ -81,7 +82,12 @@ class SplashScreenInteractor {
       return Future.value(false);
     }
 
-    final tokenResponse = await locator<AuthApi>().getTokens(mobileVerifyResult, oAuthCode);
+    CanvasToken tokenResponse;
+    try {
+      tokenResponse = await locator<AuthApi>().getTokens(mobileVerifyResult, oAuthCode);
+    } catch (e) {
+      return Future.value(false);
+    }
 
     // Key here is that realUser represents a masquerading attempt
     var isMasquerading = tokenResponse.realUser != null;

--- a/apps/flutter_parent/test/screens/login/qr_login_tutorial_screen_test.dart
+++ b/apps/flutter_parent/test/screens/login/qr_login_tutorial_screen_test.dart
@@ -68,7 +68,7 @@ void main() {
     await tester.pumpAndSettle();
 
     await tester.tap(find.text(AppLocalizations().next.toUpperCase()));
-    await tester.pump();
+    await tester.pumpAndSettle();
     verify(mockNav.pushRoute(any, '/qr_login?qrLoginUrl=${Uri.encodeQueryComponent(barcodeResultUrl)}'));
   });
 
@@ -92,6 +92,18 @@ void main() {
     await tester.tap(find.text(AppLocalizations().next.toUpperCase()));
     await tester.pump();
     expect(find.text(AppLocalizations().invalidQRCodeError), findsOneWidget);
+  });
+
+  testWidgetsWithAccessibilityChecks(
+      'Clicking next scans, returns valid result, but then displays qr login error on login failure', (tester) async {
+    when(interactor.scan()).thenAnswer((_) => Future.value(BarcodeScanResult(true, result: barcodeResultUrl)));
+    when(mockNav.pushRoute(any, any)).thenAnswer((_) => Future.value(AppLocalizations().loginWithQRCodeError));
+    await tester.pumpWidget(TestApp(QRLoginTutorialScreen()));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text(AppLocalizations().next.toUpperCase()));
+    await tester.pumpAndSettle();
+    expect(find.text(AppLocalizations().loginWithQRCodeError), findsOneWidget);
   });
 }
 

--- a/apps/flutter_parent/test/screens/login/qr_login_tutorial_screen_test.dart
+++ b/apps/flutter_parent/test/screens/login/qr_login_tutorial_screen_test.dart
@@ -15,6 +15,7 @@
  */
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_parent/l10n/app_localizations.dart';
 import 'package:flutter_parent/screens/qr_login/qr_login_tutorial_screen.dart';
 import 'package:flutter_parent/screens/qr_login/qr_login_tutorial_screen_interactor.dart';
@@ -92,6 +93,16 @@ void main() {
     await tester.tap(find.text(AppLocalizations().next.toUpperCase()));
     await tester.pump();
     expect(find.text(AppLocalizations().invalidQRCodeError), findsOneWidget);
+  });
+
+  testWidgetsWithAccessibilityChecks('Clicking next scans, user cancels, and displays no error', (tester) async {
+    when(interactor.scan()).thenAnswer((_) => Future.value(BarcodeScanResult(false, errorType: QRError.cancelled)));
+    await tester.pumpWidget(TestApp(QRLoginTutorialScreen()));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text(AppLocalizations().next.toUpperCase()));
+    await tester.pump();
+    expect(find.byType(SnackBar), findsNothing);
   });
 
   testWidgetsWithAccessibilityChecks(

--- a/apps/flutter_parent/test/screens/splash/splash_screen_interactor_test.dart
+++ b/apps/flutter_parent/test/screens/splash/splash_screen_interactor_test.dart
@@ -205,6 +205,26 @@ void main() {
     expect(data.isObserver, isTrue);
     expect(data.canMasquerade, isTrue);
   });
+
+  test('getData returns QRLoginError for invalid auth code', () async {
+    when(authApi.getTokens(any, any)).thenAnswer((_) async => Future.error(''));
+    final url = 'https://sso.canvaslms.com/canvas/login?code_android_parent=1234&domain=mobiledev.instructure.com';
+    bool fail = false;
+    await SplashScreenInteractor().getData(qrLoginUrl: url).catchError((_) {
+      fail = true; // Don't return, just update the flag
+    });
+    expect(fail, isTrue);
+  });
+
+  test('getData returns QRLoginError for error in mobile verify', () async {
+    when(authApi.mobileVerify(any)).thenAnswer((_) async => Future.error(''));
+    final url = 'https://sso.canvaslms.com/canvas/login?code_android_parent=1234&domain=mobiledev.instructure.com';
+    bool fail = false;
+    await SplashScreenInteractor().getData(qrLoginUrl: url).catchError((_) {
+      fail = true; // Don't return, just update the flag
+    });
+    expect(fail, isTrue);
+  });
 }
 
 class _MockAccountsApi extends Mock implements AccountsApi {}

--- a/apps/flutter_parent/test/utils/test_helpers/mock_helpers.dart
+++ b/apps/flutter_parent/test/utils/test_helpers/mock_helpers.dart
@@ -65,7 +65,13 @@ class MockAlertCountNotifier extends Mock implements AlertCountNotifier {}
 
 class MockAuthApi extends Mock implements AuthApi {}
 
+class MockBarcodeScanner extends Mock implements BarcodeScanVeneer {}
+
 class MockCalendarFilterDb extends Mock implements CalendarFilterDb {}
+
+class MockCourseApi extends Mock implements CourseApi {}
+
+class MockCourseRoutingShellInteractor extends Mock implements CourseRoutingShellInteractor {}
 
 class MockDatabase extends Mock implements Database {}
 
@@ -91,6 +97,8 @@ class MockNotificationUtil extends Mock implements NotificationUtil {}
 
 class MockOAuthApi extends Mock implements OAuthApi {}
 
+class MockPageApi extends Mock implements PageApi {}
+
 class MockPlugin extends Mock implements FlutterLocalNotificationsPlugin {}
 
 class MockReminderDb extends Mock implements ReminderDb {}
@@ -101,12 +109,4 @@ class MockUrlLauncher extends Mock implements UrlLauncher {}
 
 class MockWebLoginInteractor extends Mock implements WebLoginInteractor {}
 
-class MockCourseApi extends Mock implements CourseApi {}
-
-class MockPageApi extends Mock implements PageApi {}
-
-class MockCourseRoutingShellInteractor extends Mock implements CourseRoutingShellInteractor {}
-
 class MockWebViewInteractor extends Mock implements WebContentInteractor {}
-
-class MockBarcodeScanner extends Mock implements BarcodeScanVeneer {}


### PR DESCRIPTION
This is in response to this [crash](https://console.firebase.google.com/project/automatic-rite-88319/crashlytics/app/android:com.instructure.parentapp/issues/cb52c6344beab447e5e6b1c5c354592a?time=1587513600000:1587772799000&sessionId=5EA24134006600014EC6F3E1B437B260_DNE_0_v2):

How to repro:
Login with qr code, log out immediately, attempt to login again with the same qr code.

Basically, anytime something went wrong inside of the sign on portion of QR login, the error handling wasn't working. This PR fixes those issues and fixes properly handling an error message and pop without resulting in an app crash.