### PR TITLE
[Student][MBL-14622] Hide submit button for soft conclude

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsPresenter.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsPresenter.kt
@@ -20,7 +20,6 @@ import android.content.Context
 import androidx.core.content.ContextCompat
 import com.instructure.canvasapi2.models.*
 import com.instructure.canvasapi2.utils.*
-import com.instructure.pandautils.discussions.DiscussionUtils
 import com.instructure.pandautils.utils.AssignmentUtils2
 import com.instructure.student.R
 import com.instructure.student.Submission
@@ -179,7 +178,7 @@ object AssignmentDetailsPresenter : Presenter<AssignmentDetailsModel, Assignment
         visibilities.allowedAttempts = assignment.allowedAttempts != -1L
         visibilities.submitButtonEnabled = assignment.allowedAttempts == -1L || (assignment.submission?.attempt?.let{ it < assignment.allowedAttempts } ?: true)
 
-        if (isObserver || !course.isValidForCurrentDate()) {
+        if (isObserver || !course.isReadOnlyForCurrentDate()) {
             // Observers shouldn't see the submit button
             // OR if the course is soft concluded
             visibilities.submitButton = false

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsPresenter.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsPresenter.kt
@@ -18,14 +18,8 @@ package com.instructure.student.mobius.assignmentDetails
 
 import android.content.Context
 import androidx.core.content.ContextCompat
-import com.instructure.canvasapi2.models.Assignment
-import com.instructure.canvasapi2.models.DiscussionTopicHeader
-import com.instructure.canvasapi2.models.Quiz
-import com.instructure.canvasapi2.models.isDiscussionAuthorNull
-import com.instructure.canvasapi2.utils.DateHelper
-import com.instructure.canvasapi2.utils.NumberHelper
-import com.instructure.canvasapi2.utils.isRtl
-import com.instructure.canvasapi2.utils.isValid
+import com.instructure.canvasapi2.models.*
+import com.instructure.canvasapi2.utils.*
 import com.instructure.pandautils.discussions.DiscussionUtils
 import com.instructure.pandautils.utils.AssignmentUtils2
 import com.instructure.student.R
@@ -62,7 +56,7 @@ object AssignmentDetailsPresenter : Presenter<AssignmentDetailsModel, Assignment
         val quiz = model.quizResult?.dataOrNull
 
         // Loaded state
-        return presentLoadedState(assignment, quiz, model.databaseSubmission, context, model.isObserver)
+        return presentLoadedState(assignment, quiz, model.databaseSubmission, context, model.isObserver, model.course)
     }
 
     private fun presentLoadedState(
@@ -70,7 +64,8 @@ object AssignmentDetailsPresenter : Presenter<AssignmentDetailsModel, Assignment
         quiz: Quiz?,
         databaseSubmission: Submission?,
         context: Context,
-        isObserver: Boolean
+        isObserver: Boolean,
+        course: Course
     ): AssignmentDetailsViewState.Loaded {
         val visibilities = AssignmentDetailsVisibilities()
 
@@ -184,8 +179,9 @@ object AssignmentDetailsPresenter : Presenter<AssignmentDetailsModel, Assignment
         visibilities.allowedAttempts = assignment.allowedAttempts != -1L
         visibilities.submitButtonEnabled = assignment.allowedAttempts == -1L || (assignment.submission?.attempt?.let{ it < assignment.allowedAttempts } ?: true)
 
-        if (isObserver) {
+        if (isObserver || !course.isValidForCurrentDate()) {
             // Observers shouldn't see the submit button
+            // OR if the course is soft concluded
             visibilities.submitButton = false
         } else {
             //Configure stickied submit button visibility state,

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/emptySubmission/SubmissionDetailsEmptyContentPresenter.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/emptySubmission/SubmissionDetailsEmptyContentPresenter.kt
@@ -38,7 +38,7 @@ object SubmissionDetailsEmptyContentPresenter : Presenter<SubmissionDetailsEmpty
     }
 
     private fun allowedToSubmit(assignment: Assignment, course: Course): Boolean {
-        return if(!course.isValidForCurrentDate()) {
+        return if(!course.isReadOnlyForCurrentDate()) {
             // Don't show submit if the course is soft concluded
             return false
         } else if (assignment.turnInType == Assignment.TurnInType.ONLINE || assignment.turnInType == Assignment.TurnInType.EXTERNAL_TOOL) {

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/emptySubmission/SubmissionDetailsEmptyContentPresenter.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/emptySubmission/SubmissionDetailsEmptyContentPresenter.kt
@@ -17,6 +17,7 @@ package com.instructure.student.mobius.assignmentDetails.submissionDetails.conte
 
 import android.content.Context
 import com.instructure.canvasapi2.models.Assignment
+import com.instructure.canvasapi2.models.Course
 import com.instructure.student.R
 import com.instructure.student.mobius.assignmentDetails.submissionDetails.content.emptySubmission.ui.SubmissionDetailsEmptyContentViewState
 import com.instructure.student.mobius.common.ui.Presenter
@@ -29,17 +30,24 @@ import org.threeten.bp.temporal.ChronoUnit
 object SubmissionDetailsEmptyContentPresenter : Presenter<SubmissionDetailsEmptyContentModel, SubmissionDetailsEmptyContentViewState> {
     override fun present(model: SubmissionDetailsEmptyContentModel, context: Context): SubmissionDetailsEmptyContentViewState {
         return SubmissionDetailsEmptyContentViewState.Loaded(
-            allowedToSubmit(model.assignment),
+            allowedToSubmit(model.assignment, model.course),
             model.assignment.getDueString(context),
             getSubmitButtonTextResource(context, model.assignment),
             model.isObserver
         )
     }
 
-    private fun allowedToSubmit(assignment: Assignment): Boolean =
-        if (assignment.turnInType == Assignment.TurnInType.ONLINE || assignment.turnInType == Assignment.TurnInType.EXTERNAL_TOOL)
+    private fun allowedToSubmit(assignment: Assignment, course: Course): Boolean {
+        return if(!course.isValidForCurrentDate()) {
+            // Don't show submit if the course is soft concluded
+            return false
+        } else if (assignment.turnInType == Assignment.TurnInType.ONLINE || assignment.turnInType == Assignment.TurnInType.EXTERNAL_TOOL) {
             assignment.isAllowedToSubmit
-        else true
+        } else {
+            true
+        }
+    }
+
 
     private fun getSubmitButtonTextResource(context: Context, assignment: Assignment): String {
         val isExternalToolSubmission = assignment.getSubmissionTypes()

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Course.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Course.kt
@@ -200,6 +200,46 @@ data class Course(
         return false
     }
 
+
+    /**
+     * Helper function to check if the course is within a valid date range for use
+     */
+    fun isValidForCurrentDate(): Boolean {
+        val now = Date()
+        if (accessRestrictedByDate) return false
+
+        if (workflowState == "completed") return false
+
+        val isWithinCourseDates = isWithinDates(
+                startAt.toDate(),
+                endAt.toDate(),
+                now
+        )
+
+        return if (accessRestrictedByDate) {
+            isWithinCourseDates
+        } else {
+            val isWithinTermDates = isWithinDates(term?.startDate, term?.endDate, now)
+
+            val isWithinAnySection: Boolean = if (sections.isEmpty()) {
+                true
+            } else {
+                // TODO - does it only return sections that the student is in
+                sections.any { section -> isWithinDates(section.startAt.toDate(), section.endAt.toDate(), now) }
+            }
+
+            isWithinCourseDates || isWithinTermDates || isWithinAnySection
+        }
+    }
+
+    private fun isWithinDates(startAt: Date?, endAt: Date?, now: Date): Boolean {
+        // If the dates are null, we have to show it
+        val isValidStartAt: Boolean = if (startAt == null) true else now.after(startAt)
+        val isValidEndAt: Boolean = if (endAt == null) true else now.before(endAt)
+
+        return isValidEndAt && isValidStartAt
+    }
+
     /**
      * Get home page label returns the fragment identifier.
      *

--- a/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/unit/CourseTest.kt
+++ b/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/unit/CourseTest.kt
@@ -19,12 +19,19 @@ package com.instructure.canvasapi2.unit
 
 import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.models.Enrollment
+import com.instructure.canvasapi2.models.Section
+import com.instructure.canvasapi2.models.Term
+import com.instructure.canvasapi2.utils.DateHelper
 import com.instructure.canvasapi2.utils.Logger
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
+import java.time.OffsetDateTime
+import java.util.*
 
 class CourseTest {
+
+    val baseCourse = Course(accessRestrictedByDate = false, workflowState = "completed")
 
     @Before
     fun setup() {
@@ -467,5 +474,74 @@ class CourseTest {
 
         assertTrue(course.getCourseGrade(false)!!.finalScore == finalScore)
     }
+
+    @Test
+    fun courseIsReadOnly_accessRestrictedByDate() {
+        val course = Course(accessRestrictedByDate = true)
+
+        assertFalse(course.isReadOnlyForCurrentDate())
+    }
+
+    @Test
+    fun courseIsReadOnly_workFlowStateCompleted() {
+        val course = Course(workflowState = "completed")
+
+        assertFalse(course.isReadOnlyForCurrentDate())
+    }
+
+    @Test
+    fun courseIsReadOnly_restrictedToCourseDatesWithInValidDates() {
+        val startDate = OffsetDateTime.now().minusDays(30)
+        val endDate = OffsetDateTime.now().minusDays(20)
+        val course = baseCourse.copy(restrictEnrollmentsToCourseDate = true,
+                startAt = startDate.toString(), endAt = endDate.toString())
+
+        assertFalse(course.isReadOnlyForCurrentDate())
+    }
+
+    @Test
+    fun courseIsReadOnly_invalidTermDates() {
+        val badStartDate = OffsetDateTime.now().minusDays(30)
+        val badEndDate = OffsetDateTime.now().minusDays(20)
+
+        val startDate = OffsetDateTime.now().minusDays(50)
+        val endDate = OffsetDateTime.now().plusDays(50)
+
+        val term = Term(startAt = badStartDate.toString(), endAt = badEndDate.toString())
+        val course = baseCourse.copy(restrictEnrollmentsToCourseDate = true,
+                startAt = startDate.toString(), endAt = endDate.toString(), term = term)
+
+        assertFalse(course.isReadOnlyForCurrentDate())
+    }
+
+    @Test
+    fun courseIsReadOnly_invalidSectionDates() {
+        val badStartDate = OffsetDateTime.now().minusDays(30)
+        val badEndDate = OffsetDateTime.now().minusDays(20)
+
+        val startDate = OffsetDateTime.now().minusDays(50)
+        val endDate = OffsetDateTime.now().plusDays(50)
+
+        val term = Term(startAt = startDate.toString(), endAt = endDate.toString())
+        val section = Section(startAt = badStartDate.toString(), endAt = badEndDate.toString())
+        val course = baseCourse.copy(restrictEnrollmentsToCourseDate = true,
+                startAt = startDate.toString(), endAt = endDate.toString(), term = term, sections = listOf(section))
+
+        assertFalse(course.isReadOnlyForCurrentDate())
+    }
+
+    @Test
+    fun courseIsReadOnly_validDatesAllTheWayDown() {
+        val startDate = OffsetDateTime.now().minusDays(50)
+        val endDate = OffsetDateTime.now().plusDays(50)
+
+        val term = Term(startAt = startDate.toString(), endAt = endDate.toString())
+        val section = Section(startAt = startDate.toString(), endAt = endDate.toString())
+        val course = baseCourse.copy(restrictEnrollmentsToCourseDate = true,
+                startAt = startDate.toString(), endAt = endDate.toString(), term = term, sections = listOf(section))
+
+        assertFalse(course.isReadOnlyForCurrentDate())
+    }
+
 
 }


### PR DESCRIPTION
See ticket to test. The goal for this is to match canvas behavior for showing the submit button. Essentially, if the course is set to "read only" from any source we hide the submit button. This can be for course, section, or term dates, as well as the course workflow state.