### PR TITLE
[Flutter-Parent] Update gradle wrapper

### DIFF
--- a/apps/flutter_parent/.gitignore
+++ b/apps/flutter_parent/.gitignore
@@ -39,6 +39,7 @@ coverage/
 
 # Android related
 **/android/**/gradle-wrapper.jar
+**/android/**/gradle-wrapper.properties
 **/android/.gradle
 **/android/captures/
 **/android/gradlew

--- a/apps/flutter_parent/android/gradle/wrapper/gradle-wrapper.properties
+++ b/apps/flutter_parent/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,0 @@
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip

--- a/apps/flutter_parent/android/gradle/wrapper/gradle-wrapper.properties
+++ b/apps/flutter_parent/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Jun 23 08:50:38 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip

--- a/apps/flutter_parent/plugins/encrypted_shared_preferences/android/gradle/wrapper/gradle-wrapper.properties
+++ b/apps/flutter_parent/plugins/encrypted_shared_preferences/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,0 @@
-#Wed Apr 15 14:52:24 MDT 2020
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/apps/flutter_parent/plugins/webview_flutter/android/gradle/wrapper/gradle-wrapper.properties
+++ b/apps/flutter_parent/plugins/webview_flutter/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,0 @@
-#Mon Apr 13 16:22:20 MDT 2020
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
Ignored so it's built fresh every time, that way it's always up to date.