### PR TITLE
[Student][MBL-14960] Potential modules fix - needs product approval

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/adapter/ModuleListRecyclerAdapter.kt
+++ b/apps/student/src/main/java/com/instructure/student/adapter/ModuleListRecyclerAdapter.kt
@@ -83,7 +83,7 @@ open class ModuleListRecyclerAdapter(
 
         }
         isExpandedByDefault = false
-        isDisplayEmptyCell = true
+//        isDisplayEmptyCell = true TODO - make this work with scroll to functionality
         if (adapterToFragmentCallback != null) loadData() // Callback is null when testing
     }
 
@@ -339,7 +339,10 @@ open class ModuleListRecyclerAdapter(
                         ModuleManager.getFirstPageModuleItems(courseContext, it.id, getModuleItemsCallback(it, true), true)
                     }
                 }
-                adapterToFragmentCallback?.onRefreshFinished()
+                if(!this.moreCallsExist()) {
+                    // Wait until we are done exhausting pagination
+                    adapterToFragmentCallback?.onRefreshFinished()
+                }
             }
 
             override fun onFinished(type: ApiType) {
@@ -355,17 +358,13 @@ open class ModuleListRecyclerAdapter(
 
             // We only want to show modules if its a course nav option OR set to as the homepage
             if (tabs.find { it.tabId == "modules" } != null || (courseContext as Course).homePage?.apiString == "modules") {
-                ModuleManager.getFirstPageModuleObjects(courseContext, mModuleObjectCallback!!, true)
+                ModuleManager.getAllModuleObjets(courseContext, mModuleObjectCallback!!, true)
             } else {
                 adapterToFragmentCallback?.onRefreshFinished(true)
             }
         } catch {
             adapterToFragmentCallback?.onRefreshFinished(true)
         }
-    }
-
-    override fun loadNextPage(nextURL: String) {
-        ModuleManager.getNextPageModuleObjects(nextURL, mModuleObjectCallback!!, true)
     }
 
     // endregion

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/ModuleAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/ModuleAPI.kt
@@ -70,6 +70,14 @@ internal object ModuleAPI {
         }
     }
 
+    fun getAllModuleObjects(adapter: RestBuilder, params: RestParams, contextId: Long, callback: StatusCallback<List<ModuleObject>>) {
+        if (StatusCallback.isFirstPage(callback.linkHeaders)) {
+            callback.addCall(adapter.build(ModuleInterface::class.java, params).getFirstPageModuleObjects(contextId)).enqueue(callback)
+        } else {
+            callback.addCall(adapter.build(ModuleInterface::class.java, params).getNextPageModuleObjectList(callback.linkHeaders?.nextUrl ?: "")).enqueue(callback)
+        }
+    }
+
     fun getFirstPageModuleItems(adapter: RestBuilder, params: RestParams, contextId: Long, moduleId: Long, callback: StatusCallback<List<ModuleItem>>) {
         callback.addCall(adapter.build(ModuleInterface::class.java, params).getFirstPageModuleItems(contextId, moduleId)).enqueue(callback)
     }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/ModuleManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/ModuleManager.kt
@@ -42,6 +42,27 @@ object ModuleManager {
         ModuleAPI.getFirstPageModuleObjects(adapter, params, canvasContext.id, callback)
     }
 
+    fun getAllModuleObjets(
+        canvasContext: CanvasContext,
+        callback: StatusCallback<List<ModuleObject>>,
+        forceNetwork: Boolean
+    ) {
+        val adapter = RestBuilder(callback)
+        val params = RestParams(
+                canvasContext = canvasContext,
+                usePerPageQueryParam = true,
+                isForceReadFromNetwork = forceNetwork
+        )
+        val depaginatedCallback = object : ExhaustiveListCallback<ModuleObject>(callback) {
+            override fun getNextPage(callback: StatusCallback<List<ModuleObject>>, nextUrl: String, isCached: Boolean) {
+                val nextParams = params.copy(canvasContext = null, usePerPageQueryParam = false)
+                ModuleAPI.getAllModuleObjects(adapter, nextParams, canvasContext.id, callback)
+            }
+        }
+        adapter.statusCallback = depaginatedCallback
+        ModuleAPI.getAllModuleObjects(adapter, params, canvasContext.id, depaginatedCallback)
+    }
+
     fun getFirstPageModulesWithItems(
         canvasContext: CanvasContext,
         callback: StatusCallback<List<ModuleObject>>,


### PR DESCRIPTION
So the way our expandable recycler view code is set up doesn't play well with paginated modules _or_ the empty view stuff that was added back in when trying to "scroll to" a group position. This is a possible solution to get linking to modules linking fixed quickly, but it disables empty views and exhausts the pagination. A more involved solution is likely viable, but would require much more serious changes to the modules code. I think this one should go to product.

refs: MBL-14960
affects: Student
release note: Fixed a bug with links to modules