### PR TITLE
[Student][DIscussions][MBL-14436]: Another round of stabilization for discussion tests

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/DiscussionsInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/DiscussionsInteractionTest.kt
@@ -24,7 +24,6 @@ import com.instructure.canvas.espresso.mockCanvas.addDiscussionTopicToCourse
 import com.instructure.canvas.espresso.mockCanvas.addFileToCourse
 import com.instructure.canvas.espresso.mockCanvas.addReplyToDiscussion
 import com.instructure.canvas.espresso.mockCanvas.init
-import com.instructure.canvas.espresso.refresh
 import com.instructure.canvasapi2.models.CanvasContextPermission
 import com.instructure.canvasapi2.models.DiscussionEntry
 import com.instructure.canvasapi2.models.RemoteFile
@@ -178,8 +177,8 @@ class DiscussionsInteractionTest : StudentTest() {
         discussionDetailsPage.scrollToRepliesWebview() // may be necessary on shorter screens / landscape
         // From what I can tell, our self-generated HTML has a 2500 ms wait before it
         // sends the "read" call for the unread messages on the page.  So we'll wait for
-        // 3 seconds.
-        sleep(3000)
+        // a few seconds.
+        sleep(5000) // There have been instances where 3 seconds wasn't enough
         Espresso.pressBack() // Back to discussionListPage
         discussionListPage.pullToUpdate()
         discussionListPage.assertUnreadCount(topicHeader.title!!, 0)

--- a/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/CustomMatchers.kt
+++ b/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/CustomMatchers.kt
@@ -18,6 +18,10 @@ package com.instructure.canvas.espresso
 
 import android.view.View
 import android.widget.TextView
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import org.hamcrest.BaseMatcher
 import org.hamcrest.Description
 import org.hamcrest.Matcher
@@ -45,3 +49,17 @@ fun containsTextCaseInsensitive(textToMatch: String) : Matcher<View> {
         }
     }
 }
+
+/**
+ * Returns true if the element with the given resource id is currently displayed, false otherwise.
+ */
+fun isElementDisplayed(resourceId: Int) : Boolean {
+    try {
+        onView(withId(resourceId)).check(matches(isDisplayed()))
+        return true
+    }
+    catch(t: Throwable) {
+        return false
+    }
+}
+


### PR DESCRIPTION
The basic problem was that we could press the "reply" link to reply to a reply, and the RCE editor would fail to pop up.  Or we could press the attachment icon in a reply and not be taken to the attachment.  So I did all that I could to address those situations, and I *think* that they have improved.