### PR TITLE
[Student][Hotfix-6.7.1] Another Student view fix and block messaging from People details

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
@@ -135,7 +135,7 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
                             }, route)
                 }
                 R.id.navigationDrawerItem_changeUser -> {
-                    StudentLogoutTask(LogoutTask.Type.SWITCH_USERS).execute()
+                    StudentLogoutTask(if (ApiPrefs.isStudentView) LogoutTask.Type.LOGOUT else LogoutTask.Type.SWITCH_USERS).execute()
                 }
                 R.id.navigationDrawerItem_logout -> {
                     AlertDialog.Builder(this@NavigationActivity)

--- a/apps/student/src/main/java/com/instructure/student/fragment/PeopleDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/PeopleDetailsFragment.kt
@@ -27,6 +27,7 @@ import com.instructure.canvasapi2.models.BasicUser
 import com.instructure.canvasapi2.models.CanvasContext
 import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.models.User
+import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.canvasapi2.utils.Pronouns
 import com.instructure.canvasapi2.utils.displayType
 import com.instructure.canvasapi2.utils.isValid
@@ -42,6 +43,7 @@ import com.instructure.interactions.router.Route
 import com.instructure.interactions.router.RouterParams
 import com.instructure.pandautils.utils.*
 import com.instructure.student.R
+import com.instructure.student.activity.NothingToSeeHereFragment
 import com.instructure.student.router.RouteMatcher
 import kotlinx.android.synthetic.main.fragment_people_details.*
 import java.util.ArrayList
@@ -74,9 +76,13 @@ class PeopleDetailsFragment : ParentFragment(), Bookmarkable {
 
         compose.setIconDrawable(ColorKeeper.getColoredDrawable(requireContext(), R.drawable.vd_send, Color.WHITE))
         compose.setOnClickListener {
-            val participants = ArrayList<BasicUser>()
-            participants.add(BasicUser.userToBasicUser(user!!))
-            val route = InboxComposeMessageFragment.makeRoute(canvasContext, participants)
+            // Messaging other users is not available in Student view
+            val route = if (ApiPrefs.isStudentView) NothingToSeeHereFragment.makeRoute() else {
+                val participants = ArrayList<BasicUser>()
+                participants.add(BasicUser.userToBasicUser(user!!))
+                InboxComposeMessageFragment.makeRoute(canvasContext, participants)
+            }
+
             RouteMatcher.route(requireContext(), route)
         }
         when {


### PR DESCRIPTION
Found an edge case where:

1. The user is in Student view
2. Tap switch user
3. Close the app (swipe away or force close, hitting the back button doesn't work). 
4. Relaunch the app
5. The app relaunches with the intent used to start Student view, launching the app back into Student view.

Users in Student view were also able to message other users from the People details screen. We don't want them to be able to message anyone, so a condition was put in to block that.