### PR TITLE
[Parent] Student dropdown name text alignment

### DIFF
--- a/apps/flutter_parent/lib/screens/dashboard/student_horizontal_list_view.dart
+++ b/apps/flutter_parent/lib/screens/dashboard/student_horizontal_list_view.dart
@@ -80,6 +80,7 @@ class StudentHorizontalListViewState extends State<StudentHorizontalListView> {
                   student.shortName,
                   key: Key("${student.shortName}_text"),
                   style: Theme.of(context).textTheme.subtitle.copyWith(color: ParentTheme.of(context).onSurfaceColor),
+                  textAlign: TextAlign.center,
                   overflow: TextOverflow.ellipsis,
                 ),
               ],


### PR DESCRIPTION
TO Test:
Add a student with a really long name. Notice that when its overflowed it is no longer centered with the users avatar.
Before / After
<img width="732" alt="Screen Shot 2020-05-05 at 10 50 40 AM" src="https://user-images.githubusercontent.com/5596528/81092722-47ef0a80-8ebe-11ea-9cb4-ac4fef287965.png">
