### PR TITLE
[Student] Fix crash in CalendarEventFragment

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/CalendarEventFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/CalendarEventFragment.kt
@@ -244,6 +244,7 @@ class CalendarEventFragment : ParentFragment() {
     private fun setUpCallback() {
         scheduleItemCallback = object : StatusCallback<ScheduleItem>() {
             override fun onResponse(response: Response<ScheduleItem>, linkHeaders: LinkHeaders, type: ApiType) {
+                if (!isAdded) return
                 if (response.body() != null) {
                     scheduleItem = response.body() as ScheduleItem
                     initViews()


### PR DESCRIPTION
This fixes a crash that occurs in CalendarEventFragment when the fragment is removed before its initial API call completes. To repro, open a calendar event (from the calendar, to do list, or syllabus) and then quickly press the back button.