### PR TITLE
[Student][MBL-14398] Update for student app observer assignment deets

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsEffectHandler.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsEffectHandler.kt
@@ -153,10 +153,23 @@ class AssignmentDetailsEffectHandler(val context: Context, val assignmentId: Lon
                 if(courseResult.isSuccess && courseResult.dataOrNull != null) {
                     val enrollment = courseResult.dataOrNull!!.enrollments!!.firstOrNull { it.isObserver }
 
-                    val assignmentResponse = awaitApiResponse<Assignment> {
-                        AssignmentManager.getAssignment(effect.assignmentId, effect.courseId, effect.forceNetwork, it)
+                    if(enrollment != null) {
+                        val assignmentResponse = awaitApiResponse<ObserverAssignment> {
+                            AssignmentManager.getAssignmentForObserver(effect.assignmentId, effect.courseId, effect.forceNetwork, it)
+                        }
+                        val assignmentWithObserverSubmission = assignmentResponse.body()!!.toAssignmentForObservee()
+                        if(assignmentWithObserverSubmission != null) {
+                            DataResult.Success(assignmentWithObserverSubmission)
+                        } else {
+                            DataResult.Fail(null)
+                        }
+                    } else {
+                        val assignmentResponse = awaitApiResponse<Assignment> {
+                            AssignmentManager.getAssignment(effect.assignmentId, effect.courseId, effect.forceNetwork, it)
+                        }
+                        DataResult.Success(assignmentResponse.body()!!)
                     }
-                    DataResult.Success(assignmentResponse.body()!!)
+
                 } else {
                     DataResult.Fail(null)
                 }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsEffectHandler.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsEffectHandler.kt
@@ -40,8 +40,8 @@ import com.squareup.sqldelight.Query
 import kotlinx.coroutines.launch
 
 class AssignmentDetailsEffectHandler(val context: Context, val assignmentId: Long) :
-        EffectHandler<AssignmentDetailsView, AssignmentDetailsEvent, AssignmentDetailsEffect>(),
-        Query.Listener {
+    EffectHandler<AssignmentDetailsView, AssignmentDetailsEvent, AssignmentDetailsEffect>(),
+    Query.Listener {
 
     private var submissionQuery: Query<Submission>? = null
 
@@ -80,11 +80,11 @@ class AssignmentDetailsEffectHandler(val context: Context, val assignmentId: Lon
             is AssignmentDetailsEffect.ShowSubmitDialogView -> {
                 val studioUrl = effect.studioLTITool?.getResourceSelectorUrl(effect.course, effect.assignment)
                 view?.showSubmitDialogView(
-                        effect.assignment,
-                        effect.course.id,
-                        getSubmissionTypesVisibilities(effect.assignment, effect.isStudioEnabled),
-                        studioUrl,
-                        effect.studioLTITool?.name
+                    effect.assignment,
+                    effect.course.id,
+                    getSubmissionTypesVisibilities(effect.assignment, effect.isStudioEnabled),
+                    studioUrl,
+                    effect.studioLTITool?.name
                 )
             }
             is AssignmentDetailsEffect.ShowSubmissionView -> view?.showSubmissionView(effect.assignmentId, effect.course)
@@ -97,19 +97,19 @@ class AssignmentDetailsEffectHandler(val context: Context, val assignmentId: Lon
                     Assignment.SubmissionType.ONLINE_UPLOAD.apiString, Assignment.SubmissionType.MEDIA_RECORDING.apiString -> view?.showUploadStatusView(effect.submission.id)
                     Assignment.SubmissionType.ONLINE_TEXT_ENTRY.apiString -> {
                         view?.showOnlineTextEntryView(
-                                effect.submission.assignmentId,
-                                effect.submission.assignmentName,
-                                effect.submission.submissionEntry,
-                                effect.submission.errorFlag
+                            effect.submission.assignmentId,
+                            effect.submission.assignmentName,
+                            effect.submission.submissionEntry,
+                            effect.submission.errorFlag
                         )
                     }
                     Assignment.SubmissionType.ONLINE_URL.apiString -> {
                         view?.showOnlineUrlEntryView(
-                                effect.submission.assignmentId,
-                                effect.submission.assignmentName,
-                                effect.submission.canvasContext,
-                                effect.submission.submissionEntry,
-                                effect.submission.errorFlag
+                            effect.submission.assignmentId,
+                            effect.submission.assignmentName,
+                            effect.submission.canvasContext,
+                            effect.submission.submissionEntry,
+                            effect.submission.errorFlag
                         )
                     }
                     else -> Unit
@@ -204,14 +204,14 @@ class AssignmentDetailsEffectHandler(val context: Context, val assignmentId: Lon
             logEvent(getAnalyticsString(quizResult, assignmentResult))
 
             consumer.accept(
-                    AssignmentDetailsEvent.DataLoaded(
-                            assignmentResult,
-                            isStudioEnabled,
-                            studioLTITool,
-                            ltiTool,
-                            dbSubmission,
-                            quizResult
-                    )
+                AssignmentDetailsEvent.DataLoaded(
+                    assignmentResult,
+                    isStudioEnabled,
+                    studioLTITool,
+                    ltiTool,
+                    dbSubmission,
+                    quizResult
+                )
             )
         }
     }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsEffectHandler.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsEffectHandler.kt
@@ -150,8 +150,9 @@ class AssignmentDetailsEffectHandler(val context: Context, val assignmentId: Lon
             }
 
             val assignmentResult = try {
-                if(courseResult.isSuccess) {
-                    // TODO - check enrollments so we can get the right user id to make this request with
+                if(courseResult.isSuccess && courseResult.dataOrNull != null) {
+                    val enrollment = courseResult.dataOrNull!!.enrollments!!.firstOrNull { it.isObserver }
+
                     val assignmentResponse = awaitApiResponse<Assignment> {
                         AssignmentManager.getAssignment(effect.assignmentId, effect.courseId, effect.forceNetwork, it)
                     }

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsEffectHandlerTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsEffectHandlerTest.kt
@@ -20,6 +20,7 @@ import android.content.Intent
 import android.net.Uri
 import androidx.core.content.FileProvider
 import com.google.firebase.analytics.FirebaseAnalytics
+import com.instructure.canvasapi2.managers.CourseManager
 import com.instructure.canvasapi2.managers.ExternalToolManager
 import com.instructure.canvasapi2.managers.QuizManager
 import com.instructure.canvasapi2.managers.SubmissionManager
@@ -103,6 +104,11 @@ class AssignmentDetailsEffectHandlerTest : Assert() {
         connection = effectHandler.connect(eventConsumer)
 
         Analytics.firebase = firebase
+
+        mockkObject(CourseManager)
+        every { CourseManager.getCourseWithGradeAsync(any(), any()) } returns mockk {
+            coEvery { await() } returns DataResult.Success(Course())
+        }
     }
 
     private fun mockkDatabase(data: List<Submission> = emptyList()) {

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsEffectHandlerTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsEffectHandlerTest.kt
@@ -236,7 +236,7 @@ class AssignmentDetailsEffectHandlerTest : Assert() {
         val courseId = 1L
         val submission = mockkSubmission(9876L)
         val ltiTool = LTITool(url = "https://www.instructure.com")
-        val observerAssignment = ObserverAssignment(
+        val observerAssignment = ObserveeAssignment(
             id= assignmentId,
             courseId = courseId,
             submissionList = listOf(Submission(id = 9876L)),
@@ -255,7 +255,7 @@ class AssignmentDetailsEffectHandlerTest : Assert() {
         val course = Course(id = courseId, enrollments = mutableListOf(observerEnrollment))
 
         mockkStatic("com.instructure.canvasapi2.utils.weave.AwaitApiKt")
-        coEvery { awaitApiResponse<ObserverAssignment>(any()) } returns Response.success(observerAssignment)
+        coEvery { awaitApiResponse<ObserveeAssignment>(any()) } returns Response.success(observerAssignment)
 
         mockkObject(CourseManager)
         every { CourseManager.getCourseWithGradeAsync(any(), any()) } returns mockk {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/AssignmentAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/AssignmentAPI.kt
@@ -20,10 +20,7 @@ package com.instructure.canvasapi2.apis
 import com.instructure.canvasapi2.StatusCallback
 import com.instructure.canvasapi2.builders.RestBuilder
 import com.instructure.canvasapi2.builders.RestParams
-import com.instructure.canvasapi2.models.Assignment
-import com.instructure.canvasapi2.models.AssignmentGroup
-import com.instructure.canvasapi2.models.GradeableStudent
-import com.instructure.canvasapi2.models.Submission
+import com.instructure.canvasapi2.models.*
 import com.instructure.canvasapi2.models.postmodels.AssignmentPostBodyWrapper
 import retrofit2.Call
 import retrofit2.http.*
@@ -31,8 +28,11 @@ import retrofit2.http.*
 
 object AssignmentAPI {
     internal interface AssignmentInterface {
-        @GET("courses/{courseId}/assignments/{assignmentId}?include[]=submission&include[]=rubric_assessment&needs_grading_count_by_section=true&override_assignment_dates=true&all_dates=true&include[]=overrides&include[]=observed_users")
+        @GET("courses/{courseId}/assignments/{assignmentId}?include[]=submission&include[]=rubric_assessment&needs_grading_count_by_section=true&override_assignment_dates=true&all_dates=true&include[]=overrides")
         fun getAssignment(@Path("courseId") courseId: Long, @Path("assignmentId") assignmentId: Long): Call<Assignment>
+
+        @GET("courses/{courseId}/assignments/{assignmentId}?include[]=submission&include[]=rubric_assessment&needs_grading_count_by_section=true&override_assignment_dates=true&all_dates=true&include[]=overrides&include[]=observed_users")
+        fun getAssignmentForObservers(@Path("courseId") courseId: Long, @Path("assignmentId") assignmentId: Long): Call<ObserverAssignment>
 
         @GET("courses/{courseId}/assignment_groups/{assignmentGroupId}")
         fun getAssignmentGroup(
@@ -82,6 +82,10 @@ object AssignmentAPI {
 
     fun getAssignment(courseId: Long, assignmentId: Long, adapter: RestBuilder, callback: StatusCallback<Assignment>, params: RestParams) {
         callback.addCall(adapter.build(AssignmentInterface::class.java, params).getAssignment(courseId, assignmentId)).enqueue(callback)
+    }
+
+    fun getAssignmentForObserver(courseId: Long, assignmentId: Long, adapter: RestBuilder, callback: StatusCallback<ObserverAssignment>, params: RestParams) {
+        callback.addCall(adapter.build(AssignmentInterface::class.java, params).getAssignmentForObservers(courseId, assignmentId)).enqueue(callback)
     }
 
     fun getAssignmentGroup(courseId: Long, assignmentGroupId: Long, adapter: RestBuilder, callback: StatusCallback<AssignmentGroup>, params: RestParams) {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/AssignmentAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/AssignmentAPI.kt
@@ -32,7 +32,7 @@ object AssignmentAPI {
         fun getAssignment(@Path("courseId") courseId: Long, @Path("assignmentId") assignmentId: Long): Call<Assignment>
 
         @GET("courses/{courseId}/assignments/{assignmentId}?include[]=submission&include[]=rubric_assessment&needs_grading_count_by_section=true&override_assignment_dates=true&all_dates=true&include[]=overrides&include[]=observed_users")
-        fun getAssignmentForObservers(@Path("courseId") courseId: Long, @Path("assignmentId") assignmentId: Long): Call<ObserverAssignment>
+        fun getAssignmentIncludeObservees(@Path("courseId") courseId: Long, @Path("assignmentId") assignmentId: Long): Call<ObserveeAssignment>
 
         @GET("courses/{courseId}/assignment_groups/{assignmentGroupId}")
         fun getAssignmentGroup(
@@ -84,8 +84,8 @@ object AssignmentAPI {
         callback.addCall(adapter.build(AssignmentInterface::class.java, params).getAssignment(courseId, assignmentId)).enqueue(callback)
     }
 
-    fun getAssignmentForObserver(courseId: Long, assignmentId: Long, adapter: RestBuilder, callback: StatusCallback<ObserverAssignment>, params: RestParams) {
-        callback.addCall(adapter.build(AssignmentInterface::class.java, params).getAssignmentForObservers(courseId, assignmentId)).enqueue(callback)
+    fun getAssignmentIncludeObservees(courseId: Long, assignmentId: Long, adapter: RestBuilder, callback: StatusCallback<ObserveeAssignment>, params: RestParams) {
+        callback.addCall(adapter.build(AssignmentInterface::class.java, params).getAssignmentIncludeObservees(courseId, assignmentId)).enqueue(callback)
     }
 
     fun getAssignmentGroup(courseId: Long, assignmentGroupId: Long, adapter: RestBuilder, callback: StatusCallback<AssignmentGroup>, params: RestParams) {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/AssignmentAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/AssignmentAPI.kt
@@ -31,7 +31,7 @@ import retrofit2.http.*
 
 object AssignmentAPI {
     internal interface AssignmentInterface {
-        @GET("courses/{courseId}/assignments/{assignmentId}?include[]=submission&include[]=rubric_assessment&needs_grading_count_by_section=true&override_assignment_dates=true&all_dates=true&include[]=overrides")
+        @GET("courses/{courseId}/assignments/{assignmentId}?include[]=submission&include[]=rubric_assessment&needs_grading_count_by_section=true&override_assignment_dates=true&all_dates=true&include[]=overrides&include[]=observed_users")
         fun getAssignment(@Path("courseId") courseId: Long, @Path("assignmentId") assignmentId: Long): Call<Assignment>
 
         @GET("courses/{courseId}/assignment_groups/{assignmentGroupId}")

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/AssignmentManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/AssignmentManager.kt
@@ -20,10 +20,7 @@ import com.instructure.canvasapi2.StatusCallback
 import com.instructure.canvasapi2.apis.AssignmentAPI
 import com.instructure.canvasapi2.builders.RestBuilder
 import com.instructure.canvasapi2.builders.RestParams
-import com.instructure.canvasapi2.models.Assignment
-import com.instructure.canvasapi2.models.AssignmentGroup
-import com.instructure.canvasapi2.models.GradeableStudent
-import com.instructure.canvasapi2.models.Submission
+import com.instructure.canvasapi2.models.*
 import com.instructure.canvasapi2.models.postmodels.AssignmentPostBody
 import com.instructure.canvasapi2.models.postmodels.AssignmentPostBodyWrapper
 import com.instructure.canvasapi2.utils.ExhaustiveListCallback
@@ -36,6 +33,13 @@ object AssignmentManager {
         val adapter = RestBuilder(callback)
         val params = RestParams(isForceReadFromNetwork = forceNetwork)
         AssignmentAPI.getAssignment(courseId, assignmentId, adapter, callback, params)
+    }
+
+    @JvmStatic
+    fun getAssignmentForObserver(assignmentId: Long, courseId: Long, forceNetwork: Boolean, callback: StatusCallback<ObserverAssignment>) {
+        val adapter = RestBuilder(callback)
+        val params = RestParams(isForceReadFromNetwork = forceNetwork)
+        AssignmentAPI.getAssignmentForObserver(courseId, assignmentId, adapter, callback, params)
     }
 
     fun getAssignmentAsync(assignmentId: Long, courseId: Long, forceNetwork: Boolean)

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/AssignmentManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/AssignmentManager.kt
@@ -36,10 +36,10 @@ object AssignmentManager {
     }
 
     @JvmStatic
-    fun getAssignmentForObserver(assignmentId: Long, courseId: Long, forceNetwork: Boolean, callback: StatusCallback<ObserverAssignment>) {
+    fun getAssignmentIncludeObservees(assignmentId: Long, courseId: Long, forceNetwork: Boolean, callback: StatusCallback<ObserveeAssignment>) {
         val adapter = RestBuilder(callback)
         val params = RestParams(isForceReadFromNetwork = forceNetwork)
-        AssignmentAPI.getAssignmentForObserver(courseId, assignmentId, adapter, callback, params)
+        AssignmentAPI.getAssignmentIncludeObservees(courseId, assignmentId, adapter, callback, params)
     }
 
     fun getAssignmentAsync(assignmentId: Long, courseId: Long, forceNetwork: Boolean)

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/CourseManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/CourseManager.kt
@@ -134,6 +134,10 @@ object CourseManager {
         CourseAPI.getCourseWithGrade(courseId, adapter, callback, params)
     }
 
+    fun getCourseWithGradeAsync(courseId: Long, forceNetwork: Boolean) = apiAsync<Course> {
+        getCourseWithGrade(courseId, it, forceNetwork)
+    }
+
     @JvmStatic
     fun getCourseStudent(courseId: Long, studentId: Long, callback: StatusCallback<User>, forceNetwork: Boolean) {
         val adapter = RestBuilder(callback)

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/ObserveeAssignment.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/ObserveeAssignment.kt
@@ -19,8 +19,13 @@ import com.google.gson.annotations.SerializedName
 import com.instructure.canvasapi2.utils.toDate
 import kotlinx.android.parcel.Parcelize
 
+/**
+ * This assignment model is a copy of the Assignment.kt model, with one change. Its 'submission' property is a list,
+ * instead of a single object. This change is necessary to handle the api response for getAssignmentIncludeObservees,
+ * due to the addition of `include[]=observed_users`.
+ */
 @Parcelize
-data class ObserverAssignment(
+data class ObserveeAssignment(
         override var id: Long = 0,
         var name: String? = null,
         val description: String? = null,
@@ -97,6 +102,10 @@ data class ObserverAssignment(
     override val comparisonDate get() = dueAt.toDate()
     override val comparisonString get() = dueAt
 
+    /**
+     * Converts an ObserveeAssignment to an Assignment, using the first submission found. Returns null if no submission
+     * is found.
+     */
     fun toAssignmentForObservee(): Assignment? {
         val submission = submissionList?.firstOrNull()
         if (submission != null) {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/ObserverAssignment.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/ObserverAssignment.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package com.instructure.canvasapi2.models
+
+import com.google.gson.annotations.SerializedName
+import com.instructure.canvasapi2.utils.toDate
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
+data class ObserverAssignment(
+        override var id: Long = 0,
+        var name: String? = null,
+        val description: String? = null,
+        @SerializedName("submission_types")
+        val submissionTypesRaw: List<String> = arrayListOf(),
+        @SerializedName("due_at")
+        val dueAt: String? = null,
+        @SerializedName("points_possible")
+        val pointsPossible: Double = 0.0,
+        @SerializedName("course_id")
+        val courseId: Long = 0,
+        @SerializedName("grade_group_students_individually")
+        val isGradeGroupsIndividually: Boolean = false,
+        @SerializedName("grading_type")
+        val gradingType: String? = null,
+        @SerializedName("needs_grading_count")
+        val needsGradingCount: Long = 0,
+        @SerializedName("html_url")
+        val htmlUrl: String? = null,
+        val url: String? = null,
+        @SerializedName("quiz_id")
+        val quizId: Long = 0, // (Optional) id of the associated quiz (applies only when submission_types is ["online_quiz"])
+        val rubric: List<RubricCriterion>? = arrayListOf(),
+        @SerializedName("use_rubric_for_grading")
+        val isUseRubricForGrading: Boolean = false,
+        @SerializedName("rubric_settings")
+        val rubricSettings: RubricSettings? = null,
+        @SerializedName("allowed_extensions")
+        val allowedExtensions: List<String> = arrayListOf(),
+        @SerializedName("submission")
+        var submissionList: List<Submission>? = null,
+        @SerializedName("assignment_group_id")
+        val assignmentGroupId: Long = 0,
+        val position: Int = 0,
+        @SerializedName("peer_reviews")
+        val isPeerReviews: Boolean = false,
+        @SerializedName("lock_info") // Module lock info
+        val lockInfo: LockInfo? = null,
+        @SerializedName("locked_for_user")
+        val lockedForUser: Boolean = false,
+        @SerializedName("lock_at")
+        val lockAt: String? = null, // Date the teacher no longer accepts submissions.
+        @SerializedName("unlock_at")
+        val unlockAt: String? = null,
+        @SerializedName("lock_explanation")
+        val lockExplanation: String? = null,
+        @SerializedName("discussion_topic")
+        var discussionTopicHeader: DiscussionTopicHeader? = null,
+        @SerializedName("needs_grading_count_by_section")
+        val needsGradingCountBySection: List<NeedsGradingCount> = arrayListOf(),
+        @SerializedName("free_form_criterion_comments")
+        val freeFormCriterionComments: Boolean = false,
+        val published: Boolean = false,
+        @SerializedName("group_category_id")
+        val groupCategoryId: Long = 0,
+        @SerializedName("all_dates")
+        val allDates: List<AssignmentDueDate> = arrayListOf(),
+        @SerializedName("user_submitted")
+        val userSubmitted: Boolean = false,
+        val unpublishable: Boolean = false,
+        val overrides: List<AssignmentOverride>? = null,
+        @SerializedName("only_visible_to_overrides")
+        val onlyVisibleToOverrides: Boolean = false,
+        @SerializedName("anonymous_peer_reviews")
+        val anonymousPeerReviews: Boolean = false,
+        @SerializedName("moderated_grading")
+        val moderatedGrading: Boolean = false,
+        @SerializedName("anonymous_grading")
+        val anonymousGrading: Boolean = false,
+        @SerializedName("allowed_attempts")
+        val allowedAttempts: Long = -1, // API gives -1 for unlimited submissions
+        var isStudioEnabled: Boolean = false
+) : CanvasModel<Assignment>() {
+    override val comparisonDate get() = dueAt.toDate()
+    override val comparisonString get() = dueAt
+
+    fun toAssignmentForObservee(): Assignment? {
+        val submission = submissionList?.firstOrNull()
+        if (submission != null) {
+            return Assignment(
+                id = this.id,
+                name = this.name,
+                description = this.description,
+                submissionTypesRaw = this.submissionTypesRaw,
+                dueAt = this.dueAt,
+                pointsPossible = this.pointsPossible,
+                courseId = this.courseId,
+                isGradeGroupsIndividually = this.isGradeGroupsIndividually,
+                gradingType = this.gradingType,
+                needsGradingCount = this.needsGradingCount,
+                htmlUrl = this.htmlUrl,
+                url = this.url,
+                quizId = this.quizId,
+                rubric = this.rubric,
+                isUseRubricForGrading = this.isUseRubricForGrading,
+                rubricSettings = this.rubricSettings,
+                allowedExtensions = this.allowedExtensions,
+                submission = submission,
+                assignmentGroupId = this.assignmentGroupId,
+                position = this.position,
+                isPeerReviews = this.isPeerReviews,
+                lockInfo = this.lockInfo,
+                lockedForUser = this.lockedForUser,
+                lockAt = this.lockAt,
+                unlockAt = this.unlockAt,
+                lockExplanation = this.lockExplanation,
+                discussionTopicHeader = this.discussionTopicHeader,
+                needsGradingCountBySection = this.needsGradingCountBySection,
+                freeFormCriterionComments = this.freeFormCriterionComments,
+                published = this.published,
+                groupCategoryId = this.groupCategoryId,
+                allDates = this.allDates,
+                userSubmitted = this.userSubmitted,
+                unpublishable = this.unpublishable,
+                overrides = this.overrides,
+                onlyVisibleToOverrides = this.onlyVisibleToOverrides,
+                anonymousPeerReviews = this.anonymousPeerReviews,
+                moderatedGrading = this.moderatedGrading,
+                anonymousGrading = this.anonymousGrading,
+                allowedAttempts = this.allowedAttempts,
+                isStudioEnabled = this.isStudioEnabled
+            )
+        } else {
+            return null
+        }
+    }
+}


### PR DESCRIPTION
To Test:
-Log into the student app with an observer account with a submission with some status (graded, etc).
-Note that the assignment details screen now displays all the correct submission details for your first observer (no other way to "pick" observers right now in student, we just default to #1).