### PR TITLE
[Student][Teacher][MBL-14725] Pass Recipient instead of BasicUser when composing messages

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/InboxConversationFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/InboxConversationFragment.kt
@@ -26,10 +26,7 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.instructure.canvasapi2.apis.InboxApi
 import com.instructure.canvasapi2.managers.InboxManager
-import com.instructure.canvasapi2.models.Attachment
-import com.instructure.canvasapi2.models.BasicUser
-import com.instructure.canvasapi2.models.Conversation
-import com.instructure.canvasapi2.models.Message
+import com.instructure.canvasapi2.models.*
 import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.canvasapi2.utils.pageview.PageView
 import com.instructure.canvasapi2.utils.weave.WeaveJob
@@ -336,7 +333,7 @@ class InboxConversationFragment : ParentFragment() {
         val route = InboxComposeMessageFragment.makeRoute(
                 true,
                 conversation,
-                adapter.participants.values.toList(),
+                adapter.participants.values.map { Recipient.from(it) },
                 longArrayOf(),
                 null)
         RouteMatcher.route(requireContext(), route)
@@ -347,7 +344,7 @@ class InboxConversationFragment : ParentFragment() {
         val route = InboxComposeMessageFragment.makeRoute(
                 true,
                 conversation,
-                getMessageRecipientsForReplyAll(message),
+                getMessageRecipientsForReplyAll(message).map { Recipient.from(it) },
                 longArrayOf(),
                 message)
         RouteMatcher.route(requireContext(), route)
@@ -357,7 +354,7 @@ class InboxConversationFragment : ParentFragment() {
         val route = InboxComposeMessageFragment.makeRoute(
                 isReply,
                 conversation,
-                getMessageRecipientsForReply(message),
+                getMessageRecipientsForReply(message).map { Recipient.from(it) },
                 adapter.getMessageChainIdsForMessage(message),
                 message)
         RouteMatcher.route(requireContext(), route)

--- a/apps/student/src/main/java/com/instructure/student/fragment/PeopleDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/PeopleDetailsFragment.kt
@@ -76,9 +76,7 @@ class PeopleDetailsFragment : ParentFragment(), Bookmarkable {
         compose.setOnClickListener {
             // Messaging other users is not available in Student view
             val route = if (ApiPrefs.isStudentView) NothingToSeeHereFragment.makeRoute() else {
-                val participants = ArrayList<BasicUser>()
-                participants.add(BasicUser.userToBasicUser(user!!))
-                InboxComposeMessageFragment.makeRoute(canvasContext, participants)
+                InboxComposeMessageFragment.makeRoute(canvasContext, arrayListOf(Recipient.from(user!!)))
             }
 
             RouteMatcher.route(requireContext(), route)

--- a/apps/teacher/src/main/java/com/instructure/teacher/adapters/StudentContextFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/adapters/StudentContextFragment.kt
@@ -22,6 +22,7 @@ import android.widget.TextView
 import com.instructure.canvasapi2.StudentContextCardQuery.*
 import com.instructure.canvasapi2.models.BasicUser
 import com.instructure.canvasapi2.models.GradeableStudentSubmission
+import com.instructure.canvasapi2.models.Recipient
 import com.instructure.canvasapi2.models.StudentAssignee
 import com.instructure.canvasapi2.type.EnrollmentType
 import com.instructure.canvasapi2.utils.DateHelper
@@ -135,13 +136,13 @@ class StudentContextFragment : PresenterFragment<StudentContextPresenter, Studen
         messageButton.setVisible()
         ViewStyler.themeFAB(messageButton, ThemePrefs.buttonColor)
         messageButton.setOnClickListener {
-            val basicUser = BasicUser().apply {
-                id = student.id.toLong()
-                name = student.name
-                pronouns = student.pronouns
-                avatarUrl = student.avatarUrl
-            }
-            val args = AddMessageFragment.createBundle(arrayListOf(basicUser), "", "course_${course.id}", true)
+            val recipient = Recipient(
+                stringId = student.id,
+                name = student.name,
+                pronouns = student.pronouns,
+                avatarURL = student.avatarUrl,
+            )
+            val args = AddMessageFragment.createBundle(listOf(recipient), "", "course_${course.id}", true)
             RouteMatcher.route(requireContext(), Route(AddMessageFragment::class.java, null, args))
         }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/factory/AddMessagePresenterFactory.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/factory/AddMessagePresenterFactory.kt
@@ -18,6 +18,7 @@ package com.instructure.teacher.factory
 import com.instructure.canvasapi2.models.BasicUser
 import com.instructure.canvasapi2.models.Conversation
 import com.instructure.canvasapi2.models.Message
+import com.instructure.canvasapi2.models.Recipient
 import com.instructure.teacher.presenters.AddMessagePresenter
 import com.instructure.teacher.viewinterface.AddMessageView
 import instructure.androidblueprint.PresenterFactory
@@ -25,7 +26,7 @@ import java.util.*
 
 class AddMessagePresenterFactory(
     private val mConversation: Conversation?,
-    private val mParticipants: ArrayList<BasicUser>?,
+    private val mParticipants: ArrayList<Recipient>?,
     private val mMessages: ArrayList<Message>?,
     private val mIsReply: Boolean
 ) : PresenterFactory<AddMessageView, AddMessagePresenter> {

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/AssignmentSubmissionListFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/AssignmentSubmissionListFragment.kt
@@ -185,7 +185,7 @@ class AssignmentSubmissionListFragment : BaseSyncFragment<
         }
 
         addMessage.setOnClickListener {
-            val args = AddMessageFragment.createBundle(presenter.getStudents(), filterTitle.text.toString() + " " + getString(R.string.on) + " " + mAssignment.name, mCourse.contextId, false)
+            val args = AddMessageFragment.createBundle(presenter.getRecipients(), filterTitle.text.toString() + " " + getString(R.string.on) + " " + mAssignment.name, mCourse.contextId, false)
             RouteMatcher.route(requireContext(), Route(AddMessageFragment::class.java, null, args))
         }
     }

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/MessageThreadFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/MessageThreadFragment.kt
@@ -328,7 +328,7 @@ class MessageThreadFragment : BaseSyncFragment<Message, MessageThreadPresenter, 
         val args = AddMessageFragment.createBundle(
             isReply = true,
             conversation = conversation!!,
-            participants = presenter.participants,
+            participants = presenter.participants.map { Recipient.from(it) },
             messages = presenter.getMessageChainForMessage(null),
             currentMessage = null
         )
@@ -340,7 +340,7 @@ class MessageThreadFragment : BaseSyncFragment<Message, MessageThreadPresenter, 
         val args = AddMessageFragment.createBundle(
             isReply = true,
             conversation = conversation!!,
-            participants = getMessageRecipientsForReplyAll(message),
+            participants = getMessageRecipientsForReplyAll(message).map { Recipient.from(it) },
             messages = presenter.getMessageChainForMessage(null),
             currentMessage = message
         )
@@ -351,7 +351,7 @@ class MessageThreadFragment : BaseSyncFragment<Message, MessageThreadPresenter, 
         val args = AddMessageFragment.createBundle(
             isReply = isReply,
             conversation = conversation!!,
-            participants = getMessageRecipientsForReply(message),
+            participants = getMessageRecipientsForReply(message).map { Recipient.from(it) },
             messages = presenter.getMessageChainForMessage(message),
             currentMessage = message
         )

--- a/apps/teacher/src/main/java/com/instructure/teacher/presenters/AddMessagePresenter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/presenters/AddMessagePresenter.kt
@@ -33,7 +33,7 @@ import retrofit2.Response
 import java.net.URLEncoder
 import java.util.*
 
-class AddMessagePresenter(val conversation: Conversation?, private val mParticipants: ArrayList<BasicUser>?, private val mMessages: ArrayList<Message>?, val isReply: Boolean) : FragmentPresenter<AddMessageView>() {
+class AddMessagePresenter(val conversation: Conversation?, private val mParticipants: ArrayList<Recipient>?, private val mMessages: ArrayList<Message>?, val isReply: Boolean) : FragmentPresenter<AddMessageView>() {
 
     private val mAttachments = ArrayList<Attachment>()
     private var mCourse: Course? = null
@@ -171,12 +171,5 @@ class AddMessagePresenter(val conversation: Conversation?, private val mParticip
             return mCourse
         }
 
-    fun getParticipantById(recipientId: Long): BasicUser? {
-        for (participant in mParticipants ?: ArrayList()) {
-            if (participant.id == recipientId) {
-                return participant
-            }
-        }
-        return null
-    }
+    fun getParticipantById(recipientId: String): Recipient? = mParticipants?.find { it.stringId == recipientId }
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/presenters/AssignmentSubmissionListPresenter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/presenters/AssignmentSubmissionListPresenter.kt
@@ -214,8 +214,13 @@ class AssignmentSubmissionListPresenter(val mAssignment: Assignment, private var
 
     fun getFilterPoints() : Double = mFilterValue
 
-    fun getStudents() : ArrayList<BasicUser> {
-        return mFilteredSubmissions.map { BasicUser.userToBasicUser((it.assignee as StudentAssignee).student) } as ArrayList<BasicUser>
+    fun getRecipients() : List<Recipient> {
+        return mFilteredSubmissions.map { submission ->
+            when(val assignee = submission.assignee) {
+                is StudentAssignee -> Recipient.from(assignee.student)
+                is GroupAssignee -> Recipient.from(assignee.group)
+            }
+        }
     }
 
     override fun compare(item1: GradeableStudentSubmission, item2: GradeableStudentSubmission): Int {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/BasicUser.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/BasicUser.kt
@@ -27,15 +27,4 @@ data class BasicUser constructor(
         @SerializedName("avatar_url")
         var avatarUrl: String? = null,
         var pronouns: String? = null
-) : CanvasModel<BasicUser>() {
-    companion object {
-        fun userToBasicUser(user: User): BasicUser {
-            val basicUser = BasicUser()
-            basicUser.id = user.id
-            basicUser.name = user.shortName
-            basicUser.pronouns = user.pronouns
-            basicUser.avatarUrl = user.avatarUrl
-            return basicUser
-        }
-    }
-}
+) : CanvasModel<BasicUser>()

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Recipient.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Recipient.kt
@@ -110,5 +110,25 @@ data class Recipient(
             2 -> Type.Person
             else -> null
         }
+
+        fun from(user: User) = Recipient(
+            stringId = user.id.toString(),
+            name = user.shortName,
+            pronouns = user.pronouns,
+            avatarURL = user.avatarUrl,
+        )
+
+        fun from(user: BasicUser) = Recipient(
+            stringId = user.id.toString(),
+            name = user.name,
+            pronouns = user.pronouns,
+            avatarURL = user.avatarUrl,
+        )
+
+        fun from(group: Group) = Recipient(
+            stringId = group.contextId,
+            name = group.name,
+            userCount = group.membersCount,
+        )
     }
 }

--- a/libs/pandautils/src/main/res/layout/view_recipient_chips_input.xml
+++ b/libs/pandautils/src/main/res/layout/view_recipient_chips_input.xml
@@ -40,6 +40,8 @@
         android:layout_height="wrap_content"
         android:background="@null"
         android:hint="@string/search"
+        android:maxLines="1"
+        android:singleLine="true"
         android:minHeight="48dp"
         android:textSize="16sp"
         tools:ignore="LabelFor" />


### PR DESCRIPTION
Also:
 - Fixes recipient search and selection not working for 'message students who'
 - Fixes crash when trying to use 'message students who' with groups
 - Constrains recipient search input to a single line