### PR TITLE
[Student][MBL-14303] Support submission limits for Assignments 2

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/renderPages/AssignmentDetailsRenderPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/renderPages/AssignmentDetailsRenderPage.kt
@@ -17,27 +17,19 @@
 package com.instructure.student.ui.pages.renderPages
 
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.espresso.web.assertion.WebViewAssertions.webMatches
 import androidx.test.espresso.web.sugar.Web.onWebView
 import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
 import androidx.test.espresso.web.webdriver.DriverAtoms.getText
 import androidx.test.espresso.web.webdriver.Locator
-import com.instructure.espresso.OnViewWithId
-import com.instructure.espresso.OnViewWithText
-import com.instructure.espresso.assertDisplayed
-import com.instructure.espresso.assertGone
-import com.instructure.espresso.assertHasContentDescription
-import com.instructure.espresso.assertHasText
-import com.instructure.espresso.assertVisible
-import com.instructure.espresso.click
+import com.instructure.espresso.*
 import com.instructure.espresso.page.onViewWithText
 import com.instructure.student.R
 import com.instructure.student.ui.pages.AssignmentDetailsPage
 import org.hamcrest.Matchers
-import org.hamcrest.Matchers.allOf
-import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.*
 
 class AssignmentDetailsRenderPage : AssignmentDetailsPage() {
 
@@ -58,7 +50,11 @@ class AssignmentDetailsRenderPage : AssignmentDetailsPage() {
     val quizDetails by OnViewWithId(R.id.quizDetails)
     val questionCountText by OnViewWithId(R.id.questionCountText)
     val timeLimitText by OnViewWithId(R.id.timeLimitText)
+    val allowedQuizAttemptsText by OnViewWithId(R.id.allowedQuizAttemptsText)
+    val allowedAttemptsContainer by OnViewWithId(R.id.allowedAttemptsContainer)
+    val allowedAttemptsLabel by OnViewWithId(R.id.allowedAttemptsLabel)
     val allowedAttemptsText by OnViewWithId(R.id.allowedAttemptsText)
+    val usedAttemptsText by OnViewWithId(R.id.usedAttemptsText)
     val discussionTopicHeaderContainer by OnViewWithId(R.id.discussionTopicHeaderContainer)
     val authorAvatar by OnViewWithId(R.id.authorAvatar)
     val authorName by OnViewWithId(R.id.authorName)
@@ -149,24 +145,43 @@ class AssignmentDetailsRenderPage : AssignmentDetailsPage() {
         onWebView().withElement(findElement(Locator.ID, "header_content")).check(webMatches(getText(), Matchers.comparesEqualTo(text)))
     }
 
+    fun assertAssignmentAttemptsGone() {
+        allowedAttemptsContainer.assertGone()
+        allowedAttemptsLabel.assertGone()
+        allowedAttemptsText.assertGone()
+        usedAttemptsText.assertGone()
+    }
+
+    fun assertAssignmentAttempts(allowedAttempts: Long, usedAttempts: Long, enabled: Boolean) {
+        allowedAttemptsContainer.assertVisible()
+        allowedAttemptsLabel.assertVisible()
+        allowedAttemptsText.assertHasText(allowedAttempts.toString())
+        usedAttemptsText.assertHasText(usedAttempts.toString())
+        if (enabled) {
+            submitButton.waitForCheck(matches(isEnabled()))
+        } else {
+            submitButton.waitForCheck(matches(not(isEnabled())))
+        }
+    }
+
     fun assertQuizDescription(timeLimit: String, allowedAttempts: String, questionCount: String) {
         quizDetails.assertVisible()
         questionCountText.assertHasText(questionCount)
-        allowedAttemptsText.assertHasText(allowedAttempts)
+        allowedQuizAttemptsText.assertHasText(allowedAttempts)
         timeLimitText.assertHasText(timeLimit)
     }
 
     fun assertQuizDescription(timeLimit: Int, allowedAttempts: String, questionCount: String) {
         quizDetails.assertVisible()
         questionCountText.assertHasText(questionCount)
-        allowedAttemptsText.assertHasText(allowedAttempts)
+        allowedQuizAttemptsText.assertHasText(allowedAttempts)
         timeLimitText.assertHasText(timeLimit)
     }
 
     fun assertQuizDescription(timeLimit: String, allowedAttempts: Int, questionCount: String) {
         quizDetails.assertVisible()
         questionCountText.assertHasText(questionCount)
-        allowedAttemptsText.assertHasText(allowedAttempts)
+        allowedQuizAttemptsText.assertHasText(allowedAttempts)
         timeLimitText.assertHasText(timeLimit)
     }
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/renderPages/AssignmentDetailsRenderPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/renderPages/AssignmentDetailsRenderPage.kt
@@ -162,6 +162,7 @@ class AssignmentDetailsRenderPage : AssignmentDetailsPage() {
         } else {
             submitButton.waitForCheck(matches(not(isEnabled())))
         }
+        submitButton.click()
     }
 
     fun assertQuizDescription(timeLimit: String, allowedAttempts: String, questionCount: String) {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/AssignmentDetailsRenderTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/AssignmentDetailsRenderTest.kt
@@ -685,6 +685,50 @@ class AssignmentDetailsRenderTest : StudentRenderTest() {
         assignmentDetailsRenderPage.assertSubmissionStatusVisibility(true)
     }
 
+    @Test
+    @TestMetaData(Priority.P2, FeatureCategory.ASSIGNMENTS, TestCategory.RENDER)
+    fun showsAllowedAttempts() {
+        val allowed = 35L
+        val used = 20L
+        val submission = Submission(workflowState = "submitted", submittedAt = Date(), attempt = used)
+        val assignment = Assignment(
+            name = "Test Assignment",
+            allowedAttempts = allowed,
+            submission = submission
+        )
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
+        loadPageWithModel(model)
+        assignmentDetailsRenderPage.assertAssignmentAttempts(allowed, used, true)
+    }
+
+    @Test
+    @TestMetaData(Priority.P2, FeatureCategory.ASSIGNMENTS, TestCategory.RENDER)
+    fun showsAllowedAttemptsWithDisabledButton() {
+        val allowed = 35L
+        val used = 35L
+        val submission = Submission(workflowState = "submitted", submittedAt = Date(), attempt = used)
+        val assignment = Assignment(
+            name = "Test Assignment",
+            allowedAttempts = allowed,
+            submission = submission
+        )
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
+        loadPageWithModel(model)
+        assignmentDetailsRenderPage.assertAssignmentAttempts(allowed, used, false)
+    }
+
+    @Test
+    @TestMetaData(Priority.P2, FeatureCategory.ASSIGNMENTS, TestCategory.RENDER)
+    fun hidesAllowedAttemptsWhenNotSet() {
+        val assignment = Assignment(
+            name = "Test Assignment",
+            allowedAttempts = -1 // Represents unlimited attempts
+        )
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
+        loadPageWithModel(model)
+        assignmentDetailsRenderPage.assertAssignmentAttemptsGone()
+    }
+
     private fun mockkSubmission(failed: Boolean = false) = com.instructure.student.Submission.Impl(
         123L,
         null,

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/AssignmentDetailsRenderTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/AssignmentDetailsRenderTest.kt
@@ -694,7 +694,8 @@ class AssignmentDetailsRenderTest : StudentRenderTest() {
         val assignment = Assignment(
             name = "Test Assignment",
             allowedAttempts = allowed,
-            submission = submission
+            submission = submission,
+            submissionTypesRaw = listOf("online_text_entry")
         )
         val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
         loadPageWithModel(model)
@@ -710,7 +711,8 @@ class AssignmentDetailsRenderTest : StudentRenderTest() {
         val assignment = Assignment(
             name = "Test Assignment",
             allowedAttempts = allowed,
-            submission = submission
+            submission = submission,
+            submissionTypesRaw = listOf("online_text_entry")
         )
         val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
         loadPageWithModel(model)

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsPresenter.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsPresenter.kt
@@ -184,6 +184,9 @@ object AssignmentDetailsPresenter : Presenter<AssignmentDetailsModel, Assignment
         visibilities.fileTypes = assignment.allowedExtensions.isNotEmpty() && assignment.getSubmissionTypes().contains(Assignment.SubmissionType.ONLINE_UPLOAD)
         val fileTypes = assignment.allowedExtensions.joinToString(", ")
 
+        // Handle attempt limits (only show attempt details if it's not unlimited, disable the submit button if they're out of attempts)
+        visibilities.allowedAttempts = assignment.allowedAttempts != -1L
+        visibilities.submitButtonEnabled = assignment.allowedAttempts == -1L || (assignment.submission?.attempt?.let{ it < assignment.allowedAttempts } ?: true)
 
         //Configure stickied submit button visibility state,
         visibilities.submitButton = when(assignment.turnInType) {
@@ -242,7 +245,9 @@ object AssignmentDetailsPresenter : Presenter<AssignmentDetailsModel, Assignment
             assignmentDetailsVisibilities = visibilities,
             isExternalToolSubmission = isExternalToolSubmission,
             quizDescriptionViewState = quizDescriptionViewState,
-            discussionHeaderViewState = discussionHeaderViewState
+            discussionHeaderViewState = discussionHeaderViewState,
+            allowedAttempts = assignment.allowedAttempts,
+            usedAttempts = assignment.submission?.attempt ?: 0
         )
     }
 
@@ -276,7 +281,9 @@ object AssignmentDetailsPresenter : Presenter<AssignmentDetailsModel, Assignment
             submittedStateColor = submittedColor,
             submittedStateIcon = submittedIconRes,
             lockMessage = lockMessage,
-            assignmentDetailsVisibilities = visibilities
+            assignmentDetailsVisibilities = visibilities,
+            allowedAttempts = assignment.allowedAttempts,
+            usedAttempts = assignment.submission?.attempt ?: 0
         )
     }
 

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsPresenter.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsPresenter.kt
@@ -197,7 +197,7 @@ object AssignmentDetailsPresenter : Presenter<AssignmentDetailsModel, Assignment
         }
 
         // Configure stickied submit button
-        val submitButtonText = getSubmitButtonText(context, isExternalToolSubmission, assignment.isSubmitted, assignment.turnInType)
+        val submitButtonText = getSubmitButtonText(context, isExternalToolSubmission, assignment.isSubmitted, assignment.turnInType, visibilities.submitButtonEnabled)
 
         // Configure description label
         val descriptionLabel = when(assignment.turnInType) {
@@ -335,9 +335,10 @@ object AssignmentDetailsPresenter : Presenter<AssignmentDetailsModel, Assignment
         }
     }
 
