### PR TITLE
[MBL-14531] Update qr pairing

### DIFF
--- a/apps/flutter_parent/lib/utils/qr_utils.dart
+++ b/apps/flutter_parent/lib/utils/qr_utils.dart
@@ -28,9 +28,9 @@ class QRUtils {
   static const String QR_HOST_TEST = 'sso.test.canvaslms.com';
 
   // QR Pairing
-  static const String QR_PAIR_HOST = 'addobservee';
-  static const String QR_PAIR_PARAM_CODE = 'pairing_code';
-  static const String QR_PAIR_PARAM_DOMAIN = 'pairing_domain';
+  static const String QR_PAIR_PATH = 'pair';
+  static const String QR_PAIR_PARAM_CODE = 'code';
+  static const String QR_PAIR_PARAM_ACCOUNT_ID = 'account_id';
 
   static Uri verifySSOLogin(String url) {
     try {
@@ -76,8 +76,10 @@ class QRUtils {
     try {
       var uri = Uri.parse(rawUri);
       var params = uri.queryParameters;
-      if (QR_PAIR_HOST == uri.host && params[QR_PAIR_PARAM_CODE] != null && params[QR_PAIR_PARAM_DOMAIN] != null) {
-        return QRPairingScanResult.success(params[QR_PAIR_PARAM_CODE], params[QR_PAIR_PARAM_DOMAIN]);
+      if (QR_PAIR_PATH == uri.pathSegments.first &&
+          params[QR_PAIR_PARAM_CODE] != null &&
+          params[QR_PAIR_PARAM_ACCOUNT_ID] != null) {
+        return QRPairingScanResult.success(params[QR_PAIR_PARAM_CODE], uri.host, params[QR_PAIR_PARAM_ACCOUNT_ID]);
       }
     } catch (e) {
       // Intentionally left blank
@@ -89,7 +91,7 @@ class QRUtils {
 class QRPairingScanResult {
   QRPairingScanResult._();
 
-  factory QRPairingScanResult.success(String code, String domain) = QRPairingInfo._;
+  factory QRPairingScanResult.success(String code, String domain, String accountId) = QRPairingInfo._;
 
   factory QRPairingScanResult.error(QRPairingScanErrorType type) = QRPairingScanError._;
 }
@@ -97,8 +99,9 @@ class QRPairingScanResult {
 class QRPairingInfo extends QRPairingScanResult {
   final String code;
   final String domain;
+  final String accountId;
 
-  QRPairingInfo._(this.code, this.domain) : super._();
+  QRPairingInfo._(this.code, this.domain, this.accountId) : super._();
 }
 
 class QRPairingScanError extends QRPairingScanResult {

--- a/apps/flutter_parent/test/router/panda_router_test.dart
+++ b/apps/flutter_parent/test/router/panda_router_test.dart
@@ -335,12 +335,13 @@ void main() {
     });
 
     test('qrPairing returns qrPairingScreen screen', () {
-      final uri = 'canvas-parent://addObservee?pairing_code=1234&pairing_domain=mobiledev.instructure.com';
+      final uri = 'canvas-parent://mobiledev.instructure.com/pair?code=123abc&account_id=1234';
       final pairingInfo = QRUtils.parsePairingInfo(uri) as QRPairingInfo;
       final widget = _getWidgetFromRoute(PandaRouter.qrPairing(pairingUri: uri));
       expect(widget, isA<QRPairingScreen>());
       expect((widget as QRPairingScreen).pairingInfo.code, pairingInfo.code);
       expect((widget as QRPairingScreen).pairingInfo.domain, pairingInfo.domain);
+      expect((widget as QRPairingScreen).pairingInfo.accountId, pairingInfo.accountId);
     });
 
     test('syllabus returns CourseRoutingShellScreen', () {

--- a/apps/flutter_parent/test/screens/pairing/qr_pairing_screen_test.dart
+++ b/apps/flutter_parent/test/screens/pairing/qr_pairing_screen_test.dart
@@ -68,7 +68,7 @@ void main() {
     await tester.pumpWidget(TestApp(QRPairingScreen()));
     await tester.pumpAndSettle();
 
-    when(interactor.scanQRCode()).thenAnswer((_) async => QRPairingScanResult.success('', ''));
+    when(interactor.scanQRCode()).thenAnswer((_) async => QRPairingScanResult.success('', '', ''));
 
     Completer<bool> completer = Completer();
     when(interactor.pairWithStudent(any)).thenAnswer((_) async => completer.future);
@@ -80,7 +80,7 @@ void main() {
   });
 
   testWidgetsWithAccessibilityChecks('Pops with true value on success', (tester) async {
-    when(interactor.scanQRCode()).thenAnswer((_) async => QRPairingScanResult.success('', ''));
+    when(interactor.scanQRCode()).thenAnswer((_) async => QRPairingScanResult.success('', '', ''));
     when(interactor.pairWithStudent(any)).thenAnswer((_) async => true);
 
     await tester.pumpWidget(TestApp(DummyWidget()));
@@ -101,7 +101,7 @@ void main() {
   testWidgetsWithAccessibilityChecks('Navigates to splash screen on success if first route', (tester) async {
     when(interactor.pairWithStudent(any)).thenAnswer((_) async => true);
 
-    await tester.pumpWidget(TestApp(QRPairingScreen(pairingInfo: QRPairingScanResult.success('', ''))));
+    await tester.pumpWidget(TestApp(QRPairingScreen(pairingInfo: QRPairingScanResult.success('', '', ''))));
     await tester.pump();
 
     verify(nav.replaceRoute(any, PandaRouter.rootSplash()));
@@ -168,7 +168,7 @@ void main() {
     await tester.pumpWidget(TestApp(QRPairingScreen()));
     await tester.pumpAndSettle();
 
-    when(interactor.scanQRCode()).thenAnswer((_) async => QRPairingScanResult.success('', ''));
+    when(interactor.scanQRCode()).thenAnswer((_) async => QRPairingScanResult.success('', '', ''));
     when(interactor.pairWithStudent(any)).thenAnswer((_) async => null); // null represents network error
 
     await tester.tap(find.text(l10n.next.toUpperCase()));
@@ -183,7 +183,7 @@ void main() {
     await tester.pumpWidget(TestApp(QRPairingScreen()));
     await tester.pumpAndSettle();
 
-    when(interactor.scanQRCode()).thenAnswer((_) async => QRPairingScanResult.success('', ''));
+    when(interactor.scanQRCode()).thenAnswer((_) async => QRPairingScanResult.success('', '', ''));
     when(interactor.pairWithStudent(any)).thenAnswer((_) async => false); // false represents pairing failure
 
     await tester.tap(find.text(l10n.next.toUpperCase()));
@@ -207,7 +207,7 @@ void main() {
     await tester.pumpAndSettle();
 
     when(interactor.scanQRCode())
-        .thenAnswer((_) async => QRPairingScanResult.success('123abc', 'other.instructure.com'));
+        .thenAnswer((_) async => QRPairingScanResult.success('123abc', 'other.instructure.com', '123'));
     when(interactor.pairWithStudent(any)).thenAnswer((_) async => false);
 
     await tester.tap(find.text(l10n.next.toUpperCase()));
@@ -222,7 +222,7 @@ void main() {
     await tester.pumpWidget(TestApp(QRPairingScreen()));
     await tester.pumpAndSettle();
 
-    when(interactor.scanQRCode()).thenAnswer((_) async => QRPairingScanResult.success('', ''));
+    when(interactor.scanQRCode()).thenAnswer((_) async => QRPairingScanResult.success('', '', ''));
     when(interactor.pairWithStudent(any)).thenAnswer((_) async => null);
 
     await tester.tap(find.text(l10n.next.toUpperCase()));
@@ -247,7 +247,7 @@ void main() {
   });
 
   testWidgetsWithAccessibilityChecks('Initiates pairing on launch if pairing info is provided', (tester) async {
-    QRPairingInfo pairingInfo = QRPairingScanResult.success('123acb', '');
+    QRPairingInfo pairingInfo = QRPairingScanResult.success('123acb', '', '');
     await tester.pumpWidget(TestApp(QRPairingScreen(pairingInfo: pairingInfo)));
     await tester.pump();
 

--- a/apps/flutter_parent/test/utils/qr_utils_test.dart
+++ b/apps/flutter_parent/test/utils/qr_utils_test.dart
@@ -78,32 +78,26 @@ void main() {
     });
 
     test('parsePairingInfo returns invalidCode error if input has wrong host', () {
-      var input = 'canvas-parent://addStudent?pairing_code=abcd&pairing_domain=test.instructure.com';
+      var input = 'canvas-parent://test.instructure.com/addStudent?code=abcd&account_id=1234';
       var result = QRUtils.parsePairingInfo(input);
       expect(result, isA<QRPairingScanError>());
       expect((result as QRPairingScanError).type, QRPairingScanErrorType.invalidCode);
     });
 
     test('parsePairingInfo returns invalidCode error if input is missing pairing code', () {
-      var input = 'canvas-parent://addObservee?pairing_domain=test.instructure.com';
-      var result = QRUtils.parsePairingInfo(input);
-      expect(result, isA<QRPairingScanError>());
-      expect((result as QRPairingScanError).type, QRPairingScanErrorType.invalidCode);
-    });
-
-    test('parsePairingInfo returns invalidCode error if input is missing pairing domain', () {
-      var input = 'canvas-parent://addObservee?pairing_code=aBc123';
+      var input = 'canvas-parent://test.instructure.com/pair?account_id=1234';
       var result = QRUtils.parsePairingInfo(input);
       expect(result, isA<QRPairingScanError>());
       expect((result as QRPairingScanError).type, QRPairingScanErrorType.invalidCode);
     });
 
     test('parsePairingInfo returns QRPairingInfo on successful parse', () {
-      var input = 'canvas-parent://addObservee?pairing_code=aBc123&pairing_domain=test.instructure.com';
+      var input = 'canvas-parent://test.instructure.com/pair?code=aBc123&account_id=1234';
       var result = QRUtils.parsePairingInfo(input);
       expect(result, isA<QRPairingInfo>());
       expect((result as QRPairingInfo).domain, 'test.instructure.com');
       expect((result as QRPairingInfo).code, 'aBc123');
+      expect((result as QRPairingInfo).accountId, '1234');
     });
   });
 
@@ -116,12 +110,13 @@ void main() {
     });
 
     test('scanPairingCode returns QRPairingInfo on successful scan of a valid code', () async {
-      var validCode = 'canvas-parent://addObservee?pairing_code=aBc123&pairing_domain=test.instructure.com';
+      var validCode = 'canvas-parent://test.instructure.com/pair?code=aBc123&account_id=1234';
       when(barcodeScanner.scanBarcode()).thenAnswer((_) async => ScanResult(rawContent: validCode));
       var result = await QRUtils.scanPairingCode();
       expect(result, isA<QRPairingInfo>());
       expect((result as QRPairingInfo).domain, 'test.instructure.com');
       expect((result as QRPairingInfo).code, 'aBc123');
+      expect((result as QRPairingInfo).accountId, '1234');
     });
 
     test('scanPairingCode returns canceled result if scan was canceled', () async {

--- a/apps/flutter_parent/test/utils/qr_utils_test.dart
+++ b/apps/flutter_parent/test/utils/qr_utils_test.dart
@@ -77,7 +77,7 @@ void main() {
       expect((result as QRPairingScanError).type, QRPairingScanErrorType.invalidCode);
     });
 
-    test('parsePairingInfo returns invalidCode error if input has wrong host', () {
+    test('parsePairingInfo returns invalidCode error if input has wrong path', () {
       var input = 'canvas-parent://test.instructure.com/addStudent?code=abcd&account_id=1234';
       var result = QRUtils.parsePairingInfo(input);
       expect(result, isA<QRPairingScanError>());

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/PairObserverRenderTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/PairObserverRenderTest.kt
@@ -52,7 +52,8 @@ class PairObserverRenderTest : StudentRenderTest() {
     @Test
     fun displaysPairingCode() {
         val code = "code"
-        val model = baseModel.copy(pairingCode = code)
+        val accountId = 123L
+        val model = baseModel.copy(pairingCode = code, accountId = accountId)
         loadPageWithModel(model)
 
         pairObserverRenderPage.assertCodeDisplayed(code)

--- a/apps/student/src/main/java/com/instructure/student/mobius/settings/pairobserver/PairObserverEffectHandler.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/settings/pairobserver/PairObserverEffectHandler.kt
@@ -34,11 +34,8 @@ class PairObserverEffectHandler : EffectHandler<PairObserverView, PairObserverEv
     private fun loadData() {
         launch {
             val pairingCode = UserManager.generatePairingCodeAsync(true).await()
-            consumer.accept(
-                PairObserverEvent.DataLoaded(
-                    pairingCode
-                )
-            )
+            val termsOfService = UserManager.getTermsOfServiceAsync(true).await()
+            consumer.accept(PairObserverEvent.DataLoaded(pairingCode, termsOfService))
         }
     }
 }

--- a/apps/student/src/main/java/com/instructure/student/mobius/settings/pairobserver/PairObserverModels.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/settings/pairobserver/PairObserverModels.kt
@@ -17,11 +17,15 @@
 package com.instructure.student.mobius.settings.pairobserver
 
 import com.instructure.canvasapi2.models.PairingCode
+import com.instructure.canvasapi2.models.TermsOfService
 import com.instructure.canvasapi2.utils.DataResult
 
 sealed class PairObserverEvent {
     object RefreshCode : PairObserverEvent()
-    data class DataLoaded(val pairingCode: DataResult<PairingCode>) : PairObserverEvent()
+    data class DataLoaded(
+            val pairingCode: DataResult<PairingCode>,
+            val termsOfService: DataResult<TermsOfService>
+    ) : PairObserverEvent()
 }
 
 sealed class PairObserverEffect {
@@ -32,5 +36,6 @@ sealed class PairObserverEffect {
 data class PairObserverModel(
     val isLoading: Boolean = false,
     val pairingCode: String? = null,
+    val accountId: Long? = null,
     val domain: String
 )

--- a/apps/student/src/main/java/com/instructure/student/mobius/settings/pairobserver/PairObserverPresenter.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/settings/pairobserver/PairObserverPresenter.kt
@@ -19,15 +19,18 @@ package com.instructure.student.mobius.settings.pairobserver
 import android.content.Context
 import com.instructure.canvasapi2.utils.isValid
 import com.instructure.student.mobius.common.ui.Presenter
-import com.instructure.student.mobius.settings.pairobserver.PairObserverModel
 import com.instructure.student.mobius.settings.pairobserver.ui.PairObserverViewState
 
 object PairObserverPresenter : Presenter<PairObserverModel, PairObserverViewState> {
     override fun present(model: PairObserverModel, context: Context): PairObserverViewState {
         if (model.isLoading) return PairObserverViewState.Loading
 
-        if (!model.pairingCode.isValid()) return PairObserverViewState.Failed
+        if (!model.pairingCode.isValid() || model.accountId == null) return PairObserverViewState.Failed
 
-        return PairObserverViewState.Loaded(pairingCode = model.pairingCode, domain = model.domain)
+        return PairObserverViewState.Loaded(
+                pairingCode = model.pairingCode,
+                domain = model.domain,
+                accountId = model.accountId
+        )
     }
 }

--- a/apps/student/src/main/java/com/instructure/student/mobius/settings/pairobserver/PairObserverUpdate.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/settings/pairobserver/PairObserverUpdate.kt
@@ -38,7 +38,8 @@ class PairObserverUpdate : UpdateInit<PairObserverModel, PairObserverEvent, Pair
             is PairObserverEvent.DataLoaded -> {
                 Next.next(model.copy(
                     isLoading = false,
-                    pairingCode = event.pairingCode.dataOrNull?.code
+                    pairingCode = event.pairingCode.dataOrNull?.code,
+                    accountId = event.termsOfService.dataOrNull?.accountId
                 ))
             }
         }

--- a/apps/student/src/main/java/com/instructure/student/mobius/settings/pairobserver/ui/PairObserverView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/settings/pairobserver/ui/PairObserverView.kt
@@ -62,7 +62,7 @@ class PairObserverView(inflater: LayoutInflater, parent: ViewGroup) :
         when (state) {
             is PairObserverViewState.Loading -> renderLoading()
             is PairObserverViewState.Failed -> renderFailed()
-            is PairObserverViewState.Loaded -> renderPairingCode(state.domain, state.pairingCode)
+            is PairObserverViewState.Loaded -> renderPairingCode(state.domain, state.pairingCode, state.accountId)
         }.exhaustive
     }
 
@@ -80,7 +80,7 @@ class PairObserverView(inflater: LayoutInflater, parent: ViewGroup) :
         errorContainer.setVisible()
     }
 
-    private fun renderPairingCode(domain: String, pairingCode: String) {
+    private fun renderPairingCode(domain: String, pairingCode: String, accountId: Long) {
         pairObserverLoading.setGone()
         pairObserverContent.setVisible()
         errorContainer.setGone()
@@ -88,7 +88,7 @@ class PairObserverView(inflater: LayoutInflater, parent: ViewGroup) :
 
         try {
             // Open the Parent App with relevant data so it can pair the student
-            val content = "canvas-parent://addObservee?pairing_code=$pairingCode&pairing_domain=$domain"
+            val content = "canvas-parent://$domain/pair?code=$pairingCode&account_id=$accountId"
             val barcodeEncoder = BarcodeEncoder()
             val bitmap: Bitmap = barcodeEncoder.encodeBitmap(content, BarcodeFormat.QR_CODE, 100, 100)
             pairObserverQrCode.setImageBitmap(bitmap)

--- a/apps/student/src/main/java/com/instructure/student/mobius/settings/pairobserver/ui/PairObserverViewState.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/settings/pairobserver/ui/PairObserverViewState.kt
@@ -19,5 +19,5 @@ package com.instructure.student.mobius.settings.pairobserver.ui
 sealed class PairObserverViewState {
     object Loading : PairObserverViewState()
     object Failed : PairObserverViewState()
-    data class Loaded(val pairingCode: String, val domain: String) : PairObserverViewState()
+    data class Loaded(val pairingCode: String, val domain: String, val accountId: Long) : PairObserverViewState()
 }

--- a/apps/student/src/test/java/com/instructure/student/test/settings/pairobserver/PairObserverEffectHandlerTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/settings/pairobserver/PairObserverEffectHandlerTest.kt
@@ -18,6 +18,7 @@ package com.instructure.student.test.settings.pairobserver
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.instructure.canvasapi2.managers.UserManager
 import com.instructure.canvasapi2.models.PairingCode
+import com.instructure.canvasapi2.models.TermsOfService
 import com.instructure.canvasapi2.utils.Analytics
 import com.instructure.canvasapi2.utils.AnalyticsEventConstants
 import com.instructure.canvasapi2.utils.DataResult
@@ -55,11 +56,16 @@ class PairObserverEffectHandlerTest : Assert() {
     @Test
     fun `LoadData with failed pairing code results in failed DataLoaded`() {
         val expectedEvent = PairObserverEvent.DataLoaded(
+            DataResult.Fail(),
             DataResult.Fail()
         )
 
         mockkObject(UserManager)
         every { UserManager.generatePairingCodeAsync(true) } returns mockk {
+            coEvery { await() } returns DataResult.Fail()
+        }
+
+        every { UserManager.getTermsOfServiceAsync(true) } returns mockk {
             coEvery { await() } returns DataResult.Fail()
         }
 
@@ -75,13 +81,19 @@ class PairObserverEffectHandlerTest : Assert() {
     @Test
     fun `LoadData results in DataLoaded`() {
         val pairingCode = PairingCode(code = "code")
+        val termsOfService = TermsOfService(accountId = 123L)
         val expectedEvent = PairObserverEvent.DataLoaded(
-            DataResult.Success(pairingCode)
+            DataResult.Success(pairingCode),
+            DataResult.Success(termsOfService)
         )
 
         mockkObject(UserManager)
         every { UserManager.generatePairingCodeAsync(true) } returns mockk {
             coEvery { await() } returns DataResult.Success(pairingCode)
+        }
+
+        every { UserManager.getTermsOfServiceAsync(true) } returns mockk {
+            coEvery { await() } returns DataResult.Success(termsOfService)
         }
 
         connection.accept(PairObserverEffect.LoadData(true))

--- a/apps/student/src/test/java/com/instructure/student/test/settings/pairobserver/PairObserverPresenterTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/settings/pairobserver/PairObserverPresenterTest.kt
@@ -30,6 +30,7 @@ import org.junit.runner.RunWith
 class PairObserverPresenterTest : Assert() {
 
     private val domain = "domain"
+    private val accountId = 123L
 
     private lateinit var context: Context
     private lateinit var baseModel: PairObserverModel
@@ -66,8 +67,8 @@ class PairObserverPresenterTest : Assert() {
     @Test
     fun `Returns Loaded state when model has a pairing code`() {
         val code = "code"
-        val expectedState = PairObserverViewState.Loaded(code, domain)
-        val model = baseModel.copy(pairingCode = code)
+        val expectedState = PairObserverViewState.Loaded(code, domain, accountId)
+        val model = baseModel.copy(pairingCode = code, accountId = accountId)
         val actualState = PairObserverPresenter.present(model, context)
         assertEquals(expectedState, actualState)
     }

--- a/apps/student/src/test/java/com/instructure/student/test/settings/pairobserver/PairObserverUpdateTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/settings/pairobserver/PairObserverUpdateTest.kt
@@ -16,6 +16,7 @@
 package com.instructure.student.test.settings.pairobserver
 
 import com.instructure.canvasapi2.models.PairingCode
+import com.instructure.canvasapi2.models.TermsOfService
 import com.instructure.canvasapi2.utils.DataResult
 import com.instructure.student.mobius.settings.pairobserver.PairObserverEffect
 import com.instructure.student.mobius.settings.pairobserver.PairObserverEvent
@@ -79,12 +80,13 @@ class PairObserverUpdateTest : Assert() {
     fun `DataLoaded event updates the model`() {
         val code = "code"
         val pairingCode = DataResult.Success(PairingCode(code = code))
+        val termsOfService = DataResult.Success(TermsOfService(accountId = 123L))
 
-        val expectedModel = initModel.copy(isLoading = false, pairingCode = code)
+        val expectedModel = initModel.copy(isLoading = false, pairingCode = code, accountId = 123L)
 
         updateSpec
             .given(initModel.copy(isLoading = true))
-            .whenEvent(PairObserverEvent.DataLoaded(pairingCode))
+            .whenEvent(PairObserverEvent.DataLoaded(pairingCode, termsOfService))
             .then(
                 assertThatNext(
                     NextMatchers.hasModel(expectedModel)
@@ -96,11 +98,11 @@ class PairObserverUpdateTest : Assert() {
     fun `DataLoaded event updates the model when failed to get pairing code`() {
         val initModel = initModel.copy(isLoading = true, pairingCode = "Old")
 
-        val expectedModel = initModel.copy(isLoading = false, pairingCode = null)
+        val expectedModel = initModel.copy(isLoading = false, pairingCode = null, accountId = null)
 
         updateSpec
             .given(initModel)
-            .whenEvent(PairObserverEvent.DataLoaded(DataResult.Fail()))
+            .whenEvent(PairObserverEvent.DataLoaded(DataResult.Fail(), DataResult.Fail()))
             .then(
                 assertThatNext(
                     NextMatchers.hasModel(expectedModel)

--- a/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/MockCanvas.kt
+++ b/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/MockCanvas.kt
@@ -46,6 +46,14 @@ class MockCanvas {
             effectiveLocale = "en"
     )
 
+    var accountTermsOfService = TermsOfService(
+            id = 1L,
+            termsType = "default",
+            passive = false,
+            accountId = account.id,
+            content = "hodor"
+    )
+
     /** Canvas brand variables */
     var brandVariables = CanvasTheme(
             brand = "#25d6ab",

--- a/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/endpoints/AccountEndpoints.kt
+++ b/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/endpoints/AccountEndpoints.kt
@@ -55,9 +55,18 @@ object AccountEndpoint : Endpoint(
     ),
     Segment("permissions") to AccountPermissionsEndpoint,
     Segment("help_links") to HelpLinksEndpoint,
+    Segment("terms_of_service") to TermsOfServiceEndpoint,
     response = {
         // NOTE: Only supporting one account for now and we'll assume no users are admins, so return a 401
         GET { request.unauthorizedResponse() }
+    }
+)
+
+object TermsOfServiceEndpoint : Endpoint(
+    response = {
+        GET {
+            request.successResponse(data.accountTermsOfService)
+        }
     }
 )
 

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/UserManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/UserManager.kt
@@ -243,6 +243,10 @@ object UserManager {
         UserAPI.getTermsOfService(adapter, params, callback)
     }
 
+    fun getTermsOfServiceAsync(forceNetwork: Boolean) = apiAsync<TermsOfService> { callback ->
+        UserAPI.getTermsOfService(RestBuilder(callback), RestParams(isForceReadFromNetwork = forceNetwork), callback)
+    }
+
     @JvmStatic
     fun getSelfAccount(forceNetwork: Boolean, callback: StatusCallback<Account>) {
         val adapter = RestBuilder(callback)


### PR DESCRIPTION
This update just modifies the qr code url to be aligned with the code iOS is going to use, the pattern is:

`canvas-parent://host/pair?code=$code&account_id=$accountId`