### PR TITLE
[MBL-14929][Parent] Only show help links if they are available for everyone or observers.

### DIFF
--- a/apps/flutter_parent/lib/screens/help/help_screen_interactor.dart
+++ b/apps/flutter_parent/lib/screens/help/help_screen_interactor.dart
@@ -29,13 +29,11 @@ class HelpScreenInteractor {
 
   bool containsObserverLinks(BuiltList<HelpLink> links) => links.any((link) =>
       link.availableTo.contains(AvailableTo.observer) ||
-      link.availableTo.contains(AvailableTo.user) ||
-      link.availableTo.contains(AvailableTo.unenrolled));
+      link.availableTo.contains(AvailableTo.user));
 
   List<HelpLink> filterObserverLinks(BuiltList<HelpLink> list) => list
       .where((link) =>
           link.availableTo.contains(AvailableTo.observer) ||
-          link.availableTo.contains(AvailableTo.user) ||
-          link.availableTo.contains(AvailableTo.unenrolled))
+          link.availableTo.contains(AvailableTo.user))
       .toList();
 }

--- a/apps/flutter_parent/test/screens/help/help_screen_interactor_test.dart
+++ b/apps/flutter_parent/test/screens/help/help_screen_interactor_test.dart
@@ -55,7 +55,7 @@ void main() {
     expect(list.any((l) => l.availableTo.contains(AvailableTo.teacher)), false);
     expect(list.any((l) => l.availableTo.contains(AvailableTo.observer)), true);
     expect(list.any((l) => l.availableTo.contains(AvailableTo.user)), true);
-    expect(list.any((l) => l.availableTo.contains(AvailableTo.unenrolled)), true);
+    expect(list.any((l) => l.availableTo.contains(AvailableTo.unenrolled)), false);
   });
 
   test('containsObserverLinks returns true when observer links present in list, false otherwise', () async {
@@ -81,7 +81,6 @@ void main() {
     var observerLinks = [
       createHelpLink(availableTo: [AvailableTo.observer]),
       createHelpLink(availableTo: [AvailableTo.user]),
-      createHelpLink(availableTo: [AvailableTo.unenrolled]),
     ];
 
     var nonObserverLinks = [
@@ -89,6 +88,7 @@ void main() {
       createHelpLink(availableTo: [AvailableTo.teacher]),
       createHelpLink(availableTo: [AvailableTo.admin]),
       createHelpLink(availableTo: [AvailableTo.admin]),
+      createHelpLink(availableTo: [AvailableTo.unenrolled]),
     ];
 
     expect(HelpScreenInteractor().filterObserverLinks(BuiltList.from([...observerLinks, ...nonObserverLinks])),
@@ -120,7 +120,7 @@ void main() {
   test('default list is returned if there are no custom lists', () async {
     var api = _MockHelpLinksApi();
     var defaultLinks = [
-      createHelpLink(availableTo: [AvailableTo.unenrolled]),
+      createHelpLink(availableTo: [AvailableTo.user]),
       createHelpLink(availableTo: [AvailableTo.observer]),
     ];
 


### PR DESCRIPTION
refs: MBL-14929
affects: Parent
release note: Help links are only visible for the correct user group.

test plan: See ticket.