### PR TITLE
[Student][MBL-14556] Use assignment ID when routing from planner to quiz assignments

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/CalendarFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/CalendarFragment.kt
@@ -90,7 +90,7 @@ class CalendarFragment : ParentFragment() {
             "quiz" -> {
                 if (item.plannable.assignmentId != null) {
                     // This is a quiz assignment, go to the assignment page
-                    AssignmentDetailsFragment.makeRoute(item.canvasContext, item.plannable.id)
+                    AssignmentDetailsFragment.makeRoute(item.canvasContext, item.plannable.assignmentId!!)
                 } else {
                     var htmlUrl = item.htmlUrl.orEmpty()
                     if (htmlUrl.startsWith('/')) htmlUrl = ApiPrefs.fullDomain + htmlUrl


### PR DESCRIPTION
We were previously using the plannable ID when routing from the planner to the assignemnt details page, but in the case of quiz assignments the plannable ID is the quiz ID and not the assignment ID, which would cause an unhelpful error message to be displayed. This change updates the route to use the plannable's assignment ID instead for quizzes.