### PR TITLE
[MBL-14932][Student] Can't view documents linked to Global Announcements

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
@@ -357,13 +357,14 @@ open class InternalWebviewFragment : ParentFragment() {
      * Otherwise the canvasContext won't be saved and will cause issues with the dropdown navigation
      * -dw
      */
-        fun makeRoute(url: String, title: String, authenticate: Boolean, html: String): Route =
+        fun makeRoute(url: String, title: String, authenticate: Boolean, html: String, allowUnsupportedRouting: Boolean = true): Route =
                 Route(InternalWebviewFragment::class.java, CanvasContext.emptyUserContext(),
                         CanvasContext.emptyUserContext().makeBundle().apply {
                             putString(Const.INTERNAL_URL, url)
                             putString(Const.ACTION_BAR_TITLE, title)
                             putBoolean(Const.AUTHENTICATE, authenticate)
                             putString(Const.HTML, html)
+                            putBoolean(Const.ALLOW_UNSUPPORTED_ROUTING, allowUnsupportedRouting)
                         })
 
         fun makeRoute(canvasContext: CanvasContext, url: String?, title: String?, authenticate: Boolean, html: String): Route =

--- a/apps/student/src/main/java/com/instructure/student/holders/AnnouncementViewHolder.kt
+++ b/apps/student/src/main/java/com/instructure/student/holders/AnnouncementViewHolder.kt
@@ -78,7 +78,7 @@ class AnnouncementViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)
         }
 
         onClick {
-            RouteMatcher.route(context, InternalWebviewFragment.makeRoute("", announcement.subject, false, announcement.message))
+            RouteMatcher.route(context, InternalWebviewFragment.makeRoute("", announcement.subject, false, announcement.message, allowUnsupportedRouting = false))
         }
 
         dismissImageButton.onClickWithRequireNetwork { dismiss() }


### PR DESCRIPTION
Disabled unsupported routing for the WebView in global announcements, so it won't try to route to the file, instead shows it in the webview.

This ticket is marked as Student/Teacher, however it only affects Student, sincs teacher does not have this feature.

Testing: Repro steps in the ticket, account info in comments.

refs: MBL-14932
affects: Student
release note: Fixed an issue, where linked documents couldn't be viewed in global announcements.