### PR TITLE
[Student][Coverage][MBL-14704] | Beef up UI test code coverage, round 2

### DIFF
--- a/apps/polling/src/main/res/xml/global_tracker.xml
+++ b/apps/polling/src/main/res/xml/global_tracker.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <!-- Enable automatic Activity measurement -->
-    <bool name="ga_autoActivityTracking">true</bool>
-
-    <string name="ga_trackingId">UA-37592364-7</string>
-</resources>

--- a/apps/polling/src/main/res/xml/global_tracker.xml
+++ b/apps/polling/src/main/res/xml/global_tracker.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Enable automatic Activity measurement -->
+    <bool name="ga_autoActivityTracking">true</bool>
+
+    <string name="ga_trackingId">UA-37592364-7</string>
+</resources>

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/InboxInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/InboxInteractionTest.kt
@@ -15,8 +15,9 @@
  */
 package com.instructure.student.ui.interaction
 
+import android.os.SystemClock.sleep
+import androidx.test.espresso.Espresso
 import com.instructure.canvas.espresso.mockCanvas.*
-import com.instructure.canvasapi2.apis.InboxApi
 import com.instructure.canvasapi2.models.*
 import com.instructure.panda_annotations.FeatureCategory
 import com.instructure.panda_annotations.Priority
