### PR TITLE
[Student][Teacher] Fix crash in UploadFilesDialog

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/dialogs/UploadFilesDialog.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/dialogs/UploadFilesDialog.kt
@@ -711,7 +711,10 @@ class UploadFilesDialog : AppCompatDialogFragment() {
 
         override fun onBindViewHolder(holder: FileViewHolder, position: Int) {
             holder.bind(fileList[position]) {
-                onRemovedFileCallback(fileList[position], position)
+                // The position passed to onBindViewHolder could be stale at this point if the user has recently
+                // added/removed items, so we need to use the current adapter position instead.
+                val currentPosition = holder.adapterPosition
+                onRemovedFileCallback(fileList[currentPosition], currentPosition)
             }
         }
 


### PR DESCRIPTION
Repro: In the file/folder list, choose the file upload option and select two or more files to be uploaded. Then attempt to remove the files by tapping the items' 'X' buttons in rapid sequence, which will result in a crash.

refs: none
affects: Student, Teacher
release note: Fixed a crash when rapidly removing files from the file upload dialog