### PR TITLE
[MBL-11020][Teacher] Added grade slider support for "display grade as: percentage" assignments

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/SpeedGraderGradeFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/SpeedGraderGradeFragment.kt
@@ -193,7 +193,8 @@ class SpeedGraderGradeFragment : BasePresenterFragment<SpeedGraderGradePresenter
         }
     }
 
-    private fun shouldShowSliderView(assignment: Assignment): Boolean = (assignment.rubric == null || assignment.rubric!!.isEmpty()) && assignment.gradingType?.let { Assignment.getGradingTypeFromAPIString(it) } == Assignment.GradingType.POINTS
+    private fun shouldShowSliderView(assignment: Assignment): Boolean = (assignment.rubric == null || assignment.rubric!!.isEmpty())
+            && (assignment.gradingType?.let { Assignment.getGradingTypeFromAPIString(it) } == Assignment.GradingType.POINTS || assignment.gradingType?.let { Assignment.getGradingTypeFromAPIString(it) } == Assignment.GradingType.PERCENT)
 
     private fun shouldShowRubricView(assignment: Assignment): Boolean = assignment.rubric != null && assignment.rubric!!.isNotEmpty()
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/view/grade_slider/SpeedGraderSliderTooltipView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/view/grade_slider/SpeedGraderSliderTooltipView.kt
@@ -20,8 +20,6 @@ import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Rect
 import android.util.AttributeSet
-import com.instructure.pandautils.utils.positionOnScreen
-import com.instructure.teacher.utils.TeacherPrefs
 import com.instructure.teacher.view.TooltipView
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -39,8 +37,7 @@ class SpeedGraderSliderTooltipView @JvmOverloads constructor(
         } else if (event.assigneeId == assigneeId) {
             val thumbRect = event.seekBar.thumb.bounds
             val rect = Rect(thumbRect)
-            //This is needed because of the weird thumb boundaries
-            rect.left = thumbRect.left + (3 * thumbRect.width()) / 2
+            rect.left = event.seekBar.left + thumbRect.left + event.seekBar.paddingLeft
             showTip(event.description, rect)
         }
     }


### PR DESCRIPTION
refs: MBL-11020
affects: Teacher
release note: Added grade slider support for "display grade as: percentage" assignments.

test plan:
Open a "display grade as: percentage" assignment without rubrics.
The grade slider should be visible.
Assign the grade percentage using the slider > The grade should update.
If you update the grade with the custom grade dialog, the slider should update as well.
If you hold the slider at the minimum value for one second, you can clear the grade.
If you hold the slider at the maximum value one second, you can excuse the student.