### PR TITLE
[MBL-11767][Student] Display rating when only graders can like

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/DiscussionsInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/DiscussionsInteractionTest.kt
@@ -267,6 +267,43 @@ class DiscussionsInteractionTest : StudentTest() {
         discussionDetailsPage.assertLikeCount(discussionEntry, 0)
     }
 
+    // Tests that like count is shown if only graders can like
+    @Test
+    @TestMetaData(Priority.P1, FeatureCategory.DISCUSSIONS, TestCategory.INTERACTION, false)
+    fun testDiscussionLikes_whenOnlyGradersCanRate() {
+        val data = getToCourse(studentCount = 1, courseCount = 1, enableDiscussionTopicCreation = true)
+        val course = data.courses.values.first()
+        val user = data.users.values.first()
+        val topicName = "Discussion where only graders can like"
+        val topicDescription = "likable discussion"
+        val replyMessage = "A grader liked me!"
+
+        val topicHeader = data.addDiscussionTopicToCourse(
+                course = course,
+                user = user,
+                topicTitle = topicName,
+                topicDescription = topicDescription,
+                allowRating = true,
+                onlyGradersCanRate = true
+        )
+        val discussionEntry = data.addReplyToDiscussion(
+                topicHeader = topicHeader,
+                user = user,
+                replyMessage = replyMessage,
+                ratingSum = 1
+        )
+
+        // Bring up discussion page
+        courseBrowserPage.selectDiscussions()
+        discussionListPage.pullToUpdate()
+        discussionListPage.assertTopicDisplayed(topicName)
+        discussionListPage.selectTopic(topicName)
+
+        // Check that ratings show
+        discussionDetailsPage.assertFavoritingDisabled(discussionEntry)
+        discussionDetailsPage.assertLikeCount(discussionEntry, 1)
+    }
+
     // Tests that discussion entry liking is not available when disabled
     @Test
     @TestMetaData(Priority.P1, FeatureCategory.DISCUSSIONS, TestCategory.INTERACTION, false)

