### PR TITLE
[Flutter-Parent] Fix small, miscellaneous problems

### DIFF
--- a/apps/flutter_parent/android/app/src/main/res/values/colors.xml
+++ b/apps/flutter_parent/android/app/src/main/res/values/colors.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="parentApp">#008EE2</color>
+    <color name="parentApp">#007BC2</color>
 </resources>

--- a/apps/flutter_parent/lib/router/panda_router.dart
+++ b/apps/flutter_parent/lib/router/panda_router.dart
@@ -107,7 +107,7 @@ class PandaRouter {
     String authenticationProvider = null,
     LoginFlow loginFlow = LoginFlow.normal,
   }) =>
-      '$_loginWeb?${_RouterKeys.domain}=$domain&${_RouterKeys.authenticationProvider}=$authenticationProvider&${_RouterKeys.loginFlow}=${loginFlow.toString()}';
+      '$_loginWeb?${_RouterKeys.domain}=${Uri.encodeQueryComponent(domain)}&${_RouterKeys.authenticationProvider}=$authenticationProvider&${_RouterKeys.loginFlow}=${loginFlow.toString()}';
 
   static String notParent() => '/not_parent';
 
@@ -131,7 +131,7 @@ class PandaRouter {
   static final String _simpleWebView = '/internal';
 
   static String simpleWebViewRoute(String url, String infoText) =>
-      '/internal?${_RouterKeys.url}=${Uri.encodeQueryComponent(url)}&${_RouterKeys.infoText}=$infoText';
+      '/internal?${_RouterKeys.url}=${Uri.encodeQueryComponent(url)}&${_RouterKeys.infoText}=${Uri.encodeQueryComponent(infoText)}';
 
   static String settings() => '/settings';
 

--- a/apps/flutter_parent/lib/screens/inbox/create_conversation/create_conversation_screen.dart
+++ b/apps/flutter_parent/lib/screens/inbox/create_conversation/create_conversation_screen.dart
@@ -692,13 +692,13 @@ class AttachmentWidget extends StatelessWidget {
               )
             ],
           ),
-          if (handler.attachment?.thumbnailUrl != null)
+          if (handler.attachment?.thumbnailUrl != null && handler.attachment.thumbnailUrl.isNotEmpty)
             ClipRRect(
               borderRadius: new BorderRadius.circular(4),
               child: FadeInImage.memoryNetwork(
                 fadeInDuration: const Duration(milliseconds: 300),
                 fit: BoxFit.cover,
-                image: handler.attachment.thumbnailUrl ?? '',
+                image: handler.attachment.thumbnailUrl,
                 placeholder: kTransparentImage,
               ),
             ),

--- a/apps/flutter_parent/lib/utils/common_widgets/attachment_indicator_widget.dart
+++ b/apps/flutter_parent/lib/utils/common_widgets/attachment_indicator_widget.dart
@@ -64,7 +64,7 @@ class AttachmentIndicatorWidget extends StatelessWidget {
                     )
                   ],
                 ),
-                if (attachment.thumbnailUrl != null)
+                if (attachment.thumbnailUrl != null && attachment.thumbnailUrl.isNotEmpty)
                   ClipRRect(
                     borderRadius: new BorderRadius.circular(4),
                     child: FadeInImage.memoryNetwork(

--- a/apps/flutter_parent/lib/utils/common_widgets/web_view/canvas_web_view.dart
+++ b/apps/flutter_parent/lib/utils/common_widgets/web_view/canvas_web_view.dart
@@ -285,6 +285,7 @@ class _ResizingWebViewState extends State<_ResizingWebView> with WidgetsBindingO
     // One possible idea is to set to let the max height of the content be the height of the available space (wrapping
     // the ConstrainedBox in a LayoutBuilder to size appropriately). Though this would require adding the
     // WebViewGestureRecognizer, which doesn't support PTR, and would need some extra flag besides just fullScreen.
+    if (!mounted) return; // Possible race condition here
     setState(() => _height = height);
   }
 

--- a/apps/flutter_parent/lib/utils/design/parent_colors.dart
+++ b/apps/flutter_parent/lib/utils/design/parent_colors.dart
@@ -37,7 +37,7 @@ class ParentColors {
   static const failure = Color(0xFFEE0612);
 
   /// Core color for the parent app
-  static const parentApp = Color(0xFF008EE2);
+  static const parentApp = Color(0xFF007BC2);
 
   /// Core color for the student app
   static const studentApp = Color(0xFFEE0612);

--- a/apps/flutter_parent/test/router/panda_router_test.dart
+++ b/apps/flutter_parent/test/router/panda_router_test.dart
@@ -137,7 +137,7 @@ void main() {
       expect(widget.domain, domain);
     });
 
-    test('loginWeb returns web login screen with non-uri safe charachters', () {
+    test('loginWeb returns web login screen with non-uri safe characters ', () {
       final domain = 'domain%';
       final widget = _getWidgetFromRoute(
         PandaRouter.loginWeb(domain),

--- a/apps/flutter_parent/test/router/panda_router_test.dart
+++ b/apps/flutter_parent/test/router/panda_router_test.dart
@@ -137,6 +137,16 @@ void main() {
       expect(widget.domain, domain);
     });
 
+    test('loginWeb returns web login screen with non-uri safe charachters', () {
+      final domain = 'domain%';
+      final widget = _getWidgetFromRoute(
+        PandaRouter.loginWeb(domain),
+      ) as WebLoginScreen;
+
+      expect(widget, isA<WebLoginScreen>());
+      expect(widget.domain, domain);
+    });
+
     test('loginWeb returns web login screen with LoginFlow', () {
       final domain = 'domain';
       final flow = LoginFlow.siteAdmin;


### PR DESCRIPTION
When an empty url is passed to an image loader (FadeInImage/NetworkImage/etc) it can throw a non-fatal exception. It won’t crash the app but does create a non-fatal on Firebase.

Encoding domain provided by users so navigation can happen. If the url is invalid, the web login page may show an empty screen, but that’s what our native apps do in the same scenario (and it is better than not navigating to the screen with a non url safe character)

Updated native splash screen to use same accessible color as flutter