### PR TITLE
[MBL-14935][Teacher] Rubrics with points removed require users to add points in order to save rubric comments

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/view/edit_rubric/CriterionRatingLayout.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/view/edit_rubric/CriterionRatingLayout.kt
@@ -70,8 +70,10 @@ class CriterionRatingLayout @JvmOverloads constructor(
         buttons.forEach { it.isSelected = false }
         if (ratingId != null) {
             val selection = buttons.firstOrNull { it.ratingId == ratingId } ?: buttons.last()
-            value?.let { selection.pointValue = value }
-            selection.isSelected = true
+            value?.let {
+                selection.pointValue = value
+                selection.isSelected = true
+            }
         } else if (value != null) {
             val selection = buttons.firstOrNull { it.pointValue == value } ?: buttons.last()
             selection.pointValue = value

--- a/apps/teacher/src/main/java/com/instructure/teacher/view/edit_rubric/RubricEditView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/view/edit_rubric/RubricEditView.kt
@@ -237,7 +237,7 @@ class RubricEditView @JvmOverloads constructor(
     }
 
     /** Filters out assessments that have no data */
-    private val mHasData = { (points, comments): RubricCriterionAssessment -> points != null || comments != null }
+    private val mHasData = { criterion: RubricCriterionAssessment -> criterion.points != null || criterion.comments != null }
 
     val hasUnsavedChanges: Boolean get() = mOriginalAssessment.filterValues(mHasData) != mAssessment.filterValues(mHasData)
 


### PR DESCRIPTION
Testing: Steps in the ticket.

refs: MBL-14935
affects: Teacher
release note: Fixed an issue when a rubric comment cannot be saved without adding points.