### PR TITLE
[Parent][MBL-14783] Resize the refresh button in the course details AppBar

### DIFF
--- a/apps/flutter_parent/lib/screens/courses/details/course_details_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_details_screen.dart
@@ -26,7 +26,6 @@ import 'package:flutter_parent/screens/inbox/create_conversation/create_conversa
 import 'package:flutter_parent/utils/base_model.dart';
 import 'package:flutter_parent/utils/common_widgets/full_screen_scroll_container.dart';
 import 'package:flutter_parent/utils/common_widgets/loading_indicator.dart';
-import 'package:flutter_parent/utils/design/canvas_icons.dart';
 import 'package:flutter_parent/utils/design/canvas_icons_solid.dart';
 import 'package:flutter_parent/utils/design/parent_theme.dart';
 import 'package:flutter_parent/utils/quick_nav.dart';
@@ -109,7 +108,7 @@ class _CourseDetailsScreenState extends State<CourseDetailsScreen> with SingleTi
         if (tabCount > 1)
           IconButton(
             tooltip: L10n(context).refresh,
-            icon: Icon(CanvasIcons.refresh),
+            icon: Icon(CanvasIconsSolid.refresh, size: 18.0),
             onPressed: () async {
               // Clear cache for the front page of this course, as a workaround to force a refresh
               await DioConfig.canvas().clearCache(path: 'courses/${model.courseId}/front_page');

--- a/apps/flutter_parent/lib/screens/courses/routing_shell/course_routing_shell_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/routing_shell/course_routing_shell_screen.dart
@@ -20,7 +20,7 @@ import 'package:flutter_parent/screens/courses/routing_shell/course_routing_shel
 import 'package:flutter_parent/utils/common_widgets/error_panda_widget.dart';
 import 'package:flutter_parent/utils/common_widgets/loading_indicator.dart';
 import 'package:flutter_parent/utils/common_widgets/web_view/canvas_web_view.dart';
-import 'package:flutter_parent/utils/design/canvas_icons.dart';
+import 'package:flutter_parent/utils/design/canvas_icons_solid.dart';
 import 'package:flutter_parent/utils/design/parent_theme.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
 
@@ -78,7 +78,7 @@ class _CourseRoutingShellScreenState extends State<CourseRoutingShellScreen> {
           actions: <Widget>[
             IconButton(
               tooltip: L10n(context).refresh,
-              icon: Icon(CanvasIcons.refresh),
+              icon: Icon(CanvasIconsSolid.refresh, size: 18.0),
               onPressed: () async {
                 _refresh();
               },

--- a/apps/flutter_parent/test/screens/courses/course_details_screen_test.dart
+++ b/apps/flutter_parent/test/screens/courses/course_details_screen_test.dart
@@ -31,7 +31,7 @@ import 'package:flutter_parent/screens/courses/details/course_syllabus_screen.da
 import 'package:flutter_parent/screens/inbox/create_conversation/create_conversation_interactor.dart';
 import 'package:flutter_parent/screens/inbox/create_conversation/create_conversation_screen.dart';
 import 'package:flutter_parent/utils/common_widgets/web_view/web_content_interactor.dart';
-import 'package:flutter_parent/utils/design/canvas_icons.dart';
+import 'package:flutter_parent/utils/design/canvas_icons_solid.dart';
 import 'package:flutter_parent/utils/quick_nav.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
@@ -143,7 +143,7 @@ void main() {
     expect(find.text(AppLocalizations().courseGradesLabel.toUpperCase()), findsOneWidget);
     expect(find.text(AppLocalizations().courseSyllabusLabel.toUpperCase()), findsOneWidget);
     expect(find.text(AppLocalizations().courseSummaryLabel.toUpperCase()), findsOneWidget);
-    expect(find.byIcon(CanvasIcons.refresh), findsOneWidget);
+    expect(find.byIcon(CanvasIconsSolid.refresh), findsOneWidget);
 
     expect(find.text(AppLocalizations().courseFrontPageLabel.toUpperCase()), findsNothing);
   });
@@ -166,7 +166,7 @@ void main() {
     expect(find.text(AppLocalizations().courseGradesLabel.toUpperCase()), findsOneWidget);
     expect(find.text(AppLocalizations().courseSyllabusLabel.toUpperCase()), findsOneWidget);
     expect(find.text(AppLocalizations().courseSummaryLabel.toUpperCase()), findsNothing);
-    expect(find.byIcon(CanvasIcons.refresh), findsOneWidget);
+    expect(find.byIcon(CanvasIconsSolid.refresh), findsOneWidget);
 
     expect(find.text(AppLocalizations().courseFrontPageLabel.toUpperCase()), findsNothing);
   });
@@ -183,7 +183,7 @@ void main() {
 
     expect(find.text(AppLocalizations().courseGradesLabel.toUpperCase()), findsOneWidget);
     expect(find.text(AppLocalizations().courseFrontPageLabel.toUpperCase()), findsOneWidget);
-    expect(find.byIcon(CanvasIcons.refresh), findsOneWidget);
+    expect(find.byIcon(CanvasIconsSolid.refresh), findsOneWidget);
 
     expect(find.text(AppLocalizations().courseSummaryLabel.toUpperCase()), findsNothing);
   });
@@ -200,7 +200,7 @@ void main() {
     expect(find.text(AppLocalizations().courseGradesLabel.toUpperCase()), findsNothing);
     expect(find.text(AppLocalizations().courseSyllabusLabel.toUpperCase()), findsNothing);
     expect(find.text(AppLocalizations().courseSummaryLabel.toUpperCase()), findsNothing);
-    expect(find.byIcon(CanvasIcons.refresh), findsNothing);
+    expect(find.byIcon(CanvasIconsSolid.refresh), findsNothing);
   });
 
   testWidgetsWithAccessibilityChecks('Clicking grades tab shows the grades screen', (tester) async {
@@ -457,7 +457,7 @@ void main() {
     await tester.pump(); // Widget creation
     await tester.pump(); // Future resolved
 
-    await tester.tap(find.byIcon(CanvasIcons.refresh));
+    await tester.tap(find.byIcon(CanvasIconsSolid.refresh));
     await tester.pumpAndSettle();
 
     verify(courseInteractor.loadCourse(courseId, forceRefresh: true)).called(1); // Refresh load


### PR DESCRIPTION
I also changed the icon on the `CourseRoutingShellScreen` to maintain consistency, however I couldn't find where this screen can be seen. From the router it seems to me that it is unused currently, but maybe I am missing something.

refs: MBL-14783
affects: Parent
release note: Changed refresh button size