### PR TITLE
[Parent][MBL-14388] Reply all fix

### DIFF
--- a/apps/flutter_parent/lib/models/conversation.dart
+++ b/apps/flutter_parent/lib/models/conversation.dart
@@ -110,6 +110,11 @@ abstract class Conversation implements Built<Conversation, ConversationBuilder> 
     ..workflowState = ConversationWorkflowState.unread
     ..isStarred = false
     ..isVisible = false;
+
+  String getContextId() {
+    final index = contextCode.indexOf('_');
+    return contextCode.substring(index + 1, contextCode.length);
+  }
 }
 
 @BuiltValueEnum(wireName: 'workflow_state')

--- a/apps/flutter_parent/lib/screens/inbox/reply/conversation_reply_interactor.dart
+++ b/apps/flutter_parent/lib/screens/inbox/reply/conversation_reply_interactor.dart
@@ -43,8 +43,6 @@ class ConversationReplyInteractor {
         recipientIds = [replyMessage.authorId];
       }
     } else {
-      recipientIds = replyMessage.participatingUserIds.toList();
-
       // We need to make sure the recipients list doesn't contain any off limit users, such as non-observed students.
       final courseId = conversation.getContextId();
       final userId = ApiPrefs.getUser().id;

--- a/apps/flutter_parent/lib/screens/inbox/reply/conversation_reply_interactor.dart
+++ b/apps/flutter_parent/lib/screens/inbox/reply/conversation_reply_interactor.dart
@@ -15,6 +15,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_parent/models/conversation.dart';
 import 'package:flutter_parent/models/message.dart';
+import 'package:flutter_parent/network/api/course_api.dart';
+import 'package:flutter_parent/network/api/enrollments_api.dart';
 import 'package:flutter_parent/network/api/inbox_api.dart';
 import 'package:flutter_parent/network/utils/api_prefs.dart';
 import 'package:flutter_parent/screens/inbox/attachment_utils/attachment_handler.dart';
@@ -29,7 +31,7 @@ class ConversationReplyInteractor {
     String body,
     List<String> attachmentIds,
     bool replyAll,
-  ) {
+  ) async {
     Message replyMessage = message ?? conversation.messages[0];
     List<String> includedMessageIds = [if (message != null || !replyAll) replyMessage.id];
     List<String> recipientIds = [];
@@ -40,8 +42,37 @@ class ConversationReplyInteractor {
       } else {
         recipientIds = [replyMessage.authorId];
       }
-    } else if (message != null) {
+    } else {
       recipientIds = replyMessage.participatingUserIds.toList();
+
+      // We need to make sure the recipients list doesn't contain any off limit users, such as non-observed students.
+      final courseId = conversation.getContextId();
+      final userId = ApiPrefs.getUser().id;
+      final enrollments = await locator<EnrollmentsApi>().getObserveeEnrollments();
+      final observeeIds = enrollments
+          .map((enrollment) => enrollment.observedUser)
+          .where((student) => student != null)
+          .toSet()
+          .map<String>((student) => student.id);
+      final permissions = await locator<CourseApi>().getCoursePermissions(courseId);
+      final recipients = await locator<InboxApi>().getRecipients(courseId);
+      recipients.retainWhere((recipient) {
+        // Allow self and any observed students as recipients if the sendMessages permission is granted
+        if (permissions.sendMessages == true && (observeeIds.contains(recipient.id) || recipient.id == userId))
+          return true;
+
+        // Always allow instructors (teachers and TAs) as recipients
+        var enrollments = recipient.commonCourses[courseId];
+        if (enrollments == null) return false;
+        return enrollments.contains('TeacherEnrollment') || enrollments.contains('TaEnrollment');
+      });
+
+      final filteredRecipientIds = recipients.map<String>((recipient) => recipient.id);
+
+      recipientIds = replyMessage.participatingUserIds
+          .toList()
+          .where((participantId) => filteredRecipientIds.contains(participantId))
+          .toList();
     }
 
     return locator<InboxApi>().addMessage(conversation.id, body, recipientIds, attachmentIds, includedMessageIds);


### PR DESCRIPTION
Okay, so this got a lot grosser than I had hoped. In order to filter out improper recipients from all usages of reply all, we have to make a couple of api calls. I'm open to feedback and suggestions on this. For now, it's working and tested.

To Test (I found creating the repro case for this was easier from web):
-Create a message as a teacher in a course with an observer, teachers/tas, and some students
-Reply All to this message from the current parent app, notice that it replies to all, including observed and non-observed students
-This change will filter out all non-observed students, and ALL students / self if the "send messages" permission is off
