### PR TITLE
[Student][MBL-14806] Group remains on dashboard when un-favorited

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/GroupLinksInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/GroupLinksInteractionTest.kt
@@ -210,7 +210,8 @@ class GroupLinksInteractionTest : StudentTest() {
         // Add a group
         group = data.addGroupToCourse(
                 course = course,
-                members = listOf(user)
+                members = listOf(user),
+                isFavorite = true
         )
 
         // Add a discussion

--- a/apps/student/src/main/java/com/instructure/student/adapter/DashboardRecyclerAdapter.kt
+++ b/apps/student/src/main/java/com/instructure/student/adapter/DashboardRecyclerAdapter.kt
@@ -153,7 +153,7 @@ class DashboardRecyclerAdapter(
                     { GroupManager.getAllGroups(it, isRefresh) },
                     { AccountNotificationManager.getAllAccountNotifications(it, true)}
             )
-            val allDashboardCourses = awaitApi<List<DashboardCard>> { CourseManager.getDashboardCourses(isRefresh, it) }
+            val dashboardCards = awaitApi<List<DashboardCard>> { CourseManager.getDashboardCourses(isRefresh, it) }
 
             mCourseMap = rawCourses.associateBy { it.id }
             val groupMap = groups.associateBy { it.id }
@@ -164,14 +164,12 @@ class DashboardRecyclerAdapter(
             }
 
             // Map not null is needed because the dashboard api can return unpublished courses
-            val publishedDashboardCourses = allDashboardCourses.mapNotNull { mCourseMap[it.id] }
+            val visibleCourses = dashboardCards.mapNotNull { mCourseMap[it.id] }
 
             // Filter groups
             val allActiveGroups = groups.filter { group -> group.isActive(mCourseMap[group.courseId])}
 
-            val isAnyFavoritePresent = publishedDashboardCourses.any { it.isFavorite } || allActiveGroups.any { it.isFavorite }
-
-            val visibleCourses = if (isAnyFavoritePresent) publishedDashboardCourses.filter { it.isFavorite } else publishedDashboardCourses
+            val isAnyFavoritePresent = visibleCourses.any { it.isFavorite } || allActiveGroups.any { it.isFavorite }
             val visibleGroups = if (isAnyFavoritePresent) allActiveGroups.filter { it.isFavorite } else allActiveGroups
 
             // Get live conferences

--- a/apps/student/src/main/java/com/instructure/student/adapter/DashboardRecyclerAdapter.kt
+++ b/apps/student/src/main/java/com/instructure/student/adapter/DashboardRecyclerAdapter.kt
@@ -153,7 +153,7 @@ class DashboardRecyclerAdapter(
                     { GroupManager.getAllGroups(it, isRefresh) },
                     { AccountNotificationManager.getAllAccountNotifications(it, true)}
             )
-            val dashboardCards = awaitApi<List<DashboardCard>> { CourseManager.getDashboardCourses(isRefresh, it) }
+            val allDashboardCourses = awaitApi<List<DashboardCard>> { CourseManager.getDashboardCourses(isRefresh, it) }
 
             mCourseMap = rawCourses.associateBy { it.id }
             val groupMap = groups.associateBy { it.id }
@@ -164,11 +164,15 @@ class DashboardRecyclerAdapter(
             }
 
             // Map not null is needed because the dashboard api can return unpublished courses
-            val favoriteCourses = dashboardCards.mapNotNull { mCourseMap[it.id] }
+            val publishedDashboardCourses = allDashboardCourses.mapNotNull { mCourseMap[it.id] }
 
             // Filter groups
-            val rawGroups = groups.filter { group -> group.isActive(mCourseMap[group.courseId])}
-            val favoriteGroups = rawGroups.filter { it.isFavorite }.takeUnless { it.isEmpty() } ?: rawGroups
+            val allActiveGroups = groups.filter { group -> group.isActive(mCourseMap[group.courseId])}
+
+            val isAnyFavoritePresent = publishedDashboardCourses.any { it.isFavorite } || allActiveGroups.any { it.isFavorite }
+
+            val visibleCourses = if (isAnyFavoritePresent) publishedDashboardCourses.filter { it.isFavorite } else publishedDashboardCourses
+            val visibleGroups = if (isAnyFavoritePresent) allActiveGroups.filter { it.isFavorite } else allActiveGroups
 
             // Get live conferences
             val blackList = StudentPrefs.conferenceDashboardBlacklist
@@ -193,10 +197,10 @@ class DashboardRecyclerAdapter(
             addOrUpdateAllItems(ItemType.CONFERENCE_HEADER, conferences)
 
             // Add courses
-            addOrUpdateAllItems(ItemType.COURSE_HEADER, favoriteCourses)
+            addOrUpdateAllItems(ItemType.COURSE_HEADER, visibleCourses)
 
             // Add groups
-            addOrUpdateAllItems(ItemType.GROUP_HEADER, favoriteGroups)
+            addOrUpdateAllItems(ItemType.GROUP_HEADER, visibleGroups)
 
             // Add announcements
             addOrUpdateAllItems(ItemType.ANNOUNCEMENT_HEADER, announcements)

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/MockCanvas.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/MockCanvas.kt
@@ -1661,9 +1661,10 @@ fun MockCanvas.addGroupToCourse(
         course: Course,
         name: String = Faker.instance().country().capital(),
         description: String = Faker.instance().lordOfTheRings().character(),
-        members: List<User> = listOf()
+        members: List<User> = listOf(),
+        isFavorite: Boolean = false
 ) : Group {
-    var result = Group(
+    val result = Group(
             id = newItemId(),
             name = name,
             description = description,
@@ -1671,7 +1672,8 @@ fun MockCanvas.addGroupToCourse(
             users = members,
             // contextType field removed from Group
             //contextType = Group.GroupContext.Course,
-            courseId = course.id
+            courseId = course.id,
+            isFavorite = isFavorite
     )
 
     groups[result.id] = result


### PR DESCRIPTION
The reproduction steps and the expected behavior can be seen in the ticket.

refs: MBL-14775
affects: Student
release note: Fixed an issue where a group remains on the dashboard when unfavorited.