### PR TITLE
[Student][MBL-14378] Fix flutter appbar style for landscape and tablets

### DIFF
--- a/libs/flutter_student_embed/lib/screens/calendar/calendar_screen.dart
+++ b/libs/flutter_student_embed/lib/screens/calendar/calendar_screen.dart
@@ -27,6 +27,7 @@ import 'package:flutter_student_embed/screens/calendar/calendar_widget/calendar_
 import 'package:flutter_student_embed/screens/calendar/planner_fetcher.dart';
 import 'package:flutter_student_embed/screens/to_do/create_update_to_do_screen.dart';
 import 'package:flutter_student_embed/screens/to_do/to_do_details_screen.dart';
+import 'package:flutter_student_embed/utils/common_widgets/appbar_dynamic_style.dart';
 import 'package:flutter_student_embed/utils/quick_nav.dart';
 import 'package:flutter_student_embed/utils/service_locator.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -74,39 +75,42 @@ class CalendarScreenState extends State<CalendarScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text(L10n(context).calendar),
-        leading: IconButton(
-          icon: Icon(Icons.menu),
-          onPressed: () => _channel.openDrawer(),
-          tooltip: MaterialLocalizations.of(context).openAppDrawerTooltip,
-        ),
-        actions: <Widget>[
-          if (_showTodayButton)
-            Tooltip(
-              message: L10n(context).gotoTodayButtonLabel,
-              child: InkResponse(
-                child: Padding(
-                  padding: const EdgeInsets.all(12),
-                  child: SvgPicture.asset(
-                    'assets/svg/calendar-today.svg',
-                    width: 24,
-                    height: 24,
-                    color: Theme.of(context).primaryIconTheme.color,
+      appBar: dynamicStyleAppBar(
+        context: context,
+        appBar: AppBar(
+          title: Text(L10n(context).calendar),
+          leading: IconButton(
+            icon: Icon(Icons.menu),
+            onPressed: () => _channel.openDrawer(),
+            tooltip: MaterialLocalizations.of(context).openAppDrawerTooltip,
+          ),
+          actions: <Widget>[
+            if (_showTodayButton)
+              Tooltip(
+                message: L10n(context).gotoTodayButtonLabel,
+                child: InkResponse(
+                  child: Padding(
+                    padding: const EdgeInsets.all(12),
+                    child: SvgPicture.asset(
+                      'assets/svg/calendar-today.svg',
+                      width: 24,
+                      height: 24,
+                      color: Theme.of(context).primaryIconTheme.color,
+                    ),
                   ),
+                  onTap: () {
+                    var now = DateTime.now();
+                    _calendarKey.currentState.selectDay(
+                      DateTime(now.year, now.month, now.day),
+                      dayPagerBehavior: CalendarPageChangeBehavior.jump,
+                      weekPagerBehavior: CalendarPageChangeBehavior.animate,
+                      monthPagerBehavior: CalendarPageChangeBehavior.animate,
+                    );
+                  },
                 ),
-                onTap: () {
-                  var now = DateTime.now();
-                  _calendarKey.currentState.selectDay(
-                    DateTime(now.year, now.month, now.day),
-                    dayPagerBehavior: CalendarPageChangeBehavior.jump,
-                    weekPagerBehavior: CalendarPageChangeBehavior.animate,
-                    monthPagerBehavior: CalendarPageChangeBehavior.animate,
-                  );
-                },
-              ),
-            )
-        ],
+              )
+          ],
+        ),
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () async {

--- a/libs/flutter_student_embed/lib/screens/calendar/calendar_widget/calendar_filter_screen/calendar_filter_list_screen.dart
+++ b/libs/flutter_student_embed/lib/screens/calendar/calendar_widget/calendar_filter_screen/calendar_filter_list_screen.dart
@@ -15,6 +15,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_student_embed/l10n/app_localizations.dart';
 import 'package:flutter_student_embed/models/course.dart';
+import 'package:flutter_student_embed/utils/common_widgets/appbar_dynamic_style.dart';
 import 'package:flutter_student_embed/utils/common_widgets/empty_panda_widget.dart';
 import 'package:flutter_student_embed/utils/common_widgets/error_panda_widget.dart';
 import 'package:flutter_student_embed/utils/common_widgets/loading_indicator.dart';
@@ -53,8 +54,11 @@ class CalendarFilterListScreenState extends State<CalendarFilterListScreen> {
         return false;
       },
       child: Scaffold(
-        appBar: AppBar(
-          title: Text(L10n(context).calendars),
+        appBar: dynamicStyleAppBar(
+          context: context,
+          appBar: AppBar(
+            title: Text(L10n(context).calendars),
+          ),
         ),
         body: Column(
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/libs/flutter_student_embed/lib/screens/to_do/create_update_to_do_screen.dart
+++ b/libs/flutter_student_embed/lib/screens/to_do/create_update_to_do_screen.dart
@@ -17,6 +17,7 @@ import 'package:flutter_student_embed/l10n/app_localizations.dart';
 import 'package:flutter_student_embed/models/course.dart';
 import 'package:flutter_student_embed/models/planner_item.dart';
 import 'package:flutter_student_embed/screens/to_do/create_update_to_do_screen_interactor.dart';
+import 'package:flutter_student_embed/utils/common_widgets/appbar_dynamic_style.dart';
 import 'package:flutter_student_embed/utils/core_extensions/date_time_extensions.dart';
 import 'package:flutter_student_embed/utils/core_extensions/string_extensions.dart';
 import 'package:flutter_student_embed/utils/design/student_colors.dart';
@@ -64,35 +65,38 @@ class _CreateUpdateToDoScreenState extends State<CreateUpdateToDoScreen> {
       child: WhiteAppBarTheme(
         builder: (context) => Scaffold(
           key: _scaffoldKey,
-          appBar: AppBar(
-            title: Text(widget.editToDo == null ? L10n(context).newToDo : L10n(context).editToDo),
-            actions: <Widget>[
-              if (_saving)
-                Container(
-                  alignment: Alignment.center,
-                  padding: EdgeInsets.only(right: 16),
-                  child: SizedBox(
-                      width: 20,
-                      height: 20,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2,
-                        valueColor: AlwaysStoppedAnimation<Color>(Theme.of(context).buttonColor),
-                      )),
-                ),
-              if (!_saving)
-                InkWell(
-                  onTap: _save,
-                  child: Container(
-                    height: 48,
-                    padding: EdgeInsets.symmetric(horizontal: 16),
+          appBar: dynamicStyleAppBar(
+            context: context,
+            appBar: AppBar(
+              title: Text(widget.editToDo == null ? L10n(context).newToDo : L10n(context).editToDo),
+              actions: <Widget>[
+                if (_saving)
+                  Container(
                     alignment: Alignment.center,
-                    child: Text(
-                      L10n(context).save.toUpperCase(),
-                      style: Theme.of(context).textTheme.subhead.copyWith(color: Theme.of(context).buttonColor),
-                    ),
+                    padding: EdgeInsets.only(right: 16),
+                    child: SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          valueColor: AlwaysStoppedAnimation<Color>(Theme.of(context).buttonColor),
+                        )),
                   ),
-                )
-            ],
+                if (!_saving)
+                  InkWell(
+                    onTap: _save,
+                    child: Container(
+                      height: 48,
+                      padding: EdgeInsets.symmetric(horizontal: 16),
+                      alignment: Alignment.center,
+                      child: Text(
+                        L10n(context).save.toUpperCase(),
+                        style: Theme.of(context).textTheme.subhead.copyWith(color: Theme.of(context).buttonColor),
+                      ),
+                    ),
+                  )
+              ],
+            ),
           ),
           body: SingleChildScrollView(
             child: Column(

--- a/libs/flutter_student_embed/lib/screens/to_do/to_do_details_screen.dart
+++ b/libs/flutter_student_embed/lib/screens/to_do/to_do_details_screen.dart
@@ -18,6 +18,7 @@ import 'package:flutter_student_embed/l10n/app_localizations.dart';
 import 'package:flutter_student_embed/models/planner_item.dart';
 import 'package:flutter_student_embed/network/api/planner_api.dart';
 import 'package:flutter_student_embed/screens/to_do/create_update_to_do_screen.dart';
+import 'package:flutter_student_embed/utils/common_widgets/appbar_dynamic_style.dart';
 import 'package:flutter_student_embed/utils/core_extensions/date_time_extensions.dart';
 import 'package:flutter_student_embed/utils/design/student_colors.dart';
 import 'package:flutter_student_embed/utils/design/student_theme.dart';
@@ -36,22 +37,25 @@ class ToDoDetailsScreen extends StatelessWidget {
     Color contextColor = StudentTheme.of(context).getCanvasContextColor(toDo.contextCode());
     return Scaffold(
       key: _scaffoldKey,
-      appBar: AppBar(
-        title: Text(L10n(context).toDo),
-        actions: <Widget>[
-          PopupMenuButton<int>(
-            itemBuilder: (context) {
-              return [
-                PopupMenuItem(value: 0, child: Text(L10n(context).edit)),
-                PopupMenuItem(value: 1, child: Text(L10n(context).delete)),
-              ];
-            },
-            onSelected: (option) {
-              if (option == 0) _edit(context);
-              if (option == 1) _delete(context);
-            },
-          ),
-        ],
+      appBar: dynamicStyleAppBar(
+        context: context,
+        appBar: AppBar(
+          title: Text(L10n(context).toDo),
+          actions: <Widget>[
+            PopupMenuButton<int>(
+              itemBuilder: (context) {
+                return [
+                  PopupMenuItem(value: 0, child: Text(L10n(context).edit)),
+                  PopupMenuItem(value: 1, child: Text(L10n(context).delete)),
+                ];
+              },
+              onSelected: (option) {
+                if (option == 0) _edit(context);
+                if (option == 1) _delete(context);
+              },
+            ),
+          ],
+        ),
       ),
       body: SingleChildScrollView(
         child: Padding(

--- a/libs/flutter_student_embed/lib/utils/common_widgets/appbar_dynamic_style.dart
+++ b/libs/flutter_student_embed/lib/utils/common_widgets/appbar_dynamic_style.dart
@@ -17,6 +17,7 @@ import 'package:flutter/material.dart';
 const double tabletSmallestWidth = 600;
 const double appBarHeightTablet = 64;
 const double appBarHeightLandscape = 48;
+const double appBarFontSizeLandscape = 14;
 
 /// Wraps the provided [appBar] in a [PreferredSize] widget and modifies the height, font size, and padding to match
 /// the style of the native Toolbar according to device orientation and screen size.
@@ -42,9 +43,9 @@ PreferredSizeWidget dynamicStyleAppBar({@required BuildContext context, @require
   } else {
     // Portrait mode uses a short appbar and small font size
     appBarHeight = appBarHeightLandscape;
-    textTheme = (textTheme ?? TextTheme()).copyWith(
-      headline6: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
-    );
+    var theme = textTheme ?? AppBarTheme.of(context).textTheme ?? Theme.of(context).primaryTextTheme ?? TextTheme();
+    var headline = (theme.headline6 ?? TextStyle()).copyWith(fontSize: appBarFontSizeLandscape);
+    textTheme = theme.copyWith(headline6: headline);
     padding = EdgeInsets.zero;
   }
 

--- a/libs/flutter_student_embed/lib/utils/common_widgets/appbar_dynamic_style.dart
+++ b/libs/flutter_student_embed/lib/utils/common_widgets/appbar_dynamic_style.dart
@@ -1,0 +1,86 @@
+// Copyright (C) 2019 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+
+const double tabletSmallestWidth = 600;
+const double appBarHeightTablet = 64;
+const double appBarHeightLandscape = 48;
+
+/// Wraps the provided [appBar] in a [PreferredSize] widget and modifies the height, font size, and padding to match
+/// the style of the native Toolbar according to device orientation and screen size.
+PreferredSizeWidget dynamicStyleAppBar({@required BuildContext context, @required AppBar appBar}) {
+  var isTablet = MediaQuery.of(context).size.shortestSide >= tabletSmallestWidth;
+  var isLandscape = MediaQuery.of(context).orientation == Orientation.landscape;
+
+  // Return original Appbar for default configuration (i.e. non-tablet portrait)
+  if (!isTablet && !isLandscape) return appBar;
+
+  Color color = appBar.backgroundColor ?? Theme.of(context).appBarTheme?.color ?? Theme.of(context).primaryColor;
+  TextTheme textTheme = appBar.textTheme;
+  double appBarHeight;
+  EdgeInsets padding;
+
+  if (isTablet) {
+    // Regardless of device orientation, tablets use a tall appbar and have additional padding
+    appBarHeight = appBarHeightTablet;
+    padding = EdgeInsets.symmetric(
+      horizontal: appBarHeightTablet - kToolbarHeight,
+      vertical: (appBarHeightTablet - kToolbarHeight) / 2,
+    );
+  } else {
+    // Portrait mode uses a short appbar and small font size
+    appBarHeight = appBarHeightLandscape;
+    textTheme = (textTheme ?? TextTheme()).copyWith(
+      headline6: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
+    );
+    padding = EdgeInsets.zero;
+  }
+
+  // Clone the AppBar to apply the modified properties
+  AppBar flatAppbar = AppBar(
+    elevation: 0, // Remove elevation
+    textTheme: textTheme, // Use modified text theme
+    key: appBar.key,
+    leading: appBar.leading,
+    automaticallyImplyLeading: appBar.automaticallyImplyLeading,
+    title: appBar.title,
+    actions: appBar.actions,
+    flexibleSpace: appBar.flexibleSpace,
+    bottom: appBar.bottom,
+    shape: appBar.shape,
+    backgroundColor: appBar.backgroundColor,
+    brightness: appBar.brightness,
+    iconTheme: appBar.iconTheme,
+    actionsIconTheme: appBar.actionsIconTheme,
+    primary: appBar.primary,
+    centerTitle: appBar.centerTitle,
+    excludeHeaderSemantics: appBar.excludeHeaderSemantics,
+    titleSpacing: appBar.titleSpacing,
+    toolbarOpacity: appBar.toolbarOpacity,
+    bottomOpacity: appBar.bottomOpacity,
+  );
+
+  return PreferredSize(
+    preferredSize: Size.fromHeight(appBarHeight),
+    child: Material(
+      child: Container(
+        color: color,
+        height: appBarHeight,
+        padding: padding,
+        child: flatAppbar,
+      ),
+    ),
+  );
+}

--- a/libs/flutter_student_embed/test/utils/common_widgets/appbar_dynamic_style_test.dart
+++ b/libs/flutter_student_embed/test/utils/common_widgets/appbar_dynamic_style_test.dart
@@ -14,12 +14,17 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_student_embed/utils/common_widgets/appbar_dynamic_style.dart';
+import 'package:flutter_student_embed/utils/design/student_colors.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../testutils/accessibility_utils.dart';
 import '../../testutils/test_app.dart';
 
 void main() {
+  tearDown(() {
+    StudentColors.reset();
+  });
+
   testWidgetsWithAccessibilityChecks('Returns unmodified AppBar for portrait non-tablet', (tester) async {
     AppBar appBar = AppBar();
     Size screenSize = Size(300, 500); // Portrait
@@ -50,6 +55,22 @@ void main() {
 
     var fontSize = tester.getSize(find.text(title)).height;
     expect(fontSize, 14);
+  });
+
+  testWidgetsWithAccessibilityChecks('Uses correct text color for landscape', (tester) async {
+    Color expectedColor = Colors.orange;
+    StudentColors.primaryTextColor = expectedColor;
+    Size screenSize = Size(500, 300); // Landscape
+    String title = "AppBar Colored Title";
+    AppBar appBar = AppBar(title: Text(title));
+
+    await _pumpTestWidget(tester, appBar: appBar, size: screenSize);
+
+    // Apply ambient styling by finding the title element and building its widget
+    StatelessElement element = find.text(title).evaluate().first;
+    TextStyle titleStyle = (element.build() as RichText).text.style;
+
+    expect(titleStyle.color, expectedColor);
   });
 }
 

--- a/libs/flutter_student_embed/test/utils/common_widgets/appbar_dynamic_style_test.dart
+++ b/libs/flutter_student_embed/test/utils/common_widgets/appbar_dynamic_style_test.dart
@@ -1,0 +1,76 @@
+// Copyright (C) 2019 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_student_embed/utils/common_widgets/appbar_dynamic_style.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../testutils/accessibility_utils.dart';
+import '../../testutils/test_app.dart';
+
+void main() {
+  testWidgetsWithAccessibilityChecks('Returns unmodified AppBar for portrait non-tablet', (tester) async {
+    AppBar appBar = AppBar();
+    Size screenSize = Size(300, 500); // Portrait
+    var result = await _pumpTestWidget(tester, appBar: appBar, size: screenSize);
+
+    expect(result, appBar);
+    expect(result.preferredSize.height, 56);
+  });
+
+  testWidgetsWithAccessibilityChecks('Returns correct height for tablet', (tester) async {
+    var result = await _pumpTestWidget(tester); // Default size (800x600), i.e. tablet
+
+    expect(result.preferredSize.height, 64);
+  });
+
+  testWidgetsWithAccessibilityChecks('Returns correct height for landscape', (tester) async {
+    Size screenSize = Size(500, 300); // Landscape
+    var result = await _pumpTestWidget(tester, size: screenSize);
+
+    expect(result.preferredSize.height, 48);
+  });
+
+  testWidgetsWithAccessibilityChecks('Returns correct font size for landscape', (tester) async {
+    Size screenSize = Size(500, 300); // Landscape
+    String title = "AppBar Test Title";
+    AppBar appBar = AppBar(title: Text(title));
+    await _pumpTestWidget(tester, appBar: appBar, size: screenSize);
+
+    var fontSize = tester.getSize(find.text(title)).height;
+    expect(fontSize, 14);
+  });
+}
+
+Future<PreferredSizeWidget> _pumpTestWidget(WidgetTester tester, {AppBar appBar, Size size}) async {
+  AppBar appbar = appBar ?? AppBar();
+  GlobalKey<ScaffoldState> scaffoldKey = GlobalKey();
+  await tester.pumpWidget(
+    TestApp(
+      MediaQuery(
+        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(size: size),
+        child: Builder(
+          builder: (context) => Scaffold(
+            key: scaffoldKey,
+            appBar: dynamicStyleAppBar(context: context, appBar: appbar),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+
+  Scaffold scaffold = tester.state(find.byKey(scaffoldKey)).widget;
+  return scaffold.appBar;
+}


### PR DESCRIPTION
Flutter's AppBar widget always uses the same fixed height, causing a height (and style) mismatch when compared to the native Toolbar in landscape mode and on tablets. This commit wraps the AppBars and enforces size and style changes to match the native app. Specifically, on tablets the height is extended to 64 and extra padding is applied, while in landscape the height is shortened to 48 and the title font size is reduced to 14.