### PR TITLE
[Teacher][MBL-14920] Speedgrader bug fix for sliding panel

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/view/SubmissionContentView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/view/SubmissionContentView.kt
@@ -256,9 +256,9 @@ class SubmissionContentView(
 
         if (context.isTablet) return
 
-        // Resize sliding panel and content, don't if keyboard based annotations are active
+        // Resize sliding panel and content, don't if keyboard based annotations are active or selected
         // we only do this if the oldw == w so we won't be resizing on rotation
-        if (oldh > 0 && oldh != h && oldw == w && !activity.isCurrentlyAnnotating) {
+        if (oldh > 0 && oldh != h && oldw == w && !activity.isCurrentlyAnnotating && pdfFragment?.selectedAnnotations?.isEmpty() == true) {
             val newState = if (h < oldh) SlidingUpPanelLayout.PanelState.EXPANDED else SlidingUpPanelLayout.PanelState.ANCHORED
             slidingUpPanelLayout?.panelState = newState
 
@@ -626,10 +626,6 @@ class SubmissionContentView(
         if (offset >= 0.50F) { //Prevents resizing views when not necessary
             mBottomViewPager.layoutParams?.height = adjustedHeight.toInt()
             mBottomViewPager.requestLayout()
-        }
-        if (offset <= 0.50F) {
-            contentWrapper?.layoutParams?.height = Math.abs(maxHeight - adjustedHeight).toInt()
-            contentWrapper?.requestLayout()
         }
     }
 


### PR DESCRIPTION
I noticed that our sliding panel in teacher is still resizing pdf content which does not play nicely with pspdfkit. It also fully opens the sliding panel anytime you try to comment on something (with the dialog).

refs: MBL-14920
affects: Teacher
release note: Fixed a bug with the sliding panel in Speed Grader.

test plan: Make sure the sliding panel isn't resizing pdfs or fully expanding when commenting for the first time on annotations.