### PR TITLE
[Parent][MBL-14633] Include current_and_future state when fetching enrollments

### DIFF
--- a/apps/flutter_parent/lib/network/api/enrollments_api.dart
+++ b/apps/flutter_parent/lib/network/api/enrollments_api.dart
@@ -23,7 +23,7 @@ class EnrollmentsApi {
     var dio = canvasDio(pageSize: PageSize.canvasMax, forceRefresh: forceRefresh);
     var params = {
       'include': ['observed_users', 'avatar_url'],
-      'state': ['creation_pending', 'invited', 'active', 'completed']
+      'state': ['creation_pending', 'invited', 'active', 'completed', 'current_and_future']
     };
     return fetchList(dio.get('users/self/enrollments', queryParameters: params), depaginateWith: dio);
   }


### PR DESCRIPTION
This fixes an issue where users will incorrectly be shown the "Not A Parent?" screen if none of the observee courses have started. See ticket for repro steps.