### PR TITLE
[Student][MBL-10542] Improve scroll behavior when routing to a specific module

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/ModuleListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/ModuleListFragment.kt
@@ -159,7 +159,11 @@ class ModuleListFragment : ParentFragment(), Bookmarkable {
                 } else if (!arguments?.getString(MODULE_ID).isNullOrEmpty()) {
                     val groupPosition = recyclerAdapter.getGroupItemPosition(arguments!!.getString(MODULE_ID)!!.toLong())
                     if (groupPosition >= 0) {
-                        (listView.layoutManager as LinearLayoutManager).scrollToPositionWithOffset(groupPosition,  0)
+                        // We need to delay scrolling until the expand animation has completed, otherwise modules
+                        // that appear near the end of the list will not have the extra 'expanded' space needed
+                        // to scroll as far as possible toward the top
+                        val lm = listView.layoutManager as LinearLayoutManager
+                        listView?.postDelayed({ lm.scrollToPositionWithOffset(groupPosition, 0) }, 1000)
                     }
                 }
             }

--- a/apps/student/src/main/java/com/instructure/student/fragment/ModuleListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/ModuleListFragment.kt
@@ -162,8 +162,10 @@ class ModuleListFragment : ParentFragment(), Bookmarkable {
                         // We need to delay scrolling until the expand animation has completed, otherwise modules
                         // that appear near the end of the list will not have the extra 'expanded' space needed
                         // to scroll as far as possible toward the top
-                        val lm = listView.layoutManager as LinearLayoutManager
-                        listView?.postDelayed({ lm.scrollToPositionWithOffset(groupPosition, 0) }, 1000)
+                        listView?.postDelayed({
+                            val lm = listView?.layoutManager as? LinearLayoutManager
+                            lm?.scrollToPositionWithOffset(groupPosition, 0)
+                        }, 1000)
                     }
                 }
             }


### PR DESCRIPTION
When deep linking to a module, the app opens to the module list which then scrolls to and expands that module. However, because the scroll is happening prior to expansion, modules located near the bottom of the list will not be scrolled as close to the top as they could have been. This can partially or entirely negate the highlighting effect of the scroll/expand behavior.

This change introduces a delay to the scrolling behavior so that the expansion animation can finish first, providing extra vertical space which allows the module to be scrolled more closely to the top of the list.