### PR TITLE
[MBL-14964][Student][Teacher] Add possiblity to inspect network traffic in debug mode

### DIFF
--- a/apps/student/src/main/AndroidManifest.xml
+++ b/apps/student/src/main/AndroidManifest.xml
@@ -65,6 +65,7 @@
         android:largeHeap="true"
         android:usesCleartextTraffic="true"
         android:requestLegacyExternalStorage="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         tools:replace="android:supportsRtl"
         tools:overrideLibrary="com.instructure.canvasapi">
 

--- a/apps/teacher/src/main/AndroidManifest.xml
+++ b/apps/teacher/src/main/AndroidManifest.xml
@@ -45,6 +45,7 @@
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true"
         android:requestLegacyExternalStorage="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         tools:replace="android:icon">
 
         <activity

--- a/libs/pandautils/src/main/res/xml/network_security_config.xml
+++ b/libs/pandautils/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (C) 2020 - present Instructure, Inc.
+  ~
+  ~     This program is free software: you can redistribute it and/or modify
+  ~     it under the terms of the GNU General Public License as published by
+  ~     the Free Software Foundation, version 3 of the License.
+  ~
+  ~     This program is distributed in the hope that it will be useful,
+  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~     GNU General Public License for more details.
+  ~
+  ~     You should have received a copy of the GNU General Public License
+  ~     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  ~
+  -->
+<network-security-config>
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="user"/>
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>


### PR DESCRIPTION
Testing: Doesn't really require testing, it isn't affecting the app functionality. To verify the changes work check if the traffic can be inspected with Charles/Fiddler on debug builds and not on production builds.

refs: MBL-14964
affects: Teacher, Student
release note: -