### PR TITLE
[Parent][E2E][MBL-14433]: Fix Parent E2E test reporting

### DIFF
--- a/apps/flutter_parent/run_all_ui_tests.bash
+++ b/apps/flutter_parent/run_all_ui_tests.bash
@@ -56,17 +56,20 @@ do
           flutter drive --target=$target # rerun the test
         fi
 
-        # Stop the clock
-        endTime=`date +"%s"`
-        ((runSecs=endTime-startTime))
-
         # Record test result
         if [ $? -eq 0 ]
         then
+          # Stop the clock
+          endTime=`date +"%s"`
+          ((runSecs=endTime-startTime))
           echo Aggregator: $driver Passed, secs=$runSecs
           ((passed=passed+1))
           emitTestResult $driver passed $runSecs
         else
+          # Stop the clock
+          endTime=`date +"%s"`
+          ((runSecs=endTime-startTime))
+          echo Aggregator: $driver FAILED, secs=$runSecs
           ((failed=failed+1))
           failures=("${failures[@]}" $driver)
           emitTestResult $driver failed $runSecs


### PR DESCRIPTION
I had mistakenly added some logic in between running a test and checking for that test's result code, so I was always seeing passing tests.