### PR TITLE
[Student][MBL-14529] Fix FlutterTextureView crash

### DIFF
--- a/apps/student/build.gradle
+++ b/apps/student/build.gradle
@@ -207,7 +207,8 @@ android {
                     new PageViewTransformer(),
                     new LocaleTransformer(),
                     new FlutterA11yOffsetTransformer(),
-                    new FlutterTextureRenderModeFix()
+                    new FlutterTextureRenderModeFix(),
+                    new FlutterTextureDisconnectFix()
             )
     )
 

--- a/buildSrc/src/main/java/com/instructure/android/buildtools/transform/FlutterA11yOffsetTransformer.kt
+++ b/buildSrc/src/main/java/com/instructure/android/buildtools/transform/FlutterA11yOffsetTransformer.kt
@@ -73,6 +73,7 @@ class FlutterA11yOffsetTransformer() : ClassTransformer() {
                 float topOffset = (float) insets.getSystemWindowInsetTop();
                 android.opengl.Matrix.translateM(identity, 0, 0f, topOffset, 0f);
             """.trimIndent())
+            println("    :Flutter AccessibilityBridge patched")
         } else {
             throw IllegalStateException("Method 'updateSemantics' is null for transformer $transformName")
         }

--- a/buildSrc/src/main/java/com/instructure/android/buildtools/transform/FlutterTextureDisconnectFix.kt
+++ b/buildSrc/src/main/java/com/instructure/android/buildtools/transform/FlutterTextureDisconnectFix.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package com.instructure.android.buildtools.transform
+
+import javassist.ClassPool
+import javassist.CtClass
+
+class FlutterTextureDisconnectFix : ClassTransformer() {
+
+    override val transformName = "FlutterTextureDisconnectFix"
+
+    override val counter = TransformCounter.Exactly(1)
+
+    override val includeExternalLibs: List<String> = listOf("io.flutter:flutter_embedding")
+
+    private lateinit var exceptionClass: CtClass
+
+    override fun createFilter() = NameEquals("io.flutter.embedding.android.FlutterTextureView")
+
+    override fun onClassPoolReady(classPool: ClassPool) {
+        exceptionClass = classPool["java.lang.NullPointerException"]
+    }
+
+    override fun transform(cc: CtClass, classPool: ClassPool): Boolean = with(cc){
+        // Adds a NullPointerException catch to the disconnectSurfaceFromRenderer method and logs the incident
+        val method = declaredMethods.single { it.name == "disconnectSurfaceFromRenderer" }
+        val message = "FlutterTextureView.disconnectSurfaceFromRenderer called with null renderSurface"
+        method.addCatch("""
+            com.instructure.student.util.LoggingUtility.Log((android.content.Context) null, android.util.Log.DEBUG, "$message");
+            return;""".trimIndent(), exceptionClass)
+        println("    :FlutterTextureView patched")
+        true
+    }
+}

--- a/buildSrc/src/main/java/com/instructure/android/buildtools/transform/FlutterTextureRenderModeFix.kt
+++ b/buildSrc/src/main/java/com/instructure/android/buildtools/transform/FlutterTextureRenderModeFix.kt
@@ -50,8 +50,11 @@ class FlutterTextureRenderModeFix : ClassTransformer() {
     private fun CtClass.transformFlutterViewConstructor() {
         val constructor = getDeclaredConstructor(arrayOf(contextClass, attributeSetClass, flutterTextureViewClass))
         if (constructor != null) {
+            // Replaces the line "this.renderSurface = flutterSurfaceView;" in the constructor that takes a FlutterTextureView param.
+            // The exact line number(s) may change in newer Flutter versions.
             constructor.removeLines(267..268)
             constructor.insertAt(266, """renderSurface = $3;""")
+            println("    :FlutterView patched")
         } else {
             throw IllegalStateException("Could not find correct constructor for $transformName")
         }

--- a/buildSrc/src/main/java/com/instructure/android/buildtools/transform/ProjectTransformer.kt
+++ b/buildSrc/src/main/java/com/instructure/android/buildtools/transform/ProjectTransformer.kt
@@ -21,6 +21,7 @@ import com.android.build.gradle.AppExtension
 import javassist.ClassPool
 import javassist.CtClass
 import java.io.File
+import java.lang.IllegalStateException
 import java.util.jar.JarEntry
 import java.util.jar.JarFile
 import java.util.jar.JarOutputStream
@@ -143,7 +144,7 @@ class ProjectTransformer(
                 } catch (e: Throwable) {
                     println("Error transforming jar entry: ${e.message}")
                     e.printStackTrace()
-                    copyJarEntry(input, entry, output)
+                    throw e
                 }
             }
             output.close()


### PR DESCRIPTION
This commit addresses the current top crash in Student by introducing a new project transformer that adds a catch to `FlutterTextureView.disconnectSurfaceFromRenderer()`, where an edge case appears to be causing an NPE. When this NPE is caught, the incident is added to the Crashlytics logs so it can be used for troubleshooting unintended side effects of this change (if any) in the future. 

This commit also adds some informative build logs and clarifying comments, and updates ProjectTransform to always fail on a jar transform failure.

To repro: In developer settings, enable "Don't keep activities." Log into the app, click around on the bottom nav enough to get 3-4 instances of the Calendar on the back stack, then background the app. You may need to repeat this a few times before it will crash.