### PR TITLE
[MBL-14642][All] Hide help buttons on landing pages

### DIFF
--- a/apps/flutter_parent/lib/screens/login_landing_screen.dart
+++ b/apps/flutter_parent/lib/screens/login_landing_screen.dart
@@ -85,6 +85,7 @@ class LoginLandingScreen extends StatelessWidget {
                   child: FullScreenScrollContainer(
                     horizontalPadding: 0,
                     children: <Widget>[
+                      // _helpRequestButton(context), // add back after we make mobile login better
                       Expanded(child: _body(context)),
                       SizedBox(height: 56.0), // Sizedbox to offset helpRequestButton
                     ],

--- a/apps/flutter_parent/lib/screens/login_landing_screen.dart
+++ b/apps/flutter_parent/lib/screens/login_landing_screen.dart
@@ -85,7 +85,6 @@ class LoginLandingScreen extends StatelessWidget {
                   child: FullScreenScrollContainer(
                     horizontalPadding: 0,
                     children: <Widget>[
-                      _helpRequestButton(context),
                       Expanded(child: _body(context)),
                       SizedBox(height: 56.0), // Sizedbox to offset helpRequestButton
                     ],

--- a/apps/flutter_parent/test/screens/login/login_landing_screen_test.dart
+++ b/apps/flutter_parent/test/screens/login/login_landing_screen_test.dart
@@ -239,17 +239,6 @@ void main() {
     ApiPrefs.clean();
   });
 
-  testWidgetsWithAccessibilityChecks('Tapping help button shows help dialog', (tester) async {
-    await tester.pumpWidget(TestApp(LoginLandingScreen()));
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.byIcon(CanvasIcons.question));
-    await tester.pumpAndSettle();
-
-    expect(find.byType(ErrorReportDialog), findsOneWidget);
-    verify(analytics.logEvent(any)).called(1);
-  });
-
   testWidgetsWithAccessibilityChecks('Uses two-finger double-tap to cycle login flows', (tester) async {
     await tester.pumpWidget(TestApp(LoginLandingScreen()));
     await tester.pumpAndSettle();

--- a/apps/flutter_parent/test/screens/login/login_landing_screen_test.dart
+++ b/apps/flutter_parent/test/screens/login/login_landing_screen_test.dart
@@ -239,6 +239,19 @@ void main() {
     ApiPrefs.clean();
   });
 
+  /* Hiding the help button until we make mobile login better
+  testWidgetsWithAccessibilityChecks('Tapping help button shows help dialog', (tester) async {
+    await tester.pumpWidget(TestApp(LoginLandingScreen()));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(CanvasIcons.question));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ErrorReportDialog), findsOneWidget);
+    verify(analytics.logEvent(any)).called(1);
+  });
+   */
+
   testWidgetsWithAccessibilityChecks('Uses two-finger double-tap to cycle login flows', (tester) async {
     await tester.pumpWidget(TestApp(LoginLandingScreen()));
     await tester.pumpAndSettle();

--- a/libs/login-api-2/src/main/java/com/instructure/loginapi/login/activities/BaseLoginLandingPageActivity.kt
+++ b/libs/login-api-2/src/main/java/com/instructure/loginapi/login/activities/BaseLoginLandingPageActivity.kt
@@ -125,6 +125,7 @@ abstract class BaseLoginLandingPageActivity : AppCompatActivity(), ErrorReportDi
             startActivity(i)
         }
 
+        helpButton.setHidden(true)
         helpButton.onClickPopupMenu(getString(R.string.requestLoginHelp) to { requestLoginHelp() })
 
         val remoteConfigParam = when {

--- a/libs/login-api-2/src/main/java/com/instructure/loginapi/login/activities/BaseLoginLandingPageActivity.kt
+++ b/libs/login-api-2/src/main/java/com/instructure/loginapi/login/activities/BaseLoginLandingPageActivity.kt
@@ -125,7 +125,7 @@ abstract class BaseLoginLandingPageActivity : AppCompatActivity(), ErrorReportDi
             startActivity(i)
         }
 
-        helpButton.setHidden(true)
+        helpButton.setHidden(true) // hiding the help button until we make mobile login better
         helpButton.onClickPopupMenu(getString(R.string.requestLoginHelp) to { requestLoginHelp() })
 
         val remoteConfigParam = when {


### PR DESCRIPTION
This is temporary while we figure out a better solution to mobile login
issues.

Support is overwhelmed with these requests right now and are
having to mass-reply to them all so this button is doing more harm than
good right now.

Test plan: Landing pages in all the apps should not have a help button.