### PR TITLE
[Student][Teacher][MBL-14763] Fix discussions on API 23

### DIFF
--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/Pronouns.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/Pronouns.kt
@@ -25,6 +25,7 @@ import android.text.Spanned
 import android.text.SpannedString
 import android.text.style.StyleSpan
 import androidx.annotation.StringRes
+import androidx.core.text.TextUtilsCompat
 
 object Pronouns {
     /**
@@ -87,9 +88,12 @@ object Pronouns {
      * and HTML italics tags. If [pronouns] is not a valid string then [name] will be returned unmodified.
      * Whenever possible, prefer calling [span] over this function in order to add visual emphasis to the
      * user's chosen pronouns.
+     *
+     * The [name] and [pronouns] will be HTML encoded to avoid potential XSS issues.
      */
     fun html(name: String?, pronouns: String?) : String {
-        pronouns.validOrNull() ?: return name.orEmpty()
-        return """${name.orEmpty()} <i>($pronouns)</i>"""
+        val encodedName = name?.let { TextUtilsCompat.htmlEncode(it) }.orEmpty()
+        val encodedPronouns = pronouns?.let { TextUtilsCompat.htmlEncode(it) }?.validOrNull() ?: return encodedName
+        return """$encodedName <i>($encodedPronouns)</i>"""
     }
 }

--- a/libs/pandautils/build.gradle
+++ b/libs/pandautils/build.gradle
@@ -117,7 +117,6 @@ dependencies {
     api ('com.davemorrissey.labs:subsampling-scale-image-view:3.9.0') {
         exclude group: "androidx.exifinterface"
     }
-    implementation 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20200713.1'
 
     /* Crashlytics */
     implementation(Libs.CRASHLYTICS) {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/discussions/DiscussionEntryHtmlConverter.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/discussions/DiscussionEntryHtmlConverter.kt
@@ -24,7 +24,6 @@ import com.instructure.canvasapi2.utils.localized
 import com.instructure.canvasapi2.utils.toDate
 import com.instructure.pandautils.BuildConfig
 import com.instructure.pandautils.R
-import org.owasp.html.HtmlPolicyBuilder
 
 /**
  * Used to convert DiscussionEntries into HTML. Typically this class only takes data and does little calculation.
@@ -214,7 +213,7 @@ class DiscussionEntryHtmlConverter {
 
                 .replace("__AVATAR_URL__", avatarImage)
                 .replace("__AVATAR_ALT__", context.getString(R.string.userAvatar))
-                .replace("__TITLE__", sanitizePolicy.sanitize(authorName))
+                .replace("__TITLE__", authorName)
                 .replace("__DATE__", date)
                 .replace("__CONTENT_HTML__", content)
                 .replace("__HEADER_ID__", discussionEntry.id.toString())
@@ -296,8 +295,5 @@ class DiscussionEntryHtmlConverter {
                 discussionEntry.ratingSum.localized
             )
         }
-
-        // Use a default policy which should disallow all tags, attributes, etc.
-        private val sanitizePolicy = HtmlPolicyBuilder().toFactory()
     }
 }


### PR DESCRIPTION
This change removes the recently-added HTML sanitizer dependency which was triggering a [D8/AGP bug](https://issuetracker.google.com/issues/157681341) that caused a NoClassDefFoundError on API 23 when viewing discussions. Sanitization has been moved to `Pronouns.html()` and uses HTML encoding rather than element removal. While this approach continues to prevent the XSS issues resolved by #1011, it does mean that unwanted elements (like script tags) will be shown as non-executable text instead of being removed entirely.