### PR TITLE
[MBL-14973][Parent] Add possiblity to inspect network traffic in debug mode

### DIFF
--- a/apps/flutter_parent/lib/network/utils/dio_config.dart
+++ b/apps/flutter_parent/lib/network/utils/dio_config.dart
@@ -14,6 +14,7 @@
 
 import 'dart:io';
 
+import 'package:dio/adapter.dart';
 import 'package:dio/dio.dart';
 import 'package:dio_http_cache/dio_http_cache.dart';
 import 'package:dio_retry/dio_retry.dart';
@@ -121,7 +122,24 @@ class DioConfig {
       error: debug,
     ));
 
+    if (DebugFlags.isDebug) {
+      _configureDebugProxy(dio);
+    }
+
     return dio;
+  }
+
+  void _configureDebugProxy(Dio dio) {
+    const proxyIp = String.fromEnvironment('PROXY_IP', defaultValue: null);
+    const proxyPort = String.fromEnvironment('PROXY_PORT', defaultValue: null);
+    if (proxyIp == null) return;
+
+    (dio.httpClientAdapter as DefaultHttpClientAdapter).onHttpClientCreate =
+        (client) {
+      client.findProxy = (uri) => "PROXY $proxyIp:$proxyPort;";
+      client.badCertificateCallback =
+          (X509Certificate cert, String host, int port) => true;
+    };
   }
 
   Interceptor _cacheInterceptor() {


### PR DESCRIPTION
In Flutter it's not so straightforward to use a proxy for network monitoring. To achieve this we need to inline the IP and the port of our machine which we use as a proxy. This would make the code coupled for a specific IP/port and everybody would need to change that part of the code. To prevent this we can use launch arguments. Using launch arguments, we can specify our own IP and port. To specify this go to `Edit configurations...` in Android Studio and create a new run configuration with the following additional arguments:

`--dart-define=PROXY_IP=192.168.0.1,PROXY_PORT=8888` - replace the IP and the port with your own proxy settings.

Testing: This change does not change the production code, but it can be tested if the proxying works correctly.

refs: MBL-14973
affects: Parent
release note: -