### PR TITLE
[Parent] Fix for migrated deep linking

### DIFF
--- a/apps/flutter_parent/lib/network/utils/api_prefs.dart
+++ b/apps/flutter_parent/lib/network/utils/api_prefs.dart
@@ -78,6 +78,7 @@ class ApiPrefs {
   }
 
   static void clean() {
+    _prefs?.clear();
     _prefs = null;
     _packageInfo = null;
     _currentLogin = null;
@@ -316,7 +317,11 @@ class ApiPrefs {
 
   static setCurrentStudent(User currentStudent) {
     _checkInit();
-    _prefs.setString(KEY_CURRENT_STUDENT, json.encode(serialize(currentStudent)));
+    if (currentStudent == null) {
+      _prefs.remove(KEY_CURRENT_STUDENT);
+    } else {
+      _prefs.setString(KEY_CURRENT_STUDENT, json.encode(serialize(currentStudent)));
+    }
   }
 
   static User getCurrentStudent() {

--- a/apps/flutter_parent/lib/router/panda_router.dart
+++ b/apps/flutter_parent/lib/router/panda_router.dart
@@ -349,9 +349,15 @@ class PandaRouter {
     // We only care about valid app routes if they are already signed in or performing a qr login
     if (urlRouteWrapper.appRouteMatch != null && (ApiPrefs.isLoggedIn() || qrUri != null)) {
       if (urlRouteWrapper.validHost) {
-        // If its a link we can handle natively and within our domain, route
-        return (urlRouteWrapper.appRouteMatch.route.handler as Handler)
-            .handlerFunc(context, urlRouteWrapper.appRouteMatch.parameters);
+        // Before deep linking, we need to make sure a current student is set
+        if (ApiPrefs.getCurrentStudent() != null || qrUri != null) {
+          // If its a link we can handle natively and within our domain, route
+          return (urlRouteWrapper.appRouteMatch.route.handler as Handler)
+              .handlerFunc(context, urlRouteWrapper.appRouteMatch.parameters);
+        } else {
+          // This might be a migrated user or an error case, let's route them to the dashboard
+          return _dashboardHandler.handlerFunc(context, {});
+        }
       } else {
         // Otherwise, we want to route to the error page if they are already logged in
         return _routerErrorHandler.handlerFunc(context, params);

--- a/apps/flutter_parent/pubspec.lock
+++ b/apps/flutter_parent/pubspec.lock
@@ -990,4 +990,4 @@ packages:
     version: "2.2.0"
 sdks:
   dart: ">=2.7.0 <3.0.0"
-  flutter: "1.12.13+hotfix.7"
+  flutter: "1.12.13+hotfix.9"

--- a/apps/flutter_parent/pubspec.yaml
+++ b/apps/flutter_parent/pubspec.yaml
@@ -32,7 +32,7 @@ module:
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
-  flutter: 1.12.13+hotfix.7
+  flutter: 1.12.13+hotfix.9
 
 dependencies:
   flutter:

--- a/apps/flutter_parent/test/router/panda_router_test.dart
+++ b/apps/flutter_parent/test/router/panda_router_test.dart
@@ -82,6 +82,7 @@ void main() {
 
   setUp(() async {
     await setupPlatformChannels(config: PlatformConfig(initLoggedInUser: login));
+    ApiPrefs.setCurrentStudent(user);
     reset(_analytics);
     reset(_mockLauncher);
     reset(_mockNav);
@@ -347,7 +348,6 @@ void main() {
     });
 
     test('returns dashboard for https scheme', () {
-      ApiPrefs.setCurrentStudent(user);
       final url = 'https://test.instructure.com/conversations';
       final widget = _getWidgetFromRoute(
         _rootWithUrl(url),
@@ -357,8 +357,6 @@ void main() {
     });
 
     test('returns dashboard for http scheme', () {
-      ApiPrefs.setCurrentStudent(user);
-
       final url = 'http://test.instructure.com/conversations';
       final widget = _getWidgetFromRoute(
         _rootWithUrl(url),
@@ -368,8 +366,6 @@ void main() {
     });
 
     test('returns dashboard for canvas-parent scheme', () {
-      ApiPrefs.setCurrentStudent(user);
-
       final url = 'canvas-parent://test.instructure.com/conversations';
       final widget = _getWidgetFromRoute(
         _rootWithUrl(url),
@@ -379,7 +375,6 @@ void main() {
     });
 
     test('returns dashboard for canvas-courses scheme', () {
-      ApiPrefs.setCurrentStudent(user);
       final url = 'canvas-courses://test.instructure.com/conversations';
       final widget = _getWidgetFromRoute(
         _rootWithUrl(url),
@@ -389,8 +384,6 @@ void main() {
     });
 
     test('returns course details ', () {
-      ApiPrefs.setCurrentStudent(user);
-
       final url = 'https://test.instructure.com/courses/123';
       final widget = _getWidgetFromRoute(
         _rootWithUrl(url),
@@ -400,8 +393,6 @@ void main() {
     });
 
     test('returns assignment details ', () {
-      ApiPrefs.setCurrentStudent(user);
-
       final courseId = '123';
       final assignmentId = '321';
       final url = 'https://test.instructure.com/courses/$courseId/assignments/$assignmentId';
@@ -416,8 +407,6 @@ void main() {
 
     // This route conflicts with assignment details, so having a specific test for it will ensure they aren't broken
     test('returns CourseRoutingShellScreen for syllabus', () {
-      ApiPrefs.setCurrentStudent(user);
-
       final courseId = '123';
       final url = 'https://test.instructure.com/courses/$courseId/assignments/syllabus';
       final widget = _getWidgetFromRoute(_rootWithUrl(url)) as CourseRoutingShellScreen;
@@ -457,8 +446,6 @@ void main() {
 
     // Added the following below tests because they are new cases for the router, two routes, one handler
     test('returns CourseRoutingShellScreen for frontPage', () {
-      ApiPrefs.setCurrentStudent(user);
-
       final courseId = '123';
       final url = 'https://test.instructure.com/courses/$courseId/pages/first-page';
       final widget = _getWidgetFromRoute(_rootWithUrl(url)) as CourseRoutingShellScreen;
@@ -469,8 +456,6 @@ void main() {
     });
 
     test('returns CourseRoutingShellScreen for frontPageWiki', () {
-      ApiPrefs.setCurrentStudent(user);
-
       final courseId = '123';
       final url = 'https://test.instructure.com/courses/$courseId/wiki';
       final widget = _getWidgetFromRoute(_rootWithUrl(url)) as CourseRoutingShellScreen;
@@ -481,6 +466,8 @@ void main() {
     });
 
     test('returns Dashboard for any route with no current user or QR', () async {
+      ApiPrefs.setCurrentStudent(null);
+
       final courseId = '123';
       final assignmentId = '321';
       final url = 'https://test.instructure.com/courses/$courseId/assignments/$assignmentId';

--- a/apps/flutter_parent/test/router/panda_router_test.dart
+++ b/apps/flutter_parent/test/router/panda_router_test.dart
@@ -18,6 +18,7 @@ import 'package:flutter_parent/l10n/app_localizations.dart';
 import 'package:flutter_parent/models/login.dart';
 import 'package:flutter_parent/models/user.dart';
 import 'package:flutter_parent/network/utils/analytics.dart';
+import 'package:flutter_parent/network/utils/api_prefs.dart';
 import 'package:flutter_parent/router/panda_router.dart';
 import 'package:flutter_parent/router/router_error_screen.dart';
 import 'package:flutter_parent/screens/announcements/announcement_details_screen.dart';
@@ -57,10 +58,11 @@ final _analytics = _MockAnalytics();
 
 void main() {
   final String _domain = 'https://test.instructure.com';
+  final user = CanvasModelTestUtils.mockUser();
   final login = Login((b) => b
     ..domain = _domain
     ..accessToken = 'token'
-    ..user = CanvasModelTestUtils.mockUser().toBuilder());
+    ..user = user.toBuilder());
 
   final _mockNav = _MockNav();
   final _mockWebContentInteractor = _MockWebContentInteractor();
@@ -345,6 +347,7 @@ void main() {
     });
 
     test('returns dashboard for https scheme', () {
+      ApiPrefs.setCurrentStudent(user);
       final url = 'https://test.instructure.com/conversations';
       final widget = _getWidgetFromRoute(
         _rootWithUrl(url),
@@ -354,6 +357,8 @@ void main() {
     });
 
     test('returns dashboard for http scheme', () {
+      ApiPrefs.setCurrentStudent(user);
+
       final url = 'http://test.instructure.com/conversations';
       final widget = _getWidgetFromRoute(
         _rootWithUrl(url),
@@ -363,6 +368,8 @@ void main() {
     });
 
     test('returns dashboard for canvas-parent scheme', () {
+      ApiPrefs.setCurrentStudent(user);
+
       final url = 'canvas-parent://test.instructure.com/conversations';
       final widget = _getWidgetFromRoute(
         _rootWithUrl(url),
@@ -372,6 +379,7 @@ void main() {
     });
 
     test('returns dashboard for canvas-courses scheme', () {
+      ApiPrefs.setCurrentStudent(user);
       final url = 'canvas-courses://test.instructure.com/conversations';
       final widget = _getWidgetFromRoute(
         _rootWithUrl(url),
@@ -381,6 +389,8 @@ void main() {
     });
 
     test('returns course details ', () {
+      ApiPrefs.setCurrentStudent(user);
+
       final url = 'https://test.instructure.com/courses/123';
       final widget = _getWidgetFromRoute(
         _rootWithUrl(url),
@@ -390,6 +400,8 @@ void main() {
     });
 
     test('returns assignment details ', () {
+      ApiPrefs.setCurrentStudent(user);
+
       final courseId = '123';
       final assignmentId = '321';
       final url = 'https://test.instructure.com/courses/$courseId/assignments/$assignmentId';
@@ -404,6 +416,8 @@ void main() {
 
     // This route conflicts with assignment details, so having a specific test for it will ensure they aren't broken
     test('returns CourseRoutingShellScreen for syllabus', () {
+      ApiPrefs.setCurrentStudent(user);
+
       final courseId = '123';
       final url = 'https://test.instructure.com/courses/$courseId/assignments/syllabus';
       final widget = _getWidgetFromRoute(_rootWithUrl(url)) as CourseRoutingShellScreen;
@@ -443,6 +457,8 @@ void main() {
 
     // Added the following below tests because they are new cases for the router, two routes, one handler
     test('returns CourseRoutingShellScreen for frontPage', () {
+      ApiPrefs.setCurrentStudent(user);
+
       final courseId = '123';
       final url = 'https://test.instructure.com/courses/$courseId/pages/first-page';
       final widget = _getWidgetFromRoute(_rootWithUrl(url)) as CourseRoutingShellScreen;
@@ -453,6 +469,8 @@ void main() {
     });
 
     test('returns CourseRoutingShellScreen for frontPageWiki', () {
+      ApiPrefs.setCurrentStudent(user);
+
       final courseId = '123';
       final url = 'https://test.instructure.com/courses/$courseId/wiki';
       final widget = _getWidgetFromRoute(_rootWithUrl(url)) as CourseRoutingShellScreen;
@@ -460,6 +478,18 @@ void main() {
       expect(widget, isA<CourseRoutingShellScreen>());
       expect(widget.courseId, courseId);
       expect(widget.type, CourseShellType.frontPage);
+    });
+
+    test('returns Dashboard for any route with no current user or QR', () async {
+      final courseId = '123';
+      final assignmentId = '321';
+      final url = 'https://test.instructure.com/courses/$courseId/assignments/$assignmentId';
+
+      final widget = _getWidgetFromRoute(
+        _rootWithUrl(url),
+      ) as DashboardScreen;
+
+      expect(widget, isA<DashboardScreen>());
     });
   });
 


### PR DESCRIPTION
To Test:

Sooo its kinda gross to test this. You need to install a 2.0 version of parent app and sign in. Then, install this branch over it (pref over adb, you can't open the app). Without ever opening the app (and thus setting the current student) click an external link to the assignment details screen.

Let me know if you have any issues.