### PR TITLE
[Flutter-Parent][MBL-14286] Rating dialog

### DIFF
--- a/apps/flutter_parent/lib/l10n/app_localizations.dart
+++ b/apps/flutter_parent/lib/l10n/app_localizations.dart
@@ -1279,6 +1279,42 @@ class AppLocalizations {
             'Confirmation message displayed when the user wants to stop acting (masquerading) as another user and will be logged out.',
       );
 
+  /// Rating dialog
+
+  String get ratingDialogTitle => Intl.message(
+        'How are we doing?',
+        desc: 'Title for dialog asking user to rate the app out of 5 stars.',
+      );
+
+  String get ratingDialogDontShowAgain => Intl.message(
+        'Don\'t show again',
+        desc: 'Button to prevent the rating dialog from showing again.',
+      );
+
+  String get ratingDialogCommentDescription => Intl.message(
+        'What can we do better?',
+        desc: 'Hint text for providing a comment with the rating.',
+      );
+
+  String get ratingDialogSendFeedback => Intl.message('Send Feedback', desc: 'Button to send rating with feedback');
+
+  String ratingDialogEmailSubject(String version) => Intl.message(
+        'Suggestions for Android - Canvas Parent $version',
+        desc: 'The subject for an email to provide feedback for CanvasParent.',
+        name: 'ratingDialogEmailSubject',
+        args: [version],
+      );
+
+  String starRating(int position) => Intl.plural(
+        position,
+        one: '$position star',
+        other: '$position stars',
+        args: [position],
+        name: 'starRating',
+        desc: 'Accessibility label for the 1 stars to 5 stars rating',
+        examples: const {'position': 1},
+      );
+
   /// Miscellaneous
 
   String get cancel => Intl.message('Cancel');

