### PR TITLE
[Parent][MBL-14417] Add locale fallback for Material strings and Date formatting

### DIFF
--- a/apps/flutter_parent/lib/l10n/app_localizations.dart
+++ b/apps/flutter_parent/lib/l10n/app_localizations.dart
@@ -30,7 +30,7 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
       // Supported languages
       Locale('ar'),
       Locale('ca'),
-//      Locale('cy'), // Not supported by material localizations
+      Locale('cy'), // Not yet supported by flutter_localizations; 'en' fallback will be used for Material localizations
       Locale('da'),
       Locale('de'),
       Locale('en', 'AU'),
@@ -42,11 +42,11 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
       // Country has to be first so it can be matched before the general language
       Locale('fr', 'CA'),
       Locale('fr'),
-//      Locale('ht'), // Not supported by material localizations
+      Locale('ht'), // Not yet supported by flutter_localizations; 'en' fallback will be used for Material localizations
       Locale('is'),
       Locale('it'),
       Locale('ja'),
-//      Locale('mi'), // Not supported by material localizations
+      Locale('mi'), // Not yet supported by flutter_localizations; 'en' fallback will be used for Material localizations
       Locale('nb'),
       Locale('nl'),
       Locale('pl'),

--- a/apps/flutter_parent/lib/l10n/fallback_material_localizations_delegate.dart
+++ b/apps/flutter_parent/lib/l10n/fallback_material_localizations_delegate.dart
@@ -1,0 +1,39 @@
+// Copyright (C) 2020 - present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+
+/// A MaterialLocalizations delegate which wraps GlobalMaterialLocalizations.delegate and adds a fallback
+/// to the default locale ('en') for unsupported locales
+class FallbackMaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocalizations> {
+  static const LocalizationsDelegate<MaterialLocalizations> delegate = GlobalMaterialLocalizations.delegate;
+
+  const FallbackMaterialLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) => true;
+
+  @override
+  Future<MaterialLocalizations> load(Locale locale) {
+    if (delegate.isSupported(locale)) return delegate.load(locale);
+    return delegate.load(Locale('en'));
+  }
+
+  @override
+  bool shouldReload(FallbackMaterialLocalizationsDelegate old) => false;
+
+  @override
+  String toString() => 'FallbackMaterialLocalizationsDelegate - ${kMaterialSupportedLanguages.length} locales)';
+}

--- a/apps/flutter_parent/lib/models/grade_cell_data.dart
+++ b/apps/flutter_parent/lib/models/grade_cell_data.dart
@@ -80,7 +80,7 @@ abstract class GradeCellData implements Built<GradeCellData, GradeCellDataBuilde
         ..state = GradeCellState.submitted
         ..submissionText = submission.submittedAt.l10nFormat(
           l10n.submissionStatusSuccessSubtitle,
-          dateFormat: DateFormat.MMMMd(),
+          dateFormat: DateFormat.MMMMd(supportedDateLocale),
         ));
     }
 

--- a/apps/flutter_parent/lib/parent_app.dart
+++ b/apps/flutter_parent/lib/parent_app.dart
@@ -26,6 +26,8 @@ import 'package:flutter_parent/utils/common_widgets/masquerade_ui.dart';
 import 'package:flutter_parent/utils/common_widgets/respawn.dart';
 import 'package:flutter_parent/utils/design/parent_theme.dart';
 
