### PR TITLE
[Student][MBL-14645] Fix for quizzes 2 lti

### DIFF
--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/AssignmentAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/AssignmentAPI.kt
@@ -29,7 +29,7 @@ import retrofit2.http.*
 object AssignmentAPI {
     internal interface AssignmentInterface {
         @GET("courses/{courseId}/external_tools/sessionless_launch")
-        fun getExternalToolLaunchUrl(@Path("courseId") courseId: Long, @Query("id") externalToolId: Long, @Query("assignment_id") assignmentId: Long): Call<LTITool>
+        fun getExternalToolLaunchUrl(@Path("courseId") courseId: Long, @Query("id") externalToolId: Long, @Query("assignment_id") assignmentId: Long, @Query("launch_type") launchType: String = "assessment"): Call<LTITool>
 
         @GET("courses/{courseId}/assignments/{assignmentId}?include[]=submission&include[]=rubric_assessment&needs_grading_count_by_section=true&override_assignment_dates=true&all_dates=true&include[]=overrides")
         fun getAssignment(@Path("courseId") courseId: Long, @Path("assignmentId") assignmentId: Long): Call<Assignment>


### PR DESCRIPTION
Messed around for most of the day on a conditional fix that detected if the LTI tool was using quizzes 2 and then fell back to the old implementation for fetching launch url only to be informed that I was simply missing the launch_type query param. See ticket for repro.