### PR TITLE
[Parent][E2E][MBL-14433]: Fix reporting of retries in E2E tests

### DIFF
--- a/apps/flutter_parent/run_all_ui_tests.bash
+++ b/apps/flutter_parent/run_all_ui_tests.bash
@@ -50,8 +50,11 @@ do
         # Allow for a single retry for a failed test
         if [ $? -ne 0 ]
         then
+          # Stop the clock
+          endTime=`date +"%s"`
+          ((runSecs=endTime-startTime))
           echo "Aggregator: $driver failed; retrying..."
-          emitTestResult $driver retry
+          emitTestResult $driver retry $runSecs
           startTime=`date +"%s"` # restart the clock
           flutter drive --target=$target # rerun the test
         fi


### PR DESCRIPTION
Should fix the message-formatting problems that prevented retries from being reported before.