### PR TITLE
[Student][PDF][MBL-14900]: Disabled a couple of PDF interaction tests on API-23

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/PdfInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/PdfInteractionTest.kt
@@ -16,6 +16,7 @@
  */
 package com.instructure.student.ui.interaction
 
+import android.os.Build
 import androidx.test.espresso.web.sugar.Web
 import androidx.test.espresso.web.webdriver.DriverAtoms
 import androidx.test.espresso.web.webdriver.Locator
@@ -92,6 +93,13 @@ class PdfInteractionTest : StudentTest() {
     @Test
     @TestMetaData(Priority.P1, FeatureCategory.FILES, TestCategory.INTERACTION, false, FeatureCategory.ANNOTATIONS)
     fun testAnnotations_openPdfFilesInPSPDFKit() {
+
+        // This test displays a progress bar spinner, which will spin forever in Espresso
+        // on API-23.
+        if(Build.VERSION.SDK_INT < 24) {
+            return
+        }
+        
         // Annotation toolbar icon needs to be present
         val data = getToCourse()
         val course = data.courses.values.first()
@@ -113,6 +121,13 @@ class PdfInteractionTest : StudentTest() {
     @Test
     @TestMetaData(Priority.P1, FeatureCategory.ASSIGNMENTS, TestCategory.INTERACTION, false, FeatureCategory.ANNOTATIONS)
     fun testAnnotations_openPdfsInPSPDFKitFromLinksInAssignment() {
+
+        // This test displays a progress bar spinner, which will spin forever in Espresso
+        // on API-23.
+        if(Build.VERSION.SDK_INT < 24) {
+            return
+        }
+
         // Annotation toolbar icon needs to be present, this link is specific to assignment details, as that was the advertised use case
         val data = MockCanvas.init(
                 studentCount = 1,


### PR DESCRIPTION
They popped up a ProgressBar spinner, which spins forever in API-23.