### PR TITLE
[MBL-14792][Student] Don't have to press twice for HTML files to go back

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/FileListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/FileListFragment.kt
@@ -188,7 +188,8 @@ class FileListFragment : ParentFragment(), Bookmarkable {
                             url = item.getFilePreviewUrl(ApiPrefs.fullDomain, canvasContext),
                             authenticate = true,
                             isUnsupportedFeature = false,
-                            allowUnsupportedRouting = false
+                            allowUnsupportedRouting = false,
+                            shouldRouteInternally = false
                         ))
                     } else {
                         openMedia(item.contentType, item.url, item.displayName, canvasContext)


### PR DESCRIPTION
refs: MBL-14792
affects: Student
release note: Fixed a bug where you had to press back twice to go back from HTML files.

test plan:
Upload a html file to your course files.
Open the file from the files list.
You should only have to click once to go back to the files list.