### PR TITLE
[MBL-14941][Teacher] Accessibility issue on fragment_page_list in Landscape

### DIFF
--- a/apps/teacher/src/main/res/layout/adapter_page.xml
+++ b/apps/teacher/src/main/res/layout/adapter_page.xml
@@ -20,6 +20,7 @@
     android:id="@+id/pageLayout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:minHeight="48dp"
     android:background="?android:selectableItemBackground">
 
     <View


### PR DESCRIPTION
Testing: Run the mentioned UI tests on a low res (360x640 for example) phone API 25 emulator in landscape. 

refs: MBL-14941
affects: Teacher
release note: Fixed accessibility issues.