### PR TITLE
[Student] Fix crash in ShareFileDestinationDialog

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/dialog/ShareFileDestinationDialog.kt
+++ b/apps/student/src/main/java/com/instructure/student/dialog/ShareFileDestinationDialog.kt
@@ -275,6 +275,7 @@ class ShareFileDestinationDialog : DialogFragment(), OnOptionCheckedListener {
                     removeGlobalLayoutListeners(dialogContents, this)
                     val revealAnimator = createRevealAnimator(dialogContents)
                     Handler().postDelayed({
+                        if (!isAdded) return@postDelayed
                         dialogContents.visibility = View.VISIBLE
                         revealAnimator.addListener(
                             object : AnimatorListenerAdapter() {


### PR DESCRIPTION
Repro: In the files list select and view a PDF, and then in the menu overflow choose "Upload To Canvas". This will show a red screen and will begin animating a dialog into position (if it requests permissions, grant them and then back out and start over). If you press the back button after the dialog begins animating but before it finishes, the app will crash.

refs: none
affects: Student
release note: Fixed a crash when closing the share dialog shortly after opening it