-    private fun getSubmitButtonText(context: Context, isExternalToolSubmission: Boolean, submitted: Boolean, turnInType: Assignment.TurnInType): String {
+    private fun getSubmitButtonText(context: Context, isExternalToolSubmission: Boolean, submitted: Boolean, turnInType: Assignment.TurnInType, submitEnabled: Boolean): String {
         return context.getString(
                 when {
+                    !submitEnabled -> R.string.noAttemptsLeft
                     turnInType == Assignment.TurnInType.QUIZ -> R.string.viewQuiz
                     turnInType == Assignment.TurnInType.DISCUSSION -> R.string.viewDiscussion
                     isExternalToolSubmission -> R.string.launchExternalTool

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsView.kt
@@ -142,6 +142,13 @@ class AssignmentDetailsView(
             lockImageContainer.setVisible(visibilities.lockedImage)
             noDescriptionContainer.setVisible(visibilities.noDescriptionLabel)
             descriptionWebView.setVisible(visibilities.description)
+            allowedAttemptsContainer.setVisible(visibilities.allowedAttempts)
+            submitButton.isEnabled = visibilities.submitButtonEnabled
+            if (visibilities.submitButtonEnabled) {
+                submitButton.alpha = 1f
+            } else {
+                submitButton.alpha = 0.2f
+            }
             submitButton.setVisible(visibilities.submitButton)
             submissionUploadStatusContainer.setVisible(visibilities.submissionUploadStatusInProgress || visibilities.submissionUploadStatusFailed)
             submissionStatusUploading.setVisible(visibilities.submissionUploadStatusInProgress)
@@ -170,6 +177,8 @@ class AssignmentDetailsView(
         lockMessageTextView.text = state.lockMessage
         submissionTypesTextView.text = state.submissionTypes
         fileTypesTextView.text = state.fileTypes
+        allowedAttemptsText.text = state.allowedAttempts.toString()
+        usedAttemptsText.text = state.usedAttempts.toString()
         gradeCell.setState(state.gradeState)
         submitButton.text = state.submitButtonText
         if (state.visibilities.description) {
@@ -183,7 +192,7 @@ class AssignmentDetailsView(
     private fun renderQuizDetails(quizDescriptionViewState: QuizDescriptionViewState) {
         questionCountText.text = quizDescriptionViewState.questionCount
         timeLimitText.text = quizDescriptionViewState.timeLimit
-        allowedAttemptsText.text = quizDescriptionViewState.allowedAttempts
+        allowedQuizAttemptsText.text = quizDescriptionViewState.allowedAttempts
     }
 
     private fun renderDiscussionTopicHeader(discussionHeaderViewState: DiscussionHeaderViewState) {

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsViewState.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsViewState.kt
@@ -36,6 +36,8 @@ sealed class AssignmentDetailsViewState(val visibilities: AssignmentDetailsVisib
         val lockMessage: String = "",
         val submissionTypes: String = "",
         val fileTypes: String = "",
+        val allowedAttempts: Long,
+        val usedAttempts: Long,
         val description: String = "",
         val descriptionLabel: String = "",
         val submitButtonText: String = "",
@@ -62,6 +64,8 @@ data class AssignmentDetailsVisibilities (
     var noDescriptionLabel: Boolean = false,
     var description: Boolean = false,
     var submitButton: Boolean = false,
+    var submitButtonEnabled: Boolean = false, // Set to true for unlimited attempts or below the attempt count
+    var allowedAttempts: Boolean = false,
     var submissionUploadStatus: Boolean = false,
     var quizDetails: Boolean = false,
     var discussionTopicHeader: Boolean = false,

--- a/apps/student/src/main/res/layout/fragment_assignment_details.xml
+++ b/apps/student/src/main/res/layout/fragment_assignment_details.xml
@@ -310,6 +310,79 @@
 
                     </LinearLayout>
 
+                    <!-- Allowed Attempts -->
+
+                    <LinearLayout
+                        android:id="@+id/allowedAttemptsContainer"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:accessibilityHeading="true"
+                        android:orientation="vertical"
+                        android:padding="16dp">
+
+                        <TextView
+                            android:id="@+id/allowedAttemptsLabel"
+                            style="@style/TextFont.Medium"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:paddingBottom="8dp"
+                            android:text="@string/attempts"
+                            android:textColor="@color/defaultTextGray" />
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            android:paddingBottom="4dp">
+
+                            <TextView
+                                style="@style/TextFont.Regular"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/attemptsAllowedLabel"
+                                android:textSize="16sp"
+                                android:textStyle="bold"
+                                android:tint="@color/defaultTextGray" />
+
+                            <TextView
+                                android:id="@+id/allowedAttemptsText"
+                                style="@style/TextFont.Regular"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:paddingStart="4dp"
+                                android:textSize="16sp"
+                                android:tint="@color/defaultTextGray"
+                                tools:text="5" />
+
+                        </LinearLayout>
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal">
+
+                            <TextView
+                                style="@style/TextFont.Regular"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/attemptsUsedLabel"
+                                android:textSize="16sp"
+                                android:textStyle="bold"
+                                android:tint="@color/defaultTextGray" />
+
+                            <TextView
+                                android:id="@+id/usedAttemptsText"
+                                style="@style/TextFont.Regular"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:paddingStart="4dp"
+                                android:textSize="16sp"
+                                android:tint="@color/defaultTextGray"
+                                tools:text="5" />
+
+                        </LinearLayout>
+                    </LinearLayout>
+
                     <!-- Grade -->
 
                     <LinearLayout
@@ -492,13 +565,12 @@
                         </LinearLayout>
 
                         <LinearLayout
-                            android:id="@+id/allowedAttemptsContainer"
+                            android:id="@+id/allowedQuizAttemptsContainer"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:orientation="horizontal">
 
                             <TextView
-                                android:id="@+id/allowedAttemptsLabel"
                                 style="@style/TextFont.Regular"
                                 android:textStyle="bold"
                                 android:layout_width="wrap_content"
@@ -508,7 +580,7 @@
                                 android:text="@string/allowedAttemptsLabel"/>
 
                             <TextView
-                                android:id="@+id/allowedAttemptsText"
+                                android:id="@+id/allowedQuizAttemptsText"
                                 style="@style/TextFont.Regular"
                                 android:paddingStart="8dp"
                                 android:paddingEnd="8dp"
@@ -644,6 +716,7 @@
             android:id="@+id/submitButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:foreground="?attr/selectableItemBackground"
             android:background="@color/canvasDefaultAccent"
             android:text="@string/submitAssignment"
             android:textAllCaps="false"

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsPresenterTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsPresenterTest.kt
@@ -1056,7 +1056,10 @@ class AssignmentDetailsPresenterTest : Assert() {
             submission = baseSubmission.copy(attempt = 1)
         )
         val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
-        val actual = AssignmentDetailsPresenter.present(model, context).visibilities
+        val state = AssignmentDetailsPresenter.present(model, context) as AssignmentDetailsViewState.Loaded
+        val actual = state.visibilities
+
+        assertEquals("Resubmit Assignment", state.submitButtonText)
         assertTrue(actual.submitButton)
         assertTrue(actual.submitButtonEnabled)
     }
@@ -1069,7 +1072,10 @@ class AssignmentDetailsPresenterTest : Assert() {
             submission = baseSubmission.copy(attempt = 1)
         )
         val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
-        val actual = AssignmentDetailsPresenter.present(model, context).visibilities
+        val state = AssignmentDetailsPresenter.present(model, context) as AssignmentDetailsViewState.Loaded
+        val actual = state.visibilities
+
+        assertEquals("No attempts left", state.submitButtonText)
         assertTrue(actual.submitButton)
         assertFalse(actual.submitButtonEnabled)
     }

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsPresenterTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsPresenterTest.kt
@@ -72,7 +72,8 @@ class AssignmentDetailsPresenterTest : Assert() {
             submissionTypes = true,
             submissionStatus = true,
             description = true,
-            submissionAndRubricButton = true
+            submissionAndRubricButton = true,
+            submitButtonEnabled = true
         )
         baseSubmission = Submission(
             attempt = 1,
@@ -1020,6 +1021,79 @@ class AssignmentDetailsPresenterTest : Assert() {
         val model = baseModel.copy(assignmentResult = DataResult.Success(assignment), quizResult = DataResult.Success(baseQuiz))
         val state = AssignmentDetailsPresenter.present(model, context) as AssignmentDetailsViewState.Loaded
         assertTrue(state.visibilities.submissionStatus)
+    }
+
+    @Test
+    fun `Shows enabled submit button when assignment has no submission`() {
+        val assignment = baseAssignment.copy(
+            submissionTypesRaw = listOf("online_text_entry"),
+            allowedAttempts = -1,
+            submission = null
+        )
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
+        val actual = AssignmentDetailsPresenter.present(model, context).visibilities
+        assertTrue(actual.submitButton)
+        assertTrue(actual.submitButtonEnabled)
+    }
+
+    @Test
+    fun `Shows enabled submit button when submissions are allowed with unlimited attempts`() {
+        val assignment = baseAssignment.copy(
+            submissionTypesRaw = listOf("online_text_entry"),
+            allowedAttempts = -1
+        )
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
+        val actual = AssignmentDetailsPresenter.present(model, context).visibilities
+        assertTrue(actual.submitButton)
+        assertTrue(actual.submitButtonEnabled)
+    }
+
+    @Test
+    fun `Shows enabled submit button when submissions attempts are less than allowed attempts`() {
+        val assignment = baseAssignment.copy(
+            submissionTypesRaw = listOf("online_text_entry"),
+            allowedAttempts = 2,
+            submission = baseSubmission.copy(attempt = 1)
+        )
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
+        val actual = AssignmentDetailsPresenter.present(model, context).visibilities
+        assertTrue(actual.submitButton)
+        assertTrue(actual.submitButtonEnabled)
+    }
+
+    @Test
+    fun `Shows disabled submit button when submissions attempts reach allowed attempts`() {
+        val assignment = baseAssignment.copy(
+            submissionTypesRaw = listOf("online_text_entry"),
+            allowedAttempts = 1,
+            submission = baseSubmission.copy(attempt = 1)
+        )
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
+        val actual = AssignmentDetailsPresenter.present(model, context).visibilities
+        assertTrue(actual.submitButton)
+        assertFalse(actual.submitButtonEnabled)
+    }
+
+    @Test
+    fun `Shows attempt details when assignment limits allowed attempts`() {
+        val assignment = baseAssignment.copy(
+            submissionTypesRaw = listOf("online_text_entry"),
+            allowedAttempts = 1
+        )
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
+        val actual = AssignmentDetailsPresenter.present(model, context).visibilities
+        assertTrue(actual.allowedAttempts)
+    }
+
+    @Test
+    fun `Hides attempt details when assignment has unlimited allowed attempts`() {
+        val assignment = baseAssignment.copy(
+            submissionTypesRaw = listOf("online_text_entry"),
+            allowedAttempts = -1
+        )
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
+        val actual = AssignmentDetailsPresenter.present(model, context).visibilities
+        assertFalse(actual.allowedAttempts)
     }
 
 

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Assignment.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Assignment.kt
@@ -94,6 +94,8 @@ data class Assignment(
         val moderatedGrading: Boolean = false,
         @SerializedName("anonymous_grading")
         val anonymousGrading: Boolean = false,
+        @SerializedName("allowed_attempts")
+        val allowedAttempts: Long = -1, // API gives -1 for unlimited submissions
         var isStudioEnabled: Boolean = false
 ) : CanvasModel<Assignment>() {
     override val comparisonDate get() = dueDate

--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -53,6 +53,7 @@
     <string name="attempts">Attempts</string>
     <string name="attemptsAllowedLabel">Attempts Allowed</string>
     <string name="attemptsUsedLabel">Attempts Used</string>
+    <string name="noAttemptsLeft">No attempts left</string>
     <string name="resubmitAssignment">Resubmit Assignment</string>
     <string name="launchExternalTool">Launch External Tool</string>
     <string name="preview">Preview</string>

--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -50,6 +50,9 @@
     <string name="submitted">Submitted</string>
     <string name="notSubmitted">Not Submitted</string>
     <string name="allowedFileTypes">Allowable File Types</string>
+    <string name="attempts">Attempts</string>
+    <string name="attemptsAllowedLabel">Attempts Allowed</string>
+    <string name="attemptsUsedLabel">Attempts Used</string>
     <string name="resubmitAssignment">Resubmit Assignment</string>
     <string name="launchExternalTool">Launch External Tool</string>
     <string name="preview">Preview</string>


### PR DESCRIPTION
This feature is currently behind a flag at the course level in canvas.

To test:
* Verify "Attempts" don't show on old assignments
* Verify "Attempts" show correct allowed number and used number when an assignment has a limit
* Verify when all allowed attempts have been used that the resubmit button is disabled