### PR TITLE
[Student][MBL-14376] Propagate planner changes to all planner screens

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/events/RationedBusEvent.kt
+++ b/apps/student/src/main/java/com/instructure/student/events/RationedBusEvent.kt
@@ -139,12 +139,6 @@ class DiscussionTopicHeaderEvent(discussionTopicHeader: DiscussionTopicHeader, s
 /** A RationedBusEvent for updating pages. @see [RationedBusEvent] */
 class PageUpdatedEvent(page: Page, skipId: String? = null) : RationedBusEvent<Page>(page, skipId)
 
-/** A RationedBusEvent for updating the calendar list when events are created. @see [RationedBusEvent] */
-class CalendarEventCreated(scheduleItem: ScheduleItem, skipId: String? = null) : RationedBusEvent<ScheduleItem>(scheduleItem, skipId)
-
-/** A RationedBusEvent for updating the calendar list when events are deleted. @see [RationedBusEvent] */
-class CalendarEventDestroyed(scheduleItem: ScheduleItem, skipId: String? = null) : RationedBusEvent<ScheduleItem>(scheduleItem, skipId)
-
 /** A RationedBusEvent for updating modules. @see [RationedBusEvent] */
 class ModuleUpdatedEvent(moduleObject: ModuleObject, skipId: String? = null) : RationedBusEvent<ModuleObject>(moduleObject, skipId)
 

--- a/apps/student/src/main/java/com/instructure/student/flutterChannels/FlutterComm.kt
+++ b/apps/student/src/main/java/com/instructure/student/flutterChannels/FlutterComm.kt
@@ -17,9 +17,11 @@
 package com.instructure.student.flutterChannels
 
 import android.content.Context
+import android.util.Log
 import com.google.gson.Gson
 import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.canvasapi2.utils.isValid
+import com.instructure.canvasapi2.utils.toApiString
 import com.instructure.pandautils.utils.ColorKeeper
 import com.instructure.pandautils.utils.ThemePrefs
 import io.flutter.embedding.engine.FlutterEngine
@@ -33,6 +35,7 @@ object FlutterComm {
 
     private const val METHOD_RESET = "reset"
     private const val METHOD_ROUTE_TO_CALENDAR = "routeToCalendar"
+    private const val METHOD_UPDATE_CALENDAR_DATES = "updateCalendarDates"
     private const val METHOD_UPDATE_LOGIN_DATA = "updateLoginData"
     private const val METHOD_UPDATE_SHOULD_POP = "updateShouldPop"
     private const val METHOD_UPDATE_THEME_DATA = "updateThemeData"
@@ -94,4 +97,10 @@ object FlutterComm {
     fun routeToCalendar(channelId: String) = channel.invokeMethod(METHOD_ROUTE_TO_CALENDAR, channelId)
 
     fun reset() = channel.invokeMethod(METHOD_RESET, null)
+
+    fun updateCalendarDates(dates: List<Date?>) {
+        val affectedDates = dates.filterNotNull().distinct() // Sanitize
+        val isoDates = affectedDates.map { it.toApiString() }
+        channel.invokeMethod(METHOD_UPDATE_CALENDAR_DATES, isoDates)
+    }
 }

--- a/apps/student/src/main/java/com/instructure/student/fragment/CalendarEventFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/CalendarEventFragment.kt
@@ -37,8 +37,7 @@ import com.instructure.interactions.router.Route
 import com.instructure.pandautils.utils.*
 import com.instructure.pandautils.views.CanvasWebView
 import com.instructure.student.R
-import com.instructure.student.events.CalendarEventDestroyed
-import com.instructure.student.events.post
+import com.instructure.student.flutterChannels.FlutterComm
 import com.instructure.student.router.RouteMatcher
 import kotlinx.android.synthetic.main.calendar_event_layout.*
 import kotlinx.android.synthetic.main.fragment_calendar_event.*
@@ -106,7 +105,7 @@ class CalendarEventFragment : ParentFragment() {
 
     //region Fragment Interaction Overrides
     override fun applyTheme() {
-        if (scheduleItem?.contextId == ApiPrefs.user?.id) {
+        if (scheduleItem?.contextId ?: canvasContext.id == ApiPrefs.user?.id) {
             setupToolbarMenu(toolbar, R.menu.calendar_event_menu)
         }
 
@@ -241,7 +240,7 @@ class CalendarEventFragment : ParentFragment() {
 
                 toast(R.string.eventSuccessfulDeletion)
                 response.body()?.let {
-                    CalendarEventDestroyed(it).post()
+                    FlutterComm.updateCalendarDates(listOf(it.allDayDate, it.startDate, it.endDate))
                 }
                 requireActivity().onBackPressed()
             }

--- a/libs/flutter_student_embed/lib/screens/calendar/calendar_day_planner.dart
+++ b/libs/flutter_student_embed/lib/screens/calendar/calendar_day_planner.dart
@@ -66,7 +66,10 @@ class CalendarDayPlannerState extends State<CalendarDayPlanner> {
     );
   }
 
-  Future<void> _refresh() => Provider.of<PlannerFetcher>(context).refreshItemsForDate(widget._day);
+  Future<void> _refresh() async {
+    PlannerFetcher.notifyDatesChanged([widget._day]);
+    await Provider.of<PlannerFetcher>(context).refreshItemsForDate(widget._day);
+  }
 }
 
 class CalendarDayList extends StatelessWidget {

--- a/libs/flutter_student_embed/lib/screens/calendar/calendar_screen.dart
+++ b/libs/flutter_student_embed/lib/screens/calendar/calendar_screen.dart
@@ -157,7 +157,7 @@ class CalendarScreenState extends State<CalendarScreen> {
 
   void _refreshDates(@nullable List<DateTime> dates) {
     if (dates == null) return;
-    dates.forEach((date) => _fetcher.refreshItemsForDate(date.toLocal(), clearCaches: true));
+    PlannerFetcher.notifyDatesChanged(dates);
   }
 
   @override

--- a/libs/flutter_student_embed/lib/utils/native_comm.dart
+++ b/libs/flutter_student_embed/lib/utils/native_comm.dart
@@ -21,6 +21,7 @@ import 'package:flutter_student_embed/models/login.dart';
 import 'package:flutter_student_embed/models/serializers.dart';
 import 'package:flutter_student_embed/network/utils/api_prefs.dart';
 import 'package:flutter_student_embed/screens/calendar/calendar_screen.dart';
+import 'package:flutter_student_embed/screens/calendar/planner_fetcher.dart';
 
 import 'design/student_colors.dart';
 
@@ -29,6 +30,7 @@ class NativeComm {
 
   static const methodReset = 'reset';
   static const methodRouteToCalendar = 'routeToCalendar';
+  static const methodUpdateCalendarDates = 'updateCalendarDates';
   static const methodUpdateLoginData = 'updateLoginData';
   static const methodUpdateShouldPop = 'updateShouldPop';
   static const methodUpdateThemeData = 'updateThemeData';
@@ -62,6 +64,9 @@ class NativeComm {
           break;
         case methodReset:
           _performReset();
+          break;
+        case methodUpdateCalendarDates:
+          _updateCalendarDates(methodCall.arguments);
           break;
         default:
           throw 'Channel method not implemented: ${methodCall.method}';
@@ -101,6 +106,11 @@ class NativeComm {
       print('Error updating theme data!');
       FlutterError.dumpErrorToConsole(e);
     }
+  }
+
+  static void _updateCalendarDates(dynamic rawDates) {
+    List<DateTime> dates = (rawDates as List<dynamic>).map((it) => DateTime.parse(it as String).toLocal()).toList();
+    PlannerFetcher.notifyDatesChanged(dates);
   }
 
   static void _performReset() {


### PR DESCRIPTION
This PR fixes an issue where calendar screens on the back stack would not update properly when there was a change to the calendar. To test, open the calendar tab multiple times and perform calendar-related changes such as adding/editing/deleting planner notes, pulling to refresh after making changes via the web interface, and deleting calendar events. Backing out to previous calendar screens should result in those screens showing the update calendar information.

This PR also fixes an issue where the CalendarEventFragment would not show the overflow menu for deletable events.