### PR TITLE
[Teacher][MBL-13563] Remove DNS crash logging that is no longer needed

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/activities/SplashActivity.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/activities/SplashActivity.kt
@@ -182,7 +182,6 @@ class SplashActivity : AppCompatActivity() {
                     }
                     if (!ThemePrefs.isThemeApplied) themeFetch.await() else themeFetch.start()
                 } catch (e: Throwable) {
-                    LoggingUtility.log("${SplashActivity::class.java.simpleName} - Failed to load data inside weave")
                     Logger.e(e.message)
                 }
 
@@ -202,8 +201,6 @@ class SplashActivity : AppCompatActivity() {
                 finish()
             }
         } catch (e: Throwable) {
-            // TODO: MBL-13563 Watch this catch in crashlytics for any more info on why we get an unknown host exception with du11hjcvx0uqb.cloudfront.net
-            LoggingUtility.log("${SplashActivity::class.java.simpleName} - Failed to load data outside weave")
             Logger.e(e.message)
         }
     }


### PR DESCRIPTION
It turns out that the crash was happening in a different part of the app (discussions) and was inadvertently fixed in a separate pull request