### PR TITLE
[Student][R-6.8.0] Set up NDK filters to only support armabi-v7a, arm64-v8a, and x86_64

### DIFF
--- a/apps/student/build.gradle
+++ b/apps/student/build.gradle
@@ -53,7 +53,7 @@ android {
         applicationId "com.instructure.candroid"
         minSdkVersion Versions.MIN_SDK
         targetSdkVersion Versions.TARGET_SDK
-        versionCode = 212
+        versionCode = 213
         versionName = '6.8.0'
 
         vectorDrawables.useSupportLibrary = true
@@ -71,6 +71,11 @@ android {
         buildConfigField "String", "NEWRELIC_APP_TOKEN", "\"$newRelicAppToken\""
 
         testBuildType = "debug"
+
+        ndk {
+            // Filter for architectures supported by Flutter.
+            abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86_64'
+        }
     }
 
     bundle {

--- a/apps/student/build.gradle
+++ b/apps/student/build.gradle
@@ -71,11 +71,6 @@ android {
         buildConfigField "String", "NEWRELIC_APP_TOKEN", "\"$newRelicAppToken\""
 
         testBuildType = "debug"
-
-        ndk {
-            // Filter for architectures supported by Flutter.
-            abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86_64'
-        }
     }
 
     bundle {
@@ -121,6 +116,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
             ext.enableCrashlytics = false
             pseudoLocalesEnabled true
+
+            ndk {
+                // Filter for architectures supported by Flutter. Include x86 in debug builds so we don't crash on FTL.
+                abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86_64', 'x86'
+            }
         }
 
         release {
@@ -130,6 +130,11 @@ android {
             shrinkResources true
             buildConfigField 'boolean', 'IS_DEBUG', 'false'
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+
+            ndk {
+                // Filter for architectures supported by Flutter. Exclude x86 in release builds to avoid missing lib crash on x86 devices.
+                abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86_64'
+            }
         }
     }
 


### PR DESCRIPTION
This prevents a 'missing libflutter.so' crash on x86 devices by excluding the x86 libs, allowing said devices to be served the ARM version of the app.