### PR TITLE
[MBL-14444][Student/Teacher] Send context code when adding a new message

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Student | `./gradle/gradlew -p apps :student:assembleDevDebug`
 Teacher | `./gradle/gradlew -p apps :teacher:assembleDevDebug`
 Parent  | `./gradle/gradlew -p apps :parent:assembleDevDebug`
 
+## Running tests
+
+To run unit tests for Student and Teacher
+1. Open the Build Variants window and set the variant to `qaDebug` for the app that you wish to test.
+2. You can run the tests by tapping on the play button next to the test case or the test class.
+
 ## Applications:
 
 #### The Applications we have published on Google Play.

--- a/apps/student/src/main/java/com/instructure/student/fragment/InboxComposeMessageFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/InboxComposeMessageFragment.kt
@@ -387,7 +387,7 @@ class InboxComposeMessageFragment : ParentFragment() {
             val attachmentIds = attachments.map { it.id }.toLongArray()
             val recipientIds = selectedRecipients.map { it.destination }
             val conversation = awaitApi<Conversation> {
-                InboxManager.addMessage(conversation?.id ?: 0, formattedMessage, recipientIds, includedMessageIds, attachmentIds, it)
+                InboxManager.addMessage(conversation?.id ?: 0, formattedMessage, recipientIds, includedMessageIds, attachmentIds, conversation?.contextCode, it)
             }
             messageSuccess(conversation)
         } catch {

--- a/apps/teacher/src/main/java/com/instructure/teacher/presenters/AddMessagePresenter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/presenters/AddMessagePresenter.kt
@@ -125,7 +125,7 @@ class AddMessagePresenter(val conversation: Conversation?, private val mParticip
 
         // Send message
         val encodedMessage = URLEncoder.encode(message, "UTF-8")
-        InboxManager.addMessage(conversation?.id ?: 0, encodedMessage, recipientIds, messageIds, attachmentIDs, mAddConversationCallback)
+        InboxManager.addMessage(conversation?.id ?: 0, encodedMessage, recipientIds, messageIds, attachmentIDs, conversation?.contextCode, mAddConversationCallback)
     }
 
     private val mAddConversationCallback = object : StatusCallback<Conversation>() {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/InboxApi.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/InboxApi.kt
@@ -71,7 +71,7 @@ object InboxApi {
         fun deleteMessages(@Path("conversationId") conversationId: Long, @Query("remove[]") messageIds: List<Long>): Call<Conversation>
 
         @POST("conversations/{conversationId}/add_message?group_conversation=true")
-        fun addMessage(@Path("conversationId") conversationId: Long, @Query("recipients[]") recipientIds: List<String>, @Query(value = "body", encoded = true) body: String, @Query("included_messages[]") includedMessageIds: LongArray, @Query("attachment_ids[]") attachmentIds: LongArray): Call<Conversation>
+        fun addMessage(@Path("conversationId") conversationId: Long, @Query("recipients[]") recipientIds: List<String>, @Query(value = "body", encoded = true) body: String, @Query("included_messages[]") includedMessageIds: LongArray, @Query("attachment_ids[]") attachmentIds: LongArray, @Query("context_code") contextCode: String?): Call<Conversation>
 
         @PUT("conversations")
         fun markConversationAsUnread(@Query("conversation_ids[]") conversationId: Long, @Query("event") conversationEvent: String): Call<Void>
@@ -130,8 +130,8 @@ object InboxApi {
         callback.addCall(adapter.build(InboxInterface::class.java, params).deleteMessages(conversationId, messageIds)).enqueue(callback)
     }
 
-    fun addMessage(adapter: RestBuilder, callback: StatusCallback<Conversation>, params: RestParams, conversationId: Long, recipientIds: List<String>, message: String, includedMessageIds: LongArray, attachmentIds: LongArray) {
-        callback.addCall(adapter.build(InboxInterface::class.java, params).addMessage(conversationId, recipientIds, message, includedMessageIds, attachmentIds)).enqueue(callback)
+    fun addMessage(adapter: RestBuilder, callback: StatusCallback<Conversation>, params: RestParams, conversationId: Long, recipientIds: List<String>, message: String, includedMessageIds: LongArray, attachmentIds: LongArray, contextCode: String?) {
+        callback.addCall(adapter.build(InboxInterface::class.java, params).addMessage(conversationId, recipientIds, message, includedMessageIds, attachmentIds, contextCode)).enqueue(callback)
     }
 
     fun markConversationAsUnread(adapter: RestBuilder, callback: StatusCallback<Void>, params: RestParams, conversationId: Long, conversationEvent: String) {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/InboxManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/InboxManager.kt
@@ -123,6 +123,7 @@ object InboxManager {
         recipientIds: List<String>,
         includedMessageIds: LongArray,
         attachmentIds: LongArray,
+        contextId: String?,
         callback: StatusCallback<Conversation>
     ) {
         val adapter = RestBuilder(callback)
@@ -135,7 +136,8 @@ object InboxManager {
             recipientIds,
             message,
             includedMessageIds,
-            attachmentIds
+            attachmentIds,
+            contextId
         )
     }
 

--- a/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/pact/canvas/apis/InboxApiPactTests.kt
+++ b/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/pact/canvas/apis/InboxApiPactTests.kt
@@ -348,7 +348,8 @@ class InboxApiPactTests : ApiPactTestBase() {
                 recipientIds = listOf("8","9"),
                 body="addedMessageBody",
                 includedMessageIds=longArrayOf(),
-                attachmentIds=longArrayOf())
+                attachmentIds=longArrayOf(),
+                contextCode=null)
         val addMessageResult = addMessageCall.execute()
 
         assertQueryParamsAndPath(addMessageCall, addMessageQuery, addMessagePath)


### PR DESCRIPTION
refs: MBL-14444
affects: student, teacher
release note: none

Test plan:
- Log in as the student in the ticket
- Inbox > Tap the only conversation
- Reply directly to the first message (begins with _I am a teacher_)
- View the conversation as the teacher (in app or on web)
- You should not see the reply that the student made

I don't know how we test this since it doesn't impact the UI for the
current user. Only difference is that the receiver does not actually
receive the message.