### PR TITLE
[Teacher][MBL-11776] Hide the attachment button when editing announcements

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/CreateOrEditAnnouncementFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/CreateOrEditAnnouncementFragment.kt
@@ -109,8 +109,8 @@ class CreateOrEditAnnouncementFragment :
     }
 
     override fun onReadySetGo(presenter: CreateOrEditAnnouncementPresenter) {
-        setupViews()
         setupToolbar()
+        setupViews()
         presenter.loadData(true)
     }
 


### PR DESCRIPTION
Due to a difference in how announcements are created and how they are updated in the Teacher app, it is currently not possible to add attachments to an existing announcement - at least not without rewriting a significant portion of the create/edit screen. Originally the attachment icon in the toolbar was hidden while editing, but at some point a change must have erroneously begun to show the icon when it wasn't supposed to. This PR restores the original behavior by ensuring that the toolbar is set up prior to running the rest of the view setup logic that determines the icon's visibility.

refs: MBL-11776
affects: Teacher
release note: Hide non-functional attachment button when editing announcements