### PR TITLE
[Teacher] Use canvas-provided author name for submission comments when grading anonymously

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/holders/SpeedGraderCommentHolder.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/holders/SpeedGraderCommentHolder.kt
@@ -22,6 +22,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.instructure.canvasapi2.models.*
 import com.instructure.canvasapi2.models.postmodels.CommentSendStatus
 import com.instructure.canvasapi2.utils.Pronouns
+import com.instructure.canvasapi2.utils.isValid
 import com.instructure.interactions.router.Route
 import com.instructure.pandautils.utils.onClick
 import com.instructure.pandautils.utils.setGone
@@ -99,7 +100,15 @@ class SpeedGraderCommentHolder(view: View) : RecyclerView.ViewHolder(view) {
                     )
                 } else {
                     avatarView.setAnonymousAvatar()
-                    Triple(comment.comment, context.getString(R.string.anonymousStudentLabel), null)
+                    val authorName = if (comment.authorId == 0L && comment.authorName.isValid()) {
+                        // When grading anonymously, Canvas may redact the author ID and provide an anonymous author
+                        // name such as "Anonymous User" which we'll want to use to ensure that we're not displaying
+                        // all comments as being authored by "Student."
+                        comment.authorName
+                    } else {
+                        context.getString(R.string.anonymousStudentLabel)
+                    }
+                    Triple(comment.comment, authorName, null)
                 }
             }
 


### PR DESCRIPTION
When anonymous grading is enabled for an assignment, the Teacher app will show "Student" as the author for any submission comment whose author ID does not match the current user. The problem here is that for anonymous grading, Canvas generally returns submission comments with the author ID redacted - including comments authored by the current user or by other teachers/TAs. This results in most, if not all, comments being shown as authored by "Student" regardless of the actual author, which can be misleading.

Fortunately, Canvas provides an anonymous author name such as "Anonymous User" in these cases. This PR updates the comment item binder to use the canvas-provided author name when the author ID has been redacted.

refs: none
affects: Teacher
release note: Fixed an issue where the author for all comments in anonymously-graded submissions would be "Student"

test plan:
1. Create an assignment and enable "Graders cannot view student names" in the assignment settings
2. Submit an assignment as a student
3. Add one or more comments on the submission as both a teacher and a student
4. View the submission comments in Teacher speedgrader.
 - Comments added by the student should display "Anonymous User"
 - Comments added by the teacher should display either "Anonymous User" or the teacher's name