### PR TITLE
[PDF][MBL-14954] Fixed bug with stamp color and duplicate annotations

### DIFF
--- a/libs/annotations/src/main/java/com/instructure/annotations/AnnotationConverter.kt
+++ b/libs/annotations/src/main/java/com/instructure/annotations/AnnotationConverter.kt
@@ -247,7 +247,7 @@ fun StampAnnotation.convertToCanvaDoc(canvaDocId: String): CanvaDocAnnotation {
             annotationType = CanvaDocAnnotation.AnnotationType.TEXT,
             rect = listOfRectsToListOfListOfFloats(listOf(this.boundingBox)),
             icon = "Comment",
-            color = getColorHexFromStampSubject(this.title),
+            color = getColorHexFromStamp(this.subject ?: this.title),
             contents = this.contents,
             iconColor= this.colorToHexString(),
             isEditable = true
@@ -379,8 +379,8 @@ private fun getStampSubjectFromColorHex(color: String?): String {
     }
 }
 
-private fun getColorHexFromStampSubject(subject: String?): String {
-    return when (subject) {
+private fun getColorHexFromStamp(stampTitle: String?): String {
+    return when (stampTitle) {
         blackStampSubject -> blackStampHex
         blueStampSubject -> blueStampHex
         brownStampSubject -> brownStampHex


### PR DESCRIPTION
This PR fixes two bugs with the stamp/point annotations (looks like a pin). They would often not retain their color when updating or when created. In addition, duplicate annotations were occurring very regularly, this adds a race condition check to prevent them from being created twice.

refs: MBL-14954
affects: Teacher, Student
release note: Fixed a bug with the point annotation not retaining its color on updates

test plan: Create a stamp annotatation, any color other than blue. Exit the pdf and re-open it, confirm its still the same color. Now update the annotation, move it, resize it, etc. Exit/re-enter and confirm the color remains the same. For the duplicate fix, just check that there isn't a second one hiding underneath :).