+import 'l10n/fallback_material_localizations_delegate.dart';
+
 class ParentApp extends StatefulWidget {
   final Completer<void> _appCompleter;
 
@@ -71,7 +73,7 @@ class _ParentAppState extends State<ParentApp> {
           localizationsDelegates: const [
             AppLocalizations.delegate,
             // Material components use these delegate to provide default localization
-            GlobalMaterialLocalizations.delegate,
+            FallbackMaterialLocalizationsDelegate(),
             GlobalWidgetsLocalizations.delegate,
           ],
           supportedLocales: AppLocalizations.delegate.supportedLocales,

--- a/apps/flutter_parent/lib/screens/calendar/calendar_widget/calendar_day.dart
+++ b/apps/flutter_parent/lib/screens/calendar/calendar_widget/calendar_day.dart
@@ -81,8 +81,11 @@ class CalendarDay extends StatelessWidget {
                 child: AnimatedDefaultTextStyle(
                   style: textStyle,
                   duration: Duration(milliseconds: 300),
-                  child: Text(date.day.toString(),
-                      semanticsLabel: DateFormat.MMMMEEEEd().format(date), key: ValueKey('day_of_month_${date.day}')),
+                  child: Text(
+                    date.day.toString(),
+                    semanticsLabel: DateFormat.MMMMEEEEd(supportedDateLocale).format(date),
+                    key: ValueKey('day_of_month_${date.day}'),
+                  ),
                 ),
               ),
             ),

--- a/apps/flutter_parent/lib/screens/calendar/calendar_widget/calendar_day_of_week_headers.dart
+++ b/apps/flutter_parent/lib/screens/calendar/calendar_widget/calendar_day_of_week_headers.dart
@@ -13,8 +13,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import 'package:flutter/material.dart';
+import 'package:flutter_parent/utils/core_extensions/date_time_extensions.dart';
 import 'package:flutter_parent/utils/design/parent_theme.dart';
-import 'package:intl/intl.dart' hide TextDirection;
+import 'package:intl/intl.dart';
 
 class DayOfWeekHeaders extends StatelessWidget {
   static const double headerHeight = 14;
@@ -24,7 +25,7 @@ class DayOfWeekHeaders extends StatelessWidget {
     final weekendTheme = Theme.of(context).textTheme.subtitle;
     final weekdayTheme = weekendTheme.copyWith(color: ParentTheme.of(context).onSurfaceColor);
 
-    final symbols = DateFormat().dateSymbols;
+    final symbols = DateFormat(null, supportedDateLocale).dateSymbols;
     final firstDayOfWeek = symbols.FIRSTDAYOFWEEK;
 
     return ExcludeSemantics(

--- a/apps/flutter_parent/lib/screens/calendar/calendar_widget/calendar_widget.dart
+++ b/apps/flutter_parent/lib/screens/calendar/calendar_widget/calendar_widget.dart
@@ -288,7 +288,7 @@ class CalendarWidgetState extends State<CalendarWidget> with TickerProviderState
           key: Key('expand-button'),
           onTap: _canExpandMonth ? _toggleExpanded : null,
           child: Semantics(
-            label: L10n(context).selectedMonthLabel(DateFormat.yMMMM().format(selectedDay)),
+            label: L10n(context).selectedMonthLabel(DateFormat.yMMMM(supportedDateLocale).format(selectedDay)),
             onTapHint: _isMonthExpanded ? L10n(context).monthTapCollapseHint : L10n(context).monthTapExpandHint,
             excludeSemantics: true,
             child: Padding(
@@ -296,10 +296,16 @@ class CalendarWidgetState extends State<CalendarWidget> with TickerProviderState
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[
-                  Text(DateFormat.y().format(selectedDay), style: Theme.of(context).textTheme.overline),
+                  Text(
+                    DateFormat.y(supportedDateLocale).format(selectedDay),
+                    style: Theme.of(context).textTheme.overline,
+                  ),
                   Row(
                     children: <Widget>[
-                      Text(DateFormat.MMMM().format(selectedDay), style: Theme.of(context).textTheme.display1),
+                      Text(
+                        DateFormat.MMMM(supportedDateLocale).format(selectedDay),
+                        style: Theme.of(context).textTheme.display1,
+                      ),
                       SizedBox(width: 10),
                       Visibility(
                         visible: _canExpandMonth,
@@ -553,7 +559,7 @@ class CalendarWidgetState extends State<CalendarWidget> with TickerProviderState
       index = _weekController.page.toInt();
     }
 
-    final format = DateFormat.MMMMd().add_y();
+    final format = DateFormat.MMMMd(supportedDateLocale).add_y();
 
     final previousWeek = _weekStartForIndex(index - 1);
     final previousWeekName = format.format(previousWeek);
@@ -587,7 +593,7 @@ class CalendarWidgetState extends State<CalendarWidget> with TickerProviderState
       index = _monthController.page.toInt();
     }
 
-    final format = DateFormat.MMMM().add_y();
+    final format = DateFormat.MMMM(supportedDateLocale).add_y();
 
     final previousMonth = _yearAndMonthForIndex(index - 1);
     final previousMonthName = format.format(DateTime(previousMonth.item1, previousMonth.item2));

--- a/apps/flutter_parent/lib/screens/events/event_details_screen.dart
+++ b/apps/flutter_parent/lib/screens/events/event_details_screen.dart
@@ -203,11 +203,11 @@ class _EventDetails extends StatelessWidget {
   }
 
   String _dateFormat(DateTime time) {
-    return time == null ? null : DateFormat.EEEE().add_yMMMd().format(time.toLocal());
+    return time == null ? null : DateFormat.EEEE(supportedDateLocale).add_yMMMd().format(time.toLocal());
   }
 
   String _timeFormat(DateTime time) {
-    return time == null ? null : DateFormat.jm().format(time.toLocal());
+    return time == null ? null : DateFormat.jm(supportedDateLocale).format(time.toLocal());
   }
 }
 

--- a/apps/flutter_parent/lib/screens/inbox/conversation_list/conversation_list_screen.dart
+++ b/apps/flutter_parent/lib/screens/inbox/conversation_list/conversation_list_screen.dart
@@ -26,6 +26,7 @@ import 'package:flutter_parent/utils/common_widgets/badges.dart';
 import 'package:flutter_parent/utils/common_widgets/empty_panda_widget.dart';
 import 'package:flutter_parent/utils/common_widgets/error_panda_widget.dart';
 import 'package:flutter_parent/utils/common_widgets/loading_indicator.dart';
+import 'package:flutter_parent/utils/core_extensions/date_time_extensions.dart';
 import 'package:flutter_parent/utils/design/canvas_icons.dart';
 import 'package:flutter_parent/utils/design/canvas_icons_solid.dart';
 import 'package:flutter_parent/utils/design/parent_colors.dart';
@@ -189,12 +190,12 @@ class ConversationListState extends State<ConversationListScreen> {
   String _formatMessageDate(DateTime date) {
     if (date == null) return '';
     date = date.toLocal();
-    var format = DateFormat.MMM().add_d();
+    var format = DateFormat.MMM(supportedDateLocale).add_d();
     var now = DateTime.now();
     if (date.year != now.year) {
       format = format.add_y();
     } else if (date.month == now.month && date.day == now.day) {
-      format = DateFormat.jm();
+      format = DateFormat.jm(supportedDateLocale);
     }
     return format.format(date);
   }

--- a/apps/flutter_parent/lib/utils/core_extensions/date_time_extensions.dart
+++ b/apps/flutter_parent/lib/utils/core_extensions/date_time_extensions.dart
@@ -14,6 +14,10 @@
 
 import 'package:intl/intl.dart';
 
+/// Returns a locale usable by DateTime formatters. This will generally be the current locale, but will fall back
+/// to the 'en' locale if the current locale is unsupported.
+String get supportedDateLocale => DateFormat.localeExists(Intl.getCurrentLocale()) ? Intl.getCurrentLocale() : 'en';
+
 extension Format on DateTime {
   /// Formats this [DateTime] for the current locale using the provided localization function
   String l10nFormat(
@@ -23,8 +27,8 @@ extension Format on DateTime {
   }) {
     if (this == null || localizer == null) return null;
     DateTime local = toLocal();
-    String date = (dateFormat ?? DateFormat.MMMd()).format(local);
-    String time = (timeFormat ?? DateFormat.jm()).format(local);
+    String date = (dateFormat ?? DateFormat.MMMd(supportedDateLocale)).format(local);
+    String time = (timeFormat ?? DateFormat.jm(supportedDateLocale)).format(local);
     return localizer(date, time);
   }
 
@@ -35,20 +39,20 @@ extension Format on DateTime {
 
   DateTime withFirstDayOfWeek() {
     if (this == null) return null;
-    final firstDay = DateFormat().dateSymbols.FIRSTDAYOFWEEK;
+    final firstDay = DateFormat(null, supportedDateLocale).dateSymbols.FIRSTDAYOFWEEK;
     var offset = (this.weekday - 1 - firstDay) % 7;
     return DateTime(this.year, this.month, this.day - offset);
   }
 
   int get localDayOfWeek {
     if (this == null) return null;
-    final firstDay = DateFormat().dateSymbols.FIRSTDAYOFWEEK;
+    final firstDay = DateFormat(null, supportedDateLocale).dateSymbols.FIRSTDAYOFWEEK;
     return (this.weekday - 1 - firstDay) % 7;
   }
 
   bool isWeekend() {
     if (this == null) return false;
-    return DateFormat().dateSymbols.WEEKENDRANGE.contains((this.weekday - 1) % 7);
+    return DateFormat(null, supportedDateLocale).dateSymbols.WEEKENDRANGE.contains((this.weekday - 1) % 7);
   }
 
   DateTime withStartOfDay() => this == null ? null : DateTime(year, month, day);

--- a/apps/flutter_parent/test_driver/pages/assignment_details_page.dart
+++ b/apps/flutter_parent/test_driver/pages/assignment_details_page.dart
@@ -15,6 +15,7 @@
 import 'package:flutter_driver/flutter_driver.dart';
 import 'package:flutter_parent/models/assignment.dart';
 import 'package:flutter_parent/models/dataseeding/quiz.dart';
+import 'package:flutter_parent/utils/core_extensions/date_time_extensions.dart';
 import 'package:intl/intl.dart';
 import 'package:test/test.dart';
 
@@ -85,8 +86,8 @@ class AssignmentDetailsPage {
 
   static Future<void> _validateDueDate(FlutterDriver driver, DateTime dueAt) async {
     var localDate = dueAt.toLocal();
-    String date = (DateFormat.MMMd()).format(localDate);
-    String time = (DateFormat.jm()).format(localDate);
+    String date = (DateFormat.MMMd(supportedDateLocale)).format(localDate);
+    String time = (DateFormat.jm(supportedDateLocale)).format(localDate);
     var dueDateText = await driver.getText(find.byValueKey("assignment_details_due_date"));
     expect(dueDateText.contains(date), true, reason: "Expected due date to contain $date");
     expect(dueDateText.contains(time), true, reason: "Expected due date to contain $time");

--- a/apps/flutter_parent/test_driver/pages/course_summary_page.dart
+++ b/apps/flutter_parent/test_driver/pages/course_summary_page.dart
@@ -16,6 +16,7 @@ import 'package:flutter_driver/flutter_driver.dart';
 import 'package:flutter_parent/models/assignment.dart';
 import 'package:flutter_parent/models/dataseeding/quiz.dart';
 import 'package:flutter_parent/models/schedule_item.dart';
+import 'package:flutter_parent/utils/core_extensions/date_time_extensions.dart';
 import 'package:intl/intl.dart';
 import 'package:test/test.dart';
 
@@ -71,8 +72,8 @@ class CourseSummaryPage {
       expect(text, "No Due Date", reason: "Due date");
     } else {
       var localDate = dueDate.toLocal();
-      String date = (DateFormat.MMMd()).format(localDate);
-      String time = (DateFormat.jm()).format(localDate);
+      String date = (DateFormat.MMMd(supportedDateLocale)).format(localDate);
+      String time = (DateFormat.jm(supportedDateLocale)).format(localDate);
       expect(text.contains(date), true, reason: "Expected due date ($text) to contain $date");
       expect(text.contains(time), true, reason: "Expected due date ($text) to contain $time");
     }


### PR DESCRIPTION
The process for adding new Material translations does not appear to be very maintainable or automatable, so instead this change adds a locale fallback for Material translations, which have only a minimal presence in the app. 

In the process of testing, I also discovered that formatting dates would cause widget crashes when using unsupported locales. Unfortunately there does not appear to be a way to manually add new date symbols for specific locales, so a centralized solution was not attainable there. Instead, every DateFormat call site in the app has been updated to pass in a supported locale.

To test: Use web to set an observer's language to one not supported by `flutter_localizations` (Welsh, Haitian Creole, or Maori), then log into the app as that user. You should be able to browse all parts of the app without encountering widget crashes. Material components (like the nav drawer button tooltip) and screens that use date symbols (like the planner) should use English fallbacks where necessary.