### PR TITLE
[Student][MBL-14648] File sharing bug

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/activity/ShareFileUploadActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/ShareFileUploadActivity.kt
@@ -100,7 +100,7 @@ class ShareFileUploadActivity : AppCompatActivity(), ShareFileDestinationDialog.
     }
 
     private fun askForStoragePermissionIfNecessary() {
-        if (sharedURI?.scheme?.equals("file") == true && !PermissionUtils.hasPermissions(this, PermissionUtils.WRITE_EXTERNAL_STORAGE)) {
+        if ((sharedURI?.scheme?.equals("file") == true || sharedURI?.scheme?.equals("content") == true) && !PermissionUtils.hasPermissions(this, PermissionUtils.WRITE_EXTERNAL_STORAGE)) {
             ActivityCompat.requestPermissions(this, PermissionUtils.makeArray(PermissionUtils.WRITE_EXTERNAL_STORAGE), PERMISSION_REQUEST_WRITE_STORAGE)
         }
     }

--- a/apps/student/src/main/java/com/instructure/student/dialog/ShareFileDestinationDialog.kt
+++ b/apps/student/src/main/java/com/instructure/student/dialog/ShareFileDestinationDialog.kt
@@ -132,10 +132,6 @@ class ShareFileDestinationDialog : DialogFragment(), OnOptionCheckedListener {
         assignmentContainer.setVisible()
     }
 
-    override fun onDismiss(dialog: DialogInterface) {
-        (activity as? DialogCloseListener)?.onCancel(dialog)
-    }
-
     override fun onCancel(dialog: DialogInterface) {
         (activity as? DialogCloseListener)?.onCancel(dialog)
     }


### PR DESCRIPTION
The activity was being finished in between the two dialogs, I looked 3 years back into the codes history and I have no idea why it was doing this.

Also, we were only checking the contents scheme for file to determine if we need to request permission, so I added "content", which seems common, at least on Samsung.