### PR TITLE
[Student][Coverage][MBL-14682] | Increase UI test code coverage, rd1

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/AnnouncementInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/AnnouncementInteractionTest.kt
@@ -19,6 +19,7 @@ import androidx.test.espresso.Espresso
 import androidx.test.espresso.web.webdriver.Locator
 import com.instructure.canvas.espresso.Stub
 import com.instructure.canvas.espresso.mockCanvas.MockCanvas
+import com.instructure.canvas.espresso.mockCanvas.addCoursePermissions
 import com.instructure.canvas.espresso.mockCanvas.addDiscussionTopicToCourse
 import com.instructure.canvas.espresso.mockCanvas.init
 import com.instructure.canvasapi2.models.CanvasContextPermission
@@ -145,6 +146,49 @@ class AnnouncementInteractionTest : StudentTest() {
         discussionDetailsPage.assertReplyDisplayed(reply)
     }
 
+    // Tests that we can create an announcement (as teacher).
+    @Test
+    @TestMetaData(Priority.P0, FeatureCategory.ANNOUNCEMENTS, TestCategory.INTERACTION, false)
+    fun testAnnouncementCreate_base() {
+        val data = getToAnnouncementList()
+
+        val course = data.courses.values.first()
+        val announcement = data.courseDiscussionTopicHeaders[course.id]!!.first()
+        discussionListPage.assertTopicDisplayed(announcement.title!!)
+        discussionListPage.createAnnouncement("Announcement Topic", "Awesome announcement topic")
+    }
+
+    // Tests code around closing / aborting announcement creation
+    @Test
+    @TestMetaData(Priority.P1, FeatureCategory.ANNOUNCEMENTS, TestCategory.INTERACTION, false)
+    fun testAnnouncementCreate_abort() {
+        val data = getToAnnouncementList()
+
+        discussionListPage.launchCreateAnnouncementThenClose()
+        discussionListPage.verifyExitWithoutSavingDialog()
+    }
+
+    // Tests code around creating an announcement with no description
+    @Test
+    @TestMetaData(Priority.P2, FeatureCategory.ANNOUNCEMENTS, TestCategory.INTERACTION, false)
+    fun testAnnouncementCreate_missingDescription() {
+        val data = getToAnnouncementList()
+
+        discussionListPage.createAnnouncement("title", "", verify = false)
+        // easier than looking for the "A description is required" toast message
+        discussionListPage.assertOnNewAnnouncementPage()
+    }
+
+    // Tests code around creating an announcement with no title
+    @Test
+    @TestMetaData(Priority.P2, FeatureCategory.ANNOUNCEMENTS, TestCategory.INTERACTION, false)
+    fun testAnnouncementCreate_missingTitle() {
+        val data = getToAnnouncementList()
+
+        discussionListPage.createAnnouncement("", "description")
+    }
+
+
     // Mock a specified number of students and courses, and navigate to the first course
     private fun getToCourse(
             studentCount: Int = 1,
@@ -168,6 +212,36 @@ class AnnouncementInteractionTest : StudentTest() {
         dashboardPage.waitForRender()
 
         dashboardPage.selectCourse(course)
+
+        return data
+    }
+
+    // Mock a student/teacher/course/announcement, than navigate to the announcements list
+    private fun getToAnnouncementList() : MockCanvas {
+        val data = MockCanvas.init(teacherCount = 1, studentCount = 1, courseCount = 1, favoriteCourseCount = 1)
+
+        val teacher = data.teachers[0]
+        val course = data.courses.values.first()
+
+        val announcementsTab = Tab(position = 2, label = "Announcements", visibility = "public", tabId = Tab.ANNOUNCEMENTS_ID)
+        data.courseTabs[course.id]!! += announcementsTab
+
+        data.addCoursePermissions(
+                course.id,
+                CanvasContextPermission(canCreateAnnouncement = true)
+        )
+
+        data.addDiscussionTopicToCourse(
+                course = course,
+                user = teacher,
+                isAnnouncement = true
+        )
+
+        val token = data.tokenFor(teacher)!!
+        tokenLogin(data.domain, token, teacher)
+
+        dashboardPage.selectCourse(course)
+        courseBrowserPage.selectAnnouncements()
 
         return data
     }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/DiscussionsInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/DiscussionsInteractionTest.kt
@@ -21,7 +21,6 @@ import androidx.test.espresso.Espresso
 import androidx.test.espresso.web.webdriver.Locator
 import com.instructure.canvas.espresso.mockCanvas.MockCanvas
 import com.instructure.canvas.espresso.mockCanvas.addAssignment
-import com.instructure.canvas.espresso.mockCanvas.addCoursePermissions
 import com.instructure.canvas.espresso.mockCanvas.addDiscussionTopicToCourse
 import com.instructure.canvas.espresso.mockCanvas.addFileToCourse
 import com.instructure.canvas.espresso.mockCanvas.addReplyToDiscussion
@@ -579,48 +578,6 @@ class DiscussionsInteractionTest : StudentTest() {
 
     }
 
-    // Tests that we can create an announcement (as teacher).
-    @Test
-    @TestMetaData(Priority.P0, FeatureCategory.ANNOUNCEMENTS, TestCategory.INTERACTION, false)
-    fun testAnnouncementCreate_base() {
-        val data = getToAnnouncementList()
-
-        val course = data.courses.values.first()
-        val announcement = data.courseDiscussionTopicHeaders[course.id]!!.first()
-        discussionListPage.assertTopicDisplayed(announcement.title!!)
-        discussionListPage.createAnnouncement("Announcement Topic", "Awesome announcement topic")
-    }
-
-    // Tests code around closing / aborting announcement creation
-    @Test
-    @TestMetaData(Priority.P1, FeatureCategory.ANNOUNCEMENTS, TestCategory.INTERACTION, false)
-    fun testAnnouncementCreate_abort() {
-        val data = getToAnnouncementList()
-
-        discussionListPage.launchCreateAnnouncementThenClose()
-        discussionListPage.verifyExitWithoutSavingDialog()
-    }
-
-    // Tests code around creating an announcement with no description
-    @Test
-    @TestMetaData(Priority.P2, FeatureCategory.ANNOUNCEMENTS, TestCategory.INTERACTION, false)
-    fun testAnnouncementCreate_missingDescription() {
-        val data = getToAnnouncementList()
-
-        discussionListPage.createAnnouncement("title", "", verify = false)
-        // easier than looking for the "A description is required" toast message
-        discussionListPage.assertOnNewAnnouncementPage()
-    }
-
-    // Tests code around creating an announcement with no title
-    @Test
-    @TestMetaData(Priority.P2, FeatureCategory.ANNOUNCEMENTS, TestCategory.INTERACTION, false)
-    fun testAnnouncementCreate_missingTitle() {
-        val data = getToAnnouncementList()
-
-        discussionListPage.createAnnouncement("", "description")
-    }
-
     // Tests a discussion with a linked assignment.
     @Test
     @TestMetaData(Priority.P0, FeatureCategory.DISCUSSIONS, TestCategory.INTERACTION, false)
@@ -689,36 +646,6 @@ class DiscussionsInteractionTest : StudentTest() {
         assertNotNull("Can't find discussionEntry", discussionEntry)
 
         return discussionEntry!!
-    }
-
-    // Mock a student/teacher/course/announcement, than navigate to the announcements list
-    private fun getToAnnouncementList() : MockCanvas {
-        val data = MockCanvas.init(teacherCount = 1, studentCount = 1, courseCount = 1, favoriteCourseCount = 1)
-
-        val teacher = data.teachers[0]
-        val course = data.courses.values.first()
-
-        val announcementsTab = Tab(position = 2, label = "Announcements", visibility = "public", tabId = Tab.ANNOUNCEMENTS_ID)
-        data.courseTabs[course.id]!! += announcementsTab
-
-        data.addCoursePermissions(
-                course.id,
-                CanvasContextPermission(canCreateAnnouncement = true)
-        )
-
-        data.addDiscussionTopicToCourse(
-                course = course,
-                user = teacher,
-                isAnnouncement = true
-        )
-
-        val token = data.tokenFor(teacher)!!
-        tokenLogin(data.domain, token, teacher)
-
-        dashboardPage.selectCourse(course)
-        courseBrowserPage.selectAnnouncements()
-
-        return data
     }
 
     // Mock a specified number of students and courses, and navigate to the first course

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/DiscussionsInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/DiscussionsInteractionTest.kt
@@ -582,33 +582,43 @@ class DiscussionsInteractionTest : StudentTest() {
     // Tests that we can create an announcement (as teacher).
     @Test
     @TestMetaData(Priority.P0, FeatureCategory.ANNOUNCEMENTS, TestCategory.INTERACTION, false)
-    fun testAnnouncement_create() {
-        val data = MockCanvas.init(teacherCount = 1, studentCount = 1, courseCount = 1, favoriteCourseCount = 1)
+    fun testAnnouncementCreate_base() {
+        val data = getToAnnouncementList()
 
-        val teacher = data.teachers[0]
         val course = data.courses.values.first()
-
-        val announcementsTab = Tab(position = 2, label = "Announcements", visibility = "public", tabId = Tab.ANNOUNCEMENTS_ID)
-        data.courseTabs[course.id]!! += announcementsTab
-
-        data.addCoursePermissions(
-                course.id,
-                CanvasContextPermission(canCreateAnnouncement = true)
-        )
-
-        val announcement = data.addDiscussionTopicToCourse(
-                course = course,
-                user = teacher,
-                isAnnouncement = true
-        )
-
-        val token = data.tokenFor(teacher)!!
-        tokenLogin(data.domain, token, teacher)
-
-        dashboardPage.selectCourse(course)
-        courseBrowserPage.selectAnnouncements()
+        val announcement = data.courseDiscussionTopicHeaders[course.id]!!.first()
         discussionListPage.assertTopicDisplayed(announcement.title!!)
         discussionListPage.createAnnouncement("Announcement Topic", "Awesome announcement topic")
+    }
+
+    // Tests code around closing / aborting announcement creation
+    @Test
+    @TestMetaData(Priority.P1, FeatureCategory.ANNOUNCEMENTS, TestCategory.INTERACTION, false)
+    fun testAnnouncementCreate_abort() {
+        val data = getToAnnouncementList()
+
+        discussionListPage.launchCreateAnnouncementThenClose()
+        discussionListPage.verifyExitWithoutSavingDialog()
+    }
+
+    // Tests code around creating an announcement with no description
+    @Test
+    @TestMetaData(Priority.P2, FeatureCategory.ANNOUNCEMENTS, TestCategory.INTERACTION, false)
+    fun testAnnouncementCreate_missingDescription() {
+        val data = getToAnnouncementList()
+
+        discussionListPage.createAnnouncement("title", "", verify = false)
+        // easier than looking for the "A description is required" toast message
+        discussionListPage.assertOnNewAnnouncementPage()
+    }
+
+    // Tests code around creating an announcement with no title
+    @Test
+    @TestMetaData(Priority.P2, FeatureCategory.ANNOUNCEMENTS, TestCategory.INTERACTION, false)
+    fun testAnnouncementCreate_missingTitle() {
+        val data = getToAnnouncementList()
+
+        discussionListPage.createAnnouncement("", "description")
     }
 
     // Tests a discussion with a linked assignment.
@@ -679,6 +689,36 @@ class DiscussionsInteractionTest : StudentTest() {
         assertNotNull("Can't find discussionEntry", discussionEntry)
 
         return discussionEntry!!
+    }
+
+    // Mock a student/teacher/course/announcement, than navigate to the announcements list
+    private fun getToAnnouncementList() : MockCanvas {
+        val data = MockCanvas.init(teacherCount = 1, studentCount = 1, courseCount = 1, favoriteCourseCount = 1)
+
+        val teacher = data.teachers[0]
+        val course = data.courses.values.first()
+
+        val announcementsTab = Tab(position = 2, label = "Announcements", visibility = "public", tabId = Tab.ANNOUNCEMENTS_ID)
+        data.courseTabs[course.id]!! += announcementsTab
+
+        data.addCoursePermissions(
+                course.id,
+                CanvasContextPermission(canCreateAnnouncement = true)
+        )
+
+        data.addDiscussionTopicToCourse(
+                course = course,
+                user = teacher,
+                isAnnouncement = true
+        )
+
+        val token = data.tokenFor(teacher)!!
+        tokenLogin(data.domain, token, teacher)
+
+        dashboardPage.selectCourse(course)
+        courseBrowserPage.selectAnnouncements()
+
+        return data
     }
 
     // Mock a specified number of students and courses, and navigate to the first course

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/ProfileSettingsInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/ProfileSettingsInteractionTest.kt
@@ -1,0 +1,54 @@
+package com.instructure.student.ui.interaction
+
+import androidx.test.espresso.Espresso
+import com.instructure.canvas.espresso.mockCanvas.MockCanvas
+import com.instructure.canvas.espresso.mockCanvas.addUserPermissions
+import com.instructure.canvas.espresso.mockCanvas.init
+import com.instructure.panda_annotations.FeatureCategory
+import com.instructure.panda_annotations.Priority
+import com.instructure.panda_annotations.TestCategory
+import com.instructure.panda_annotations.TestMetaData
+import com.instructure.student.ui.utils.StudentTest
+import com.instructure.student.ui.utils.tokenLogin
+import org.junit.Test
+
+class ProfileSettingsInteractionTest : StudentTest() {
+
+    override fun displaysPageObjects() = Unit // Not used for interaction tests
+
+    @Test
+    @TestMetaData(Priority.P1, FeatureCategory.SETTINGS, TestCategory.INTERACTION)
+    fun testProfileSettings_changeUsername() {
+        val data = MockCanvas.init(studentCount = 1, teacherCount = 1, courseCount = 1, favoriteCourseCount = 1)
+        val student = data.students[0]
+        val newUserName = "New User Name"
+
+        data.addUserPermissions(userId = student.id, canUpdateName = true, canUpdateAvatar = true)
+
+        val token = data.tokenFor(student)!!
+        tokenLogin(data.domain, token, student)
+
+        dashboardPage.launchSettingsPage()
+        settingsPage.launchProfileSettings()
+        profileSettingsPage.changeUserNameTo(newUserName)
+
+        Espresso.pressBack() // to settings page
+        Espresso.pressBack() // to dashboard
+
+        dashboardPage.assertUserLoggedIn(newUserName)
+    }
+
+    @Test
+    @TestMetaData(Priority.P1, FeatureCategory.SETTINGS, TestCategory.INTERACTION)
+    fun testProfileSettings_disabledIfNoPermissions() {
+        val data = MockCanvas.init(studentCount = 1, teacherCount = 1, courseCount = 1, favoriteCourseCount = 1)
+        val student = data.students[0]
+
+        val token = data.tokenFor(student)!!
+        tokenLogin(data.domain, token, student)
+
+        dashboardPage.launchSettingsPage()
+        settingsPage.launchProfileSettings()
+        profileSettingsPage.assertSettingsDisabled() // No permissions granted
+    }
+}

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DashboardPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DashboardPage.kt
@@ -181,6 +181,12 @@ class DashboardPage : BasePage(R.id.dashboardPage) {
         Espresso.pressBack()
     }
 
+    fun assertUserLoggedIn(userName: String) {
+        onView(hamburgerButtonMatcher).click()
+        onViewWithText(userName).assertDisplayed()
+        Espresso.pressBack()
+    }
+
     fun assertUnreadEmails(count: Int) {
         onView(allOf(withParent(R.id.bottomNavigationInbox), withId(R.id.badge), withText(count.toString()))).assertDisplayed()
     }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DiscussionDetailsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DiscussionDetailsPage.kt
@@ -17,21 +17,20 @@
 package com.instructure.student.ui.pages
 
 import android.os.SystemClock.sleep
-import android.util.Log
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.swipeDown
+import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast
 import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.web.assertion.WebViewAssertions
 import androidx.test.espresso.web.assertion.WebViewAssertions.webMatches
 import androidx.test.espresso.web.sugar.Web.onWebView
 import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
 import androidx.test.espresso.web.webdriver.DriverAtoms.getText
 import androidx.test.espresso.web.webdriver.DriverAtoms.webClick
 import androidx.test.espresso.web.webdriver.Locator
+import com.instructure.canvas.espresso.containsTextCaseInsensitive
 import com.instructure.canvas.espresso.isElementDisplayed
-import com.instructure.canvas.espresso.waitForMatcherWithRefreshes
 import com.instructure.canvas.espresso.waitForMatcherWithSleeps
 import com.instructure.canvas.espresso.withCustomConstraints
 import com.instructure.canvas.espresso.withElementRepeat
@@ -293,6 +292,10 @@ class DiscussionDetailsPage : BasePage(R.id.discussionDetailsPage) {
         }
 
         assertTrue("Timed out waiting for unread indicator to disappear", false)
+    }
+
+    fun assertPointsPossibleDisplayed(points: String) {
+        onView(withId(R.id.pointsTextView)).check(matches(containsTextCaseInsensitive(points)))
     }
 
     private fun isUnreadIndicatorVisible(reply: DiscussionEntry) : Boolean {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DiscussionListPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DiscussionListPage.kt
@@ -17,11 +17,16 @@
 package com.instructure.student.ui.pages
 
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.hasSibling
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withParent
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.platform.app.InstrumentationRegistry
 import com.instructure.canvas.espresso.DirectlyPopulateEditText
+import com.instructure.canvas.espresso.containsTextCaseInsensitive
 import com.instructure.canvas.espresso.explicitClick
 import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.canvas.espresso.waitForMatcherWithRefreshes
@@ -101,12 +106,28 @@ class DiscussionListPage : BasePage(R.id.discussionListPage) {
         waitForDiscussionTopicToDisplay(name)
     }
 
-    fun createAnnouncement(name: String, description: String) {
+    fun createAnnouncement(name: String, description: String, verify: Boolean = true) {
         createNewDiscussion.click()
         onView(withId(R.id.announcementNameEditText)).perform(DirectlyPopulateEditText(name))
         onView(withId(R.id.rce_webView)).perform(TypeInRCETextEditor(description))
         onView(withId(R.id.menuSaveAnnouncement)).perform(explicitClick())
-        waitForDiscussionTopicToDisplay(name)
+
+        if(verify) {
+            var expectedTitle = name
+            if (name.isNullOrEmpty()) {
+                expectedTitle = InstrumentationRegistry.getInstrumentation().targetContext.resources.getString(R.string.utils_noTitle)
+            }
+            waitForDiscussionTopicToDisplay(expectedTitle)
+        }
+    }
+
+    fun launchCreateAnnouncementThenClose() {
+        createNewDiscussion.click()
+        onView(withContentDescription("Close")).click()
+    }
+
+    fun verifyExitWithoutSavingDialog() {
+        onView(withText(R.string.exitWithoutSavingMessage)).check(matches(isDisplayed()))
     }
 
     fun pullToUpdate() {
@@ -117,6 +138,10 @@ class DiscussionListPage : BasePage(R.id.discussionListPage) {
 
     fun assertDiscussionCreationDisabled() {
         onView(withId(R.id.createNewDiscussion)).assertNotDisplayed()
+    }
+
+    fun assertOnNewAnnouncementPage() {
+        onView(withText(R.string.newAnnouncement)).assertDisplayed()
     }
 
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DiscussionListPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DiscussionListPage.kt
@@ -101,6 +101,14 @@ class DiscussionListPage : BasePage(R.id.discussionListPage) {
         waitForDiscussionTopicToDisplay(name)
     }
 
+    fun createAnnouncement(name: String, description: String) {
+        createNewDiscussion.click()
+        onView(withId(R.id.announcementNameEditText)).perform(DirectlyPopulateEditText(name))
+        onView(withId(R.id.rce_webView)).perform(TypeInRCETextEditor(description))
+        onView(withId(R.id.menuSaveAnnouncement)).perform(explicitClick())
+        waitForDiscussionTopicToDisplay(name)
+    }
+
     fun pullToUpdate() {
         // I don't think that we need to worry about scrolling to the top first,
         // but we may at some point.

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/ProfileSettingsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/ProfileSettingsPage.kt
@@ -1,0 +1,36 @@
+package com.instructure.student.ui.pages
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.clearText
+import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.isEnabled
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import com.instructure.canvas.espresso.containsTextCaseInsensitive
+import com.instructure.espresso.OnViewWithId
+import com.instructure.espresso.click
+import com.instructure.espresso.page.BasePage
+import com.instructure.student.R
+import org.hamcrest.Matchers.not
+
+class ProfileSettingsPage : BasePage(R.id.profile_settings_fragment) {
+    private val editUsername by OnViewWithId(R.id.editUsername)
+    private val editPhoto by OnViewWithId(R.id.editPhoto)
+    private val createPandaAvatar by OnViewWithId(R.id.createPandaAvatar)
+
+    fun changeUserNameTo(newUserName: String) {
+        editUsername.click()
+
+        onView(withId(R.id.textInput)).perform(clearText())
+        onView(withId(R.id.textInput)).perform(typeText(newUserName))
+
+        onView(containsTextCaseInsensitive("OK")).click()
+    }
+
+    fun assertSettingsDisabled() {
+        editUsername.check(matches(not(isEnabled())))
+        editPhoto.check(matches(not(isEnabled())))
+        createPandaAvatar.check(matches(not(isEnabled())))
+    }
+}

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SettingsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SettingsPage.kt
@@ -54,4 +54,8 @@ class SettingsPage : BasePage(R.id.settingsFragment) {
     fun launchPairObserverPage() {
         pairObserverLabel.scrollTo().click()
     }
+
+    fun launchProfileSettings() {
+        profileSettingLabel.scrollTo().click()
+    }
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTest.kt
@@ -89,6 +89,7 @@ abstract class StudentTest : CanvasTest() {
     val annotationCommentListPage = AnnotationCommentListPage()
     val pickerSubmissionUploadPage = PickerSubmissionUploadPage()
     val remoteConfigSettingsPage = RemoteConfigSettingsPage()
+    val profileSettingsPage = ProfileSettingsPage()
 
     // A no-op interaction to afford us an easy, harmless way to get a11y checking to trigger.
     fun meaninglessSwipe() {

--- a/apps/student/src/main/res/layout/dialog_edit_text.xml
+++ b/apps/student/src/main/res/layout/dialog_edit_text.xml
@@ -19,10 +19,18 @@
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <TextView
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:labelFor="@id/textInput"
+        android:text="@string/enterValue"
+        android:visibility="gone"/>
+
     <androidx.appcompat.widget.AppCompatEditText
         android:id="@+id/textInput"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:minHeight="48dp"
         android:inputType="textCapSentences"
         android:layout_marginStart="?dialogPreferredPadding"
         android:layout_marginEnd="?dialogPreferredPadding"/>

--- a/apps/student/src/main/res/layout/fragment_create_announcement.xml
+++ b/apps/student/src/main/res/layout/fragment_create_announcement.xml
@@ -58,14 +58,19 @@
                 android:id="@+id/announcementNameTextInput"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:labelFor="@+id/announcementNameEditText"
-                android:contentDescription="@string/title"
                 android:layout_marginEnd="6dp"
                 android:layout_marginStart="6dp"
                 android:layout_marginTop="8dp"
                 android:background="@android:color/transparent"
                 android:textColorHint="@color/defaultTextGray"
                 app:hintTextAppearance="@style/TextInputLabel">
+
+                <TextView
+                    android:layout_height="wrap_content"
+                    android:layout_width="wrap_content"
+                    android:text="@string/title"
+                    android:labelFor="@id/announcementNameEditText"
+                    android:visibility="gone"/>
 
                 <androidx.appcompat.widget.AppCompatEditText
                     android:id="@+id/announcementNameEditText"

--- a/apps/student/src/main/res/layout/fragment_create_announcement.xml
+++ b/apps/student/src/main/res/layout/fragment_create_announcement.xml
@@ -130,7 +130,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:minHeight="48dp"
-                    android:maxWidth="48dp"
+                    android:minWidth="48dp"
                     android:layout_alignParentEnd="true"
                     android:layout_centerVertical="true"
                     android:backgroundTint="@color/canvasDefaultPrimary"/>
@@ -165,7 +165,7 @@
                     android:layout_alignParentEnd="true"
                     android:layout_centerVertical="true"
                     android:backgroundTint="@color/canvasDefaultPrimary"
-                    android:maxWidth="48dp"
+                    android:minWidth="48dp"
                     android:minHeight="48dp" />
 
             </RelativeLayout>

--- a/apps/student/src/main/res/layout/fragment_profile_settings.xml
+++ b/apps/student/src/main/res/layout/fragment_profile_settings.xml
@@ -18,6 +18,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/profile_settings_fragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/canvasBackgroundWhite"

--- a/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/MockCanvas.kt
+++ b/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/MockCanvas.kt
@@ -460,6 +460,15 @@ fun MockCanvas.addGradingPeriod(courseId : Long, gradingPeriod: GradingPeriod) {
 /** Adds the provided permissions to the course */
 fun MockCanvas.addCoursePermissions(courseId: Long, permissions: CanvasContextPermission) {
     coursePermissions[courseId] = permissions
+
+    // Let's go ahead and attach these permissions to the course in question
+    val course = courses[courseId]
+    course?.permissions = permissions
+}
+
+fun MockCanvas.addUserPermissions(userId: Long, canUpdateName: Boolean, canUpdateAvatar: Boolean) {
+    val user = users[userId]
+    user?.permissions = CanvasContextPermission(canUpdateAvatar = canUpdateAvatar, canUpdateName = canUpdateName)
 }
 
 /**
@@ -1158,7 +1167,8 @@ fun MockCanvas.addDiscussionTopicToCourse(
         attachment: RemoteFile? = null,
         isAnnouncement: Boolean = false,
         sections: List<Section> = listOf(),
-        groupId: Long? = null
+        groupId: Long? = null,
+        assignment: Assignment? = null
 ) : DiscussionTopicHeader {
 
     var topicHeader = prePopulatedTopicHeader
@@ -1182,6 +1192,8 @@ fun MockCanvas.addDiscussionTopicToCourse(
     }
     topicHeader.announcement = isAnnouncement
     topicHeader.sections = sections
+    topicHeader.assignment = assignment
+    topicHeader.assignmentId = assignment?.id ?: 0L
 
     var topicHeaderList = if(groupId != null) groupDiscussionTopicHeaders[groupId] else courseDiscussionTopicHeaders[course.id]
     if(topicHeaderList == null) {

--- a/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/endpoints/CourseEndpoints.kt
+++ b/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/endpoints/CourseEndpoints.kt
@@ -385,7 +385,8 @@ object CourseDiscussionTopicListEndpoint : Endpoint(
                         topicDescription = newHeader.message!!, // or else it will be defaulted to something random
                         allowRating = data.discussionRatingsEnabled,
                         allowReplies = data.discussionRepliesEnabled,
-                        allowAttachments = data.discussionAttachmentsEnabled
+                        allowAttachments = data.discussionAttachmentsEnabled,
+                        isAnnouncement = newHeader.announcement
                 )
                 Log.d("<--", "new discussion topic request body: $jsonObject")
                 Log.d("<--", "new header: $newHeader")

--- a/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/endpoints/UserEndpoints.kt
+++ b/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/endpoints/UserEndpoints.kt
@@ -63,7 +63,36 @@ object UserEndpoint : Endpoint(
     Segment("folders") to UserFoldersEndpoint,
     Segment("files") to UserFilesEndpoint,
     Segment("todo") to UserTodoEndpoint,
-    Segment("observer_pairing_codes") to UserPairingCodeEndpoint
+    Segment("observer_pairing_codes") to UserPairingCodeEndpoint,
+    response = {
+        GET {
+            val userId = pathVars.userId
+            val user = data.users[userId]
+            if(user != null) {
+                request.successResponse(user)
+            }
+            else {
+                request.unauthorizedResponse()
+            }
+        }
+
+        PUT {
+            val userId = pathVars.userId
+            val user = data.users[userId]
+            val newShortName = request.url().queryParameter("user[short_name]")
+            if(user != null && newShortName != null) {
+                // Replace the user object with a clone that has the new short name
+                val newUser = user.copy(shortName = newShortName)
+                data.users[userId] = newUser
+
+                // And return the altered user
+                request.successResponse(newUser)
+            }
+            else {
+                request.unauthorizedResponse()
+            }
+        }
+    }
 )
 
 /**

--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -140,6 +140,7 @@
     <!-- Content Descriptions -->
     <string name="canvasLogo">Canvas Logo</string>
     <string name="enterURL">Enter your Canvas URL:</string>
+    <string name="enterValue">Enter a value</string>
     <string name="exampleURLSimple">myschool.instructure.com</string>
     <string name="signIntoCanvasNetwork">Trying to sign into Canvas Network?</string>
     <string name="mobileVerifyGeneral">This app is not authorized for use</string>


### PR DESCRIPTION
Worked on tests for announcement creation, discussions linked to assignments and profile settings.

ProfileSettingsFragment: 0% coverage -> 22% coverage
CreateAnnouncementFragment: 0% -> 79%
DIscussionDetailsFragment: 60% -> 70%

Overall coverage: 50.1% to 51.5%. (I'll try to get more bang for the buck in future related PRs.)

refs: MBL-14682
affects: Student
release note: Fixed some minor Student a11y issues