### PR TITLE
[Student] Fix crash during submission file upload

### DIFF
--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/NumberHelper.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/NumberHelper.kt
@@ -23,8 +23,10 @@ import java.math.RoundingMode
 import java.text.DecimalFormat
 import java.text.NumberFormat
 import java.util.*
+import kotlin.math.floor
 import kotlin.math.log10
 import kotlin.math.pow
+import kotlin.math.roundToInt
 
 object NumberHelper {
 
@@ -67,9 +69,14 @@ object NumberHelper {
 
     fun readableFileSize(context: Context, size: Long): String {
         val units = context.resources.getStringArray(R.array.file_size_units)
+        return readableFileSize(units, size)
+    }
+
+    fun readableFileSize(units: Array<String>, fileSize: Long): String {
+        val size = fileSize.coerceAtLeast(0L)
         var digitGroups = 0
-        if (size > 0) digitGroups = (log10(size.toDouble()) / log10(1024.0)).toInt()
-        val byteSize = size / 1024.0.pow(digitGroups.toDouble())
+        if (size > 0) digitGroups = (log10(size.toDouble()) / log10(1024.0)).toInt().coerceIn(0, units.size-1)
+        val byteSize = floor(size / 1024.0.pow(digitGroups.toDouble()) * 10) / 10
         val displaySize = DecimalFormat("#,##0.#").format(byteSize)
 
         return "$displaySize ${units[digitGroups]}"

--- a/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/unit/NumberHelperTest.kt
+++ b/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/unit/NumberHelperTest.kt
@@ -25,8 +25,9 @@ import org.junit.Test
 
 import org.junit.Assert.assertEquals
 
-
 class NumberHelperTest {
+
+    private val fileUnits = arrayOf("B", "KB", "MB", "GB", "TB")
 
     @Test
     fun doubleToPercentage_TestHundred() {
@@ -106,6 +107,49 @@ class NumberHelperTest {
         val input = 12345.67789
         val output = NumberHelper.formatDecimal(input, 3, true)
         assertEquals(expected, output)
+    }
+
+    @Test
+    fun `readableFileSize formats negative size as zero bytes`() {
+        assertEquals("0 B", NumberHelper.readableFileSize(fileUnits, -1L))
+        assertEquals("0 B", NumberHelper.readableFileSize(fileUnits, -1099511627776L))
+    }
+
+    @Test
+    fun `readableFileSize correctly formats bytes`() {
+        assertEquals("0 B", NumberHelper.readableFileSize(fileUnits, 0L))
+        assertEquals("1,023 B", NumberHelper.readableFileSize(fileUnits, 1023L))
+    }
+
+    @Test
+    fun `readableFileSize correctly formats kilobytes`() {
+        assertEquals("1 KB", NumberHelper.readableFileSize(fileUnits, 1024L))
+        assertEquals("1,023.9 KB", NumberHelper.readableFileSize(fileUnits, 1048575L))
+    }
+
+    @Test
+    fun `readableFileSize correctly formats megabytes`() {
+        assertEquals("1 MB", NumberHelper.readableFileSize(fileUnits, 1048576L))
+        assertEquals("1,023.9 MB", NumberHelper.readableFileSize(fileUnits, 1073741823L))
+    }
+
+    @Test
+    fun `readableFileSize correctly formats gigabytes`() {
+        assertEquals("1 GB", NumberHelper.readableFileSize(fileUnits, 1073741824L))
+        assertEquals("1,023.9 GB", NumberHelper.readableFileSize(fileUnits, 1099511627775L))
+    }
+
+    @Test
+    fun `readableFileSize correctly formats terabytes`() {
+        // Terabytes
+        assertEquals("1 TB", NumberHelper.readableFileSize(fileUnits, 1099511627776L))
+        assertEquals("1,023.9 TB", NumberHelper.readableFileSize(fileUnits, 1125899906842623L))
+    }
+
+    @Test
+    fun `readableFileSize formats petabytes and above as terabytes`() {
+        assertEquals("1,024 TB", NumberHelper.readableFileSize(fileUnits, 1125899906842624L))
+        assertEquals("2,000,000 TB", NumberHelper.readableFileSize(fileUnits, 2199023255552000000L))
     }
 
 }


### PR DESCRIPTION
I was unable to repro the crash, so this is a speculative fix. As far as I can tell the crash occurs when `NumberHelper.readableFileSize()` is passed what appears to be a very incorrect file size (e.g. 1 exabyte or more), causing an ArrayIndexOutOfBoundsException when attempting to look up the unit name from an array that only handles units up to the terabyte. I'm not sure where the bad files size is coming from, but it appears to disproportionately affect OPPO devices.

This change fixes the crash by capping the max unit to terabyte, and hardens the function with additional range checks. It also changes how file sizes are rounded, fixing an issue where file sizes slightly below the threshold of the next-highest unit were displayed in a potentially confusing way. For example, 1023.96 KB would display as "1024 KB" which is technically 1 MB, but with this change it will display as "1023.9 KB" instead.