### PR TITLE
[Student][Tests][MBL-14828]: EZ: Disable animations during tests

### DIFF
--- a/apps/student/build.gradle
+++ b/apps/student/build.gradle
@@ -175,6 +175,7 @@ android {
     }
 
     testOptions.unitTests.includeAndroidResources = true
+    testOptions.animationsDisabled = true
 
     configurations.all {
         resolutionStrategy.force 'com.google.code.findbugs:jsr305:1.3.9'


### PR DESCRIPTION
This is the magic bullet to disabling animations in the student app when running tests locally.  I don't know exactly what is currently happening in Flank/FTL (i.e., whether animations are being properly disabled there), but this should also take care of any problems there.