### PR TITLE
[Student][MBL-14791] Added Record Audio permission for video comment recording.

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/drawer/comments/SubmissionCommentsEffectHandler.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/drawer/comments/SubmissionCommentsEffectHandler.kt
@@ -103,7 +103,7 @@ class SubmissionCommentsEffectHandler(val context: Context) : EffectHandler<Subm
     }
 
     private fun launchVideo() {
-        if(needsPermissions(::launchVideo, PermissionUtils.CAMERA)) return
+        if(needsPermissions(::launchVideo, PermissionUtils.CAMERA, PermissionUtils.RECORD_AUDIO)) return
         showVideoCommentDialog()
     }
 


### PR DESCRIPTION
refs: MBL-14791
affects: Student
release note: Fixed the bug, where video comment recording would not start the first time after giving permission.

test plan:
- Revoke Camera and Audio permissions if needed.
- Submission > Comments > Add > Add video comment > The recording should be visible after giving the permissions