### PR TITLE
[Teacher][MBL-14662] Fix viewing quiz files

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/router/RouteMatcher.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/router/RouteMatcher.kt
@@ -95,6 +95,7 @@ object RouteMatcher : BaseRouteMatcher() {
         // Same as above, but if they access nested user files instead of course files
         routes.add(Route("/files/folder(\\/.*)*", RouteContext.FILE))
         routes.add(Route("/files/:${RouterParams.FILE_ID}", RouteContext.FILE)) // Triggered by new RCE content file links
+        routes.add(Route("/files/:${RouterParams.FILE_ID}/download", RouteContext.FILE))
 
         routes.add(Route(courseOrGroup("/:course_id/files"), FileListFragment::class.java))
 

--- a/apps/teacher/src/main/res/layout/fragment_unsupported_file_type.xml
+++ b/apps/teacher/src/main/res/layout/fragment_unsupported_file_type.xml
@@ -58,6 +58,7 @@
                 android:layout_gravity="center"
                 android:layout_marginTop="24dp"
                 android:focusable="true"
+                android:gravity="center"
                 android:importantForAccessibility="yes"
                 android:textColor="#2D3B45"
                 android:textSize="20sp"

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/loaders/OpenMediaAsyncTaskLoader.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/loaders/OpenMediaAsyncTaskLoader.kt
@@ -271,7 +271,10 @@ class OpenMediaAsyncTaskLoader(context: Context, args: Bundle?) : AsyncTaskLoade
         if (cookie.isValid()) requestBuilder.addHeader("Cookie", cookie)
         val request = requestBuilder.build()
         val response = client.newCall(request).execute()
-        if (!response.isSuccessful) throw IOException("Unable to download. Error code \${response.code()}")
+        if (!response.isSuccessful) {
+            response.body()?.close()
+            throw IOException("Unable to download. Error code ${response.code()}")
+        }
         toWriteTo.parentFile.mkdirs()
         val sink = Okio.buffer(Okio.sink(toWriteTo))
         val source: Source = response.body()!!.source()


### PR DESCRIPTION
SpeedGraderQuizWebViewFragment currently disallows internal routing. In the case of canvas file download links, this causes files to be loaded via the redirect URL which drops important information such as the file name and mime type. The result is that the file may download successfully, but the app does not know how to handle it.

This PR adds a route for context-less file download links (as seen in quiz file submissions), and updates the fragment to allow internal routing for files.

Additional changes:
 - Fixes a resource leak and typo in the media loader
 - Adds authentication to the quiz webview so users don't have to sign in again after switching logins
 - Centers the filename text in ViewUnsupportedFileFragment

refs: MBL-14662
affects: Teacher
release note: Fixed an issue where quiz files could not be viewed