### PR TITLE
[Parent][E2E][MBL-14439]: Add log info for failing test

### DIFF
--- a/apps/flutter_parent/test_driver/pages/course_summary_page.dart
+++ b/apps/flutter_parent/test_driver/pages/course_summary_page.dart
@@ -73,8 +73,8 @@ class CourseSummaryPage {
       var localDate = dueDate.toLocal();
       String date = (DateFormat.MMMd()).format(localDate);
       String time = (DateFormat.jm()).format(localDate);
-      expect(text.contains(date), true, reason: "Expected due date to contain $date");
-      expect(text.contains(time), true, reason: "Expected due date to contain $time");
+      expect(text.contains(date), true, reason: "Expected due date ($text) to contain $date");
+      expect(text.contains(time), true, reason: "Expected due date ($text) to contain $time");
     }
   }
 }


### PR DESCRIPTION
I'm confused as to why this test is failing with "Expected due date to contain 12:00 AM" so I'm including the element text in my printout.