### PR TITLE
[Parent][MBL-14430] Fix broken cold deep links from Flutter 1.17

### DIFF
--- a/apps/flutter_parent/android/app/src/main/kotlin/com/instructure/parentapp/MainActivity.kt
+++ b/apps/flutter_parent/android/app/src/main/kotlin/com/instructure/parentapp/MainActivity.kt
@@ -51,7 +51,9 @@ class MainActivity : FlutterActivity() {
         if (newIntent) {
             flutterEngine?.navigationChannel?.pushRoute(route)
         } else {
-            this.intent = intent.putExtra("initial_route", route)
+            this.intent = intent.putExtra("route", route)
+//            this.intent = intent.putExtra(FlutterActivityLaunchConfigs.EXTRA_INITIAL_ROUTE, route) // Package private, can't use directly but is exactly what we want. Leaving in for future reference
+//            flutterEngine?.navigationChannel?.setInitialRoute(route) // Doesn't actually work, not implemented flutter side ¯\_(ツ)_/¯
         }
     }
 }


### PR DESCRIPTION
Leaving in some extra comments with it in case the next Flutter version changes this again.

For more info, if anyone is curious, there is not a documented way that works for doing deep links from Android using Flutter.
The closest thing is this link: https://api.flutter.dev/flutter/dart-ui/Window/defaultRouteName.html
Which says to use the deprecated (non-embedded native side lib) FlutterView to do setInitialRoute. This method was removed in the newer FlutterView (that was changed in Flutter 1.12) and was completely left out of the migration notes: https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects

Hence why we're hacking around and using the intent extra that is package private.

To test:
* Run the parent app
* Kill the app
* Click a link to open the app from the killed state
* Verify it opens to the correct place