### PR TITLE
[Student][CodeCov][MBL-14551]: Added gradle task to report combined coverage

### DIFF
--- a/apps/student/build.gradle
+++ b/apps/student/build.gradle
@@ -349,4 +349,35 @@ if (coverageEnabled) {
             xml.enabled  false
         }
     }
+
+    task combinedJacoco(type: JacocoReport) {
+        group = "Reporting"
+        description = "Generate Jacoco coverage reports for FTL + unit tests."
+
+        def productFlavor = 'qa'
+        def buildType = 'debug'
+
+        classDirectories = fileTree(
+                dir: "${project.buildDir}/tmp/kotlin-classes/qaDebug",
+                excludes: ['**/R.class',
+                           '**/R$*.class',
+                           '**/*$ViewInjector*.*',
+                           '**/*$ViewBinder*.*',
+                           '**/BuildConfig.*',
+                           '**/Manifest*.*'],
+                //includes: ['**/com/instructure/*']
+        )
+
+        // project.buildDir is /canvas-android/apps/teacher/build
+        sourceDirectories = files(['src/main/java'] + android.sourceSets[productFlavor].java.srcDirs)
+        executionData = fileTree(dir: ".", includes: ['results/**/*.ec', '**/testQaDebugUnitTest.exec'])
+
+        reports {
+            // default path: /canvas-android/apps/teacher/build/reports/jacoco/firebaseJacoco/html/
+            html.enabled true
+            csv.enabled  false
+            xml.enabled  false
+        }
+    }
+
 }


### PR DESCRIPTION
The rest of the heavy lifting is done in the "ui-test-coverage" workflow in the "Android Student UI Tests" Bitrise app.  That workflow now generates and reports coverage data for UI tests ("normal" + E2E) as well as combined UI/unit tests.