--- a/apps/student/src/main/java/com/instructure/student/fragment/DiscussionDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/DiscussionDetailsFragment.kt
@@ -343,7 +343,7 @@ class DiscussionDetailsFragment : ParentFragment(), Bookmarkable {
 
     private fun updateDiscussionLikedState(discussionEntry: DiscussionEntry, methodName: String) {
         val likingSum = if (discussionEntry.ratingSum == 0) "" else "(${discussionEntry.ratingSum})"
-        val likingSumAllyText = DiscussionEntryHtmlConverter.getLikeCountAllyText(requireContext(), discussionEntry)
+        val likingSumAllyText = DiscussionEntryHtmlConverter.getLikeCountText(requireContext(), discussionEntry)
         val likingColor = DiscussionUtils.getHexColorString(if (discussionEntry._hasRated) ThemePrefs.brandColor else ContextCompat.getColor(requireContext(), R.color.discussionLiking))
         activity?.runOnUiThread {
             discussionRepliesWebView.loadUrl("javascript:$methodName('${discussionEntry.id}')")

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/DiscussionsDetailsFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/DiscussionsDetailsFragment.kt
@@ -608,7 +608,7 @@ class DiscussionsDetailsFragment : BasePresenterFragment<
 
     private fun updateDiscussionLikedState(discussionEntry: DiscussionEntry, methodName: String) {
         val likingSum = if(discussionEntry.ratingSum == 0) "" else "(" + discussionEntry.ratingSum + ")"
-        val likingSumAllyText = DiscussionEntryHtmlConverter.getLikeCountAllyText(requireContext(), discussionEntry)
+        val likingSumAllyText = DiscussionEntryHtmlConverter.getLikeCountText(requireContext(), discussionEntry)
         val likingColor = DiscussionUtils.getHexColorString(if (discussionEntry._hasRated) ThemePrefs.brandColor else ContextCompat.getColor(requireContext(), R.color.discussionLiking))
         requireActivity().runOnUiThread {
             discussionRepliesWebView.loadUrl("javascript:$methodName('${discussionEntry.id}')")

--- a/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/MockCanvas.kt
+++ b/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/MockCanvas.kt
@@ -1090,6 +1090,7 @@ fun MockCanvas.addDiscussionTopicToCourse(
         topicTitle: String = Randomizer.randomConversationSubject(),
         topicDescription: String = Randomizer.randomPageTitle(),
         allowRating: Boolean = true,
+        onlyGradersCanRate: Boolean = false,
         allowReplies: Boolean = true,
         allowAttachments: Boolean = true,
         attachment: RemoteFile? = null,
@@ -1110,6 +1111,7 @@ fun MockCanvas.addDiscussionTopicToCourse(
     topicHeader.author = DiscussionParticipant(id = user.id, displayName = user.name)
     topicHeader.published = true
     topicHeader.allowRating = allowRating
+    topicHeader.onlyGradersCanRate = onlyGradersCanRate
     topicHeader.permissions = DiscussionTopicPermission(attach = allowAttachments, reply = allowReplies)
     topicHeader.id = newItemId()
     topicHeader.postedDate = Calendar.getInstance().time
@@ -1147,7 +1149,8 @@ fun MockCanvas.addReplyToDiscussion(
         topicHeader: DiscussionTopicHeader,
         user: User,
         replyMessage: String = Faker.instance().chuckNorris().fact(),
-        attachment: RemoteFile? = null
+        attachment: RemoteFile? = null,
+        ratingSum: Int = 0
 ) : DiscussionEntry {
     val topic = discussionTopics[topicHeader.id]
     val entry = DiscussionEntry(
@@ -1158,7 +1161,8 @@ fun MockCanvas.addReplyToDiscussion(
                     id = user.id,
                     displayName = user.name
             ),
-            createdAt = Calendar.getInstance().time.toString()
+            createdAt = Calendar.getInstance().time.toString(),
+            ratingSum = ratingSum
     )
     if(attachment != null) {
         entry.attachments = mutableListOf(attachment)

--- a/libs/pandautils/src/main/assets/discussion_html_template_item.html
+++ b/libs/pandautils/src/main/assets/discussion_html_template_item.html
@@ -179,7 +179,7 @@
             display: flex;
             justify-content: center;
             align-items: center;
-            __LIKE_ALLOWED__
+            __SHOW_LIKES__
         }
 
         .likes_count___ENTRY_ID__ {
@@ -192,6 +192,10 @@
             float: right;
             margin-right: 8px;
             color: #8b969e;
+        }
+
+        .likes_icon_wrapper___ENTRY_ID__ {
+            __LIKE_ALLOWED__
         }
 
         .likes_icon___ENTRY_ID__ {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/discussions/DiscussionEntryHtmlConverter.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/discussions/DiscussionEntryHtmlConverter.kt
@@ -42,6 +42,7 @@ class DiscussionEntryHtmlConverter {
             canReply: Boolean,
             canEdit: Boolean,
             allowLiking: Boolean,
+            showLikes: Boolean,
             canDelete: Boolean,
             reachedViewableEnd: Boolean,
             indent: Int,
@@ -50,7 +51,7 @@ class DiscussionEntryHtmlConverter {
             deletedText: String): String {
 
         val repliesButtonText = context.resources.getQuantityString(R.plurals.utils_discussionsReplies, discussionEntry.totalChildren, discussionEntry.totalChildren.localized)
-        val likeCountLabel = getLikeCountAllyText(context, discussionEntry)
+        val likeCountLabel = getLikeCountText(context, discussionEntry)
         val likeEntryLabel = context.resources.getString(R.string.likeEntryLabel)
 
         val htmlListener = getItemClickListener(discussionEntry.id.toString())
@@ -81,8 +82,10 @@ class DiscussionEntryHtmlConverter {
         var indentDisplay5 = "display: none;"
         val attachments = getAttachments(discussionEntry)
 
+        val showingLikes = if(showLikes) "display: flex;" else "display: none;"
         val liking = if(allowLiking) "display: flex;" else "display: none;"
-        val likingSum = if(discussionEntry.ratingSum == 0) "" else "(" + discussionEntry.ratingSum.localized + ")"
+        val likeCountShort = if(discussionEntry.ratingSum == 0) "" else "(" + discussionEntry.ratingSum.localized + ")"
+        val likeSum = if(allowLiking) likeCountShort else likeCountLabel
         val likingIcon = if(discussionEntry._hasRated) likeImage else "file:///android_asset/discussion_unliked.png"
         val likingColor = if(discussionEntry._hasRated) brandColor else likeColor
 
@@ -178,11 +181,13 @@ class DiscussionEntryHtmlConverter {
         return template
                 .replace("__GROUP__", "display: block;")
                 .replace("__LIKE_ICON__", likingIcon)
-                .replace("__LIKE_COUNT__", likingSum)
+                .replace("__LIKE_COUNT_SHORT__", likeCountShort)
+                .replace("__LIKE_COUNT__", likeSum)
                 .replace("__LIKE_ARIA__", likeEntryLabel)
                 .replace("__LIKE_CHECKED_ARIA__", discussionEntry._hasRated.toString())
                 .replace("__LIKE_COUNT_ARIA__", likeCountLabel)
                 .replace("__LIKE_ALLOWED__", liking)
+                .replace("__SHOW_LIKES__", showingLikes)
                 .replace("__LIKE_COLOR__", colorToHex(likingColor))
                 .replace("__BRAND_COLOR__", colorToHex(brandColor))
                 .replace("__ATTACHMENTS_WRAPPER__", attachments)
@@ -283,7 +288,7 @@ class DiscussionEntryHtmlConverter {
     }
 
     companion object {
-        fun getLikeCountAllyText(context: Context, discussionEntry: DiscussionEntry): String {
+        fun getLikeCountText(context: Context, discussionEntry: DiscussionEntry): String {
             return if (discussionEntry.ratingSum == 0) "" else context.resources.getQuantityString(
                 R.plurals.likeCountLabel,
                 discussionEntry.ratingSum,

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/discussions/DiscussionUtils.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/discussions/DiscussionUtils.kt
@@ -305,6 +305,7 @@ object DiscussionUtils {
                 allowReplies(canvasContext, discussionTopicHeader),
                 allowEditing(canvasContext),
                 allowLiking(canvasContext, discussionTopicHeader),
+                discussionTopicHeader.allowRating,
                 allowDeleting(canvasContext),
                 reachedViewableEnd,
                 indent,
@@ -391,16 +392,10 @@ object DiscussionUtils {
     }
 
     private fun allowLiking(canvasContext: CanvasContext?, header: DiscussionTopicHeader): Boolean {
-        if (header.allowRating) {
-            if (header.onlyGradersCanRate) {
-                if (canvasContext?.type == CanvasContext.Type.COURSE) {
-                    return (canvasContext as Course).isTeacher || canvasContext.isTA
-                }
-            } else {
-                return true
-            }
-        }
-        return false
+        val isGrader = ((canvasContext as Course).isTeacher || canvasContext.isTA)
+        return header.allowRating && (
+            !header.onlyGradersCanRate || isGrader
+        )
     }
 
     private fun allowDeleting(canvasContext: CanvasContext?): Boolean {


### PR DESCRIPTION
refs: MBL-11767
affects: student
release note: Adding rating to discussions when only graders can like

Test plan:
- View a discussion that does not allow rating
  - Student & Teacher: No rating content should be displayed
- View a discussion that allows ratings
  - Student & Teacher: You should be able to like and see the like count
- View a discussion that allows ratings and only allows graders to like
  - Student:
    - You should see like counts when the count is greater than 0
    - You should not see the like button
    - You should not be able to edit likes
  - Teacher:
    - You should be able to like the replies and the count should be displayed