### PR TITLE
[Student] Disable submit button for observers

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/AssignmentDetailsRenderTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/AssignmentDetailsRenderTest.kt
@@ -343,6 +343,18 @@ class AssignmentDetailsRenderTest : StudentRenderTest() {
     }
 
     @Test
+    @TestMetaData(Priority.P2, FeatureCategory.ASSIGNMENTS, TestCategory.RENDER, secondaryFeature = FeatureCategory.SUBMISSIONS)
+    fun neverDisplaysSubmitButtonForObserver() {
+        val assignment = Assignment(
+                name = "Test Assignment",
+                submissionTypesRaw = listOf("online_upload")
+        )
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment), isObserver = true)
+        loadPageWithModel(model)
+        assignmentDetailsRenderPage.submitButton.assertGone()
+    }
+
+    @Test
     @TestMetaData(Priority.P2, FeatureCategory.ASSIGNMENTS, TestCategory.RENDER, secondaryFeature = FeatureCategory.QUIZZES)
     fun displaysViewQuizButton() {
         val quizId = 123L

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/SubmissionDetailsEmptyContentRenderTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/SubmissionDetailsEmptyContentRenderTest.kt
@@ -70,6 +70,14 @@ class SubmissionDetailsEmptyContentRenderTest : StudentRenderTest() {
     }
 
     @Test
+    fun submitButtonIsHiddenWhenUserIsObserver() {
+        baseModel = baseModel.copy(isObserver = true)
+        loadPageWithModel(baseModel)
+
+        submissionDetailsEmptyContentRenderPage.assertSubmitButtonHidden()
+    }
+
+    @Test
     fun displaysDueYesterday() {
         val expectedText = "Due yesterday at 1:59 pm"
         loadPageWithModel(baseModel.copy(

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsEffectHandler.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsEffectHandler.kt
@@ -87,7 +87,7 @@ class AssignmentDetailsEffectHandler(val context: Context, val assignmentId: Lon
                     effect.studioLTITool?.name
                 )
             }
-            is AssignmentDetailsEffect.ShowSubmissionView -> view?.showSubmissionView(effect.assignmentId, effect.course)
+            is AssignmentDetailsEffect.ShowSubmissionView -> view?.showSubmissionView(effect.assignmentId, effect.course, effect.isObserver)
             is AssignmentDetailsEffect.ShowQuizStartView -> view?.showQuizStartView(effect.course, effect.quiz)
             is AssignmentDetailsEffect.ShowDiscussionDetailView -> view?.showDiscussionDetailView(effect.course, effect.discussionTopicHeaderId)
             is AssignmentDetailsEffect.ShowDiscussionAttachment -> view?.showDiscussionAttachment(effect.course, effect.discussionAttachment)

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsEffectHandler.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsEffectHandler.kt
@@ -147,8 +147,9 @@ class AssignmentDetailsEffectHandler(val context: Context, val assignmentId: Lon
                 DataResult.Fail(null)
             }
 
+            val isObserver = courseResult.isSuccess && courseResult.dataOrNull != null && courseResult.dataOrNull!!.enrollments!!.firstOrNull { it.isObserver } != null
             val assignmentResult = try {
-                if (courseResult.isSuccess && courseResult.dataOrNull != null && courseResult.dataOrNull!!.enrollments!!.firstOrNull { it.isObserver } != null) {
+                if (isObserver) {
                     // Valid observer enrollment, this means we need to include observers in our assignment response
                     val assignmentResponse = awaitApiResponse<ObserveeAssignment> {
                         AssignmentManager.getAssignmentIncludeObservees(effect.assignmentId, effect.courseId, effect.forceNetwork, it)
@@ -210,7 +211,8 @@ class AssignmentDetailsEffectHandler(val context: Context, val assignmentId: Lon
                     studioLTITool,
                     ltiTool,
                     dbSubmission,
-                    quizResult
+                    quizResult,
+                    isObserver
                 )
             )
         }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsModels.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsModels.kt
@@ -45,7 +45,8 @@ sealed class AssignmentDetailsEvent {
         val studioLTIToolResult: DataResult<LTITool>?,
         val ltiToolResult: DataResult<LTITool>?,
         val submission: Submission?,
-        val quizResult: DataResult<Quiz>?
+        val quizResult: DataResult<Quiz>?,
+        val isObserver: Boolean = false
     ) : AssignmentDetailsEvent()
     data class SubmissionStatusUpdated(val submission: Submission?) : AssignmentDetailsEvent()
     data class InternalRouteRequested(val url: String) : AssignmentDetailsEvent()
@@ -92,5 +93,6 @@ data class AssignmentDetailsModel(
     val ltiTool: DataResult<LTITool>? = null,
     val databaseSubmission: Submission? = null,
     val videoFileUri: Uri? = null,
-    var shouldRouteToSubmissionDetails: Boolean = false
+    var shouldRouteToSubmissionDetails: Boolean = false,
+    val isObserver: Boolean = false
 )

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsModels.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsModels.kt
@@ -71,7 +71,7 @@ sealed class AssignmentDetailsEffect {
     data class ShowQuizStartView(val quiz: Quiz, val course: Course) : AssignmentDetailsEffect()
     data class ShowDiscussionDetailView(val discussionTopicHeaderId: Long, val course: Course) : AssignmentDetailsEffect()
     data class ShowDiscussionAttachment(val discussionAttachment: Attachment, val course: Course) : AssignmentDetailsEffect()
-    data class ShowSubmissionView(val assignmentId: Long, val course: Course) : AssignmentDetailsEffect()
+    data class ShowSubmissionView(val assignmentId: Long, val course: Course, val isObserver: Boolean = false) : AssignmentDetailsEffect()
     data class ShowUploadStatusView(val submission: Submission) : AssignmentDetailsEffect()
     data class ShowCreateSubmissionView(val submissionType: Assignment.SubmissionType, val course: Course, val assignment: Assignment, val ltiUrl: String? = null) : AssignmentDetailsEffect()
     data class LoadData(val assignmentId: Long, val courseId: Long, val forceNetwork: Boolean) : AssignmentDetailsEffect()

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsPresenter.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsPresenter.kt
@@ -62,14 +62,15 @@ object AssignmentDetailsPresenter : Presenter<AssignmentDetailsModel, Assignment
         val quiz = model.quizResult?.dataOrNull
 
         // Loaded state
-        return presentLoadedState(assignment, quiz, model.databaseSubmission, context)
+        return presentLoadedState(assignment, quiz, model.databaseSubmission, context, model.isObserver)
     }
 
     private fun presentLoadedState(
         assignment: Assignment,
         quiz: Quiz?,
         databaseSubmission: Submission?,
-        context: Context
+        context: Context,
+        isObserver: Boolean
     ): AssignmentDetailsViewState.Loaded {
         val visibilities = AssignmentDetailsVisibilities()
 
@@ -183,12 +184,17 @@ object AssignmentDetailsPresenter : Presenter<AssignmentDetailsModel, Assignment
         visibilities.allowedAttempts = assignment.allowedAttempts != -1L
         visibilities.submitButtonEnabled = assignment.allowedAttempts == -1L || (assignment.submission?.attempt?.let{ it < assignment.allowedAttempts } ?: true)
 
-        //Configure stickied submit button visibility state,
-        visibilities.submitButton = when(assignment.turnInType) {
-            // We always show the button for quizzes and discussions, so the users can always route
-            Assignment.TurnInType.QUIZ, Assignment.TurnInType.DISCUSSION -> true
-            Assignment.TurnInType.ONLINE, Assignment.TurnInType.EXTERNAL_TOOL -> assignment.isAllowedToSubmit
-            else -> false // On Paper / etc
+        if (isObserver) {
+            // Observers shouldn't see the submit button
+            visibilities.submitButton = false
+        } else {
+            //Configure stickied submit button visibility state,
+            visibilities.submitButton = when(assignment.turnInType) {
+                // We always show the button for quizzes and discussions, so the users can always route
+                Assignment.TurnInType.QUIZ, Assignment.TurnInType.DISCUSSION -> true
+                Assignment.TurnInType.ONLINE, Assignment.TurnInType.EXTERNAL_TOOL -> assignment.isAllowedToSubmit
+                else -> false // On Paper / etc
+            }
         }
 
         // Configure stickied submit button

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsUpdate.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsUpdate.kt
@@ -117,7 +117,8 @@ class AssignmentDetailsUpdate : UpdateInit<AssignmentDetailsModel, AssignmentDet
                 studioLTIToolResult = event.studioLTIToolResult,
                 ltiTool = event.ltiToolResult,
                 quizResult = event.quizResult,
-                databaseSubmission = dbSubmission
+                databaseSubmission = dbSubmission,
+                isObserver = event.isObserver
             )
 
             if (newModel.shouldRouteToSubmissionDetails) {

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsUpdate.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsUpdate.kt
@@ -41,7 +41,7 @@ class AssignmentDetailsUpdate : UpdateInit<AssignmentDetailsModel, AssignmentDet
             Next.dispatch<AssignmentDetailsModel, AssignmentDetailsEffect>(getSubmitClickedEffect(model.assignmentResult, model, submissionTypes))
         }
         AssignmentDetailsEvent.ViewSubmissionClicked -> {
-            Next.dispatch(setOf(AssignmentDetailsEffect.ShowSubmissionView(model.assignmentId, model.course)))
+            Next.dispatch(setOf(AssignmentDetailsEffect.ShowSubmissionView(model.assignmentId, model.course, model.isObserver)))
         }
         AssignmentDetailsEvent.DiscussionAttachmentClicked -> {
             // They can't click on an attachment if there aren't any present
@@ -123,7 +123,7 @@ class AssignmentDetailsUpdate : UpdateInit<AssignmentDetailsModel, AssignmentDet
 
             if (newModel.shouldRouteToSubmissionDetails) {
                 Next.next<AssignmentDetailsModel, AssignmentDetailsEffect>(
-                    newModel.copy(shouldRouteToSubmissionDetails = false), setOf(AssignmentDetailsEffect.ShowSubmissionView(model.assignmentId, model.course))
+                    newModel.copy(shouldRouteToSubmissionDetails = false), setOf(AssignmentDetailsEffect.ShowSubmissionView(model.assignmentId, model.course, model.isObserver))
                 )
             } else {
                 Next.next<AssignmentDetailsModel, AssignmentDetailsEffect>(newModel)

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsEffectHandler.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsEffectHandler.kt
@@ -107,7 +107,7 @@ class SubmissionDetailsEffectHandler : EffectHandler<SubmissionDetailsView, Subm
                 }
             } else null
 
-            consumer.accept(SubmissionDetailsEvent.DataLoaded(assignmentResult, submissionResult, ltiUrl, isStudioEnabled, quizResult, studioLTIToolResult))
+            consumer.accept(SubmissionDetailsEvent.DataLoaded(assignmentResult, submissionResult, ltiUrl, isStudioEnabled, quizResult, studioLTIToolResult, effect.isObserver))
         }
     }
 

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsModels.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsModels.kt
@@ -33,7 +33,7 @@ sealed class SubmissionDetailsEvent {
     data class AttachmentClicked(val file: Attachment) : SubmissionDetailsEvent()
     data class SubmissionClicked(val submissionAttempt: Long) : SubmissionDetailsEvent()
     data class SubmissionAndAttachmentClicked(val submissionAttempt: Long, val attachment: Attachment) : SubmissionDetailsEvent()
-    data class DataLoaded(val assignment: DataResult<Assignment>, val rootSubmissionResult: DataResult<Submission>, val ltiUrlResult: DataResult<LTITool?>, val isStudioEnabled: Boolean, val quizResult: DataResult<Quiz>?, val studioLTIToolResult: DataResult<LTITool>?) :
+    data class DataLoaded(val assignment: DataResult<Assignment>, val rootSubmissionResult: DataResult<Submission>, val ltiUrlResult: DataResult<LTITool?>, val isStudioEnabled: Boolean, val quizResult: DataResult<Quiz>?, val studioLTIToolResult: DataResult<LTITool>?, val isObserver: Boolean = false) :
         SubmissionDetailsEvent()
 }
 
@@ -45,7 +45,7 @@ sealed class SubmissionDetailsEffect {
     object MediaCommentDialogClosed : SubmissionDetailsEffect()
     data class ShowVideoRecordingPlayback(val file: File) : SubmissionDetailsEffect()
     data class UploadMediaComment(val file: File) : SubmissionDetailsEffect()
-    data class LoadData(val courseId: Long, val assignmentId: Long) : SubmissionDetailsEffect()
+    data class LoadData(val courseId: Long, val assignmentId: Long, val isObserver: Boolean = false) : SubmissionDetailsEffect()
     data class ShowSubmissionContentType(val submissionContentType: SubmissionDetailsContentType) :
         SubmissionDetailsEffect()
 }
@@ -60,7 +60,8 @@ data class SubmissionDetailsModel(
     val rootSubmissionResult: DataResult<Submission>? = null,
     val isStudioEnabled: Boolean? = null,
     val quizResult: DataResult<Quiz>? = null,
-    val studioLTIToolResult: DataResult<LTITool>? = null
+    val studioLTIToolResult: DataResult<LTITool>? = null,
+    val isObserver: Boolean = false
 )
 
 sealed class SubmissionDetailsContentType {
@@ -75,7 +76,7 @@ sealed class SubmissionDetailsContentType {
         val displayName: String?
     ) : SubmissionDetailsContentType()
 
-    data class NoSubmissionContent(val canvasContext: CanvasContext, val assignment: Assignment, val isStudioEnabled: Boolean, val quiz: Quiz? = null, val studioLTITool: LTITool? = null) : SubmissionDetailsContentType()
+    data class NoSubmissionContent(val canvasContext: CanvasContext, val assignment: Assignment, val isStudioEnabled: Boolean, val quiz: Quiz? = null, val studioLTITool: LTITool? = null, val isObserver: Boolean = false) : SubmissionDetailsContentType()
     object NoneContent : SubmissionDetailsContentType()
     data class ExternalToolContent(val canvasContext: CanvasContext, val url: String) : SubmissionDetailsContentType()
     object OnPaperContent : SubmissionDetailsContentType()

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsUpdate.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsUpdate.kt
@@ -35,7 +35,7 @@ class SubmissionDetailsUpdate : UpdateInit<SubmissionDetailsModel, SubmissionDet
             model.copy(
                 isLoading = true
             ),
-            setOf(SubmissionDetailsEffect.LoadData(model.canvasContext.id, model.assignmentId))
+            setOf(SubmissionDetailsEffect.LoadData(model.canvasContext.id, model.assignmentId, model.isObserver))
         )
     }
 
@@ -57,7 +57,8 @@ class SubmissionDetailsUpdate : UpdateInit<SubmissionDetailsModel, SubmissionDet
                         model.isStudioEnabled,
                         null,
                         quiz = model.quizResult?.dataOrNull,
-                        studioLTITool = model.studioLTIToolResult?.dataOrNull
+                        studioLTITool = model.studioLTIToolResult?.dataOrNull,
+                        isObserver = model.isObserver
                     )
                     Next.next<SubmissionDetailsModel, SubmissionDetailsEffect>(
                         model.copy(
@@ -74,7 +75,9 @@ class SubmissionDetailsUpdate : UpdateInit<SubmissionDetailsModel, SubmissionDet
                     event.isStudioEnabled,
                     event.ltiUrlResult.dataOrNull,
                     event.quizResult?.dataOrNull,
-                    event.studioLTIToolResult?.dataOrNull)
+                    event.studioLTIToolResult?.dataOrNull,
+                    event.isObserver
+                )
                 Next.next(
                     model.copy(
                         isLoading = false,
@@ -149,7 +152,8 @@ class SubmissionDetailsUpdate : UpdateInit<SubmissionDetailsModel, SubmissionDet
         isStudioEnabled: Boolean?,
         ltiUrl: LTITool?,
         quiz: Quiz?,
-        studioLTITool: LTITool?
+        studioLTITool: LTITool?,
+        isObserver: Boolean = false
     ): SubmissionDetailsContentType {
         return when {
             Assignment.SubmissionType.NONE.apiString in assignment?.submissionTypesRaw ?: emptyList() -> SubmissionDetailsContentType.NoneContent
@@ -159,7 +163,7 @@ class SubmissionDetailsUpdate : UpdateInit<SubmissionDetailsModel, SubmissionDet
                     SubmissionDetailsContentType.ExternalToolContent(canvasContext, ltiUrl?.url ?: "")
                 else SubmissionDetailsContentType.LockedContent
             }
-            submission?.submissionType == null -> SubmissionDetailsContentType.NoSubmissionContent(canvasContext, assignment!!, isStudioEnabled!!, quiz, studioLTITool)
+            submission?.submissionType == null -> SubmissionDetailsContentType.NoSubmissionContent(canvasContext, assignment!!, isStudioEnabled!!, quiz, studioLTITool, isObserver)
             submission.workflowState != "submitted" && AssignmentUtils2.getAssignmentState(assignment, submission) in listOf(AssignmentUtils2.ASSIGNMENT_STATE_MISSING, AssignmentUtils2.ASSIGNMENT_STATE_GRADED_MISSING) -> SubmissionDetailsContentType.NoSubmissionContent(canvasContext, assignment!!, isStudioEnabled!!, quiz)
             else -> when (Assignment.getSubmissionTypeFromAPIString(submission.submissionType)) {
 

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/emptySubmission/SubmissionDetailsEmptyContentPresenter.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/emptySubmission/SubmissionDetailsEmptyContentPresenter.kt
@@ -31,7 +31,8 @@ object SubmissionDetailsEmptyContentPresenter : Presenter<SubmissionDetailsEmpty
         return SubmissionDetailsEmptyContentViewState.Loaded(
             allowedToSubmit(model.assignment),
             model.assignment.getDueString(context),
-            getSubmitButtonTextResource(context, model.assignment)
+            getSubmitButtonTextResource(context, model.assignment),
+            model.isObserver
         )
     }
 

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/emptySubmission/SubmissionDetailsEmptyModels.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/emptySubmission/SubmissionDetailsEmptyModels.kt
@@ -60,5 +60,6 @@ data class SubmissionDetailsEmptyContentModel(
     val isStudioEnabled: Boolean,
     val quiz: Quiz? = null,
     val studioLTITool: LTITool? = null,
-    val videoFileUri: Uri? = null
+    val videoFileUri: Uri? = null,
+    val isObserver: Boolean = false
 )

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/emptySubmission/ui/SubmissionDetailsEmptyContentFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/emptySubmission/ui/SubmissionDetailsEmptyContentFragment.kt
@@ -40,12 +40,13 @@ class SubmissionDetailsEmptyContentFragment :
     val canvasContext by ParcelableArg<Course>(key = Const.CANVAS_CONTEXT)
     val quiz by NullableParcelableArg<Quiz>(key = Const.QUIZ)
     val studioLTITool by NullableParcelableArg<LTITool>(key = Const.STUDIO_LTI_TOOL)
+    val isObserver by BooleanArg(key = Const.IS_OBSERVER, default = false)
 
     override fun makeEffectHandler() = SubmissionDetailsEmptyContentEffectHandler(requireContext(), assignment.id)
     override fun makeUpdate() = SubmissionDetailsEmptyContentUpdate()
     override fun makeView(inflater: LayoutInflater, parent: ViewGroup) = SubmissionDetailsEmptyContentView(canvasContext, inflater, parent)
     override fun makePresenter() = SubmissionDetailsEmptyContentPresenter
-    override fun makeInitModel() = SubmissionDetailsEmptyContentModel(assignment, canvasContext, isStudioEnabled, quiz, studioLTITool = studioLTITool)
+    override fun makeInitModel() = SubmissionDetailsEmptyContentModel(assignment, canvasContext, isStudioEnabled, quiz, studioLTITool = studioLTITool, isObserver = isObserver)
     override fun getExternalEventSources() = listOf(
         SubmissionDetailsEmptyContentEventBusSource(),
         DBSource.ofSingle<Submission, SubmissionDetailsEmptyContentEvent>(
@@ -67,8 +68,9 @@ class SubmissionDetailsEmptyContentFragment :
         const val CHOOSE_MEDIA_REQUEST_CODE = 45521
 
         @JvmStatic
-        fun newInstance(course: Course, assignment: Assignment, isStudioEnabled: Boolean, quiz: Quiz? = null, studioLTITool: LTITool? = null): SubmissionDetailsEmptyContentFragment {
+        fun newInstance(course: Course, assignment: Assignment, isStudioEnabled: Boolean, quiz: Quiz? = null, studioLTITool: LTITool? = null, isObserver: Boolean = false): SubmissionDetailsEmptyContentFragment {
             val bundle = course.makeBundle {
+                putBoolean(Const.IS_OBSERVER, isObserver)
                 putParcelable(Const.ASSIGNMENT, assignment)
                 putParcelable(Const.QUIZ, quiz)
                 putBoolean(Const.IS_STUDIO_ENABLED, isStudioEnabled)

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/emptySubmission/ui/SubmissionDetailsEmptyContentView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/emptySubmission/ui/SubmissionDetailsEmptyContentView.kt
@@ -81,7 +81,7 @@ class SubmissionDetailsEmptyContentView(
                 title.text = if (state.isAllowedToSubmit) context.getString(R.string.submissionDetailsNoSubmissionYet) else context.getString(R.string.submissionDetailsAssignmentLocked)
                 message.text = state.dueDateText
                 submitButton.apply {
-                    setHidden(!state.isAllowedToSubmit)
+                    setHidden(!state.isAllowedToSubmit || state.isObserver)
                     text = state.submitButtonText
                 }
             }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/emptySubmission/ui/SubmissionDetailsEmptyContentViewState.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/emptySubmission/ui/SubmissionDetailsEmptyContentViewState.kt
@@ -19,6 +19,7 @@ sealed class SubmissionDetailsEmptyContentViewState {
     data class Loaded(
         val isAllowedToSubmit: Boolean = true,
         val dueDateText: String = "",
-        val submitButtonText: String = ""
+        val submitButtonText: String = "",
+        val isObserver: Boolean = false
     ) : SubmissionDetailsEmptyContentViewState()
 }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/ui/SubmissionDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/ui/SubmissionDetailsFragment.kt
@@ -43,6 +43,7 @@ class SubmissionDetailsFragment :
 
     @get:PageViewUrlParam(name = "assignmentId")
     val assignmentId by LongArg(key = Const.ASSIGNMENT_ID)
+    val isObserver by BooleanArg(key = Const.IS_OBSERVER, default = false)
 
     override fun makeEffectHandler() = SubmissionDetailsEffectHandler()
 
@@ -53,7 +54,7 @@ class SubmissionDetailsFragment :
 
     override fun makePresenter() = SubmissionDetailsPresenter
 
-    override fun makeInitModel() = SubmissionDetailsModel(canvasContext = canvasContext, assignmentId = assignmentId)
+    override fun makeInitModel() = SubmissionDetailsModel(canvasContext = canvasContext, assignmentId = assignmentId, isObserver = isObserver)
 
     override fun getExternalEventSources() = listOf(
         ChannelSource.getSource<SubmissionDetailsSharedEvent, SubmissionDetailsEvent> {
@@ -86,9 +87,11 @@ class SubmissionDetailsFragment :
 
     companion object {
         @JvmStatic
-        fun makeRoute(course: CanvasContext, assignmentId: Long): Route {
+        fun makeRoute(course: CanvasContext, assignmentId: Long, isObserver: Boolean = false): Route {
             val bundle = course.makeBundle {
-                putLong(Const.ASSIGNMENT_ID, assignmentId) }
+                putLong(Const.ASSIGNMENT_ID, assignmentId)
+                putBoolean(Const.IS_OBSERVER, isObserver)
+            }
             return Route(null, SubmissionDetailsFragment::class.java, course, bundle)
         }
 

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/ui/SubmissionDetailsView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/ui/SubmissionDetailsView.kt
@@ -257,7 +257,7 @@ class SubmissionDetailsView(
 
     private fun getFragmentForContent(type: SubmissionDetailsContentType): Fragment {
         return when (type) {
-            is SubmissionDetailsContentType.NoSubmissionContent -> SubmissionDetailsEmptyContentFragment.newInstance(type.canvasContext as Course, type.assignment, type.isStudioEnabled, type.quiz, type.studioLTITool)
+            is SubmissionDetailsContentType.NoSubmissionContent -> SubmissionDetailsEmptyContentFragment.newInstance(type.canvasContext as Course, type.assignment, type.isStudioEnabled, type.quiz, type.studioLTITool, type.isObserver)
             is SubmissionDetailsContentType.UrlContent -> UrlSubmissionViewFragment.newInstance(type.url, type.previewUrl)
             is SubmissionDetailsContentType.QuizContent -> QuizSubmissionViewFragment.newInstance(type.url)
             is SubmissionDetailsContentType.TextContent -> TextSubmissionViewFragment.newInstance(type.text)

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsView.kt
@@ -268,9 +268,9 @@ class AssignmentDetailsView(
         RouteMatcher.routeUrl(context, url, domain, extras)
     }
 
-    fun showSubmissionView(assignmentId: Long, course: Course) {
+    fun showSubmissionView(assignmentId: Long, course: Course, isObserver: Boolean = false) {
         logEvent(AnalyticsEventConstants.SUBMISSION_CELL_SELECTED)
-        RouteMatcher.route(context, SubmissionDetailsFragment.makeRoute(course, assignmentId))
+        RouteMatcher.route(context, SubmissionDetailsFragment.makeRoute(course, assignmentId, isObserver))
     }
 
     fun showUploadStatusView(submissionId: Long) {

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsEffectHandlerTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsEffectHandlerTest.kt
@@ -249,7 +249,8 @@ class AssignmentDetailsEffectHandlerTest : Assert() {
                 DataResult.Fail(null),
                 DataResult.Success(ltiTool),
                 submission,
-                null
+                null,
+                true
         )
         val observerEnrollment = Enrollment(id = 1, role = Enrollment.EnrollmentType.Observer)
         val course = Course(id = courseId, enrollments = mutableListOf(observerEnrollment))

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsPresenterTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsPresenterTest.kt
@@ -445,6 +445,16 @@ class AssignmentDetailsPresenterTest : Assert() {
     }
 
     @Test
+    fun `Never shows submit button when isObserver is true`() {
+        val assignment = baseAssignment.copy(
+                submissionTypesRaw = listOf("online_text_entry")
+        )
+        val model = baseModel.copy(assignmentResult = DataResult.Success(assignment), isObserver = true)
+        val actual = AssignmentDetailsPresenter.present(model, context).visibilities
+        assertFalse(actual.submitButton)
+    }
+
+    @Test
     fun `Submit button reads "Submit Assignment" if there are no existing submissions`() {
         val assignment = baseAssignment.copy(
             submissionTypesRaw = listOf("online_text_entry")

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/submissionDetails/SubmissionDetailsEmptyContentPresenterTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/submissionDetails/SubmissionDetailsEmptyContentPresenterTest.kt
@@ -287,6 +287,15 @@ class SubmissionDetailsEmptyContentPresenterTest : Assert() {
     }
 
     @Test
+    fun `Sets isObserver visible state when isObserver`() {
+        baseModel = baseModel.copy(isObserver = true)
+        val actualState = SubmissionDetailsEmptyContentPresenter.present(baseModel, context)
+
+        assertTrue((actualState as Loaded).isObserver)
+    }
+
+
+    @Test
     fun `Submit button disabled if not allowed to submit when assignment is online upload`() {
         baseModel = baseModel.copy(Assignment(lockedForUser = true, submissionTypesRaw = listOf("online_upload")))
         val actualState = SubmissionDetailsEmptyContentPresenter.present(baseModel, context)

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/Const.java
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/Const.java
@@ -104,6 +104,7 @@ public class Const {
     public static final String IS_STARRED = "isStarred";
     public static final String IS_GROUP = "isGroup";
     public static final String IS_UNSUPPORTED_FEATURE ="isUnsupportedFeature";
+    public static final String IS_OBSERVER ="isObserver";
     public static final String ALLOW_UNSUPPORTED_ROUTING ="allowUnsupportedRouting";
     public static final String LAYOUT_ID = "layout_id";
     public static final String MASTERY_PATH = "mastery_path";


### PR DESCRIPTION
To Test:
-Sign into the student app with an observer
-Go to any submittable assignment, note that the submission button should now be gone
-Make sure its still visible for students