### PR TITLE
[MBL-14891][Teacher] Unable to view discussion replies in SpeedGrader when masquerading

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/SimpleWebViewFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/SimpleWebViewFragment.kt
@@ -28,8 +28,6 @@ import kotlinx.coroutines.Job
  */
 class SimpleWebViewFragment : InternalWebViewFragment() {
 
-    private var apiCall: Job? = null
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         retainInstance = true
@@ -37,6 +35,8 @@ class SimpleWebViewFragment : InternalWebViewFragment() {
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         setShouldLoadUrl(false)
+        setShouldAuthenticateUponLoad(true)
+        setShouldRouteInternally(false)
         canvasWebView.setInitialScale(100)
         super.onActivityCreated(savedInstanceState)
 


### PR DESCRIPTION
Testing: Details in the ticket. I also added a comment to the ticket for easier testing.

refs: MBL-14891
affects: Teacher
release note: Fixed an issue where login is needed to view a discussion in speed grader.