### PR TITLE
[Student][MBL-14584] Module title fix

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/CourseModuleProgressionFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/CourseModuleProgressionFragment.kt
@@ -291,7 +291,6 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
                 getCurrentModuleItem(currentPos)?.completionRequirement?.completed = true
 
                 setupNextModule(getModuleItemGroup(currentPos))
-                setupPrevModuleName(getModuleItemGroup(currentPos))
 
                 // Update the module list fragment to show that these requirements are done,
                 ModuleUpdatedEvent(modules[groupPos]).post()


### PR DESCRIPTION
Sooo it looks like we were simply overriding the name of the current module fragment by incorrectly calling setPrevModuleName when calling markAsRead. I've tested this a bunch and it seems to be completely unnecessary. 