### PR TITLE
[Student] Fix PTR for empty syllabus state

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/renderPages/SyllabusRenderPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/renderPages/SyllabusRenderPage.kt
@@ -38,7 +38,7 @@ class SyllabusRenderPage : SyllabusPage() {
     private val tabs by OnViewWithId(R.id.syllabusTabLayout)
     private val webView by WaitForViewWithId(R.id.syllabusWebView)
     private val eventsRecycler by WaitForViewWithId(R.id.syllabusEventsRecycler)
-    private val emptyView by WaitForViewWithId(R.id.emptyView)
+    private val eventsEmpty by WaitForViewWithId(R.id.syllabusEmptyView)
     private val eventsError by WaitForViewWithId(R.id.syllabusEventsError)
 
     fun assertDisplaysToolbarTitle(text: String) {
@@ -51,7 +51,7 @@ class SyllabusRenderPage : SyllabusPage() {
 
     fun assertDoesNotDisplaySyllabus() {
         tabs.assertNotDisplayed()
-        onView(withId(R.id.syllabusWebView)).check(doesNotExist())
+        webView.assertNotDisplayed()
     }
 
     fun assertDisplaysSyllabus(text: String, shouldDisplayTabs: Boolean = true) {
@@ -61,7 +61,7 @@ class SyllabusRenderPage : SyllabusPage() {
     }
 
     fun assertDisplaysEmpty() {
-        emptyView.assertDisplayed()
+        eventsEmpty.assertDisplayed()
     }
 
     fun assertDisplaysError() {

--- a/apps/student/src/main/java/com/instructure/student/mobius/syllabus/SyllabusPresenter.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/syllabus/SyllabusPresenter.kt
@@ -36,22 +36,17 @@ object SyllabusPresenter : Presenter<SyllabusModel, SyllabusViewState> {
         if (model.isLoading) return SyllabusViewState.Loading
 
         if (model.course?.isFail == true && model.events?.isFail == true) {
-            return SyllabusViewState.LoadedNoSyllabus(EventsViewState.Error)
+            return SyllabusViewState.Loaded(eventsState = EventsViewState.Error)
         }
 
         val course = model.course?.dataOrNull
         val events = mapEventsResultToViewState(course?.color ?: 0, model.events, context)
         val body = model.syllabus?.description?.takeIf { it.isValid() }
 
-        return if (events is EventsViewState.Empty && body == null) {
-            SyllabusViewState.LoadedNothing
-        } else if (body == null) {
-            SyllabusViewState.LoadedNoSyllabus(events)
-        } else if (events is EventsViewState.Empty) {
-            SyllabusViewState.LoadedNoEvents(body)
-        } else {
-            SyllabusViewState.LoadedFull(body, events)
-        }
+        return SyllabusViewState.Loaded(
+            syllabus = body,
+            eventsState = events.takeUnless { it == EventsViewState.Empty && body != null }
+        )
     }
 
     private fun mapEventsResultToViewState(color: Int, eventsResult: DataResult<List<ScheduleItem>>?, context: Context): EventsViewState {

--- a/apps/student/src/main/java/com/instructure/student/mobius/syllabus/ui/SyllabusViewState.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/syllabus/ui/SyllabusViewState.kt
@@ -19,16 +19,10 @@ package com.instructure.student.mobius.syllabus.ui
 sealed class SyllabusViewState {
     object Loading : SyllabusViewState()
 
-    object LoadedNothing : SyllabusViewState()
-
-    data class LoadedFull(
-        val syllabus: String,
-        val eventsState: EventsViewState
+    data class Loaded(
+        val syllabus: String? = null,
+        val eventsState: EventsViewState? = null
     ) : SyllabusViewState()
-
-    data class LoadedNoSyllabus(val eventsState: EventsViewState) : SyllabusViewState()
-
-    data class LoadedNoEvents(val syllabus: String) : SyllabusViewState()
 }
 
 sealed class EventsViewState(val visibility: EventsVisibility) {

--- a/apps/student/src/main/res/layout/fragment_syllabus.xml
+++ b/apps/student/src/main/res/layout/fragment_syllabus.xml
@@ -74,9 +74,4 @@
 
     </com.instructure.pandautils.views.MultiSwipeRefreshLayout>
 
-    <com.instructure.student.view.EmptyView
-        android:id="@+id/emptyView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone" />
 </LinearLayout>

--- a/apps/student/src/test/java/com/instructure/student/test/syllabus/SyllabusPresenterTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/syllabus/SyllabusPresenterTest.kt
@@ -129,16 +129,16 @@ class SyllabusPresenterTest : Assert() {
     }
 
     @Test
-    fun `Returns failed state when model result is failed`() {
-        val expectedState = SyllabusViewState.LoadedNoSyllabus(EventsViewState.Error)
+    fun `Returns Loaded state with event failure when model result is failed`() {
+        val expectedState = SyllabusViewState.Loaded(eventsState = EventsViewState.Error)
         val model = baseModel.copy(course = DataResult.Fail(), events = DataResult.Fail())
         val actualState = SyllabusPresenter.present(model, context)
         assertEquals(expectedState, actualState)
     }
 
     @Test
-    fun `Returns LoadedNoSyllabus state with event failure when model has no syllabus and failed events`() {
-        val expectedState = SyllabusViewState.LoadedNoSyllabus(EventsViewState.Error)
+    fun `Returns Loaded state with event failure when model has no syllabus and failed events`() {
+        val expectedState = SyllabusViewState.Loaded(eventsState = EventsViewState.Error)
         val model =
             baseModel.copy(course = DataResult.Success(baseCourse), events = DataResult.Fail())
         val actualState = SyllabusPresenter.present(model, context)
@@ -146,8 +146,8 @@ class SyllabusPresenterTest : Assert() {
     }
 
     @Test
-    fun `Returns LoadedNothing state with empty events when course model has no syllabus and no events`() {
-        val expectedState = SyllabusViewState.LoadedNothing
+    fun `Returns Loaded state with empty events when course model has no syllabus and no events`() {
+        val expectedState = SyllabusViewState.Loaded(eventsState = EventsViewState.Empty)
         val model = baseModel.copy(
             course = DataResult.Success(baseCourse),
             events = DataResult.Success(emptyList())
@@ -157,9 +157,9 @@ class SyllabusPresenterTest : Assert() {
     }
 
     @Test
-    fun `Returns LoadedNoSyllabus state with events when course model has no syllabus`() {
+    fun `Returns Loaded state with events when course model has no syllabus`() {
         val expectedState =
-            SyllabusViewState.LoadedNoSyllabus(EventsViewState.Loaded(baseEventsViewState))
+            SyllabusViewState.Loaded(eventsState = EventsViewState.Loaded(baseEventsViewState))
         val model = baseModel.copy(
             course = DataResult.Success(baseCourse),
             events = DataResult.Success(baseEvents)
@@ -169,9 +169,9 @@ class SyllabusPresenterTest : Assert() {
     }
 
     @Test
-    fun `Returns LoadedNoSyllabus state with events when course failed`() {
+    fun `Returns Loaded state with events when course failed`() {
         val expectedState =
-            SyllabusViewState.LoadedNoSyllabus(EventsViewState.Loaded(baseEventsViewState.map {
+            SyllabusViewState.Loaded(eventsState = EventsViewState.Loaded(baseEventsViewState.map {
                 it.copy(color = 0)
             }))
         val model =
@@ -181,8 +181,8 @@ class SyllabusPresenterTest : Assert() {
     }
 
     @Test
-    fun `Returns LoadedNoEvents state with syllabus and no events`() {
-        val expectedState = SyllabusViewState.LoadedNoEvents("syllabus")
+    fun `Returns Loaded state with syllabus and empty events`() {
+        val expectedState = SyllabusViewState.Loaded(syllabus = "syllabus")
         val model = baseModel.copy(
             course = DataResult.Success(baseCourse),
             events = DataResult.Success(emptyList()),
@@ -193,9 +193,9 @@ class SyllabusPresenterTest : Assert() {
     }
 
     @Test
-    fun `Returns LoadedFull state with events and syllabus`() {
+    fun `Returns Loaded state with events and syllabus`() {
         val expectedState =
-            SyllabusViewState.LoadedFull("syllabus", EventsViewState.Loaded(baseEventsViewState))
+            SyllabusViewState.Loaded(syllabus = "syllabus", eventsState = EventsViewState.Loaded(baseEventsViewState))
         val model = baseModel.copy(
             course = DataResult.Success(baseCourse),
             events = DataResult.Success(baseEvents),
@@ -206,7 +206,7 @@ class SyllabusPresenterTest : Assert() {
     }
 
     @Test
-    fun `Returns LoadedFull state with locked events`() {
+    fun `Returns Loaded state with locked events`() {
         val time = Calendar.getInstance().timeInMillis
         val futureDate = Date(time + 100000)
         val pastDate = Date(time - 100000)
@@ -234,7 +234,7 @@ class SyllabusPresenterTest : Assert() {
         )
 
         val expectedState =
-            SyllabusViewState.LoadedNoSyllabus(EventsViewState.Loaded(eventsViewState))
+            SyllabusViewState.Loaded(eventsState = EventsViewState.Loaded(eventsViewState))
         val model = baseModel.copy(course = DataResult.Success(baseCourse), events = events)
         val actualState = SyllabusPresenter.present(model, context)
         assertEquals(expectedState, actualState)


### PR DESCRIPTION
This addresses a recent regression which affects the ability to Pull-To-Refresh the syllabus in its empty state. It also cleans up and consolidates some of the syllabus View and Presenter logic.