@@ -29,322 +30,351 @@ import org.junit.Test
 class InboxInteractionTest : StudentTest() {
     override fun displaysPageObjects() = Unit // Not used for interaction tests
 
-    @Test
-    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
-    fun testInbox_createAndSendMessageToIndividual() {
-        // Should be able to create and send a message to an individual recipient
-        val data = goToInbox()
-        dashboardPage.clickInboxTab()
-        val subject = "Hodor"
-        data.addSentConversation(subject, student1.id, messageBody = "Short body")
-        inboxPage.pressNewMessageButton()
-        newMessagePage.selectCourse(course1)
-        newMessagePage.setRecipient(data.teachers.first(), userType = "Teachers")
-        newMessagePage.setSubject(subject)
-        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
-        newMessagePage.hitSend()
-        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
-        inboxPage.assertConversationDisplayed(subject)
-    }
-
-    @Test
-    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
-    fun testInbox_createAndSendMessageToMultiple() {
-        // Should be able to create and send a message to multiple recipients
-        val data = goToInbox(teacherCount = 3)
-        dashboardPage.clickInboxTab()
-        val subject = "Hodor"
-        data.addSentConversation(subject, student1.id, messageBody = "Short body")
-        inboxPage.pressNewMessageButton()
-        newMessagePage.selectCourse(course1)
-        newMessagePage.setRecipients(data.teachers, userType = "Teachers")
-        newMessagePage.setSubject(subject)
-        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
-        newMessagePage.hitSend()
-        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
-        inboxPage.assertConversationDisplayed(subject)
-    }
-
-    @Test
-    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
-    fun testInbox_createAndSendMessageToAllUsers() {
-        // Should be able to create and send a message to all users in a course
-        // Note: There isn't a "single" way to send a message to all users, so I'm just going to select all the
-        // recipient group checkboxes
-        val data = goToInbox()
-        dashboardPage.clickInboxTab()
-        val subject = "Hodor"
-        data.addSentConversation(subject, student1.id, messageBody = "Short body")
-        inboxPage.pressNewMessageButton()
-        newMessagePage.selectCourse(course1)
-        newMessagePage.selectAllRecipients(listOf("Teachers", "Students"))
-        newMessagePage.setSubject(subject)
-        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
-        newMessagePage.hitSend()
-        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
-        inboxPage.assertConversationDisplayed(subject)
-    }
-
-    @Test
-    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
-    fun testInbox_createAndSendMessageToIndividualWithAttachment() {
-        // Should be able to create and send a message, with an attachment, to an individual recipient
-        val data = goToInbox()
-        dashboardPage.clickInboxTab()
-        val subject = "Hodor"
-        val message = "What is this, hodor?"
-        data.addSentConversation(subject, student1.id, messageBody = "Short body")
-        inboxPage.pressNewMessageButton()
-        newMessagePage.selectCourse(course1)
-        newMessagePage.setRecipient(teacher1, userType = "Teachers")
-        newMessagePage.setSubject(subject)
-        newMessagePage.setMessage(message)
-        newMessagePage.hitSend()
-        // Now let's append the attachment after-the-fact, since it is very hard
-        // to manually attach anything via Espresso, since it would require manipulating
-        // system UIs.
-        val attachmentName = "attachment.html"
-        val sentConversation = getFirstConversation(data, true)
-        addAttachmentToConversation(
-            attachmentName,
-            sentConversation,
-            data
-        )
-        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
-        inboxPage.selectConversation(sentConversation)
-        inboxConversationPage.assertAttachmentDisplayed(attachmentName)
-    }
-
-    @Test
-    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
-    fun testInbox_createAndSendMessageToMultipleWithAttachment() {
-        // Should be able to create and send a message, with an attachment, to multiple recipients
-        val data = goToInbox()
-        dashboardPage.clickInboxTab()
-        val subject = "Hodor"
-        data.addSentConversation(subject, student1.id, messageBody = "Short body")
-        inboxPage.pressNewMessageButton()
-        newMessagePage.selectCourse(course1)
-        newMessagePage.setRecipients(data.teachers, userType = "Teachers")
-        newMessagePage.setSubject(subject)
-        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
-        newMessagePage.hitSend()
-        // Now let's append the attachment after-the-fact, since it is very hard
-        // to manually attach anything via Espresso, since it would require manipulating
-        // system UIs.
-        val attachmentName = "attachment.html"
-        val sentConversation = getFirstConversation(data, true)
-        addAttachmentToConversation(
-            attachmentName,
-            sentConversation,
-            data
-        )
-        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
-        inboxPage.selectConversation(sentConversation)
-        inboxConversationPage.assertAttachmentDisplayed(attachmentName)
-    }
-
-    @Test
-    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
-    fun testInbox_createAndSendMessageToAllUsersWithAttachment() {
-        // Should be able to create and send a message, with an attachment, to all users in a course
-        val data = goToInbox()
-        dashboardPage.clickInboxTab()
-        val subject = "Hodor"
-        data.addSentConversation(subject, student1.id, messageBody = "Short body")
-        inboxPage.pressNewMessageButton()
-        newMessagePage.selectCourse(course1)
-        newMessagePage.selectAllRecipients(listOf("Teachers", "Students"))
-        newMessagePage.setSubject(subject)
-        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
-        newMessagePage.hitSend()
-        // Now let's append the attachment after-the-fact, since it is very hard
-        // to manually attach anything via Espresso, since it would require manipulating
-        // system UIs.
-        val attachmentName = "attachment.html"
-        val sentConversation = getFirstConversation(data, true)
-        addAttachmentToConversation(
-            attachmentName,
-            sentConversation,
-            data
-        )
-        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
-        inboxPage.selectConversation(sentConversation)
-        inboxConversationPage.assertAttachmentDisplayed(attachmentName)
-    }
-
-    @Test
-    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
-    fun testInbox_replyToMessage() {
-        // Should be able to reply to a message
-        val data = goToInbox()
-        data.addConversations(userId = student1.id, messageBody = "Short body")
-        dashboardPage.clickInboxTab()
-        inboxPage.selectConversation(getFirstConversation(data))
-        val message = "What is this, hodor?"
-        inboxConversationPage.replyToMessage(message)
-        inboxConversationPage.assertMessageDisplayed(message)
-    }
-
-    @Test
-    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
-    fun testInbox_replyToMessageWithAttachment() {
-        // Should be able to reply (with attachment) to a message
-        val data = goToInbox()
-        data.addConversations(userId = student1.id, messageBody = "Short body")
-        dashboardPage.clickInboxTab()
-        val conversation = getFirstConversation(data)
-        inboxPage.selectConversation(conversation)
-        val message = "What is this, hodor?"
-        inboxConversationPage.replyToMessage(message)
-
-        // Now let's append the attachment after-the-fact, since it is very hard
-        // to manually attach anything via Espresso, since it would require manipulating
-        // system UIs.
-        val attachmentName = "attachment.html"
-        addAttachmentToMessage(attachmentName, conversation.id, message, data)
-        inboxConversationPage.refresh()
-        inboxConversationPage.assertAttachmentDisplayed(attachmentName)
-    }
+//    @Test
+//    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+//    fun testInbox_createAndSendMessageToIndividual() {
+//        // Should be able to create and send a message to an individual recipient
+//        val data = goToInbox()
+//        dashboardPage.clickInboxTab()
+//        val subject = "Hodor"
+//        data.addSentConversation(subject, student1.id, messageBody = "Short body")
+//        inboxPage.pressNewMessageButton()
+//        newMessagePage.selectCourse(course1)
+//        newMessagePage.setRecipient(data.teachers.first(), userType = "Teachers")
+//        newMessagePage.setSubject(subject)
+//        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
+//        newMessagePage.hitSend()
+//        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+//        inboxPage.assertConversationDisplayed(subject)
+//    }
+//
+//    @Test
+//    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+//    fun testInbox_createAndSendMessageToMultiple() {
+//        // Should be able to create and send a message to multiple recipients
+//        val data = goToInbox(teacherCount = 3)
+//        dashboardPage.clickInboxTab()
+//        val subject = "Hodor"
+//        data.addSentConversation(subject, student1.id, messageBody = "Short body")
+//        inboxPage.pressNewMessageButton()
+//        newMessagePage.selectCourse(course1)
+//        newMessagePage.setRecipients(data.teachers, userType = "Teachers")
+//        newMessagePage.setSubject(subject)
+//        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
+//        newMessagePage.hitSend()
+//        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+//        inboxPage.assertConversationDisplayed(subject)
+//    }
+//
+//    @Test
+//    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+//    fun testInbox_createAndSendMessageToAllUsers() {
+//        // Should be able to create and send a message to all users in a course
+//        // Note: There isn't a "single" way to send a message to all users, so I'm just going to select all the
+//        // recipient group checkboxes
+//        val data = goToInbox()
+//        dashboardPage.clickInboxTab()
+//        val subject = "Hodor"
+//        data.addSentConversation(subject, student1.id, messageBody = "Short body")
+//        inboxPage.pressNewMessageButton()
+//        newMessagePage.selectCourse(course1)
+//        newMessagePage.selectAllRecipients(listOf("Teachers", "Students"))
+//        newMessagePage.setSubject(subject)
+//        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
+//        newMessagePage.hitSend()
+//        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+//        inboxPage.assertConversationDisplayed(subject)
+//    }
+//
+//    @Test
+//    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+//    fun testInbox_createAndSendMessageToIndividualWithAttachment() {
+//        // Should be able to create and send a message, with an attachment, to an individual recipient
+//        val data = goToInbox()
+//        dashboardPage.clickInboxTab()
+//        val subject = "Hodor"
+//        val message = "What is this, hodor?"
+//        data.addSentConversation(subject, student1.id, messageBody = "Short body")
+//        inboxPage.pressNewMessageButton()
+//        newMessagePage.selectCourse(course1)
+//        newMessagePage.setRecipient(teacher1, userType = "Teachers")
+//        newMessagePage.setSubject(subject)
+//        newMessagePage.setMessage(message)
+//        newMessagePage.hitSend()
+//        // Now let's append the attachment after-the-fact, since it is very hard
+//        // to manually attach anything via Espresso, since it would require manipulating
+//        // system UIs.
+//        val attachmentName = "attachment.html"
+//        val sentConversation = getFirstConversation(data, true)
+//        addAttachmentToConversation(
+//            attachmentName,
+//            sentConversation,
+//            data
+//        )
+//        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+//        inboxPage.selectConversation(sentConversation)
+//        inboxConversationPage.assertAttachmentDisplayed(attachmentName)
+//    }
+//
+//    @Test
+//    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+//    fun testInbox_createAndSendMessageToMultipleWithAttachment() {
+//        // Should be able to create and send a message, with an attachment, to multiple recipients
+//        val data = goToInbox()
+//        dashboardPage.clickInboxTab()
+//        val subject = "Hodor"
+//        data.addSentConversation(subject, student1.id, messageBody = "Short body")
+//        inboxPage.pressNewMessageButton()
+//        newMessagePage.selectCourse(course1)
+//        newMessagePage.setRecipients(data.teachers, userType = "Teachers")
+//        newMessagePage.setSubject(subject)
+//        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
+//        newMessagePage.hitSend()
+//        // Now let's append the attachment after-the-fact, since it is very hard
+//        // to manually attach anything via Espresso, since it would require manipulating
+//        // system UIs.
+//        val attachmentName = "attachment.html"
+//        val sentConversation = getFirstConversation(data, true)
+//        addAttachmentToConversation(
+//            attachmentName,
+//            sentConversation,
+//            data
+//        )
+//        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+//        inboxPage.selectConversation(sentConversation)
+//        inboxConversationPage.assertAttachmentDisplayed(attachmentName)
+//    }
+//
+//    @Test
+//    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+//    fun testInbox_createAndSendMessageToAllUsersWithAttachment() {
+//        // Should be able to create and send a message, with an attachment, to all users in a course
+//        val data = goToInbox()
+//        dashboardPage.clickInboxTab()
+//        val subject = "Hodor"
+//        data.addSentConversation(subject, student1.id, messageBody = "Short body")
+//        inboxPage.pressNewMessageButton()
+//        newMessagePage.selectCourse(course1)
+//        newMessagePage.selectAllRecipients(listOf("Teachers", "Students"))
+//        newMessagePage.setSubject(subject)
+//        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
+//        newMessagePage.hitSend()
+//        // Now let's append the attachment after-the-fact, since it is very hard
+//        // to manually attach anything via Espresso, since it would require manipulating
+//        // system UIs.
+//        val attachmentName = "attachment.html"
+//        val sentConversation = getFirstConversation(data, true)
+//        addAttachmentToConversation(
+//            attachmentName,
+//            sentConversation,
+//            data
+//        )
+//        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+//        inboxPage.selectConversation(sentConversation)
+//        inboxConversationPage.assertAttachmentDisplayed(attachmentName)
+//    }
+//
+//    @Test
+//    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+//    fun testInbox_replyToMessage() {
+//        // Should be able to reply to a message
+//        val data = goToInbox()
+//        data.addConversations(userId = student1.id, messageBody = "Short body")
+//        dashboardPage.clickInboxTab()
+//        inboxPage.selectConversation(getFirstConversation(data))
+//        val message = "What is this, hodor?"
+//        inboxConversationPage.replyToMessage(message)
+//        inboxConversationPage.assertMessageDisplayed(message)
+//    }
+//
+//    @Test
+//    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+//    fun testInbox_replyToMessageWithAttachment() {
+//        // Should be able to reply (with attachment) to a message
+//        val data = goToInbox()
+//        data.addConversations(userId = student1.id, messageBody = "Short body")
+//        dashboardPage.clickInboxTab()
+//        val conversation = getFirstConversation(data)
+//        inboxPage.selectConversation(conversation)
+//        val message = "What is this, hodor?"
+//        inboxConversationPage.replyToMessage(message)
+//
+//        // Now let's append the attachment after-the-fact, since it is very hard
+//        // to manually attach anything via Espresso, since it would require manipulating
+//        // system UIs.
+//        val attachmentName = "attachment.html"
+//        addAttachmentToMessage(attachmentName, conversation.id, message, data)
+//        inboxConversationPage.refresh()
+//        inboxConversationPage.assertAttachmentDisplayed(attachmentName)
+//    }
+//
+//    @Test
+//    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
+//    fun testInbox_filterMessagesByTypeAll() {
+//        // Should be able to filter messages by All
+//        val data = goToInbox()
+//        data.addConversations(userId = student1.id, messageBody = "Short body")
+//        val conversation = getFirstConversation(data)
+//        dashboardPage.clickInboxTab()
+//        inboxPage.assertConversationDisplayed(conversation.subject!!)
+//    }
+//
+//    @Test
+//    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
+//    fun testInbox_filterMessagesByTypeUnread() {
+//        // Should be able to filter messages by Unread
+//        val data = goToInbox()
+//        data.addConversations(userId = student1.id, messageBody = "Short body")
+//        dashboardPage.clickInboxTab()
+//        val conversation = data.conversations.values.first {
+//            it.workflowState == Conversation.WorkflowState.UNREAD
+//        }
+//        inboxPage.selectInboxScope(InboxApi.Scope.UNREAD)
+//        inboxPage.assertConversationDisplayed(conversation.subject!!)
+//    }
+//
+//    @Test
+//    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
+//    fun testInbox_filterMessagesByTypeStarred() {
+//        // Should be able to filter messages by Starred
+//        val data = goToInbox()
+//        data.addConversations(userId = student1.id, messageBody = "Short body")
+//        dashboardPage.clickInboxTab()
+//        val conversation = data.conversations.values.first {
+//            it.isStarred
+//        }
+//        inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
+//        inboxPage.assertConversationDisplayed(conversation.subject!!)
+//    }
+//
+//    @Test
+//    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
+//    fun testInbox_filterMessagesByTypeSend() {
+//        // Should be able to filter messages by Send
+//        val data = goToInbox()
+//        data.addConversations(userId = student1.id, messageBody = "Short body")
+//        dashboardPage.clickInboxTab()
+//        val conversation = data.conversations.values.first {
+//            it.workflowState == Conversation.WorkflowState.UNREAD
+//        }
+//        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+//        inboxPage.assertConversationDisplayed(conversation.subject!!)
+//    }
+//
+//    @Test
+//    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
+//    fun testInbox_filterMessagesByTypeArchived() {
+//        // Should be able to filter messages by Archived
+//        val data = goToInbox()
+//        data.addConversations(userId = student1.id, messageBody = "Short body")
+//        dashboardPage.clickInboxTab()
+//        val conversation = data.conversations.values.first {
+//            it.workflowState == Conversation.WorkflowState.ARCHIVED
+//        }
+//        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+//        inboxPage.assertConversationDisplayed(conversation.subject!!)
+//    }
+//
+//    @Test
+//    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
+//    fun testInbox_filterMessagesByContext() {
+//        // Should be able to filter messages by course or group
+//        val data = goToInbox(courseCount = 2)
+//        data.addConversationsToCourseMap(student1.id, data.courses.values.toList(), messageBody = "Short body")
+//        val conversation = data.conversationCourseMap[course1.id]!!.first()
+//        dashboardPage.clickInboxTab()
+//        inboxPage.selectInboxFilter(course1)
+//        inboxPage.assertConversationDisplayed(conversation.subject!!)
+//    }
+//
+//    @Test
+//    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
+//    fun testInbox_canComposeAndSendToRoleGroupsIfPermissionEnabled() {
+//        // Can compose and send messages to one or more role groups if "Send messages to the entire class is enabled"
+//        val data = goToInbox(teacherCount = 3)
+//        dashboardPage.clickInboxTab()
+//        val subject = "Hodor"
+//        data.addSentConversation(subject, student1.id, messageBody = "Short body")
+//        inboxPage.pressNewMessageButton()
+//        newMessagePage.selectCourse(course1)
+//        newMessagePage.setRecipientGroup(userType = "Teachers")
+//        newMessagePage.setSubject(subject)
+//        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
+//        newMessagePage.hitSend()
+//        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+//        inboxPage.assertConversationDisplayed(subject)
+//    }
+//
+//    @Test
+//    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
+//    fun testInbox_canNotComposeAndSendToRoleGroupsIfPermissionDisabled() {
+//        // Can NOT compose and send messages to one or more role groups if "Send messages to the entire class is disabled"
+//        val data = goToInbox(sendMessagesAll = false)
+//        dashboardPage.clickInboxTab()
+//        inboxPage.pressNewMessageButton()
+//        newMessagePage.selectCourse(course1)
+//        newMessagePage.assertRecipientGroupsNotDisplayed(userType = "Teachers")
+//    }
+//
+//    @Test
+//    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
+//    fun testInbox_canComposeAndSendToIndividualCourseMembersIfPermissionEnabled() {
+//        // Can compose and send messages to individual course members if "Send messages to individual course members" is enabled
+//        // This test is identical to testInbox_createAndSendMessageToIndividual, not sure if its worth having both
+//        val data = goToInbox()
+//        dashboardPage.clickInboxTab()
+//        val subject = "Hodor"
+//        data.addSentConversation(subject, student1.id, messageBody = "Short body")
+//        inboxPage.pressNewMessageButton()
+//        newMessagePage.selectCourse(course1)
+//        newMessagePage.setRecipient(teacher1, userType = "Teachers")
+//        newMessagePage.setSubject(subject)
+//        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
+//        newMessagePage.hitSend()
+//        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+//        inboxPage.assertConversationDisplayed(subject)
+//    }
+//
+//    @Test
+//    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
+//    fun testInbox_canNotComposeAndSendToIndividualCourseMembersIfPermissionDisabled() {
+//        // Can NOT compose and send messages to individual course members if "Send messages to individual course members" is disabled
+//        // This test is controlled by the api, so while we are utilizing a mocked CanvasContextPermission value, the only
+//        // thing making this test pass or fail is what's implemented in the MockCanvas endpoints.
+//        val data = goToInbox(sendMessages = false, studentCount = 10)
+//        dashboardPage.clickInboxTab()
+//        inboxPage.pressNewMessageButton()
+//        newMessagePage.selectCourse(course1)
+//        newMessagePage.assertRecipientGroupContains("Students", 1)
+//    }
 
     @Test
     @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
-    fun testInbox_filterMessagesByTypeAll() {
-        // Should be able to filter messages by All
-        val data = goToInbox()
-        data.addConversations(userId = student1.id, messageBody = "Short body")
-        val conversation = getFirstConversation(data)
-        dashboardPage.clickInboxTab()
-        inboxPage.assertConversationDisplayed(conversation.subject!!)
-    }
-
-    @Test
-    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
-    fun testInbox_filterMessagesByTypeUnread() {
-        // Should be able to filter messages by Unread
-        val data = goToInbox()
-        data.addConversations(userId = student1.id, messageBody = "Short body")
-        dashboardPage.clickInboxTab()
-        val conversation = data.conversations.values.first {
-            it.workflowState == Conversation.WorkflowState.UNREAD
-        }
-        inboxPage.selectInboxScope(InboxApi.Scope.UNREAD)
-        inboxPage.assertConversationDisplayed(conversation.subject!!)
-    }
-
-    @Test
-    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
-    fun testInbox_filterMessagesByTypeStarred() {
-        // Should be able to filter messages by Starred
-        val data = goToInbox()
-        data.addConversations(userId = student1.id, messageBody = "Short body")
-        dashboardPage.clickInboxTab()
-        val conversation = data.conversations.values.first {
-            it.isStarred
-        }
-        inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
-        inboxPage.assertConversationDisplayed(conversation.subject!!)
-    }
-
-    @Test
-    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
-    fun testInbox_filterMessagesByTypeSend() {
-        // Should be able to filter messages by Send
-        val data = goToInbox()
-        data.addConversations(userId = student1.id, messageBody = "Short body")
-        dashboardPage.clickInboxTab()
-        val conversation = data.conversations.values.first {
-            it.workflowState == Conversation.WorkflowState.UNREAD
-        }
-        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
-        inboxPage.assertConversationDisplayed(conversation.subject!!)
-    }
-
-    @Test
-    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
-    fun testInbox_filterMessagesByTypeArchived() {
-        // Should be able to filter messages by Archived
-        val data = goToInbox()
-        data.addConversations(userId = student1.id, messageBody = "Short body")
-        dashboardPage.clickInboxTab()
-        val conversation = data.conversations.values.first {
-            it.workflowState == Conversation.WorkflowState.ARCHIVED
-        }
-        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
-        inboxPage.assertConversationDisplayed(conversation.subject!!)
-    }
-
-    @Test
-    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
-    fun testInbox_filterMessagesByContext() {
-        // Should be able to filter messages by course or group
-        val data = goToInbox(courseCount = 2)
-        data.addConversationsToCourseMap(student1.id, data.courses.values.toList(), messageBody = "Short body")
-        val conversation = data.conversationCourseMap[course1.id]!!.first()
-        dashboardPage.clickInboxTab()
-        inboxPage.selectInboxFilter(course1)
-        inboxPage.assertConversationDisplayed(conversation.subject!!)
-    }
-
-    @Test
-    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
-    fun testInbox_canComposeAndSendToRoleGroupsIfPermissionEnabled() {
-        // Can compose and send messages to one or more role groups if "Send messages to the entire class is enabled"
-        val data = goToInbox(teacherCount = 3)
-        dashboardPage.clickInboxTab()
-        val subject = "Hodor"
-        data.addSentConversation(subject, student1.id, messageBody = "Short body")
-        inboxPage.pressNewMessageButton()
-        newMessagePage.selectCourse(course1)
-        newMessagePage.setRecipientGroup(userType = "Teachers")
-        newMessagePage.setSubject(subject)
-        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
-        newMessagePage.hitSend()
-        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
-        inboxPage.assertConversationDisplayed(subject)
-    }
-
-    @Test
-    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
-    fun testInbox_canNotComposeAndSendToRoleGroupsIfPermissionDisabled() {
-        // Can NOT compose and send messages to one or more role groups if "Send messages to the entire class is disabled"
-        val data = goToInbox(sendMessagesAll = false)
-        dashboardPage.clickInboxTab()
-        inboxPage.pressNewMessageButton()
-        newMessagePage.selectCourse(course1)
-        newMessagePage.assertRecipientGroupsNotDisplayed(userType = "Teachers")
-    }
-
-    @Test
-    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
-    fun testInbox_canComposeAndSendToIndividualCourseMembersIfPermissionEnabled() {
-        // Can compose and send messages to individual course members if "Send messages to individual course members" is enabled
-        // This test is identical to testInbox_createAndSendMessageToIndividual, not sure if its worth having both
-        val data = goToInbox()
-        dashboardPage.clickInboxTab()
-        val subject = "Hodor"
-        data.addSentConversation(subject, student1.id, messageBody = "Short body")
-        inboxPage.pressNewMessageButton()
-        newMessagePage.selectCourse(course1)
-        newMessagePage.setRecipient(teacher1, userType = "Teachers")
-        newMessagePage.setSubject(subject)
-        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
-        newMessagePage.hitSend()
-        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
-        inboxPage.assertConversationDisplayed(subject)
-    }
-
-    @Test
-    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
-    fun testInbox_canNotComposeAndSendToIndividualCourseMembersIfPermissionDisabled() {
+    fun testInbox_replyAll() {
         // Can NOT compose and send messages to individual course members if "Send messages to individual course members" is disabled
         // This test is controlled by the api, so while we are utilizing a mocked CanvasContextPermission value, the only
         // thing making this test pass or fail is what's implemented in the MockCanvas endpoints.
-        val data = goToInbox(sendMessages = false, studentCount = 10)
+        val data = goToInbox(studentCount = 3, teacherCount = 1)
+        val conversationSubject = "Reply All Message Subject"
+        val conversationMessageBody = "Reply All Message Body"
+        val replyAllReply = "Reply All Reply"
+        val conversation = data.addConversation(
+                senderId = data.students[2].id,
+                receiverIds = data.students.take(2).map {user -> user.id},
+                messageBody = conversationMessageBody,
+                messageSubject = conversationSubject
+        )
+
         dashboardPage.clickInboxTab()
-        inboxPage.pressNewMessageButton()
-        newMessagePage.selectCourse(course1)
-        newMessagePage.assertRecipientGroupContains("Students", 1)
+        inboxPage.assertConversationDisplayed(conversationSubject)
+        inboxPage.selectConversation(conversation)
+        inboxConversationPage.assertMessageDisplayed(conversationMessageBody)
+        inboxConversationPage.replyAllToMessage(replyAllReply, 2)
+        Espresso.pressBack() // To main inbox page
+        inboxPage.assertMessageBodyDisplayed(replyAllReply)
+
+        sleep(5000)
+
     }
 
     /*
@@ -418,7 +448,8 @@ class InboxInteractionTest : StudentTest() {
         teacherCount: Int = 1,
         courseCount: Int = 1,
         sendMessages: Boolean = true,
-        sendMessagesAll: Boolean = true
+        sendMessagesAll: Boolean = true,
+        seedMessagesFromOtherStudents: Boolean = false
     ): MockCanvas {
         val data = MockCanvas.init(
             studentCount = studentCount,

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/InboxInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/InboxInteractionTest.kt
@@ -553,8 +553,7 @@ class InboxInteractionTest : StudentTest() {
         teacherCount: Int = 1,
         courseCount: Int = 1,
         sendMessages: Boolean = true,
-        sendMessagesAll: Boolean = true,
-        seedMessagesFromOtherStudents: Boolean = false
+        sendMessagesAll: Boolean = true
     ): MockCanvas {
         val data = MockCanvas.init(
             studentCount = studentCount,

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/InboxInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/InboxInteractionTest.kt
@@ -15,9 +15,10 @@
  */
 package com.instructure.student.ui.interaction
 
-import android.os.SystemClock.sleep
 import androidx.test.espresso.Espresso
+import androidx.test.espresso.matcher.ViewMatchers
 import com.instructure.canvas.espresso.mockCanvas.*
+import com.instructure.canvasapi2.apis.InboxApi
 import com.instructure.canvasapi2.models.*
 import com.instructure.panda_annotations.FeatureCategory
 import com.instructure.panda_annotations.Priority
@@ -348,16 +349,82 @@ class InboxInteractionTest : StudentTest() {
 //        newMessagePage.assertRecipientGroupContains("Students", 1)
 //    }
 
+//    @Test
+//    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+//    fun testInbox_replyAll() {
+//        val data = goToInbox(studentCount = 3, teacherCount = 1)
+//        val conversationSubject = "Reply All Message Subject"
+//        val conversationMessageBody = "Reply All Message Body"
+//        val replyAllReply = "Reply All Reply"
+//        val conversation = data.addConversation(
+//                senderId = data.students[2].id,
+//                receiverIds = data.students.take(2).map {user -> user.id},
+//                messageBody = conversationMessageBody,
+//                messageSubject = conversationSubject
+//        )
+//
+//        dashboardPage.clickInboxTab()
+//        inboxPage.assertConversationDisplayed(conversationSubject)
+//        inboxPage.selectConversation(conversation)
+//        inboxConversationPage.assertMessageDisplayed(conversationMessageBody)
+//        inboxConversationPage.replyAllToMessage(replyAllReply, 2)
+//        Espresso.pressBack() // To main inbox page
+//        inboxPage.assertMessageBodyDisplayed(replyAllReply)
+//    }
+//
+//    @Test
+//    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+//    fun testInbox_toggleStarred() {
+//        val data = goToInbox(studentCount = 3, teacherCount = 1)
+//        val conversationSubject = "Toggle Starred Message Subject"
+//        val conversationMessageBody = "Toggle Starred Message Body"
+//        val conversation = data.addConversation(
+//                senderId = data.students[2].id,
+//                receiverIds = data.students.take(2).map {user -> user.id},
+//                messageBody = conversationMessageBody,
+//                messageSubject = conversationSubject
+//        )
+//
+//        dashboardPage.clickInboxTab()
+//        inboxPage.assertConversationDisplayed(conversationSubject)
+//        inboxPage.selectConversation(conversation)
+//        inboxConversationPage.assertNotStarred()
+//        inboxConversationPage.toggleStarred()
+//        inboxConversationPage.assertStarred()
+//        Espresso.pressBack() // To main inbox page
+//        inboxPage.assertConversationStarred(conversation)
+//    }
+
     @Test
-    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
-    fun testInbox_replyAll() {
-        // Can NOT compose and send messages to individual course members if "Send messages to individual course members" is disabled
-        // This test is controlled by the api, so while we are utilizing a mocked CanvasContextPermission value, the only
-        // thing making this test pass or fail is what's implemented in the MockCanvas endpoints.
+    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_markUnread() {
         val data = goToInbox(studentCount = 3, teacherCount = 1)
-        val conversationSubject = "Reply All Message Subject"
-        val conversationMessageBody = "Reply All Message Body"
-        val replyAllReply = "Reply All Reply"
+        val conversationSubject = "Mark Unread Message Subject"
+        val conversationMessageBody = "Mark Unread Message Body"
+        val conversation = data.addConversation(
+                senderId = data.students[2].id,
+                receiverIds = data.students.take(2).map {user -> user.id},
+                messageBody = conversationMessageBody,
+                messageSubject = conversationSubject
+        )
+
+        dashboardPage.clickInboxTab()
+        inboxPage.assertConversationDisplayed(conversationSubject)
+        inboxPage.assertUnreadMarkerVisibility(conversation, ViewMatchers.Visibility.VISIBLE)
+        inboxPage.selectConversation(conversation)
+        Espresso.pressBack()
+        inboxPage.assertUnreadMarkerVisibility(conversation, ViewMatchers.Visibility.GONE)
+        inboxPage.selectConversation(conversation)
+        inboxConversationPage.markUnread() // Should kick us back to the main inbox page
+        inboxPage.assertUnreadMarkerVisibility(conversation, ViewMatchers.Visibility.VISIBLE)
+    }
+
+    @Test
+    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_archive() {
+        val data = goToInbox(studentCount = 3, teacherCount = 1)
+        val conversationSubject = "Archive Message Subject"
+        val conversationMessageBody = "Archive Message Body"
         val conversation = data.addConversation(
                 senderId = data.students[2].id,
                 receiverIds = data.students.take(2).map {user -> user.id},
@@ -368,13 +435,9 @@ class InboxInteractionTest : StudentTest() {
         dashboardPage.clickInboxTab()
         inboxPage.assertConversationDisplayed(conversationSubject)
         inboxPage.selectConversation(conversation)
-        inboxConversationPage.assertMessageDisplayed(conversationMessageBody)
-        inboxConversationPage.replyAllToMessage(replyAllReply, 2)
-        Espresso.pressBack() // To main inbox page
-        inboxPage.assertMessageBodyDisplayed(replyAllReply)
-
-        sleep(5000)
-
+        inboxConversationPage.archive() // Should kick you back to the main inbox page
+        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.assertConversationDisplayed(conversationSubject)
     }
 
     /*

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/InboxInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/InboxInteractionTest.kt
@@ -31,369 +31,369 @@ import org.junit.Test
 class InboxInteractionTest : StudentTest() {
     override fun displaysPageObjects() = Unit // Not used for interaction tests
 
-//    @Test
-//    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
-//    fun testInbox_createAndSendMessageToIndividual() {
-//        // Should be able to create and send a message to an individual recipient
-//        val data = goToInbox()
-//        dashboardPage.clickInboxTab()
-//        val subject = "Hodor"
-//        data.addSentConversation(subject, student1.id, messageBody = "Short body")
-//        inboxPage.pressNewMessageButton()
-//        newMessagePage.selectCourse(course1)
-//        newMessagePage.setRecipient(data.teachers.first(), userType = "Teachers")
-//        newMessagePage.setSubject(subject)
-//        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
-//        newMessagePage.hitSend()
-//        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
-//        inboxPage.assertConversationDisplayed(subject)
-//    }
-//
-//    @Test
-//    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
-//    fun testInbox_createAndSendMessageToMultiple() {
-//        // Should be able to create and send a message to multiple recipients
-//        val data = goToInbox(teacherCount = 3)
-//        dashboardPage.clickInboxTab()
-//        val subject = "Hodor"
-//        data.addSentConversation(subject, student1.id, messageBody = "Short body")
-//        inboxPage.pressNewMessageButton()
-//        newMessagePage.selectCourse(course1)
-//        newMessagePage.setRecipients(data.teachers, userType = "Teachers")
-//        newMessagePage.setSubject(subject)
-//        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
-//        newMessagePage.hitSend()
-//        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
-//        inboxPage.assertConversationDisplayed(subject)
-//    }
-//
-//    @Test
-//    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
-//    fun testInbox_createAndSendMessageToAllUsers() {
-//        // Should be able to create and send a message to all users in a course
-//        // Note: There isn't a "single" way to send a message to all users, so I'm just going to select all the
-//        // recipient group checkboxes
-//        val data = goToInbox()
-//        dashboardPage.clickInboxTab()
-//        val subject = "Hodor"
-//        data.addSentConversation(subject, student1.id, messageBody = "Short body")
-//        inboxPage.pressNewMessageButton()
-//        newMessagePage.selectCourse(course1)
-//        newMessagePage.selectAllRecipients(listOf("Teachers", "Students"))
-//        newMessagePage.setSubject(subject)
-//        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
-//        newMessagePage.hitSend()
-//        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
-//        inboxPage.assertConversationDisplayed(subject)
-//    }
-//
-//    @Test
-//    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
-//    fun testInbox_createAndSendMessageToIndividualWithAttachment() {
-//        // Should be able to create and send a message, with an attachment, to an individual recipient
-//        val data = goToInbox()
-//        dashboardPage.clickInboxTab()
-//        val subject = "Hodor"
-//        val message = "What is this, hodor?"
-//        data.addSentConversation(subject, student1.id, messageBody = "Short body")
-//        inboxPage.pressNewMessageButton()
-//        newMessagePage.selectCourse(course1)
-//        newMessagePage.setRecipient(teacher1, userType = "Teachers")
-//        newMessagePage.setSubject(subject)
-//        newMessagePage.setMessage(message)
-//        newMessagePage.hitSend()
-//        // Now let's append the attachment after-the-fact, since it is very hard
-//        // to manually attach anything via Espresso, since it would require manipulating
-//        // system UIs.
-//        val attachmentName = "attachment.html"
-//        val sentConversation = getFirstConversation(data, true)
-//        addAttachmentToConversation(
-//            attachmentName,
-//            sentConversation,
-//            data
-//        )
-//        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
-//        inboxPage.selectConversation(sentConversation)
-//        inboxConversationPage.assertAttachmentDisplayed(attachmentName)
-//    }
-//
-//    @Test
-//    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
-//    fun testInbox_createAndSendMessageToMultipleWithAttachment() {
-//        // Should be able to create and send a message, with an attachment, to multiple recipients
-//        val data = goToInbox()
-//        dashboardPage.clickInboxTab()
-//        val subject = "Hodor"
-//        data.addSentConversation(subject, student1.id, messageBody = "Short body")
-//        inboxPage.pressNewMessageButton()
-//        newMessagePage.selectCourse(course1)
-//        newMessagePage.setRecipients(data.teachers, userType = "Teachers")
-//        newMessagePage.setSubject(subject)
-//        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
-//        newMessagePage.hitSend()
-//        // Now let's append the attachment after-the-fact, since it is very hard
-//        // to manually attach anything via Espresso, since it would require manipulating
-//        // system UIs.
-//        val attachmentName = "attachment.html"
-//        val sentConversation = getFirstConversation(data, true)
-//        addAttachmentToConversation(
-//            attachmentName,
-//            sentConversation,
-//            data
-//        )
-//        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
-//        inboxPage.selectConversation(sentConversation)
-//        inboxConversationPage.assertAttachmentDisplayed(attachmentName)
-//    }
-//
-//    @Test
-//    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
-//    fun testInbox_createAndSendMessageToAllUsersWithAttachment() {
-//        // Should be able to create and send a message, with an attachment, to all users in a course
-//        val data = goToInbox()
-//        dashboardPage.clickInboxTab()
-//        val subject = "Hodor"
-//        data.addSentConversation(subject, student1.id, messageBody = "Short body")
-//        inboxPage.pressNewMessageButton()
-//        newMessagePage.selectCourse(course1)
-//        newMessagePage.selectAllRecipients(listOf("Teachers", "Students"))
-//        newMessagePage.setSubject(subject)
-//        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
-//        newMessagePage.hitSend()
-//        // Now let's append the attachment after-the-fact, since it is very hard
-//        // to manually attach anything via Espresso, since it would require manipulating
-//        // system UIs.
-//        val attachmentName = "attachment.html"
-//        val sentConversation = getFirstConversation(data, true)
-//        addAttachmentToConversation(
-//            attachmentName,
-//            sentConversation,
-//            data
-//        )
-//        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
-//        inboxPage.selectConversation(sentConversation)
-//        inboxConversationPage.assertAttachmentDisplayed(attachmentName)
-//    }
-//
-//    @Test
-//    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
-//    fun testInbox_replyToMessage() {
-//        // Should be able to reply to a message
-//        val data = goToInbox()
-//        data.addConversations(userId = student1.id, messageBody = "Short body")
-//        dashboardPage.clickInboxTab()
-//        inboxPage.selectConversation(getFirstConversation(data))
-//        val message = "What is this, hodor?"
-//        inboxConversationPage.replyToMessage(message)
-//        inboxConversationPage.assertMessageDisplayed(message)
-//    }
-//
-//    @Test
-//    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
-//    fun testInbox_replyToMessageWithAttachment() {
-//        // Should be able to reply (with attachment) to a message
-//        val data = goToInbox()
-//        data.addConversations(userId = student1.id, messageBody = "Short body")
-//        dashboardPage.clickInboxTab()
-//        val conversation = getFirstConversation(data)
-//        inboxPage.selectConversation(conversation)
-//        val message = "What is this, hodor?"
-//        inboxConversationPage.replyToMessage(message)
-//
-//        // Now let's append the attachment after-the-fact, since it is very hard
-//        // to manually attach anything via Espresso, since it would require manipulating
-//        // system UIs.
-//        val attachmentName = "attachment.html"
-//        addAttachmentToMessage(attachmentName, conversation.id, message, data)
-//        inboxConversationPage.refresh()
-//        inboxConversationPage.assertAttachmentDisplayed(attachmentName)
-//    }
-//
-//    @Test
-//    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
-//    fun testInbox_filterMessagesByTypeAll() {
-//        // Should be able to filter messages by All
-//        val data = goToInbox()
-//        data.addConversations(userId = student1.id, messageBody = "Short body")
-//        val conversation = getFirstConversation(data)
-//        dashboardPage.clickInboxTab()
-//        inboxPage.assertConversationDisplayed(conversation.subject!!)
-//    }
-//
-//    @Test
-//    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
-//    fun testInbox_filterMessagesByTypeUnread() {
-//        // Should be able to filter messages by Unread
-//        val data = goToInbox()
-//        data.addConversations(userId = student1.id, messageBody = "Short body")
-//        dashboardPage.clickInboxTab()
-//        val conversation = data.conversations.values.first {
-//            it.workflowState == Conversation.WorkflowState.UNREAD
-//        }
-//        inboxPage.selectInboxScope(InboxApi.Scope.UNREAD)
-//        inboxPage.assertConversationDisplayed(conversation.subject!!)
-//    }
-//
-//    @Test
-//    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
-//    fun testInbox_filterMessagesByTypeStarred() {
-//        // Should be able to filter messages by Starred
-//        val data = goToInbox()
-//        data.addConversations(userId = student1.id, messageBody = "Short body")
-//        dashboardPage.clickInboxTab()
-//        val conversation = data.conversations.values.first {
-//            it.isStarred
-//        }
-//        inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
-//        inboxPage.assertConversationDisplayed(conversation.subject!!)
-//    }
-//
-//    @Test
-//    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
-//    fun testInbox_filterMessagesByTypeSend() {
-//        // Should be able to filter messages by Send
-//        val data = goToInbox()
-//        data.addConversations(userId = student1.id, messageBody = "Short body")
-//        dashboardPage.clickInboxTab()
-//        val conversation = data.conversations.values.first {
-//            it.workflowState == Conversation.WorkflowState.UNREAD
-//        }
-//        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
-//        inboxPage.assertConversationDisplayed(conversation.subject!!)
-//    }
-//
-//    @Test
-//    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
-//    fun testInbox_filterMessagesByTypeArchived() {
-//        // Should be able to filter messages by Archived
-//        val data = goToInbox()
-//        data.addConversations(userId = student1.id, messageBody = "Short body")
-//        dashboardPage.clickInboxTab()
-//        val conversation = data.conversations.values.first {
-//            it.workflowState == Conversation.WorkflowState.ARCHIVED
-//        }
-//        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
-//        inboxPage.assertConversationDisplayed(conversation.subject!!)
-//    }
-//
-//    @Test
-//    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
-//    fun testInbox_filterMessagesByContext() {
-//        // Should be able to filter messages by course or group
-//        val data = goToInbox(courseCount = 2)
-//        data.addConversationsToCourseMap(student1.id, data.courses.values.toList(), messageBody = "Short body")
-//        val conversation = data.conversationCourseMap[course1.id]!!.first()
-//        dashboardPage.clickInboxTab()
-//        inboxPage.selectInboxFilter(course1)
-//        inboxPage.assertConversationDisplayed(conversation.subject!!)
-//    }
-//
-//    @Test
-//    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
-//    fun testInbox_canComposeAndSendToRoleGroupsIfPermissionEnabled() {
-//        // Can compose and send messages to one or more role groups if "Send messages to the entire class is enabled"
-//        val data = goToInbox(teacherCount = 3)
-//        dashboardPage.clickInboxTab()
-//        val subject = "Hodor"
-//        data.addSentConversation(subject, student1.id, messageBody = "Short body")
-//        inboxPage.pressNewMessageButton()
-//        newMessagePage.selectCourse(course1)
-//        newMessagePage.setRecipientGroup(userType = "Teachers")
-//        newMessagePage.setSubject(subject)
-//        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
-//        newMessagePage.hitSend()
-//        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
-//        inboxPage.assertConversationDisplayed(subject)
-//    }
-//
-//    @Test
-//    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
-//    fun testInbox_canNotComposeAndSendToRoleGroupsIfPermissionDisabled() {
-//        // Can NOT compose and send messages to one or more role groups if "Send messages to the entire class is disabled"
-//        val data = goToInbox(sendMessagesAll = false)
-//        dashboardPage.clickInboxTab()
-//        inboxPage.pressNewMessageButton()
-//        newMessagePage.selectCourse(course1)
-//        newMessagePage.assertRecipientGroupsNotDisplayed(userType = "Teachers")
-//    }
-//
-//    @Test
-//    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
-//    fun testInbox_canComposeAndSendToIndividualCourseMembersIfPermissionEnabled() {
-//        // Can compose and send messages to individual course members if "Send messages to individual course members" is enabled
-//        // This test is identical to testInbox_createAndSendMessageToIndividual, not sure if its worth having both
-//        val data = goToInbox()
-//        dashboardPage.clickInboxTab()
-//        val subject = "Hodor"
-//        data.addSentConversation(subject, student1.id, messageBody = "Short body")
-//        inboxPage.pressNewMessageButton()
-//        newMessagePage.selectCourse(course1)
-//        newMessagePage.setRecipient(teacher1, userType = "Teachers")
-//        newMessagePage.setSubject(subject)
-//        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
-//        newMessagePage.hitSend()
-//        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
-//        inboxPage.assertConversationDisplayed(subject)
-//    }
-//
-//    @Test
-//    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
-//    fun testInbox_canNotComposeAndSendToIndividualCourseMembersIfPermissionDisabled() {
-//        // Can NOT compose and send messages to individual course members if "Send messages to individual course members" is disabled
-//        // This test is controlled by the api, so while we are utilizing a mocked CanvasContextPermission value, the only
-//        // thing making this test pass or fail is what's implemented in the MockCanvas endpoints.
-//        val data = goToInbox(sendMessages = false, studentCount = 10)
-//        dashboardPage.clickInboxTab()
-//        inboxPage.pressNewMessageButton()
-//        newMessagePage.selectCourse(course1)
-//        newMessagePage.assertRecipientGroupContains("Students", 1)
-//    }
+    @Test
+    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_createAndSendMessageToIndividual() {
+        // Should be able to create and send a message to an individual recipient
+        val data = goToInbox()
+        dashboardPage.clickInboxTab()
+        val subject = "Hodor"
+        data.addSentConversation(subject, student1.id, messageBody = "Short body")
+        inboxPage.pressNewMessageButton()
+        newMessagePage.selectCourse(course1)
+        newMessagePage.setRecipient(data.teachers.first(), userType = "Teachers")
+        newMessagePage.setSubject(subject)
+        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
+        newMessagePage.hitSend()
+        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+        inboxPage.assertConversationDisplayed(subject)
+    }
 
-//    @Test
-//    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
-//    fun testInbox_replyAll() {
-//        val data = goToInbox(studentCount = 3, teacherCount = 1)
-//        val conversationSubject = "Reply All Message Subject"
-//        val conversationMessageBody = "Reply All Message Body"
-//        val replyAllReply = "Reply All Reply"
-//        val conversation = data.addConversation(
-//                senderId = data.students[2].id,
-//                receiverIds = data.students.take(2).map {user -> user.id},
-//                messageBody = conversationMessageBody,
-//                messageSubject = conversationSubject
-//        )
-//
-//        dashboardPage.clickInboxTab()
-//        inboxPage.assertConversationDisplayed(conversationSubject)
-//        inboxPage.selectConversation(conversation)
-//        inboxConversationPage.assertMessageDisplayed(conversationMessageBody)
-//        inboxConversationPage.replyAllToMessage(replyAllReply, 2)
-//        Espresso.pressBack() // To main inbox page
-//        inboxPage.assertMessageBodyDisplayed(replyAllReply)
-//    }
-//
-//    @Test
-//    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
-//    fun testInbox_toggleStarred() {
-//        val data = goToInbox(studentCount = 3, teacherCount = 1)
-//        val conversationSubject = "Toggle Starred Message Subject"
-//        val conversationMessageBody = "Toggle Starred Message Body"
-//        val conversation = data.addConversation(
-//                senderId = data.students[2].id,
-//                receiverIds = data.students.take(2).map {user -> user.id},
-//                messageBody = conversationMessageBody,
-//                messageSubject = conversationSubject
-//        )
-//
-//        dashboardPage.clickInboxTab()
-//        inboxPage.assertConversationDisplayed(conversationSubject)
-//        inboxPage.selectConversation(conversation)
-//        inboxConversationPage.assertNotStarred()
-//        inboxConversationPage.toggleStarred()
-//        inboxConversationPage.assertStarred()
-//        Espresso.pressBack() // To main inbox page
-//        inboxPage.assertConversationStarred(conversation)
-//    }
+    @Test
+    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_createAndSendMessageToMultiple() {
+        // Should be able to create and send a message to multiple recipients
+        val data = goToInbox(teacherCount = 3)
+        dashboardPage.clickInboxTab()
+        val subject = "Hodor"
+        data.addSentConversation(subject, student1.id, messageBody = "Short body")
+        inboxPage.pressNewMessageButton()
+        newMessagePage.selectCourse(course1)
+        newMessagePage.setRecipients(data.teachers, userType = "Teachers")
+        newMessagePage.setSubject(subject)
+        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
+        newMessagePage.hitSend()
+        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+        inboxPage.assertConversationDisplayed(subject)
+    }
+
+    @Test
+    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_createAndSendMessageToAllUsers() {
+        // Should be able to create and send a message to all users in a course
+        // Note: There isn't a "single" way to send a message to all users, so I'm just going to select all the
+        // recipient group checkboxes
+        val data = goToInbox()
+        dashboardPage.clickInboxTab()
+        val subject = "Hodor"
+        data.addSentConversation(subject, student1.id, messageBody = "Short body")
+        inboxPage.pressNewMessageButton()
+        newMessagePage.selectCourse(course1)
+        newMessagePage.selectAllRecipients(listOf("Teachers", "Students"))
+        newMessagePage.setSubject(subject)
+        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
+        newMessagePage.hitSend()
+        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+        inboxPage.assertConversationDisplayed(subject)
+    }
+
+    @Test
+    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_createAndSendMessageToIndividualWithAttachment() {
+        // Should be able to create and send a message, with an attachment, to an individual recipient
+        val data = goToInbox()
+        dashboardPage.clickInboxTab()
+        val subject = "Hodor"
+        val message = "What is this, hodor?"
+        data.addSentConversation(subject, student1.id, messageBody = "Short body")
+        inboxPage.pressNewMessageButton()
+        newMessagePage.selectCourse(course1)
+        newMessagePage.setRecipient(teacher1, userType = "Teachers")
+        newMessagePage.setSubject(subject)
+        newMessagePage.setMessage(message)
+        newMessagePage.hitSend()
+        // Now let's append the attachment after-the-fact, since it is very hard
+        // to manually attach anything via Espresso, since it would require manipulating
+        // system UIs.
+        val attachmentName = "attachment.html"
+        val sentConversation = getFirstConversation(data, true)
+        addAttachmentToConversation(
+            attachmentName,
+            sentConversation,
+            data
+        )
+        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+        inboxPage.selectConversation(sentConversation)
+        inboxConversationPage.assertAttachmentDisplayed(attachmentName)
+    }
+
+    @Test
+    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_createAndSendMessageToMultipleWithAttachment() {
+        // Should be able to create and send a message, with an attachment, to multiple recipients
+        val data = goToInbox()
+        dashboardPage.clickInboxTab()
+        val subject = "Hodor"
+        data.addSentConversation(subject, student1.id, messageBody = "Short body")
+        inboxPage.pressNewMessageButton()
+        newMessagePage.selectCourse(course1)
+        newMessagePage.setRecipients(data.teachers, userType = "Teachers")
+        newMessagePage.setSubject(subject)
+        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
+        newMessagePage.hitSend()
+        // Now let's append the attachment after-the-fact, since it is very hard
+        // to manually attach anything via Espresso, since it would require manipulating
+        // system UIs.
+        val attachmentName = "attachment.html"
+        val sentConversation = getFirstConversation(data, true)
+        addAttachmentToConversation(
+            attachmentName,
+            sentConversation,
+            data
+        )
+        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+        inboxPage.selectConversation(sentConversation)
+        inboxConversationPage.assertAttachmentDisplayed(attachmentName)
+    }
+
+    @Test
+    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_createAndSendMessageToAllUsersWithAttachment() {
+        // Should be able to create and send a message, with an attachment, to all users in a course
+        val data = goToInbox()
+        dashboardPage.clickInboxTab()
+        val subject = "Hodor"
+        data.addSentConversation(subject, student1.id, messageBody = "Short body")
+        inboxPage.pressNewMessageButton()
+        newMessagePage.selectCourse(course1)
+        newMessagePage.selectAllRecipients(listOf("Teachers", "Students"))
+        newMessagePage.setSubject(subject)
+        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
+        newMessagePage.hitSend()
+        // Now let's append the attachment after-the-fact, since it is very hard
+        // to manually attach anything via Espresso, since it would require manipulating
+        // system UIs.
+        val attachmentName = "attachment.html"
+        val sentConversation = getFirstConversation(data, true)
+        addAttachmentToConversation(
+            attachmentName,
+            sentConversation,
+            data
+        )
+        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+        inboxPage.selectConversation(sentConversation)
+        inboxConversationPage.assertAttachmentDisplayed(attachmentName)
+    }
+
+    @Test
+    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_replyToMessage() {
+        // Should be able to reply to a message
+        val data = goToInbox()
+        data.addConversations(userId = student1.id, messageBody = "Short body")
+        dashboardPage.clickInboxTab()
+        inboxPage.selectConversation(getFirstConversation(data))
+        val message = "What is this, hodor?"
+        inboxConversationPage.replyToMessage(message)
+        inboxConversationPage.assertMessageDisplayed(message)
+    }
+
+    @Test
+    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_replyToMessageWithAttachment() {
+        // Should be able to reply (with attachment) to a message
+        val data = goToInbox()
+        data.addConversations(userId = student1.id, messageBody = "Short body")
+        dashboardPage.clickInboxTab()
+        val conversation = getFirstConversation(data)
+        inboxPage.selectConversation(conversation)
+        val message = "What is this, hodor?"
+        inboxConversationPage.replyToMessage(message)
+
+        // Now let's append the attachment after-the-fact, since it is very hard
+        // to manually attach anything via Espresso, since it would require manipulating
+        // system UIs.
+        val attachmentName = "attachment.html"
+        addAttachmentToMessage(attachmentName, conversation.id, message, data)
+        inboxConversationPage.refresh()
+        inboxConversationPage.assertAttachmentDisplayed(attachmentName)
+    }
+
+    @Test
+    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_filterMessagesByTypeAll() {
+        // Should be able to filter messages by All
+        val data = goToInbox()
+        data.addConversations(userId = student1.id, messageBody = "Short body")
+        val conversation = getFirstConversation(data)
+        dashboardPage.clickInboxTab()
+        inboxPage.assertConversationDisplayed(conversation.subject!!)
+    }
+
+    @Test
+    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_filterMessagesByTypeUnread() {
+        // Should be able to filter messages by Unread
+        val data = goToInbox()
+        data.addConversations(userId = student1.id, messageBody = "Short body")
+        dashboardPage.clickInboxTab()
+        val conversation = data.conversations.values.first {
+            it.workflowState == Conversation.WorkflowState.UNREAD
+        }
+        inboxPage.selectInboxScope(InboxApi.Scope.UNREAD)
+        inboxPage.assertConversationDisplayed(conversation.subject!!)
+    }
+
+    @Test
+    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_filterMessagesByTypeStarred() {
+        // Should be able to filter messages by Starred
+        val data = goToInbox()
+        data.addConversations(userId = student1.id, messageBody = "Short body")
+        dashboardPage.clickInboxTab()
+        val conversation = data.conversations.values.first {
+            it.isStarred
+        }
+        inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
+        inboxPage.assertConversationDisplayed(conversation.subject!!)
+    }
+
+    @Test
+    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_filterMessagesByTypeSend() {
+        // Should be able to filter messages by Send
+        val data = goToInbox()
+        data.addConversations(userId = student1.id, messageBody = "Short body")
+        dashboardPage.clickInboxTab()
+        val conversation = data.conversations.values.first {
+            it.workflowState == Conversation.WorkflowState.UNREAD
+        }
+        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+        inboxPage.assertConversationDisplayed(conversation.subject!!)
+    }
+
+    @Test
+    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_filterMessagesByTypeArchived() {
+        // Should be able to filter messages by Archived
+        val data = goToInbox()
+        data.addConversations(userId = student1.id, messageBody = "Short body")
+        dashboardPage.clickInboxTab()
+        val conversation = data.conversations.values.first {
+            it.workflowState == Conversation.WorkflowState.ARCHIVED
+        }
+        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.assertConversationDisplayed(conversation.subject!!)
+    }
+
+    @Test
+    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_filterMessagesByContext() {
+        // Should be able to filter messages by course or group
+        val data = goToInbox(courseCount = 2)
+        data.addConversationsToCourseMap(student1.id, data.courses.values.toList(), messageBody = "Short body")
+        val conversation = data.conversationCourseMap[course1.id]!!.first()
+        dashboardPage.clickInboxTab()
+        inboxPage.selectInboxFilter(course1)
+        inboxPage.assertConversationDisplayed(conversation.subject!!)
+    }
+
+    @Test
+    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_canComposeAndSendToRoleGroupsIfPermissionEnabled() {
+        // Can compose and send messages to one or more role groups if "Send messages to the entire class is enabled"
+        val data = goToInbox(teacherCount = 3)
+        dashboardPage.clickInboxTab()
+        val subject = "Hodor"
+        data.addSentConversation(subject, student1.id, messageBody = "Short body")
+        inboxPage.pressNewMessageButton()
+        newMessagePage.selectCourse(course1)
+        newMessagePage.setRecipientGroup(userType = "Teachers")
+        newMessagePage.setSubject(subject)
+        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
+        newMessagePage.hitSend()
+        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+        inboxPage.assertConversationDisplayed(subject)
+    }
+
+    @Test
+    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_canNotComposeAndSendToRoleGroupsIfPermissionDisabled() {
+        // Can NOT compose and send messages to one or more role groups if "Send messages to the entire class is disabled"
+        val data = goToInbox(sendMessagesAll = false)
+        dashboardPage.clickInboxTab()
+        inboxPage.pressNewMessageButton()
+        newMessagePage.selectCourse(course1)
+        newMessagePage.assertRecipientGroupsNotDisplayed(userType = "Teachers")
+    }
+
+    @Test
+    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_canComposeAndSendToIndividualCourseMembersIfPermissionEnabled() {
+        // Can compose and send messages to individual course members if "Send messages to individual course members" is enabled
+        // This test is identical to testInbox_createAndSendMessageToIndividual, not sure if its worth having both
+        val data = goToInbox()
+        dashboardPage.clickInboxTab()
+        val subject = "Hodor"
+        data.addSentConversation(subject, student1.id, messageBody = "Short body")
+        inboxPage.pressNewMessageButton()
+        newMessagePage.selectCourse(course1)
+        newMessagePage.setRecipient(teacher1, userType = "Teachers")
+        newMessagePage.setSubject(subject)
+        newMessagePage.setMessage("Hodor, Hodor? Hodor!")
+        newMessagePage.hitSend()
+        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+        inboxPage.assertConversationDisplayed(subject)
+    }
+
+    @Test
+    @TestMetaData(Priority.P1, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_canNotComposeAndSendToIndividualCourseMembersIfPermissionDisabled() {
+        // Can NOT compose and send messages to individual course members if "Send messages to individual course members" is disabled
+        // This test is controlled by the api, so while we are utilizing a mocked CanvasContextPermission value, the only
+        // thing making this test pass or fail is what's implemented in the MockCanvas endpoints.
+        val data = goToInbox(sendMessages = false, studentCount = 10)
+        dashboardPage.clickInboxTab()
+        inboxPage.pressNewMessageButton()
+        newMessagePage.selectCourse(course1)
+        newMessagePage.assertRecipientGroupContains("Students", 1)
+    }
+
+    @Test
+    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_replyAll() {
+        val data = goToInbox(studentCount = 3, teacherCount = 1)
+        val conversationSubject = "Reply All Message Subject"
+        val conversationMessageBody = "Reply All Message Body"
+        val replyAllReply = "Reply All Reply"
+        val conversation = data.addConversation(
+                senderId = data.students[2].id,
+                receiverIds = data.students.take(2).map {user -> user.id},
+                messageBody = conversationMessageBody,
+                messageSubject = conversationSubject
+        )
+
+        dashboardPage.clickInboxTab()
+        inboxPage.assertConversationDisplayed(conversationSubject)
+        inboxPage.selectConversation(conversation)
+        inboxConversationPage.assertMessageDisplayed(conversationMessageBody)
+        inboxConversationPage.replyAllToMessage(replyAllReply, 2)
+        Espresso.pressBack() // To main inbox page
+        inboxPage.assertMessageBodyDisplayed(replyAllReply)
+    }
+
+    @Test
+    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_toggleStarred() {
+        val data = goToInbox(studentCount = 3, teacherCount = 1)
+        val conversationSubject = "Toggle Starred Message Subject"
+        val conversationMessageBody = "Toggle Starred Message Body"
+        val conversation = data.addConversation(
+                senderId = data.students[2].id,
+                receiverIds = data.students.take(2).map {user -> user.id},
+                messageBody = conversationMessageBody,
+                messageSubject = conversationSubject
+        )
+
+        dashboardPage.clickInboxTab()
+        inboxPage.assertConversationDisplayed(conversationSubject)
+        inboxPage.selectConversation(conversation)
+        inboxConversationPage.assertNotStarred()
+        inboxConversationPage.toggleStarred()
+        inboxConversationPage.assertStarred()
+        Espresso.pressBack() // To main inbox page
+        inboxPage.assertConversationStarred(conversation)
+    }
 
     @Test
     @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
@@ -438,6 +438,48 @@ class InboxInteractionTest : StudentTest() {
         inboxConversationPage.archive() // Should kick you back to the main inbox page
         inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
         inboxPage.assertConversationDisplayed(conversationSubject)
+    }
+
+    @Test
+    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_deleteConversation() {
+        val data = goToInbox(studentCount = 3, teacherCount = 1)
+        val conversationSubject = "Delete Conversation Message Subject"
+        val conversationMessageBody = "Delete Conversation Message Body"
+        val conversation = data.addConversation(
+                senderId = data.students[2].id,
+                receiverIds = data.students.take(2).map {user -> user.id},
+                messageBody = conversationMessageBody,
+                messageSubject = conversationSubject
+        )
+
+        dashboardPage.clickInboxTab()
+        inboxPage.assertConversationDisplayed(conversationSubject)
+        inboxPage.selectConversation(conversation)
+        inboxConversationPage.deleteConversation() // Should kick you back to the main inbox page
+        inboxPage.assertConversationNotDisplayed(conversationSubject)
+    }
+
+    @Test
+    @TestMetaData(Priority.P0, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_deleteMessage() {
+        val data = goToInbox(studentCount = 3, teacherCount = 1)
+        val conversationSubject = "Delete Message Message Subject"
+        val conversationMessageBody = "Delete Message Message Body"
+        val replyMessage = "A reply to be deleted"
+        val conversation = data.addConversation(
+                senderId = data.students[2].id,
+                receiverIds = data.students.take(2).map {user -> user.id},
+                messageBody = conversationMessageBody,
+                messageSubject = conversationSubject
+        )
+
+        dashboardPage.clickInboxTab()
+        inboxPage.assertConversationDisplayed(conversationSubject)
+        inboxPage.selectConversation(conversation)
+        inboxConversationPage.replyToMessage(replyMessage)
+        inboxConversationPage.deleteMessage(replyMessage)
+        inboxConversationPage.assertMessageNotDisplayed(replyMessage)
     }
 
     /*

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/SyllabusInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/SyllabusInteractionTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package com.instructure.student.ui.interaction
+
+import com.instructure.canvas.espresso.mockCanvas.MockCanvas
+import com.instructure.canvas.espresso.mockCanvas.addAssignment
+import com.instructure.canvas.espresso.mockCanvas.addCourseCalendarEvent
+import com.instructure.canvas.espresso.mockCanvas.addCourseSettings
+import com.instructure.canvas.espresso.mockCanvas.init
+import com.instructure.canvasapi2.models.Assignment
+import com.instructure.canvasapi2.models.CourseSettings
+import com.instructure.canvasapi2.models.Tab
+import com.instructure.dataseeding.util.days
+import com.instructure.dataseeding.util.fromNow
+import com.instructure.dataseeding.util.iso8601
+import com.instructure.panda_annotations.FeatureCategory
+import com.instructure.panda_annotations.Priority
+import com.instructure.panda_annotations.TestCategory
+import com.instructure.panda_annotations.TestMetaData
+import com.instructure.student.ui.utils.StudentTest
+import com.instructure.student.ui.utils.tokenLogin
+import org.junit.Test
+
+class SyllabusInteractionTest : StudentTest() {
+
+    override fun displaysPageObjects() = Unit // Not used for interaction tests
+
+    // Tests that we can display a calendar event from the syllabus/summary,
+    // and does some verification of the calendar event.
+    @Test
+    @TestMetaData(Priority.P0, FeatureCategory.SYLLABUS, TestCategory.INTERACTION, false)
+    fun testSyllabus_calendarEvent() {
+        val data = goToSyllabus(eventCount = 1, assignmentCount = 0)
+
+        val course = data.courses.values.first()
+        val event = data.courseCalendarEvents[course.id]!!.first()
+
+        syllabusPage.selectSummaryTab()
+        syllabusPage.assertItemDisplayed(event.title!!)
+        syllabusPage.selectSummaryEvent(event.title!!)
+        calendarEventPage.verifyTitle(event.title!!)
+        calendarEventPage.verifyDescription(event.description!!)
+    }
+
+    private fun goToSyllabus(eventCount: Int, assignmentCount: Int) : MockCanvas {
+
+        val data = MockCanvas.init(studentCount = 1, teacherCount = 1, courseCount = 1, favoriteCourseCount = 1)
+
+        val course = data.courses.values.first()
+        val student = data.students[0]
+
+        // Give the course a syllabus body
+        val updatedCourse = course.copy(syllabusBody = "Syllabus Body")
+        data.courses[course.id] = updatedCourse
+
+        // Give the course a syllabus tab
+        val syllabusTab = Tab(position = 2, label = "Syllabus", visibility = "public", tabId = Tab.SYLLABUS_ID)
+        data.courseTabs[course.id]!! += syllabusTab
+
+        // Enable the courseSummary setting to get a course summary
+        data.addCourseSettings(course.id, CourseSettings(courseSummary = true))
+
+        repeat(eventCount) {
+            data.addCourseCalendarEvent(
+                    courseId = course.id,
+                    date = 2.days.fromNow.iso8601,
+                    title = "Test Calendar Event",
+                    description = "The calendar event to end all calendar events"
+            )
+        }
+
+        repeat(assignmentCount) {
+            data.addAssignment(
+                    courseId = course.id,
+                    submissionType = Assignment.SubmissionType.ONLINE_TEXT_ENTRY,
+                    dueAt = 2.days.fromNow.iso8601
+            )
+        }
+
+        val token = data.tokenFor(student)!!
+        tokenLogin(data.domain, token, student)
+
+        dashboardPage.selectCourse(course)
+        courseBrowserPage.selectSyllabus()
+
+        return data
+    }
+}

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/CalendarEventPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/CalendarEventPage.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.student.ui.pages
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withParent
+import androidx.test.espresso.web.assertion.WebViewAssertions.webMatches
+import androidx.test.espresso.web.sugar.Web.onWebView
+import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
+import androidx.test.espresso.web.webdriver.DriverAtoms.getText
+import androidx.test.espresso.web.webdriver.Locator
+import com.instructure.canvas.espresso.containsTextCaseInsensitive
+import com.instructure.espresso.assertDisplayed
+import com.instructure.espresso.page.BasePage
+import com.instructure.student.R
+import org.hamcrest.Matchers
+import org.hamcrest.Matchers.allOf
+
+class CalendarEventPage : BasePage(R.id.calendarEventFragment) {
+
+    fun verifyTitle(title: String) {
+        onView(allOf(withParent(withId(R.id.toolbar)), containsTextCaseInsensitive(title))).assertDisplayed()
+    }
+
+    fun verifyDescription(description: String) {
+        onWebView(withId(R.id.calendarEventWebView))
+                .withElement(findElement(Locator.ID,"content"))
+                .check(webMatches(getText(), Matchers.comparesEqualTo(description)))
+    }
+}

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxConversationPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxConversationPage.kt
@@ -17,10 +17,14 @@
 package com.instructure.student.ui.pages
 
 import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.hasChildCount
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
+import androidx.test.espresso.matcher.ViewMatchers.withHint
 import com.instructure.canvas.espresso.explicitClick
 import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.canvas.espresso.withCustomConstraints
@@ -38,6 +42,7 @@ import com.instructure.espresso.replaceText
 import com.instructure.student.R
 import org.hamcrest.CoreMatchers
 import org.hamcrest.Matchers
+import org.hamcrest.Matchers.allOf
 
 class InboxConversationPage : BasePage(R.id.inboxConversationPage) {
 
@@ -47,6 +52,15 @@ class InboxConversationPage : BasePage(R.id.inboxConversationPage) {
         onViewWithContentDescription("Send").perform(explicitClick())
         // Wait for reply to propagate, and for us to return to the email thread page
         waitForView(withId(R.id.starred)).assertDisplayed()
+    }
+
+    fun replyAllToMessage(replyMessage: String, expectedChipCount: Int) {
+        onView(withId(R.id.messageOptions)).click()
+        onView(withText("Reply All")).click()
+        onView(withId(R.id.chipGroup)).check(matches(hasChildCount(expectedChipCount)))
+        onView(withHint(R.string.message)).replaceText(replyMessage)
+        onView(withContentDescription("Send")).perform(explicitClick())
+        onView(allOf(withId(R.id.messageBody), withText(replyMessage))).assertDisplayed()
     }
 
     fun assertMessageDisplayed(message: String) {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxConversationPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxConversationPage.kt
@@ -22,15 +22,20 @@ import android.graphics.Canvas
 import android.graphics.drawable.Drawable
 import android.view.View
 import android.widget.ImageButton
+import androidx.appcompat.widget.AppCompatButton
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.hasChildCount
+import androidx.test.espresso.matcher.ViewMatchers.hasSibling
+import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withHint
+import com.instructure.canvas.espresso.containsTextCaseInsensitive
 import com.instructure.canvas.espresso.explicitClick
 import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.canvas.espresso.withCustomConstraints
@@ -83,6 +88,30 @@ class InboxConversationPage : BasePage(R.id.inboxConversationPage) {
         onView(withText("Archive")).click()
     }
 
+    fun deleteConversation() {
+        onView(withContentDescription("More options")).click()
+        onView(withText("Delete")).click()
+        onView(allOf(isAssignableFrom(AppCompatButton::class.java), containsTextCaseInsensitive("DELETE")))
+                .click() // Confirmation click
+    }
+
+    fun deleteMessage(messageBody: String) {
+        val targetMatcher = allOf(
+                withId(R.id.messageOptions),
+                hasSibling(
+                        allOf(
+                                withId(R.id.messageBody),
+                                withText(messageBody)
+                        )
+                )
+        )
+
+        onView(targetMatcher).click()
+        onView(withText("Delete")).click()
+        onView(allOf(isAssignableFrom(AppCompatButton::class.java), containsTextCaseInsensitive("DELETE")))
+                .click() // Confirmation click
+    }
+
     fun assertMessageDisplayed(message: String) {
         val itemMatcher = CoreMatchers.allOf(
                 ViewMatchers.hasSibling(withId(R.id.attachmentContainer)),
@@ -91,6 +120,10 @@ class InboxConversationPage : BasePage(R.id.inboxConversationPage) {
                 withText(message)
         )
         waitForView(itemMatcher).assertDisplayed()
+    }
+
+    fun assertMessageNotDisplayed(message: String) {
+        onView(withText(message)).check(doesNotExist())
     }
 
     fun assertAttachmentDisplayed(displayName: String) {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
@@ -17,8 +17,13 @@
 package com.instructure.student.ui.pages
 
 import androidx.test.espresso.Espresso.onData
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import com.instructure.canvas.espresso.containsTextCaseInsensitive
 import com.instructure.canvas.espresso.scrollRecyclerView
+import com.instructure.canvas.espresso.waitForMatcherWithRefreshes
 import com.instructure.canvasapi2.apis.InboxApi
 import com.instructure.canvasapi2.models.Conversation
 import com.instructure.canvasapi2.models.Course
@@ -29,6 +34,7 @@ import com.instructure.espresso.click
 import com.instructure.espresso.page.*
 import com.instructure.espresso.scrollTo
 import com.instructure.student.R
+import org.hamcrest.Matchers.allOf
 
 class InboxPage : BasePage(R.id.inboxPage) {
 
@@ -43,6 +49,13 @@ class InboxPage : BasePage(R.id.inboxPage) {
 
     fun assertConversationDisplayed(subject: String) {
         val matcher = withText(subject)
+        scrollRecyclerView(R.id.inboxRecyclerView, matcher)
+        onView(matcher).assertDisplayed()
+    }
+
+    fun assertMessageBodyDisplayed(messageBody: String) {
+        val matcher = allOf(withId(R.id.message), withText(messageBody))
+        waitForMatcherWithRefreshes(matcher) // May need to refresh before the new message body shows up
         scrollRecyclerView(R.id.inboxRecyclerView, matcher)
         onView(matcher).assertDisplayed()
     }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
@@ -17,13 +17,19 @@
 package com.instructure.student.ui.pages
 
 import androidx.test.espresso.Espresso.onData
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.hasSibling
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast
+import androidx.test.espresso.matcher.ViewMatchers.withChild
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.instructure.canvas.espresso.containsTextCaseInsensitive
 import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.canvas.espresso.waitForMatcherWithRefreshes
+import com.instructure.canvas.espresso.waitForMatcherWithSleeps
 import com.instructure.canvasapi2.apis.InboxApi
 import com.instructure.canvasapi2.models.Conversation
 import com.instructure.canvasapi2.models.Course
@@ -35,6 +41,7 @@ import com.instructure.espresso.page.*
 import com.instructure.espresso.scrollTo
 import com.instructure.student.R
 import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.not
 
 class InboxPage : BasePage(R.id.inboxPage) {
 
@@ -96,6 +103,38 @@ class InboxPage : BasePage(R.id.inboxPage) {
 
     fun goToDashboard() {
         onView(withId(R.id.bottomNavigationCourses)).click()
+    }
+
+    fun assertConversationStarred(conversation: Conversation) {
+        val matcher = allOf(
+                withId(R.id.star),
+                withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE),
+                ViewMatchers.withParent(ViewMatchers.withParent(withChild(
+                        allOf(withId(R.id.message), withText(conversation.lastMessage))
+                ))))
+        waitForMatcherWithRefreshes(matcher) // May need to refresh before the star shows up
+        scrollRecyclerView(R.id.inboxRecyclerView, matcher)
+        onView(matcher).assertDisplayed()
+
+    }
+
+    fun assertUnreadMarkerVisibility(conversation: Conversation, visibility: ViewMatchers.Visibility) {
+        val matcher = allOf(
+                withId(R.id.unreadMark),
+                withEffectiveVisibility(visibility),
+                ViewMatchers.withParent(ViewMatchers.hasSibling(withChild(
+                        allOf(withId(R.id.message), withText(conversation.lastMessage))
+                ))))
+
+        if(visibility == ViewMatchers.Visibility.VISIBLE) {
+            waitForMatcherWithRefreshes(matcher) // May need to refresh before the unread mark shows up
+            scrollRecyclerView(R.id.inboxRecyclerView, matcher)
+            onView(matcher).assertDisplayed()
+        }
+        else if(visibility == ViewMatchers.Visibility.GONE) {
+            onView(matcher).check(matches(not(isDisplayed())))
+        }
+
     }
 
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
@@ -60,6 +60,11 @@ class InboxPage : BasePage(R.id.inboxPage) {
         onView(matcher).assertDisplayed()
     }
 
+    fun assertConversationNotDisplayed(subject: String) {
+        val matcher = withText(subject)
+        onView(matcher).check(doesNotExist())
+    }
+
     fun assertMessageBodyDisplayed(messageBody: String) {
         val matcher = allOf(withId(R.id.message), withText(messageBody))
         waitForMatcherWithRefreshes(matcher) // May need to refresh before the new message body shows up

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SyllabusPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SyllabusPage.kt
@@ -18,8 +18,10 @@ package com.instructure.student.ui.pages
 
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import com.instructure.canvas.espresso.containsTextCaseInsensitive
 import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.espresso.assertDisplayed
+import com.instructure.espresso.click
 import com.instructure.espresso.page.BasePage
 import com.instructure.espresso.page.withAncestor
 import com.instructure.espresso.swipeDown
@@ -34,6 +36,14 @@ open class SyllabusPage : BasePage(R.id.syllabusPage) {
 
     fun assertEmptyView() {
         onView(withId(R.id.syllabusEmptyView)).assertDisplayed()
+    }
+
+    fun selectSummaryTab() {
+        onView(containsTextCaseInsensitive("summary")).click()
+    }
+
+    fun selectSummaryEvent(name: String) {
+        onView(containsTextCaseInsensitive(name)).click()
     }
 
     fun refresh() {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTest.kt
@@ -90,6 +90,7 @@ abstract class StudentTest : CanvasTest() {
     val pickerSubmissionUploadPage = PickerSubmissionUploadPage()
     val remoteConfigSettingsPage = RemoteConfigSettingsPage()
     val profileSettingsPage = ProfileSettingsPage()
+    val calendarEventPage = CalendarEventPage()
 
     // A no-op interaction to afford us an easy, harmless way to get a11y checking to trigger.
     fun meaninglessSwipe() {

--- a/apps/student/src/main/res/layout/fragment_calendar_event.xml
+++ b/apps/student/src/main/res/layout/fragment_calendar_event.xml
@@ -19,6 +19,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:id="@+id/calendarEventFragment"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="@color/canvasBackgroundWhite">

--- a/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/MockCanvas.kt
+++ b/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/MockCanvas.kt
@@ -629,6 +629,10 @@ fun MockCanvas.addConversations(conversationCount: Int = 1, userId: Long, messag
     }
 }
 
+/**
+ * Adds a single conversation, with sender [senderId] and receivers [receiverIds].  It will not
+ * be associated with any course.
+ */
 fun MockCanvas.addConversation(
         senderId: Long,
         receiverIds: List<Long>,

--- a/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/endpoints/CourseEndpoints.kt
+++ b/automation/canvas_espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/endpoints/CourseEndpoints.kt
@@ -40,6 +40,7 @@ import com.instructure.canvas.espresso.mockCanvas.utils.unauthorizedResponse
 import com.instructure.canvas.espresso.mockCanvas.utils.user
 import com.instructure.canvasapi2.models.Attachment
 import com.instructure.canvasapi2.models.Course
+import com.instructure.canvasapi2.models.CourseSettings
 import com.instructure.canvasapi2.models.DiscussionEntry
 import com.instructure.canvasapi2.models.DiscussionParticipant
 import com.instructure.canvasapi2.models.DiscussionTopicHeader
@@ -102,6 +103,15 @@ object CourseEndpoint : Endpoint(
         Segment("enrollments") to CourseEnrollmentsEndpoint,
         Segment("features") to Endpoint(
                 Segment("enabled") to CourseEnabledFeaturesEndpoint
+        ),
+        Segment("settings") to Endpoint(
+                response = {
+                    GET {
+                        val courseId = pathVars.courseId
+                        val settings = data.courseSettings[courseId] ?: CourseSettings()
+                        request.successResponse(settings)
+                    }
+                }
         ),
 
         response = {


### PR DESCRIPTION
Attempted to beef up UI test coverage for Student app.  Added CalendarEventFragment coverage via the Todo page (since we can't test via the Flutter calendar), and added InboxConversationFragment coverage via tests for archiving a conversation, marking a conversation unread, starring a conversation, deleting a conversation and deleting a message.

Results:
--CalendarEventFragment: 0% to 57% 
--InboxConversationFragment: 53% to 82%
--com.instructure.student.fragment: 44% to 47%
--overall: 51.3% to 52.2%


refs: MBL-14704
affects: Student
release note: Added UI tests