--- a/apps/flutter_parent/lib/network/utils/analytics.dart
+++ b/apps/flutter_parent/lib/network/utils/analytics.dart
@@ -38,6 +38,8 @@ class AnalyticsEventConstants {
   static const QR_LOGIN_CLICKED = 'qr_code_login_clicked';
   static const QR_LOGIN_FAILURE = 'qr_code_login_failure';
   static const QR_LOGIN_SUCCESS = 'qr_code_login_success';
+  static const RATING_DIALOG = 'rating_dialog';
+  static const RATING_DIALOG_DONT_SHOW_AGAIN = 'rating_dialog_dont_show_again';
   static const REMINDER_ASSIGNMENT_CREATE = 'reminder_assignment';
   static const REMINDER_EVENT_CREATE = 'reminder_event';
   static const SWITCH_USERS = 'switch_users';
@@ -53,20 +55,20 @@ class AnalyticsEventConstants {
 /// Due to the limits on custom params, we will mostly be using a mapping of the pre-defined params,
 /// mappings will be recorded below. Make sure we are only using params where the data is relevant.
 ///
-/// [DOMAIN_PARAM] -> AFFILIATION
-/// [USER_CONTEXT_ID] -> CHARACTER
+/// [ASSIGNMENT_ID]/DISCUSSION/ETC ID -> ITEM_ID There is also ITEM_CATEGORY if the event is vague regarding the type of item
 /// [CANVAS_CONTEXT_ID] -> GROUP_ID
-/// [ASSIGNMENT_ID]/DISCUSSION/ETC ID -> ITEM_ID
-///   There is also ITEM_CATEGORY if the event is vague regarding the type of item
-/// [SCREEN_OF_ORIGIN] -> ORIGIN
-///   Used when events can originate from multiple locations
+/// [DOMAIN_PARAM] -> AFFILIATION
+/// [SCREEN_OF_ORIGIN] -> ORIGIN Used when events can originate from multiple locations
+/// [STAR_RATING] -> The star rating a user gave in the rating dialog
+/// [USER_CONTEXT_ID] -> CHARACTER
 ///
 class AnalyticsParamConstants {
-  static const DOMAIN_PARAM = 'affiliation';
-  static const USER_CONTEXT_ID = 'character';
-  static const CANVAS_CONTEXT_ID = 'group_id';
   static const ASSIGNMENT_ID = 'item_id';
+  static const CANVAS_CONTEXT_ID = 'group_id';
+  static const DOMAIN_PARAM = 'affiliation';
   static const SCREEN_OF_ORIGIN = 'origin';
+  static const STAR_RATING = 'star_rating';
+  static const USER_CONTEXT_ID = 'character';
 }
 
 class Analytics {
@@ -83,8 +85,12 @@ class Analytics {
     }
   }
 
-  /// Log an event to Firebase analytics (only ini release mode).
+  /// Log an event to Firebase analytics (only in release mode).
   /// If isDebug, it will also print to the console
+  ///
+  /// Params
+  /// * [event] should be one of [AnalyticsEventConstants]
+  /// * [extras] a map of keys [AnalyticsParamConstants] to values. Use sparingly, we only get 25 unique parameters
   void logEvent(String event, {Map<String, dynamic> extras = const {}}) async {
     if (kReleaseMode) {
       await _analytics.logEvent(name: event, parameters: extras);

--- a/apps/flutter_parent/lib/network/utils/analytics.dart
+++ b/apps/flutter_parent/lib/network/utils/analytics.dart
@@ -39,6 +39,7 @@ class AnalyticsEventConstants {
   static const QR_LOGIN_FAILURE = 'qr_code_login_failure';
   static const QR_LOGIN_SUCCESS = 'qr_code_login_success';
   static const RATING_DIALOG = 'rating_dialog';
+  static const RATING_DIALOG_SHOW = 'rating_dialog_show';
   static const RATING_DIALOG_DONT_SHOW_AGAIN = 'rating_dialog_dont_show_again';
   static const REMINDER_ASSIGNMENT_CREATE = 'reminder_assignment';
   static const REMINDER_EVENT_CREATE = 'reminder_event';

--- a/apps/flutter_parent/lib/network/utils/api_prefs.dart
+++ b/apps/flutter_parent/lib/network/utils/api_prefs.dart
@@ -33,13 +33,16 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'dio_config.dart';
 
 class ApiPrefs {
+  static const String KEY_CAMERA_COUNT = 'camera_count';
+  static const String KEY_CURRENT_LOGIN_UUID = 'current_login_uuid';
+  static const String KEY_CURRENT_STUDENT = 'current_student';
   static const String KEY_HAS_MIGRATED = 'has_migrated_from_old_app';
   static const String KEY_HAS_CHECKED_OLD_REMINDERS = 'has_checked_old_reminders';
   static const String KEY_HAS_MIGRATED_TO_ENCRYPTED_PREFS = 'has_migrated_to_encrypted_prefs';
   static const String KEY_LOGINS = 'logins';
-  static const String KEY_CURRENT_LOGIN_UUID = 'current_login_uuid';
-  static const String KEY_CURRENT_STUDENT = 'current_student';
-  static const String KEY_CAMERA_COUNT = 'camera_count';
+  static const String KEY_RATING_SHOW_AGAIN_WAIT = 'date_show_again';
+  static const String KEY_RATING_DONT_SHOW_AGAIN = 'dont_show_again';
+  static const String KEY_RATING_FIRST_LAUNCH_DATE = 'date_first_launched';
 
   static EncryptedSharedPreferences _prefs;
   static PackageInfo _packageInfo;
@@ -236,6 +239,8 @@ class ApiPrefs {
     }
   }
 
+  /// Prefs
+
   static String getCurrentLoginUuid() => _getPrefString(KEY_CURRENT_LOGIN_UUID);
 
   static User getUser() => getCurrentLogin()?.currentUser;
@@ -266,6 +271,23 @@ class ApiPrefs {
 
   static Future<void> setCameraCount(int count) => _setPrefInt(KEY_CAMERA_COUNT, count);
 
+  static int getRatingShowAgainWait() => _getPrefInt(KEY_RATING_SHOW_AGAIN_WAIT);
+
+  static Future<void> setRatingShowAgainWait(int showAgainDate) =>
+      _setPrefInt(KEY_RATING_SHOW_AGAIN_WAIT, showAgainDate);
+
+  static int getRatingFirstLaunchDate() => _getPrefInt(KEY_RATING_FIRST_LAUNCH_DATE);
+
+  static Future<void> setRatingFirstLaunchDate(int firstLaunch) =>
+      _setPrefInt(KEY_RATING_FIRST_LAUNCH_DATE, firstLaunch);
+
+  static bool getRatingDontShowAgain() => _getPrefBool(KEY_RATING_DONT_SHOW_AGAIN);
+
+  static Future<void> setRatingDontShowAgain(bool dontShowAgain) =>
+      _setPrefBool(KEY_RATING_DONT_SHOW_AGAIN, dontShowAgain);
+
+  /// Pref helpers
+
   static Future<void> _setPrefBool(String key, bool value) async {
     _checkInit();
     await _prefs.setBool(key, value);
@@ -290,6 +312,8 @@ class ApiPrefs {
     _checkInit();
     return _prefs.setInt(key, value);
   }
+
+  /// Utility functions
 
   static Map<String, String> getHeaderMap({
     bool forceDeviceLanguage = false,

--- a/apps/flutter_parent/lib/network/utils/api_prefs.dart
+++ b/apps/flutter_parent/lib/network/utils/api_prefs.dart
@@ -40,9 +40,8 @@ class ApiPrefs {
   static const String KEY_HAS_CHECKED_OLD_REMINDERS = 'has_checked_old_reminders';
   static const String KEY_HAS_MIGRATED_TO_ENCRYPTED_PREFS = 'has_migrated_to_encrypted_prefs';
   static const String KEY_LOGINS = 'logins';
-  static const String KEY_RATING_SHOW_AGAIN_WAIT = 'date_show_again';
   static const String KEY_RATING_DONT_SHOW_AGAIN = 'dont_show_again';
-  static const String KEY_RATING_FIRST_LAUNCH_DATE = 'date_first_launched';
+  static const String KEY_RATING_NEXT_SHOW_DATE = 'next_show_date';
 
   static EncryptedSharedPreferences _prefs;
   static PackageInfo _packageInfo;
@@ -271,15 +270,14 @@ class ApiPrefs {
 
   static Future<void> setCameraCount(int count) => _setPrefInt(KEY_CAMERA_COUNT, count);
 
-  static int getRatingShowAgainWait() => _getPrefInt(KEY_RATING_SHOW_AGAIN_WAIT);
+  static DateTime getRatingNextShowDate() {
+    final nextShow = _getPrefString(KEY_RATING_NEXT_SHOW_DATE);
+    if (nextShow == null) return null;
+    return DateTime.parse(nextShow);
+  }
 
-  static Future<void> setRatingShowAgainWait(int showAgainDate) =>
-      _setPrefInt(KEY_RATING_SHOW_AGAIN_WAIT, showAgainDate);
-
-  static int getRatingFirstLaunchDate() => _getPrefInt(KEY_RATING_FIRST_LAUNCH_DATE);
-
-  static Future<void> setRatingFirstLaunchDate(int firstLaunch) =>
-      _setPrefInt(KEY_RATING_FIRST_LAUNCH_DATE, firstLaunch);
+  static Future<void> setRatingNextShowDate(DateTime nextShowDate) =>
+      _setPrefString(KEY_RATING_NEXT_SHOW_DATE, nextShowDate?.toIso8601String());
 
   static bool getRatingDontShowAgain() => _getPrefBool(KEY_RATING_DONT_SHOW_AGAIN);
 
@@ -296,6 +294,11 @@ class ApiPrefs {
   static bool _getPrefBool(String key) {
     _checkInit();
     return _prefs.getBool(key);
+  }
+
+  static Future<void> _setPrefString(String key, String value) async {
+    _checkInit();
+    await _prefs.setString(key, value);
   }
 
   static String _getPrefString(String key) {

--- a/apps/flutter_parent/lib/screens/dashboard/dashboard_screen.dart
+++ b/apps/flutter_parent/lib/screens/dashboard/dashboard_screen.dart
@@ -36,6 +36,7 @@ import 'package:flutter_parent/utils/common_widgets/dropdown_arrow.dart';
 import 'package:flutter_parent/utils/common_widgets/empty_panda_widget.dart';
 import 'package:flutter_parent/utils/common_widgets/loading_indicator.dart';
 import 'package:flutter_parent/utils/common_widgets/masquerade_ui.dart';
+import 'package:flutter_parent/utils/common_widgets/rating_dialog.dart';
 import 'package:flutter_parent/utils/common_widgets/user_name.dart';
 import 'package:flutter_parent/utils/design/canvas_icons.dart';
 import 'package:flutter_parent/utils/design/parent_colors.dart';
@@ -108,6 +109,11 @@ class DashboardState extends State<DashboardScreen> {
 
     _interactor.getInboxCountNotifier().update();
     _showOldReminderMessage();
+
+    // Try to show the rating dialog
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      RatingDialog.asDialog(context);
+    });
   }
 
   void _loadSelf() {

--- a/apps/flutter_parent/lib/utils/common_widgets/rating_dialog.dart
+++ b/apps/flutter_parent/lib/utils/common_widgets/rating_dialog.dart
@@ -1,0 +1,253 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import 'package:device_info/device_info.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_parent/l10n/app_localizations.dart';
+import 'package:flutter_parent/network/utils/analytics.dart';
+import 'package:flutter_parent/network/utils/api_prefs.dart';
+import 'package:flutter_parent/utils/common_widgets/arrow_aware_focus_scope.dart';
+import 'package:flutter_parent/utils/common_widgets/full_screen_scroll_container.dart';
+import 'package:flutter_parent/utils/design/parent_colors.dart';
+import 'package:flutter_parent/utils/service_locator.dart';
+import 'package:flutter_parent/utils/veneers/AndroidIntentVeneer.dart';
+import 'package:package_info/package_info.dart';
+
+import '../url_launcher.dart';
+
+class RatingDialog extends StatefulWidget {
+  static const FOUR_WEEKS = 28;
+  static const SIX_WEEKS = 42;
+  static const _RATING_TO_APP_STORE_THRESHOLD = 3;
+
+  /// Will show the rating dialog when:
+  /// - user has used the app for 4 weeks
+  /// - when the user sees the dialog again there will be a "don't show again" button
+  /// - when the user sees the dialog, there are a few use cases for when to show the dialog again
+  ///
+  /// 1. User presses 5 stars -> take user to play store and don't show dialog again
+  /// 2. User presses < 5 stars with no comment -> show again 4 weeks later
+  /// 3. User presses < 5 stars with a comment -> show again 6 weeks later
+  /// 4. User presses back -> show again 4 weeks later
+  static Future<void> asDialog(BuildContext context) {
+    // Don't show dialog in tests, so that they run more stable. Testing this rating dialog can be achieved by
+    // using the method `RatingDialog.showDialogIfPossible()`
+    final hideForAutomatedTests = WidgetsBinding.instance.runtimeType != WidgetsFlutterBinding;
+    return showDialogIfPossible(context, hideForAutomatedTests);
+  }
+
+  /// A helper function for showing the dialog, so that this dialog can still be widget tested
+  @visibleForTesting
+  static Future<void> showDialogIfPossible(BuildContext context, bool hideForAutomatedTests) {
+    if (ApiPrefs.getRatingDontShowAgain() == true || hideForAutomatedTests) return Future.value();
+
+    final date = DateTime.now().millisecondsSinceEpoch;
+    if ((ApiPrefs.getRatingFirstLaunchDate() ?? 0) == 0) {
+      ApiPrefs.setRatingFirstLaunchDate(date);
+      return Future.value();
+    }
+
+    if (date < (ApiPrefs.getRatingFirstLaunchDate() + _showAgainDate())) return Future.value();
+
+    ApiPrefs.setRatingShowAgainWait(FOUR_WEEKS); // Update the show again to 4 weeks, in case they cancel the dialog
+    ApiPrefs.setRatingFirstLaunchDate(date); // Reset the date first launched to now
+
+    return showDialog(
+      context: context,
+      builder: (context) => RatingDialog._internal(),
+    );
+  }
+
+  /// Gets the show again date from prefs and converts it to milliseconds, defaulting to four weeks
+  static int _showAgainDate() {
+    final showAgainDate = ApiPrefs.getRatingShowAgainWait() ?? FOUR_WEEKS;
+    return showAgainDate * 24 * 60 * 60 * 1000;
+  }
+
+  const RatingDialog._internal({Key key}) : super(key: key);
+
+  @override
+  _RatingDialogState createState() => _RatingDialogState();
+}
+
+class _RatingDialogState extends State<RatingDialog> {
+  String _comment;
+  int _focusedStar;
+  int _selectedStar;
+  bool _sending;
+
+  @override
+  void initState() {
+    super.initState();
+    _comment = '';
+    _focusedStar = -1;
+    _selectedStar = -1;
+    _sending = false;
+  }
+
+  /// Widget building
+
+  @override
+  Widget build(BuildContext context) {
+    return FullScreenScrollContainer(
+      horizontalPadding: 0,
+      children: [
+        ArrowAwareFocusScope(
+          child: AlertDialog(
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),
+            title: Text(L10n(context).ratingDialogTitle),
+            actions: <Widget>[
+              FlatButton(
+                child: Text(L10n(context).ratingDialogDontShowAgain.toUpperCase()),
+                onPressed: _handleDontShowAgain,
+              )
+            ],
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                _stars(),
+                if (_selectedStar >= 0 && _selectedStar < RatingDialog._RATING_TO_APP_STORE_THRESHOLD) _commentWidget(),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _stars() {
+    return Semantics(
+      container: true,
+      label: L10n(context).starRating(_selectedStar + 1),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: List.generate(5, (index) {
+          return _materialButton(index);
+        }),
+      ),
+    );
+  }
+
+  Widget _materialButton(int index) {
+    final starColor = _focusedStar >= index ? ParentColors.parentApp : ParentColors.ash;
+    return Semantics(
+      child: MaterialButton(
+        child: Icon(Icons.star, color: starColor, size: 48, semanticLabel: L10n(context).starRating(index + 1)),
+        height: 48,
+        minWidth: 48,
+        shape: CircleBorder(),
+        onPressed: () => _handleStarPressed(index),
+        onHighlightChanged: (highlighted) => setState(() => _focusedStar = highlighted ? index : _selectedStar),
+        padding: EdgeInsets.zero,
+      ),
+    );
+  }
+
+  Widget _commentWidget() {
+    return Column(
+      children: <Widget>[
+        MergeSemantics(
+          // If not wrapped in merge semantics, it will not be focusable with talkback
+          child: TextField(
+            maxLines: null,
+            textCapitalization: TextCapitalization.sentences,
+            decoration: InputDecoration(hintText: L10n(context).ratingDialogCommentDescription),
+            onChanged: (text) => setState(() => _comment = text),
+          ),
+        ),
+        SizedBox(height: 8),
+        RaisedButton(
+          child: Text(L10n(context).ratingDialogSendFeedback.toUpperCase()),
+          color: Theme.of(context).accentColor,
+          textColor: Colors.white,
+          onPressed: _sending ? null : _sendFeedbackPressed,
+        ),
+      ],
+    );
+  }
+
+  /// Helper functions
+
+  _handleDontShowAgain() {
+    ApiPrefs.setRatingDontShowAgain(true);
+    locator<Analytics>().logEvent(AnalyticsEventConstants.RATING_DIALOG_DONT_SHOW_AGAIN);
+    Navigator.of(context).pop();
+  }
+
+  _popAndSendAnalytics(int index) {
+    locator<Analytics>().logEvent(
+      AnalyticsEventConstants.RATING_DIALOG,
+      extras: {AnalyticsParamConstants.STAR_RATING: index + 1},
+    );
+    Navigator.of(context).pop();
+  }
+
+  _handleStarPressed(int index) {
+    // If the rating is high, don't show the rating dialog again and launch the app store so they can review there too
+    if (index >= RatingDialog._RATING_TO_APP_STORE_THRESHOLD) {
+      ApiPrefs.setRatingDontShowAgain(true);
+      locator<UrlLauncher>().launchAppStore();
+      _popAndSendAnalytics(index);
+      return;
+    }
+
+    setState(() {
+      _focusedStar = index;
+      _selectedStar = index;
+    });
+  }
+
+  _sendFeedbackPressed() async {
+    setState(() {
+      _sending = true; // Prevent the send button from getting clicked multiple times
+    });
+
+    if (_comment.isNotEmpty) await _sendFeedback();
+    _popAndSendAnalytics(_selectedStar);
+  }
+
+  _sendFeedback() async {
+    try {
+      ApiPrefs.setRatingShowAgainWait(RatingDialog.SIX_WEEKS); // Show again in 6 weeks since they're leaving a comment
+
+      final l10n = L10n(context);
+
+      final parentId = ApiPrefs.getUser()?.id ?? 0;
+      final email = ApiPrefs.getUser()?.primaryEmail ?? '';
+      final domain = ApiPrefs.getDomain() ?? '';
+
+      final info = await Future.wait([PackageInfo.fromPlatform(), DeviceInfoPlugin().androidInfo]);
+      PackageInfo package = info[0];
+      AndroidDeviceInfo device = info[1];
+
+      final subject = l10n.ratingDialogEmailSubject(package.version);
+
+      // Populate the email body with information about the user
+      String emailBody = '' +
+          '$_comment\r\n' +
+          '\r\n' +
+          '${l10n.helpUserId} $parentId\r\n' +
+          '${l10n.helpEmail} $email\r\n' +
+          '${l10n.helpDomain} $domain\r\n' +
+          '${l10n.versionNumber}: ${package.appName} v${package.version} (${package.buildNumber})\r\n' +
+          '${l10n.device}: ${device.manufacturer} ${device.model}\r\n' +
+          '${l10n.osVersion}: Android ${device.version.release}\r\n' +
+          '----------------------------------------------\r\n';
+
+      locator<AndroidIntentVeneer>().launchEmailWithBody(subject, emailBody);
+    } catch (_) {} // Catch any errors that come from trying to launch an email
+  }
+}

--- a/apps/flutter_parent/lib/utils/common_widgets/rating_dialog.dart
+++ b/apps/flutter_parent/lib/utils/common_widgets/rating_dialog.dart
@@ -63,6 +63,8 @@ class RatingDialog extends StatefulWidget {
     ApiPrefs.setRatingShowAgainWait(FOUR_WEEKS); // Update the show again to 4 weeks, in case they cancel the dialog
     ApiPrefs.setRatingFirstLaunchDate(date); // Reset the date first launched to now
 
+    locator<Analytics>().logEvent(AnalyticsEventConstants.RATING_DIALOG_SHOW);
+
     return showDialog(
       context: context,
       builder: (context) => RatingDialog._internal(),

--- a/apps/flutter_parent/lib/utils/url_launcher.dart
+++ b/apps/flutter_parent/lib/utils/url_launcher.dart
@@ -40,4 +40,6 @@ class UrlLauncher {
       },
     );
   }
+
+  Future<void> launchAppStore() => launch('https://play.google.com/store/apps/details?id=com.instructure.parentapp');
 }

--- a/apps/flutter_parent/lib/utils/veneers/AndroidIntentVeneer.dart
+++ b/apps/flutter_parent/lib/utils/veneers/AndroidIntentVeneer.dart
@@ -13,7 +13,54 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import 'package:android_intent/android_intent.dart';
+import 'package:intent/action.dart' as android;
+import 'package:intent/extra.dart' as android;
+import 'package:intent/intent.dart' as android;
 
 class AndroidIntentVeneer {
   launch(AndroidIntent intent) => intent.launch();
+
+  launchPhone(String phoneNumber) {
+    android.Intent()
+      ..setAction(android.Action.ACTION_DIAL)
+      ..setData(Uri.parse(phoneNumber))
+      ..startActivity(createChooser: false);
+  }
+
+  launchEmail(String url) {
+    android.Intent()
+      ..setAction(android.Action.ACTION_SENDTO)
+      ..setData(Uri.parse(url))
+      ..startActivity(createChooser: true);
+  }
+
+  // TODO: Switch to AndroidIntent once it supports emails properly (either can't specify 'to' email, or body doesn't support multiline)
+  launchEmailWithBody(String subject, String emailBody, {String recipientEmail = 'mobilesupport@instructure.com'}) {
+//    _launchEmailWithBody(canvasEmail, subject, emailBody); // Can't do until it supports email better
+    android.Intent()
+      ..setAction(android.Action.ACTION_SENDTO)
+      ..setData(Uri(scheme: 'mailto'))
+      ..putExtra(android.Extra.EXTRA_EMAIL, [recipientEmail])
+      ..putExtra(android.Extra.EXTRA_SUBJECT, subject)
+      ..putExtra(android.Extra.EXTRA_TEXT, emailBody)
+      ..startActivity(createChooser: true);
+  }
+
+  // Can't use yet, this doesn't set the 'email' field properly. Also can't specify all components via the data uri, as
+  //  the encoding isn't properly handled by receiving apps (either spaces are turned into '+' or new lines aren't included).
+  //  Can update once AndroidIntent supports string arrays rather than just string array lists (confirmed this is what's
+  //  breaking, can include a link to the flutter plugin PR to fix this once I get one made)
+  void _launchEmailWithBody(String recipientEmail, String subject, String emailBody) {
+    final intent = AndroidIntent(
+      action: 'android.intent.action.SENDTO',
+      data: Uri(scheme: 'mailto').toString(),
+      arguments: {
+        'android.intent.extra.EMAIL': [recipientEmail],
+        'android.intent.extra.SUBJECT': subject,
+        'android.intent.extra.TEXT': emailBody,
+      },
+    );
+
+    launch(intent);
+  }
 }

--- a/apps/flutter_parent/test/utils/test_helpers/mock_helpers.dart
+++ b/apps/flutter_parent/test/utils/test_helpers/mock_helpers.dart
@@ -40,6 +40,7 @@ import 'package:flutter_parent/utils/db/calendar_filter_db.dart';
 import 'package:flutter_parent/utils/db/reminder_db.dart';
 import 'package:flutter_parent/utils/notification_util.dart';
 import 'package:flutter_parent/utils/url_launcher.dart';
+import 'package:flutter_parent/utils/veneers/AndroidIntentVeneer.dart';
 import 'package:flutter_parent/utils/veneers/barcode_scan_veneer.dart';
 import 'package:mockito/mockito.dart';
 import 'package:sqflite/sqflite.dart';
@@ -58,6 +59,8 @@ MockRemoteConfig setupMockRemoteConfig({Map<String, String> valueSettings = null
 }
 
 class MockAnalytics extends Mock implements Analytics {}
+
+class MockAndroidIntentVeneer extends Mock implements AndroidIntentVeneer {}
 
 class MockAlertsApi extends Mock implements AlertsApi {}
 

--- a/apps/flutter_parent/test/utils/veneer/android_intent_veneer_test.dart
+++ b/apps/flutter_parent/test/utils/veneer/android_intent_veneer_test.dart
@@ -1,0 +1,86 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_parent/utils/veneers/AndroidIntentVeneer.dart';
+import 'package:test/test.dart';
+
+import '../test_app.dart';
+
+void main() {
+  setUp(() {
+    setupPlatformChannels();
+  });
+
+  test('launch email with body calls a platform channel', () async {
+    final subject = 'subject here';
+    final emailBody = 'multi\r\nline\r\nbody\r\n';
+    final completer = Completer();
+
+    await MethodChannel('intent').setMockMethodCallHandler((MethodCall call) async {
+      expect(call.method, 'startActivity');
+      expect(call.arguments['action'], 'android.intent.action.SENDTO');
+      expect(call.arguments['data'], 'mailto:');
+      expect(call.arguments['extra'], {
+        'android.intent.extra.EMAIL': ['mobilesupport@instructure.com'], // By default this is used
+        'android.intent.extra.SUBJECT': subject,
+        'android.intent.extra.TEXT': emailBody,
+      });
+
+      completer.complete(); // Finish the completer so the test can finish
+      return null;
+    });
+
+    AndroidIntentVeneer().launchEmailWithBody(subject, emailBody);
+
+    await completer.future; // Wait for the completer to finish the test
+  });
+
+  test('launch telephone uri', () async {
+    var telUri = 'tel:+123';
+    final completer = Completer();
+
+    await MethodChannel('intent').setMockMethodCallHandler((MethodCall call) async {
+      expect(call.method, 'startActivity');
+      expect(call.arguments['action'], 'android.intent.action.DIAL');
+      expect(call.arguments['data'], Uri.parse(telUri).toString());
+
+      completer.complete(); // Finish the completer so the test can finish
+      return null;
+    });
+
+    AndroidIntentVeneer().launchPhone(telUri);
+
+    await completer.future; // Wait for the completer to finish the test
+  });
+
+  test('launches email uri', () async {
+    var mailto = 'mailto:pandas@instructure.com';
+    final completer = Completer();
+
+    await MethodChannel('intent').setMockMethodCallHandler((MethodCall call) async {
+      expect(call.method, 'startActivity');
+      expect(call.arguments['action'], 'android.intent.action.SENDTO');
+      expect(call.arguments['data'], Uri.parse(mailto).toString());
+
+      completer.complete(); // Finish the completer so the test can finish
+      return null;
+    });
+
+    AndroidIntentVeneer().launchEmail(mailto);
+
+    await completer.future;
+  });
+}

--- a/apps/flutter_parent/test/utils/widgets/rating_dialog_test.dart
+++ b/apps/flutter_parent/test/utils/widgets/rating_dialog_test.dart
@@ -1,0 +1,264 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import 'package:flutter/material.dart';
+import 'package:flutter_parent/l10n/app_localizations.dart';
+import 'package:flutter_parent/network/utils/analytics.dart';
+import 'package:flutter_parent/network/utils/api_prefs.dart';
+import 'package:flutter_parent/utils/common_widgets/rating_dialog.dart';
+import 'package:flutter_parent/utils/url_launcher.dart';
+import 'package:flutter_parent/utils/veneers/AndroidIntentVeneer.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../accessibility_utils.dart';
+import '../platform_config.dart';
+import '../test_app.dart';
+import '../test_helpers/mock_helpers.dart';
+
+void main() {
+  final analytics = MockAnalytics();
+  final intentVeneer = MockAndroidIntentVeneer();
+  final launcher = MockUrlLauncher();
+
+  setupTestLocator((locator) {
+    locator.registerLazySingleton<Analytics>(() => analytics);
+    locator.registerLazySingleton<AndroidIntentVeneer>(() => intentVeneer);
+    locator.registerLazySingleton<UrlLauncher>(() => launcher);
+  });
+
+  _validShowDate() => DateTime.now().subtract(Duration(days: 7 * 4)).millisecondsSinceEpoch;
+
+  Future<void> _showDialog(tester, {Map<String, dynamic> mockApiPrefs = const {}}) async {
+    return TestApp.showWidgetFromTap(
+      tester,
+      (context) => RatingDialog.showDialogIfPossible(context, false),
+      config: PlatformConfig(mockApiPrefs: mockApiPrefs),
+    );
+  }
+
+  /// Tests
+
+  testWidgetsWithAccessibilityChecks('asDialog does not show because this is a test', (tester) async {
+    final date = DateTime.now().millisecondsSinceEpoch;
+    await TestApp.showWidgetFromTap(
+      tester,
+      (context) => RatingDialog.asDialog(context),
+      config: PlatformConfig(mockApiPrefs: {
+        ApiPrefs.KEY_RATING_FIRST_LAUNCH_DATE: date,
+        ApiPrefs.KEY_RATING_SHOW_AGAIN_WAIT: 0,
+      }),
+    );
+
+    expect(find.byType(RatingDialog), findsNothing);
+    expect(ApiPrefs.getRatingFirstLaunchDate(), date); // Should not be changed
+    expect(ApiPrefs.getRatingShowAgainWait(), 0); // Should not be changed
+  });
+
+  group('showDialog', () {
+    testWidgetsWithAccessibilityChecks('does not show when hiding for tests', (tester) async {
+      await TestApp.showWidgetFromTap(tester, (context) => RatingDialog.showDialogIfPossible(context, true));
+
+      expect(find.byType(RatingDialog), findsNothing);
+      expect(ApiPrefs.getRatingFirstLaunchDate(), isNull); // Should not be set yet
+    });
+
+    testWidgetsWithAccessibilityChecks('does not show when dont show again is true', (tester) async {
+      await _showDialog(tester, mockApiPrefs: {ApiPrefs.KEY_RATING_DONT_SHOW_AGAIN: true});
+
+      expect(find.byType(RatingDialog), findsNothing);
+      expect(ApiPrefs.getRatingFirstLaunchDate(), isNull); // Should not be set yet
+    });
+
+    testWidgetsWithAccessibilityChecks('does not show when first launch is not set', (tester) async {
+      await _showDialog(tester, mockApiPrefs: {ApiPrefs.KEY_RATING_FIRST_LAUNCH_DATE: null});
+
+      expect(find.byType(RatingDialog), findsNothing);
+      expect(ApiPrefs.getRatingFirstLaunchDate(), isNotNull); // Should now be set
+    });
+
+    testWidgetsWithAccessibilityChecks('does not show when first launch is not past the show again date',
+        (tester) async {
+      final date = DateTime.now().millisecondsSinceEpoch;
+
+      await _showDialog(tester, mockApiPrefs: {
+        ApiPrefs.KEY_RATING_FIRST_LAUNCH_DATE: date,
+        ApiPrefs.KEY_RATING_SHOW_AGAIN_WAIT: date + 10,
+      });
+
+      expect(find.byType(RatingDialog), findsNothing);
+      expect(ApiPrefs.getRatingFirstLaunchDate(), date); // Should not be changed
+    });
+
+    testWidgetsWithAccessibilityChecks('does show when first launch is past the show again date', (tester) async {
+      final date = _validShowDate();
+      await _showDialog(tester, mockApiPrefs: {
+        ApiPrefs.KEY_RATING_FIRST_LAUNCH_DATE: date,
+      });
+
+      expect(ApiPrefs.getRatingFirstLaunchDate(), isNot(date)); // Should not be changed
+      expect(ApiPrefs.getRatingShowAgainWait(), RatingDialog.FOUR_WEEKS); // Should be set to four weeks now
+      expect(find.byType(RatingDialog), findsOneWidget);
+      expect(find.text(AppLocalizations().ratingDialogTitle), findsOneWidget);
+      expect(find.text(AppLocalizations().ratingDialogDontShowAgain.toUpperCase()), findsOneWidget);
+      expect(find.byIcon(Icons.star), findsNWidgets(5));
+    });
+  });
+
+  testWidgetsWithAccessibilityChecks('dont show again button closes and sets pref', (tester) async {
+    await _showDialog(tester, mockApiPrefs: {
+      ApiPrefs.KEY_RATING_FIRST_LAUNCH_DATE: _validShowDate(),
+    });
+
+    expect(find.byType(RatingDialog), findsOneWidget);
+    await tester.tap(find.text(AppLocalizations().ratingDialogDontShowAgain.toUpperCase()));
+    await tester.pumpAndSettle();
+
+    expect(ApiPrefs.getRatingDontShowAgain(), true);
+    verify(analytics.logEvent(AnalyticsEventConstants.RATING_DIALOG_DONT_SHOW_AGAIN)).called(1);
+  });
+
+  group('Send comments', () {
+    testWidgetsWithAccessibilityChecks('are visible when less the 4 stars selected', (tester) async {
+      await _showDialog(tester, mockApiPrefs: {
+        ApiPrefs.KEY_RATING_FIRST_LAUNCH_DATE: _validShowDate(),
+      });
+
+      expect(find.byType(RatingDialog), findsOneWidget);
+      expect(find.byIcon(Icons.star), findsNWidgets(5));
+
+      // Tap each icon, expect that comments are still visible
+      final icons = find.byIcon(Icons.star);
+      for (int i = 0; i < 3; i++) {
+        await tester.tap(icons.at(i));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(RatingDialog), findsOneWidget);
+        expect(find.text(AppLocalizations().ratingDialogCommentDescription), findsOneWidget);
+        expect(find.text(AppLocalizations().ratingDialogSendFeedback.toUpperCase()), findsOneWidget);
+      }
+    });
+
+    testWidgetsWithAccessibilityChecks('dismiss the dialog when comments are empty', (tester) async {
+      await _showDialog(tester, mockApiPrefs: {
+        ApiPrefs.KEY_RATING_FIRST_LAUNCH_DATE: _validShowDate(),
+      });
+
+      expect(find.byType(RatingDialog), findsOneWidget);
+
+      // Tap the rating
+      final icons = find.byIcon(Icons.star);
+      await tester.tap(icons.first);
+      await tester.pumpAndSettle();
+
+      // Send feedback
+      await tester.tap(find.text(AppLocalizations().ratingDialogSendFeedback.toUpperCase()));
+      await tester.pumpAndSettle();
+
+      // Asserts
+      expect(find.byType(RatingDialog), findsNothing);
+      expect(ApiPrefs.getRatingDontShowAgain(), isNot(true)); // Shouldn't set this if we are sending feedback
+      expect(ApiPrefs.getRatingShowAgainWait(), RatingDialog.FOUR_WEEKS); // Four weeks when without a comment
+      verify(analytics.logEvent(
+        AnalyticsEventConstants.RATING_DIALOG,
+        extras: {AnalyticsParamConstants.STAR_RATING: 1}, // First was clicked, should send a 1
+      )).called(1);
+    });
+
+    testWidgetsWithAccessibilityChecks('dismiss the dialog and open email when comments are not empty', (tester) async {
+      final comment = 'comment here';
+      await _showDialog(tester, mockApiPrefs: {
+        ApiPrefs.KEY_RATING_FIRST_LAUNCH_DATE: _validShowDate(),
+      });
+
+      expect(find.byType(RatingDialog), findsOneWidget);
+
+      // Tap the rating
+      final icons = find.byIcon(Icons.star);
+      await tester.tap(icons.at(1));
+      await tester.pumpAndSettle();
+
+      // Type a comment
+      await tester.enterText(find.byType(TextField), comment);
+
+      // Send feedback
+      await tester.tap(find.text(AppLocalizations().ratingDialogSendFeedback.toUpperCase()));
+      await tester.pumpAndSettle();
+
+      final emailBody = '' +
+          '$comment\r\n' +
+          '\r\n' +
+          '${AppLocalizations().helpUserId} 0\r\n' +
+          '${AppLocalizations().helpEmail} \r\n' +
+          '${AppLocalizations().helpDomain} \r\n' +
+          '${AppLocalizations().versionNumber}: Canvas v1.0.0 (3)\r\n' +
+          '${AppLocalizations().device}: Instructure Canvas Phone\r\n' +
+          '${AppLocalizations().osVersion}: Android FakeOS 9000\r\n' +
+          '----------------------------------------------\r\n';
+
+      // Asserts
+      expect(find.byType(RatingDialog), findsNothing);
+      expect(ApiPrefs.getRatingDontShowAgain(), isNot(true)); // Shouldn't set this if we are sending feedback
+      expect(ApiPrefs.getRatingShowAgainWait(), RatingDialog.SIX_WEEKS); // Four weeks when without a comment
+      verify(intentVeneer.launchEmailWithBody(AppLocalizations().ratingDialogEmailSubject('1.0.0'), emailBody));
+      verify(analytics.logEvent(
+        AnalyticsEventConstants.RATING_DIALOG,
+        extras: {AnalyticsParamConstants.STAR_RATING: 2}, // Second was clicked, should send a 2
+      )).called(1);
+    });
+  });
+
+  group('App store', () {
+    testWidgetsWithAccessibilityChecks('4 stars goes to the app store', (tester) async {
+      await _showDialog(tester, mockApiPrefs: {
+        ApiPrefs.KEY_RATING_FIRST_LAUNCH_DATE: _validShowDate(),
+      });
+
+      expect(find.byType(RatingDialog), findsOneWidget);
+      expect(find.byIcon(Icons.star), findsNWidgets(5));
+
+      // Tap 4 star icon
+      await tester.tap(find.byIcon(Icons.star).at(3));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RatingDialog), findsNothing);
+      expect(ApiPrefs.getRatingDontShowAgain(), isTrue);
+      verify(launcher.launchAppStore());
+      verify(analytics.logEvent(
+        AnalyticsEventConstants.RATING_DIALOG,
+        extras: {AnalyticsParamConstants.STAR_RATING: 4},
+      )).called(1);
+    });
+
+    testWidgetsWithAccessibilityChecks('5 stars goes to the app store', (tester) async {
+      await _showDialog(tester, mockApiPrefs: {
+        ApiPrefs.KEY_RATING_FIRST_LAUNCH_DATE: _validShowDate(),
+      });
+
+      expect(find.byType(RatingDialog), findsOneWidget);
+      expect(find.byIcon(Icons.star), findsNWidgets(5));
+
+      // Tap 5 star icon
+      await tester.tap(find.byIcon(Icons.star).last);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RatingDialog), findsNothing);
+      expect(ApiPrefs.getRatingDontShowAgain(), isTrue);
+      verify(launcher.launchAppStore());
+      verify(analytics.logEvent(
+        AnalyticsEventConstants.RATING_DIALOG,
+        extras: {AnalyticsParamConstants.STAR_RATING: 5},
+      )).called(1);
+    });
+  });
+}

--- a/apps/flutter_parent/test/utils/widgets/rating_dialog_test.dart
+++ b/apps/flutter_parent/test/utils/widgets/rating_dialog_test.dart
@@ -106,6 +106,8 @@ void main() {
         ApiPrefs.KEY_RATING_FIRST_LAUNCH_DATE: date,
       });
 
+      verify(analytics.logEvent(AnalyticsEventConstants.RATING_DIALOG_SHOW)).called(1);
+
       expect(ApiPrefs.getRatingFirstLaunchDate(), isNot(date)); // Should not be changed
       expect(ApiPrefs.getRatingShowAgainWait(), RatingDialog.FOUR_WEEKS); // Should be set to four weeks now
       expect(find.byType(RatingDialog), findsOneWidget);

--- a/apps/flutter_parent/test/utils/widgets/rating_dialog_test.dart
+++ b/apps/flutter_parent/test/utils/widgets/rating_dialog_test.dart
@@ -37,6 +37,12 @@ void main() {
     locator.registerLazySingleton<UrlLauncher>(() => launcher);
   });
 
+  setUp(() {
+    reset(analytics);
+    reset(intentVeneer);
+    reset(launcher);
+  });
+
   _validShowDate() => DateTime.now().subtract(Duration(days: 7 * 4)).millisecondsSinceEpoch;
 
   Future<void> _showDialog(tester, {Map<String, dynamic> mockApiPrefs = const {}}) async {
@@ -69,6 +75,8 @@ void main() {
     testWidgetsWithAccessibilityChecks('does not show when hiding for tests', (tester) async {
       await TestApp.showWidgetFromTap(tester, (context) => RatingDialog.showDialogIfPossible(context, true));
 
+      verifyNever(analytics.logEvent(AnalyticsEventConstants.RATING_DIALOG_SHOW));
+
       expect(find.byType(RatingDialog), findsNothing);
       expect(ApiPrefs.getRatingFirstLaunchDate(), isNull); // Should not be set yet
     });
@@ -76,12 +84,16 @@ void main() {
     testWidgetsWithAccessibilityChecks('does not show when dont show again is true', (tester) async {
       await _showDialog(tester, mockApiPrefs: {ApiPrefs.KEY_RATING_DONT_SHOW_AGAIN: true});
 
+      verifyNever(analytics.logEvent(AnalyticsEventConstants.RATING_DIALOG_SHOW));
+
       expect(find.byType(RatingDialog), findsNothing);
       expect(ApiPrefs.getRatingFirstLaunchDate(), isNull); // Should not be set yet
     });
 
     testWidgetsWithAccessibilityChecks('does not show when first launch is not set', (tester) async {
       await _showDialog(tester, mockApiPrefs: {ApiPrefs.KEY_RATING_FIRST_LAUNCH_DATE: null});
+
+      verifyNever(analytics.logEvent(AnalyticsEventConstants.RATING_DIALOG_SHOW));
 
       expect(find.byType(RatingDialog), findsNothing);
       expect(ApiPrefs.getRatingFirstLaunchDate(), isNotNull); // Should now be set
@@ -95,6 +107,8 @@ void main() {
         ApiPrefs.KEY_RATING_FIRST_LAUNCH_DATE: date,
         ApiPrefs.KEY_RATING_SHOW_AGAIN_WAIT: date + 10,
       });
+
+      verifyNever(analytics.logEvent(AnalyticsEventConstants.RATING_DIALOG_SHOW));
 
       expect(find.byType(RatingDialog), findsNothing);
       expect(ApiPrefs.getRatingFirstLaunchDate(), date); // Should not be changed


### PR DESCRIPTION
Added a rating dialog, only shows after 4 weeks, good luck testing that 😉

Also consolidated some intent logic behind a veneer to be reusable by different screens.

Unable to add a widget test for the dashboard showing this new dialog, as we purposefully don't show the rating dialog during tests to keep e2e tests stable (this may not be an issue in flutter, it was in native so I'm also hiding it in tests here).

To test locally:
* Comment out the first block of the `showDialogIfPossible ` in the RatingDialog class so that the method just runs `showDialog`. This will show the dialog every time you open the app. 
* 4 & 5 stars go to the app store (native only did 5 stars, we're adding 4 here as we need the positive ratings)
* 3 and under are asked to leave a comment. If no comment is provided the dialog closes. If a comment is provided it opens an email (and closes the dialog)