### PR TITLE
[Flutter-Parent] Fix broken login help dialog

### DIFF
--- a/apps/flutter_parent/lib/utils/common_widgets/error_report/error_report_interactor.dart
+++ b/apps/flutter_parent/lib/utils/common_widgets/error_report/error_report_interactor.dart
@@ -25,7 +25,7 @@ class ErrorReportInteractor {
     final becomeUser = (user?.id?.isNotEmpty == true) ? '$domain?become_user_id=${user.id}' : '';
     final userEmail = (email?.isNotEmpty == true) ? email : user?.primaryEmail ?? '';
 
-    final enrollments = await locator<EnrollmentsApi>().getSelfEnrollments(forceRefresh: true);
+    final enrollments = user == null ? [] : await locator<EnrollmentsApi>().getSelfEnrollments(forceRefresh: true);
     final userRoles = Set.from(enrollments?.map((enrollment) => enrollment.type) ?? []).toList().join(',');
 
     return locator<ErrorReportApi>().submitErrorReport(


### PR DESCRIPTION
To test:
Current app will never send an error report from the login screen.
Can pull down locally and comment out the actual network call in the error_report_interactor, verify it no longer crashes. If you really want to be thorough you can send a login help request and make a note in the description that you're testing on the mobile team (since this actually opens up a support ticket for Canvas)