### PR TITLE
[Parent][MBL-14782] Deleting an unread alert from the alert list does not update the alert count badge

### DIFF
--- a/apps/flutter_parent/lib/screens/alerts/alerts_screen.dart
+++ b/apps/flutter_parent/lib/screens/alerts/alerts_screen.dart
@@ -267,7 +267,8 @@ class __AlertsListState extends State<_AlertsList> {
   }
 
   void _dismissAlert(Alert alert) async {
-    widget._interactor.markAlertDismissed(widget._student.id, alert.id);
+    _markAlertDismissed(alert);
+
     int itemIndex = _data.alerts.indexOf(alert);
 
     _listKey.currentState.removeItem(
@@ -275,6 +276,10 @@ class __AlertsListState extends State<_AlertsList> {
         duration: const Duration(milliseconds: 200));
 
     setState(() => _data.alerts.remove(alert));
+  }
+
+  void _markAlertDismissed(Alert alert) async {
+    await widget._interactor.markAlertDismissed(widget._student.id, alert.id);
 
     // Update the unread count if the alert was unread
     if (alert.workflowState == AlertWorkflowState.unread) {


### PR DESCRIPTION
Repro steps included in the ticket.

refs: MBL-14782
affects: Parent
release note: Alert count badge is now properly updated after deleting an unread alert.