### PR TITLE
[Student][Teacher] Retire remote configs set to true

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/SettingsInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/SettingsInteractionTest.kt
@@ -251,35 +251,14 @@ class SettingsInteractionTest : StudentTest() {
     @Test
     @TestMetaData(Priority.P0, FeatureCategory.SETTINGS, TestCategory.INTERACTION, false)
     fun testPairObserver_refreshCode() {
+        setUpAndSignIn()
 
-        // Let's simulate the QR_PAIR_OBSERVER_ENABLED remote-config flag being on,
-        // remembering our original value.
-        val originalVal = RemoteConfigPrefs.getString(RemoteConfigParam.QR_PAIR_OBSERVER_ENABLED.rc_name);
-        RemoteConfigPrefs.putString(RemoteConfigParam.QR_PAIR_OBSERVER_ENABLED.rc_name, "true")
+        dashboardPage.launchSettingsPage()
+        settingsPage.launchPairObserverPage()
 
-        // In case this is a retry, reset the pairingCodeCount in UserEndpoints to 0
-        pairingCodeCount = 0
-
-
-        try {
-            setUpAndSignIn()
-
-            dashboardPage.launchSettingsPage()
-            settingsPage.launchPairObserverPage()
-
-            pairObserverPage.hasCode("1")
-            pairObserverPage.refresh()
-            pairObserverPage.hasCode("2")
-        }
-        finally {
-            // Restore the original remote-config setting
-            if(originalVal == null) {
-                RemoteConfigPrefs.remove(RemoteConfigParam.QR_PAIR_OBSERVER_ENABLED.rc_name);
-            }
-            else {
-                RemoteConfigPrefs.putString(RemoteConfigParam.QR_PAIR_OBSERVER_ENABLED.rc_name, originalVal);
-            }
-        }
+        pairObserverPage.hasCode("1")
+        pairObserverPage.refresh()
+        pairObserverPage.hasCode("2")
     }
 
     // Mock a single student and course, sign in, then navigate to the dashboard.

--- a/apps/student/src/main/java/com/instructure/student/activity/InterwebsToApplication.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/InterwebsToApplication.kt
@@ -82,10 +82,7 @@ class InterwebsToApplication : AppCompatActivity() {
             val signedIn = token.isNotEmpty()
             val domain = ApiPrefs.domain
 
-            val qrLoginEnabled = RemoteConfigUtils.getString(
-                    RemoteConfigParam.QR_LOGIN_ENABLED)?.equals("true", ignoreCase = true)
-                    ?: false
-            if (verifySSOLoginUri(data) && qrLoginEnabled) {
+            if (verifySSOLoginUri(data)) {
                 // This is an App Link from a QR code, let's try to login the user and launch navigationActivity
                 try {
                     if(signedIn) { // If the user is already signed in, use the QR Switch

--- a/apps/student/src/main/java/com/instructure/student/fragment/ApplicationSettingsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/ApplicationSettingsFragment.kt
@@ -92,14 +92,12 @@ class ApplicationSettingsFragment : ParentFragment() {
         help.onClick { HelpDialogStyled.show(requireActivity()) }
         pinAndFingerprint.setGone() // TODO: Wire up once implemented
 
-        if (RemoteConfigUtils.getBoolean(RemoteConfigParam.QR_PAIR_OBSERVER_ENABLED) == true) {
-            pairObserver.setVisible()
-            pairObserver.onClick {
-                if (APIHelper.hasNetworkConnection()) {
-                    addFragment(PairObserverFragment.newInstance())
-                } else {
-                    NoInternetConnectionDialog.show(requireFragmentManager())
-                }
+        pairObserver.setVisible()
+        pairObserver.onClick {
+            if (APIHelper.hasNetworkConnection()) {
+                addFragment(PairObserverFragment.newInstance())
+            } else {
+                NoInternetConnectionDialog.show(requireFragmentManager())
             }
         }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/activities/RouteValidatorActivity.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/activities/RouteValidatorActivity.kt
@@ -67,10 +67,7 @@ class RouteValidatorActivity : FragmentActivity() {
             val isSignedIn = ApiPrefs.getValidToken().isNotEmpty()
             val domain = ApiPrefs.domain
 
-            val qrLoginEnabled = RemoteConfigUtils.getString(
-                    RemoteConfigParam.QR_LOGIN_ENABLED_TEACHER)?.equals("true", ignoreCase = true)
-                    ?: false
-            if (verifySSOLoginUri(data, true) && qrLoginEnabled) {
+            if (verifySSOLoginUri(data, true)) {
                 // This is an App Link from a QR code, let's try to login the user and launch navigationActivity
                 try {
                     if (isSignedIn) { // If the user is already signed in, use the QR Switch

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/RemoteConfigUtils.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/RemoteConfigUtils.kt
@@ -11,9 +11,6 @@ import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
  */
 enum class RemoteConfigParam(val rc_name: String, val safeValueAsString: String) {
     MOBILE_VERIFY_BETA_ENABLED("mobile_verify_beta_enabled", "true"),
-    QR_LOGIN_ENABLED("qr_login_enabled", "true"),
-    QR_LOGIN_ENABLED_TEACHER("qr_login_enabled_teacher", "false"),
-    QR_PAIR_OBSERVER_ENABLED("qr_pair_observer_enabled", "false"),
     TEST_BOOL("test_bool", "false"),
     TEST_FLOAT("test_float", "0f"),
     TEST_LONG("test_long", "42"),

--- a/libs/login-api-2/src/main/java/com/instructure/loginapi/login/activities/BaseLoginLandingPageActivity.kt
+++ b/libs/login-api-2/src/main/java/com/instructure/loginapi/login/activities/BaseLoginLandingPageActivity.kt
@@ -128,15 +128,7 @@ abstract class BaseLoginLandingPageActivity : AppCompatActivity(), ErrorReportDi
         helpButton.setHidden(true) // hiding the help button until we make mobile login better
         helpButton.onClickPopupMenu(getString(R.string.requestLoginHelp) to { requestLoginHelp() })
 
-        val remoteConfigParam = when {
-            packageName.contains("teacher") -> RemoteConfigParam.QR_LOGIN_ENABLED_TEACHER
-            else -> RemoteConfigParam.QR_LOGIN_ENABLED
-        }
-
-        val qrLoginEnabled = RemoteConfigUtils.getString(
-                remoteConfigParam)?.equals("true", ignoreCase = true)
-                ?: false
-        if(loginWithQRCodeEnabled() && qrLoginEnabled) {
+        if(loginWithQRCodeEnabled()) {
             qrLogin.setVisible()
             qrDivider.setVisible()
             qrLogin.onClick {


### PR DESCRIPTION
This PR removes the existing remote configs currently set to true in student/teacher. To test, simply check that the features are on and working. This includes qr_login and pairing (from student).