### PR TITLE
[Teacher][Student] Api 29 File Scope Fix

### DIFF
--- a/apps/student/src/main/AndroidManifest.xml
+++ b/apps/student/src/main/AndroidManifest.xml
@@ -64,6 +64,7 @@
         android:supportsRtl="true"
         android:largeHeap="true"
         android:usesCleartextTraffic="true"
+        android:requestLegacyExternalStorage="true"
         tools:replace="android:supportsRtl"
         tools:overrideLibrary="com.instructure.canvasapi">
 

--- a/apps/teacher/src/main/AndroidManifest.xml
+++ b/apps/teacher/src/main/AndroidManifest.xml
@@ -44,6 +44,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true"
+        android:requestLegacyExternalStorage="true"
         tools:replace="android:icon">
 
         <activity


### PR DESCRIPTION
Temporary fix to get api 29 working for downloading/saving files locally. To Test: On either master or prod, using an api 29 device, attempt to save a panda avatar or download a file. You should get an error. With this fix, no error :D.