### PR TITLE
[Student][Inbox][MBL-14772]: Fixed problems with new inbox tests on API-27/28/29

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DiscussionDetailsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DiscussionDetailsPage.kt
@@ -130,11 +130,12 @@ class DiscussionDetailsPage : BasePage(R.id.discussionDetailsPage) {
         }
 
         // If we have not yet seen the desired reply, try one more time, allowing up to
-        // 30 seconds for the page to render and the reply to appear.
+        // 3 retries for the page to render and the reply to appear.  (Each attempt
+        // waits ~10 secs before failing.)
         // (It can take a *long* time for the reply to get rendered to the webview on
         // tablets (in FTL, anyway).)
         onWebView(withId(R.id.discussionRepliesWebView))
-                .withElement(findElement(Locator.ID, "message_content_${reply.id}"))
+                .withElementRepeat(findElement(Locator.ID, "message_content_${reply.id}"), 3)
                 .check(webMatches(getText(),containsString(reply.message)))
     }
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DiscussionDetailsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DiscussionDetailsPage.kt
@@ -134,7 +134,7 @@ class DiscussionDetailsPage : BasePage(R.id.discussionDetailsPage) {
         // (It can take a *long* time for the reply to get rendered to the webview on
         // tablets (in FTL, anyway).)
         onWebView(withId(R.id.discussionRepliesWebView))
-                .withElementRepeat(findElement(Locator.ID, "message_content_${reply.id}"), 30)
+                .withElement(findElement(Locator.ID, "message_content_${reply.id}"))
                 .check(webMatches(getText(),containsString(reply.message)))
     }
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxConversationPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxConversationPage.kt
@@ -36,6 +36,7 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withHint
 import com.instructure.canvas.espresso.containsTextCaseInsensitive
+import com.instructure.canvas.espresso.stringContainsTextCaseInsensitive
 import com.instructure.canvas.espresso.explicitClick
 import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.canvas.espresso.withCustomConstraints
@@ -79,17 +80,17 @@ class InboxConversationPage : BasePage(R.id.inboxConversationPage) {
     }
 
     fun markUnread() {
-        onView(withContentDescription("More options")).click()
+        onView(withContentDescription(stringContainsTextCaseInsensitive("More options"))).click()
         onView(withText("Mark as Unread")).click()
     }
 
     fun archive() {
-        onView(withContentDescription("More options")).click()
+        onView(withContentDescription(stringContainsTextCaseInsensitive("More options"))).click()
         onView(withText("Archive")).click()
     }
 
     fun deleteConversation() {
-        onView(withContentDescription("More options")).click()
+        onView(withContentDescription(stringContainsTextCaseInsensitive("More options"))).click()
         onView(withText("Delete")).click()
         onView(allOf(isAssignableFrom(AppCompatButton::class.java), containsTextCaseInsensitive("DELETE")))
                 .click() // Confirmation click

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/CustomMatchers.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/CustomMatchers.kt
@@ -46,7 +46,26 @@ fun containsTextCaseInsensitive(textToMatch: String) : Matcher<View> {
         }
 
         override fun describeTo(description: Description?) {
-            description?.appendText("check to see if TextView contains $textToMatch, case insensitive")
+            description?.appendText("check to see if TextView contains \"$textToMatch\", case insensitive")
+        }
+    }
+}
+
+// Similar to containsTextCaseInsensitive(), but operates on a String rather than a TextView.
+// Originally created to combat situations where a content description contains garbage characters.
+fun stringContainsTextCaseInsensitive(textToMatch: String) : Matcher<String> {
+    return object: BaseMatcher<String>() {
+        override fun matches(item: Any?): Boolean {
+            when(item) {
+                is String -> {
+                    return item.contains(textToMatch, ignoreCase = true)
+                }
+            }
+            return false
+        }
+
+        override fun describeTo(description: Description?) {
+            description?.appendText("check to see if String contains \"$textToMatch\", case insensitive")
         }
     }
 }


### PR DESCRIPTION
I was matching against a content description to pull up a menu, and that content description could get extra junk characters embedded in it on API 27/28/29.

The normal PR logic won't test the fix, since the issue only manifests on API 27/28/29.  But I did manually run an FTL job with this code against the InboxInteractionTest on API 27/28/29 and it passed.  So I *think* that I've fixed the issue(s).

refs: MBL-14772
affects: Student
release note: Fixed new inbox tests for later android versions