### PR TITLE
[Teacher][MBL-13062] Fix extra spacing between messages

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/MessageThreadFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/MessageThreadFragment.kt
@@ -233,6 +233,7 @@ class MessageThreadFragment : BaseSyncFragment<Message, MessageThreadPresenter, 
                 (it.layoutManager as LinearLayoutManager).orientation
             )
             dividerItemDecoration.setDrawable(requireContext().getDrawableCompat(R.drawable.item_decorator_gray))
+            it.removeAllItemDecorations()
             it.addItemDecoration(dividerItemDecoration)
             addSwipeToRefresh(swipeRefreshLayout)
         }


### PR DESCRIPTION
Every time the conversation was refreshed, an additional divider decoration item was being added to the recycler view. This change causes existing decorations to be removed before adding new ones, preventing more than one divider.

repro: Reply to a conversation, or pull to refresh a conversation