### PR TITLE
[Teacher][RC-1.11.1] Fix message thread crash

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/presenters/MessageThreadPresenter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/presenters/MessageThreadPresenter.kt
@@ -72,11 +72,10 @@ class MessageThreadPresenter(
 
                 // Add/update messages
                 data.addOrUpdate(conversation.messages.flatMap { it.forwardedMessages + it })
-            } catch (e: Throwable) {
-                viewCallback?.onConversationLoadFailed()
-            } finally {
                 viewCallback?.onRefreshFinished()
                 viewCallback?.checkIfEmpty()
+            } catch (e: Throwable) {
+                viewCallback?.onConversationLoadFailed()
             }
         }
     }


### PR DESCRIPTION
This fixes a crash that can occur when a conversation fails to load from the API after routing to MessageThreadFragment from a push notification. After some investigation is appears that this was an existing crash, but shows up as a new crash due to line changes.