### PR TITLE
[Teacher][MBL-14864] Edit Syllabus

### DIFF
--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/EditSyllabusPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/EditSyllabusPageTest.kt
@@ -49,7 +49,7 @@ class EditSyllabusPageTest : TeacherTest() {
         goToEditSyllabus()
 
         editSyllabusPage.editSyllabusBody("Syllabus edited")
-        editSyllabusPage.changeShowSummary()
+        editSyllabusPage.toggleShowSummary()
         editSyllabusPage.saveSyllabusEdit()
 
         syllabusPage.assertDisplaysSyllabus("Syllabus edited", false)

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/EditSyllabusPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/EditSyllabusPageTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.teacher.ui
+
+import com.instructure.canvas.espresso.mockCanvas.*
+import com.instructure.canvasapi2.models.Assignment
+import com.instructure.canvasapi2.models.CanvasContextPermission
+import com.instructure.canvasapi2.models.CourseSettings
+import com.instructure.canvasapi2.models.Tab
+import com.instructure.dataseeding.util.days
+import com.instructure.dataseeding.util.fromNow
+import com.instructure.dataseeding.util.iso8601
+import com.instructure.espresso.ActivityHelper
+import com.instructure.teacher.ui.utils.TeacherTest
+import com.instructure.teacher.ui.utils.tokenLogin
+import org.junit.Test
+
+class EditSyllabusPageTest : TeacherTest() {
+
+    override fun displaysPageObjects() = Unit
+
+    @Test
+    fun testSaveEditedSyllabus() {
+        goToEditSyllabus()
+
+        editSyllabusPage.editSyllabusBody("Syllabus edited")
+        editSyllabusPage.saveSyllabusEdit()
+
+        syllabusPage.assertDisplaysSyllabus("Syllabus edited", true)
+        syllabusPage.assertSuccessfulSave(ActivityHelper.currentActivity())
+    }
+
+    @Test
+    fun testSaveEditedSyllabusWhenShowSummaryWasDisabled() {
+        goToEditSyllabus()
+
+        editSyllabusPage.editSyllabusBody("Syllabus edited")
+        editSyllabusPage.changeShowSummary()
+        editSyllabusPage.saveSyllabusEdit()
+
+        syllabusPage.assertDisplaysSyllabus("Syllabus edited", false)
+        syllabusPage.assertSuccessfulSave(ActivityHelper.currentActivity())
+    }
+
+    private fun goToEditSyllabus(): MockCanvas {
+
+        val data = MockCanvas.init(studentCount = 1, teacherCount = 1, courseCount = 1, favoriteCourseCount = 1)
+        val course = data.courses.values.first()
+
+        data.addCoursePermissions(course.id, CanvasContextPermission(canManageContent = true))
+
+        // Give the course a syllabus body
+        val updatedCourse = course.copy(syllabusBody = "Syllabus Body")
+        data.courses[course.id] = updatedCourse
+
+        // Give the course a syllabus tab
+        val syllabusTab = Tab(position = 2, label = "Syllabus", visibility = "public", tabId = Tab.SYLLABUS_ID)
+        data.courseTabs[course.id]!! += syllabusTab
+
+        // Enable the courseSummary setting to get a course summary
+        data.addCourseSettings(course.id, CourseSettings(courseSummary = true))
+
+        data.addCourseCalendarEvent(
+            courseId = course.id,
+            date = 2.days.fromNow.iso8601,
+            title = "Test Calendar Event",
+            description = "Calendar event: 1"
+        )
+
+        data.addAssignment(
+            courseId = course.id,
+            submissionType = Assignment.SubmissionType.ONLINE_TEXT_ENTRY,
+            dueAt = 2.days.fromNow.iso8601,
+            name = "Assignment: 1"
+        )
+
+        val teacher = data.teachers[0]
+        val token = data.tokenFor(teacher)!!
+        tokenLogin(data.domain, token, teacher)
+
+        coursesListPage.openCourse(course)
+        courseBrowserPage.openSyllabus()
+        syllabusPage.openEditSyllabus()
+
+        return data
+    }
+}

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/SyllabusPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/SyllabusPageTest.kt
@@ -68,12 +68,24 @@ class SyllabusPageTest : TeacherTest() {
         calendarEventPage.verifyDescription(calendarEvent.description!!)
     }
 
+    // Tests that we can open the edit syllabus.
+    @Test
+    fun testSyllabus_openEditSyllabus() {
+        // We have to add this delay to be sure that the remote config is already fetched before we want to override remote config values.
+        Thread.sleep(3000)
+        RemoteConfigPrefs.putString(RemoteConfigParam.SHOW_TEACHER_SYLLABUS.rc_name, "true")
+        goToSyllabus(eventCount = 0, assignmentCount = 1)
+
+        syllabusPage.openEditSyllabus()
+        editSyllabusPage.assertToolbarDisplayedWithCorrectTitle()
+    }
+
     private fun goToSyllabus(eventCount: Int, assignmentCount: Int): MockCanvas {
 
         val data = MockCanvas.init(studentCount = 1, teacherCount = 1, courseCount = 1, favoriteCourseCount = 1)
         val course = data.courses.values.first()
 
-        data.addCoursePermissions(course.id, CanvasContextPermission())
+        data.addCoursePermissions(course.id, CanvasContextPermission(canManageContent = true))
 
         // Give the course a syllabus body
         val updatedCourse = course.copy(syllabusBody = "Syllabus Body")

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/EditSyllabusPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/EditSyllabusPage.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.teacher.ui.pages
+
+import com.instructure.espresso.WaitForViewWithText
+import com.instructure.espresso.assertDisplayed
+import com.instructure.espresso.page.BasePage
+import com.instructure.teacher.R
+
+class EditSyllabusPage : BasePage(R.id.editSyllabusPage) {
+
+    private val toolbar by WaitForViewWithText(R.string.editSyllabusTitle)
+
+    fun assertToolbarDisplayedWithCorrectTitle() {
+        toolbar.assertDisplayed()
+    }
+}

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/EditSyllabusPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/EditSyllabusPage.kt
@@ -40,7 +40,7 @@ class EditSyllabusPage : BasePage(R.id.editSyllabusPage) {
         saveButton.click()
     }
 
-    fun changeShowSummary() {
+    fun toggleShowSummary() {
         showCourseSummarySwitch.click()
     }
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/EditSyllabusPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/EditSyllabusPage.kt
@@ -16,16 +16,31 @@
  */
 package com.instructure.teacher.ui.pages
 
-import com.instructure.espresso.WaitForViewWithText
-import com.instructure.espresso.assertDisplayed
+import com.instructure.espresso.*
 import com.instructure.espresso.page.BasePage
 import com.instructure.teacher.R
+import com.instructure.teacher.ui.utils.TypeInRCETextEditor
 
 class EditSyllabusPage : BasePage(R.id.editSyllabusPage) {
 
     private val toolbar by WaitForViewWithText(R.string.editSyllabusTitle)
+    private val saveButton by OnViewWithId(R.id.menuSaveSyllabus)
+    private val contentRceView by WaitForViewWithId(R.id.rce_webView)
+    private val showCourseSummarySwitch by OnViewWithId(R.id.showSummarySwitch)
 
     fun assertToolbarDisplayedWithCorrectTitle() {
         toolbar.assertDisplayed()
+    }
+
+    fun editSyllabusBody(text: String) {
+        contentRceView.perform(TypeInRCETextEditor(text))
+    }
+
+    fun saveSyllabusEdit() {
+        saveButton.click()
+    }
+
+    fun changeShowSummary() {
+        showCourseSummarySwitch.click()
     }
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/SyllabusPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/SyllabusPage.kt
@@ -23,6 +23,7 @@ import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.espresso.assertDisplayed
 import com.instructure.espresso.click
 import com.instructure.espresso.page.BasePage
+import com.instructure.espresso.page.onViewWithId
 import com.instructure.espresso.page.withAncestor
 import com.instructure.espresso.swipeDown
 import com.instructure.teacher.R
@@ -48,6 +49,10 @@ open class SyllabusPage : BasePage(R.id.syllabusPage) {
 
     fun refresh() {
         Espresso.onView(Matchers.allOf(ViewMatchers.withId(R.id.swipeRefreshLayout), withAncestor(R.id.syllabusPage))).swipeDown()
+    }
+
+    fun openEditSyllabus() {
+        onViewWithId(R.id.menu_edit).click()
     }
 
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/SyllabusPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/SyllabusPage.kt
@@ -16,20 +16,29 @@
  */
 package com.instructure.teacher.ui.pages
 
+import android.app.Activity
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.web.assertion.WebViewAssertions
+import androidx.test.espresso.web.sugar.Web
+import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
+import androidx.test.espresso.web.webdriver.DriverAtoms.getText
+import androidx.test.espresso.web.webdriver.Locator
+import com.instructure.canvas.espresso.checkToastText
 import com.instructure.canvas.espresso.containsTextCaseInsensitive
 import com.instructure.canvas.espresso.scrollRecyclerView
-import com.instructure.espresso.assertDisplayed
-import com.instructure.espresso.click
+import com.instructure.espresso.*
 import com.instructure.espresso.page.BasePage
 import com.instructure.espresso.page.onViewWithId
 import com.instructure.espresso.page.withAncestor
-import com.instructure.espresso.swipeDown
 import com.instructure.teacher.R
-import org.hamcrest.Matchers
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.comparesEqualTo
 
 open class SyllabusPage : BasePage(R.id.syllabusPage) {
+
+    private val tabs by OnViewWithId(R.id.syllabusTabLayout)
+    private val webView by WaitForViewWithId(R.id.syllabusWebView)
 
     fun assertItemDisplayed(itemText: String) {
         scrollRecyclerView(R.id.syllabusEventsRecyclerView, itemText)
@@ -48,11 +57,22 @@ open class SyllabusPage : BasePage(R.id.syllabusPage) {
     }
 
     fun refresh() {
-        Espresso.onView(Matchers.allOf(ViewMatchers.withId(R.id.swipeRefreshLayout), withAncestor(R.id.syllabusPage))).swipeDown()
+        Espresso.onView(allOf(ViewMatchers.withId(R.id.swipeRefreshLayout), withAncestor(R.id.syllabusPage))).swipeDown()
     }
 
     fun openEditSyllabus() {
         onViewWithId(R.id.menu_edit).click()
     }
 
+    fun assertDisplaysSyllabus(syllabusBody: String, shouldDisplayTabs: Boolean = true) {
+        if (shouldDisplayTabs) tabs.assertDisplayed() else tabs.assertNotDisplayed()
+        webView.assertDisplayed()
+        Web.onWebView()
+            .withElement(findElement(Locator.TAG_NAME, "html"))
+            .check(WebViewAssertions.webMatches(getText(), comparesEqualTo(syllabusBody)))
+    }
+
+    fun assertSuccessfulSave(activity: Activity) {
+        checkToastText(R.string.syllabusSuccessfullyUpdated, activity)
+    }
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/renderTests/EditSyllabusRenderTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/renderTests/EditSyllabusRenderTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.teacher.ui.renderTests
+
+import com.instructure.canvasapi2.models.Course
+import com.instructure.teacher.features.syllabus.edit.EditSyllabusFragment
+import com.instructure.teacher.features.syllabus.edit.EditSyllabusViewState
+import com.instructure.teacher.ui.renderTests.pages.EditSyllabusRenderPage
+import com.instructure.teacher.ui.utils.TeacherRenderTest
+import com.spotify.mobius.runners.WorkRunner
+import org.junit.Test
+
+class EditSyllabusRenderTest : TeacherRenderTest() {
+
+    private val editSyllabusRenderPage = EditSyllabusRenderPage()
+
+    @Test
+    fun displayCorrectLoadedState() {
+        val viewState = EditSyllabusViewState.Loaded("Syllabus body", true)
+        loadPageWithState(viewState)
+
+        editSyllabusRenderPage.assertLoadedStateDisplayed()
+    }
+
+    @Test
+    fun displayCorrectSavedState() {
+        val viewState = EditSyllabusViewState.Saving
+        loadPageWithState(viewState)
+
+        editSyllabusRenderPage.assertSavingStateDisplayed()
+    }
+
+    @Test
+    fun displayCorrectDataWithSummaryNotAllowed() {
+        val viewState = EditSyllabusViewState.Loaded("Syllabus body", false)
+        loadPageWithState(viewState)
+
+        editSyllabusRenderPage.assertCorrectDataDisplayed("Syllabus body", false)
+    }
+
+    @Test
+    fun displayCorrectDataWithSummaryAllowed() {
+        val viewState = EditSyllabusViewState.Loaded("Syllabus body", true)
+        loadPageWithState(viewState)
+
+        editSyllabusRenderPage.assertCorrectDataDisplayed("Syllabus body", true)
+    }
+
+    private fun loadPageWithState(viewState: EditSyllabusViewState) {
+        val emptyEffectRunner = object : WorkRunner {
+            override fun dispose() = Unit
+            override fun post(runnable: Runnable) = Unit
+        }
+        val bundle = EditSyllabusFragment.createArgs(Course(), false)
+        val fragment = EditSyllabusFragment.newInstance(bundle).apply {
+            overrideInitViewState = viewState
+            loopMod = { it.effectRunner { emptyEffectRunner } }
+        }
+        activityRule.activity.loadFragment(fragment)
+    }
+}

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/renderTests/SyllabusRenderTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/renderTests/SyllabusRenderTest.kt
@@ -16,6 +16,7 @@
  */
 package com.instructure.teacher.ui.renderTests
 
+import com.instructure.canvasapi2.models.CanvasContextPermission
 import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.models.ScheduleItem
 import com.instructure.canvasapi2.utils.DataResult
@@ -123,6 +124,15 @@ class SyllabusRenderTest : TeacherRenderTest() {
         syllabusRenderPage.assertDisplaysEvents()
         syllabusRenderPage.swipeToSyllabusTab()
         syllabusRenderPage.assertDisplaysEvents()
+    }
+
+    @Test
+    fun editShownIfTeacherHavePermissionToEdit() {
+        val permissions = CanvasContextPermission(canManageContent = true)
+        val model = baseModel.copy(syllabus = null, events = DataResult.Success(List(3) { ScheduleItem(title = it.toString()) }), permissions = DataResult.Success(permissions))
+        loadPageWithModel(model)
+
+        syllabusRenderPage.assertDisplayEditIcon()
     }
 
     private fun loadPageWithModel(model: SyllabusModel) {

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/renderTests/SyllabusRenderTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/renderTests/SyllabusRenderTest.kt
@@ -43,7 +43,8 @@ class SyllabusRenderTest : TeacherRenderTest() {
             course = DataResult.Success(Course(id = courseId, name = "Test Course", syllabusBody = syllabusDescription)),
             isLoading = false,
             syllabus = ScheduleItem.createSyllabus("", "<p>$syllabusDescription</p>"),
-            events = DataResult.Success(emptyList())
+            events = DataResult.Success(emptyList()),
+            summaryAllowed = true
         )
     }
 

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/renderTests/pages/EditSyllabusRenderPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/renderTests/pages/EditSyllabusRenderPage.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.teacher.ui.renderTests.pages
+
+import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.web.assertion.WebViewAssertions.webMatches
+import androidx.test.espresso.web.sugar.Web.onWebView
+import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
+import androidx.test.espresso.web.webdriver.DriverAtoms.getText
+import androidx.test.espresso.web.webdriver.Locator
+import com.instructure.espresso.OnViewWithId
+import com.instructure.espresso.WaitForViewWithId
+import com.instructure.espresso.assertDisplayed
+import com.instructure.espresso.page.BasePage
+import com.instructure.teacher.R
+import org.hamcrest.Matchers.containsString
+
+class EditSyllabusRenderPage : BasePage(R.id.editSyllabusPage) {
+
+    private val toolbar by OnViewWithId(R.id.toolbar)
+    private val saveButton by OnViewWithId(R.id.menuSaveSyllabus)
+    private val savingProgressBar by OnViewWithId(R.id.savingProgressBar)
+    private val contentLabel by OnViewWithId(R.id.contentLabel)
+    private val contentRceView by WaitForViewWithId(R.id.rce_webView)
+    private val detailsLabel by OnViewWithId(R.id.detailsLabel)
+    private val showCourseSummaryLabel by OnViewWithId(R.id.showSummaryLabel)
+    private val showCourseSummarySwitch by OnViewWithId(R.id.showSummarySwitch)
+
+    fun assertLoadedStateDisplayed() {
+        toolbar.assertDisplayed()
+        saveButton.assertDisplayed()
+        contentLabel.assertDisplayed()
+        contentRceView.assertDisplayed()
+        detailsLabel.assertDisplayed()
+        showCourseSummaryLabel.assertDisplayed()
+        showCourseSummaryLabel.assertDisplayed()
+    }
+
+    fun assertSavingStateDisplayed() {
+        savingProgressBar.assertDisplayed()
+    }
+
+    fun assertCorrectDataDisplayed(syllabusBody: String, showSummary: Boolean) {
+        val checkedMatcher = if (showSummary) ViewMatchers.isChecked() else ViewMatchers.isNotChecked()
+        showCourseSummarySwitch.check(ViewAssertions.matches(checkedMatcher))
+
+        onWebView()
+            .withElement(findElement(Locator.TAG_NAME, "html"))
+            .check(webMatches(getText(), containsString(syllabusBody)))
+    }
+}

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/renderTests/pages/SyllabusRenderPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/renderTests/pages/SyllabusRenderPage.kt
@@ -35,6 +35,7 @@ class SyllabusRenderPage : SyllabusPage() {
     private val eventsRecycler by WaitForViewWithId(R.id.syllabusEventsRecyclerView)
     private val eventsEmpty by WaitForViewWithId(R.id.syllabusEmptyView)
     private val eventsError by WaitForViewWithId(R.id.syllabusEventsError)
+    private val editIcon by WaitForViewWithId(R.id.menu_edit)
 
     fun assertDisplaysToolbarText(text: String) {
         findChildTextInToolbar(text).assertDisplayed()
@@ -75,5 +76,9 @@ class SyllabusRenderPage : SyllabusPage() {
 
     fun swipeToSyllabusTab() {
         onView(withId(R.id.syllabusPager)).perform(ViewActions.swipeRight())
+    }
+
+    fun assertDisplayEditIcon() {
+        editIcon.assertDisplayed()
     }
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/renderTests/pages/SyllabusRenderPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/renderTests/pages/SyllabusRenderPage.kt
@@ -48,12 +48,6 @@ class SyllabusRenderPage : SyllabusPage() {
         webView.assertNotDisplayed()
     }
 
-    fun assertDisplaysSyllabus(text: String, shouldDisplayTabs: Boolean = true) {
-        if (shouldDisplayTabs) tabs.assertDisplayed() else tabs.assertNotDisplayed()
-        webView.assertDisplayed()
-        Web.onWebView().withElement(DriverAtoms.findElement(Locator.TAG_NAME, "p")).check(WebViewAssertions.webMatches(DriverAtoms.getText(), Matchers.comparesEqualTo(text)))
-    }
-
     fun assertDisplaysEmpty() {
         eventsEmpty.assertDisplayed()
     }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/utils/TeacherTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/utils/TeacherTest.kt
@@ -17,11 +17,17 @@
 package com.instructure.teacher.ui.utils
 
 import android.app.Activity
+import android.view.View
+import androidx.test.espresso.UiController
+import androidx.test.espresso.ViewAction
+import androidx.test.espresso.matcher.ViewMatchers
 import com.instructure.canvas.espresso.CanvasTest
 import com.instructure.espresso.InstructureActivityTestRule
 import com.instructure.teacher.BuildConfig
 import com.instructure.teacher.activities.LoginActivity
 import com.instructure.teacher.ui.pages.*
+import instructure.rceditor.RCETextEditor
+import org.hamcrest.Matcher
 
 abstract class TeacherTest : CanvasTest() {
 
@@ -73,4 +79,24 @@ abstract class TeacherTest : CanvasTest() {
     val dashboardPage = DashboardPage()
     val editSyllabusPage = EditSyllabusPage()
 
+}
+
+/*
+ * Custom action to enter text into an RCETextEditor
+ * This had to go here, instead of CustomActions, because CustomActions is not aware of RCETExtEditor.
+ */
+class TypeInRCETextEditor(val text: String) : ViewAction {
+    override fun getDescription(): String {
+        return "Enters text into an RCETextEditor"
+    }
+
+    override fun getConstraints(): Matcher<View> {
+        return ViewMatchers.isAssignableFrom(RCETextEditor::class.java)
+    }
+
+    override fun perform(uiController: UiController?, view: View?) {
+        when(view) {
+            is RCETextEditor -> view.applyHtml(text)
+        }
+    }
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/utils/TeacherTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/utils/TeacherTest.kt
@@ -71,5 +71,6 @@ abstract class TeacherTest : CanvasTest() {
     val syllabusPage = SyllabusPage()
     val calendarEventPage = CalendarEventPage()
     val dashboardPage = DashboardPage()
+    val editSyllabusPage = EditSyllabusPage()
 
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/events/BusEvents.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/events/BusEvents.kt
@@ -208,4 +208,4 @@ class CourseColorOverlayToggledEvent
 
 class DiscussionOverflowMenuClickedEvent(val type: DiscussionBottomSheetChoice, val entryId: Long)
 
-class SyllabusUpdatedEvent(skipId: String? = null) : RationedBusEvent<Boolean>(true, skipId)
+class SyllabusUpdatedEvent(val content: String, val summaryAllowed: Boolean, skipId: String? = null) : RationedBusEvent<String>(content, skipId)

--- a/apps/teacher/src/main/java/com/instructure/teacher/events/BusEvents.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/events/BusEvents.kt
@@ -207,3 +207,5 @@ class SubmissionFilterChangedEvent(val filterIndex: Int = -1, val canvasContext:
 class CourseColorOverlayToggledEvent
 
 class DiscussionOverflowMenuClickedEvent(val type: DiscussionBottomSheetChoice, val entryId: Long)
+
+class SyllabusUpdatedEvent(skipId: String? = null) : RationedBusEvent<Boolean>(true, skipId)

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusEffectHandler.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusEffectHandler.kt
@@ -34,6 +34,7 @@ class SyllabusEffectHandler : EffectHandler<SyllabusView, SyllabusEvent, Syllabu
             is SyllabusEffect.LoadData -> loadData(effect)
             is SyllabusEffect.ShowAssignmentView -> view?.showAssignmentView(effect.assignment, effect.course)
             is SyllabusEffect.ShowScheduleItemView -> view?.showScheduleItemView(effect.scheduleItem, effect.course)
+            is SyllabusEffect.OpenEditSyllabus -> view?.openEditSyllabus(effect.course, effect.summaryAllowed)
         }.exhaustive
     }
 
@@ -49,7 +50,7 @@ class SyllabusEffectHandler : EffectHandler<SyllabusView, SyllabusEvent, Syllabu
             val summaryResult: DataResult<List<ScheduleItem>>
             if (course.isFail) {
                 summaryResult = if (summaryAllowed) DataResult.Fail() else DataResult.Success(emptyList())
-                consumer.accept(SyllabusEvent.DataLoaded(course, summaryResult, DataResult.Fail()))
+                consumer.accept(SyllabusEvent.DataLoaded(course, summaryResult, DataResult.Fail(), summaryAllowed))
                 return@launch
             }
 
@@ -74,7 +75,7 @@ class SyllabusEffectHandler : EffectHandler<SyllabusView, SyllabusEvent, Syllabu
             val permissionsDeferred = CourseManager.getPermissionsAsync(course.dataOrThrow.id, listOf(CanvasContextPermission.MANAGE_CONTENT))
             val permissionsResult = permissionsDeferred.await()
 
-            consumer.accept(SyllabusEvent.DataLoaded(course, summaryResult, permissionsResult))
+            consumer.accept(SyllabusEvent.DataLoaded(course, summaryResult, permissionsResult, summaryAllowed))
         }
     }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusModels.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusModels.kt
@@ -33,6 +33,7 @@ sealed class SyllabusEvent {
     ) : SyllabusEvent()
 
     data class SyllabusItemClicked(val itemId: String) : SyllabusEvent()
+    data class SyllabusUpdatedEvent(val content: String, val summaryAllowed: Boolean) : SyllabusEvent()
     object EditClicked : SyllabusEvent()
 }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusModels.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusModels.kt
@@ -24,14 +24,23 @@ import com.instructure.canvasapi2.utils.DataResult
 
 sealed class SyllabusEvent {
     object PullToRefresh : SyllabusEvent()
-    data class DataLoaded(val course: DataResult<Course>, val events: DataResult<List<ScheduleItem>>, val permissionsResult: DataResult<CanvasContextPermission>) : SyllabusEvent()
+
+    data class DataLoaded(
+        val course: DataResult<Course>,
+        val events: DataResult<List<ScheduleItem>>,
+        val permissionsResult: DataResult<CanvasContextPermission>,
+        val summaryAllowed: Boolean = false
+    ) : SyllabusEvent()
+
     data class SyllabusItemClicked(val itemId: String) : SyllabusEvent()
+    object EditClicked : SyllabusEvent()
 }
 
 sealed class SyllabusEffect {
     data class LoadData(val courseId: Long, val forceNetwork: Boolean) : SyllabusEffect()
     data class ShowAssignmentView(val assignment: Assignment, val course: Course) : SyllabusEffect()
     data class ShowScheduleItemView(val scheduleItem: ScheduleItem, val course: Course) : SyllabusEffect()
+    data class OpenEditSyllabus(val course: Course, val summaryAllowed: Boolean) : SyllabusEffect()
 }
 
 data class SyllabusModel(
@@ -40,5 +49,6 @@ data class SyllabusModel(
         val course: DataResult<Course>? = null,
         val syllabus: ScheduleItem? = null,
         val events: DataResult<List<ScheduleItem>>? = null,
-        val permissions: DataResult<CanvasContextPermission>? = null
+        val permissions: DataResult<CanvasContextPermission>? = null,
+        val summaryAllowed: Boolean = false
 )

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusModels.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusModels.kt
@@ -17,13 +17,14 @@
 package com.instructure.teacher.features.syllabus
 
 import com.instructure.canvasapi2.models.Assignment
+import com.instructure.canvasapi2.models.CanvasContextPermission
 import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.models.ScheduleItem
 import com.instructure.canvasapi2.utils.DataResult
 
 sealed class SyllabusEvent {
     object PullToRefresh : SyllabusEvent()
-    data class DataLoaded(val course: DataResult<Course>, val events: DataResult<List<ScheduleItem>>) : SyllabusEvent()
+    data class DataLoaded(val course: DataResult<Course>, val events: DataResult<List<ScheduleItem>>, val permissionsResult: DataResult<CanvasContextPermission>) : SyllabusEvent()
     data class SyllabusItemClicked(val itemId: String) : SyllabusEvent()
 }
 
@@ -38,5 +39,6 @@ data class SyllabusModel(
         val isLoading: Boolean = false,
         val course: DataResult<Course>? = null,
         val syllabus: ScheduleItem? = null,
-        val events: DataResult<List<ScheduleItem>>? = null
+        val events: DataResult<List<ScheduleItem>>? = null,
+        val permissions: DataResult<CanvasContextPermission>? = null
 )

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusPresenter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusPresenter.kt
@@ -53,7 +53,8 @@ class SyllabusPresenter : Presenter<SyllabusModel, SyllabusViewState> {
         return SyllabusViewState.Loaded(
             syllabus = body,
             eventsState = events.takeUnless { it == EventsViewState.Empty && body != null },
-            canEdit = canEdit)
+            canEdit = canEdit,
+            showSummary = model.summaryAllowed)
     }
 
     private fun mapEventsResultToViewState(color: Int, eventsResult: DataResult<List<ScheduleItem>>?, context: Context): EventsViewState {

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusPresenter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusPresenter.kt
@@ -48,10 +48,12 @@ class SyllabusPresenter : Presenter<SyllabusModel, SyllabusViewState> {
         val course = model.course?.dataOrNull
         val events = mapEventsResultToViewState(course?.color ?: 0, model.events, context)
         val body = model.syllabus?.description?.takeIf { it.isValid() }
+        val canEdit = model.permissions?.dataOrNull?.canManageContent == true
 
         return SyllabusViewState.Loaded(
-                syllabus = body,
-                eventsState = events.takeUnless { it == EventsViewState.Empty && body != null })
+            syllabus = body,
+            eventsState = events.takeUnless { it == EventsViewState.Empty && body != null },
+            canEdit = canEdit)
     }
 
     private fun mapEventsResultToViewState(color: Int, eventsResult: DataResult<List<ScheduleItem>>?, context: Context): EventsViewState {

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusUpdate.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusUpdate.kt
@@ -17,6 +17,7 @@
 package com.instructure.teacher.features.syllabus
 
 import com.instructure.canvasapi2.models.ScheduleItem
+import com.instructure.canvasapi2.utils.DataResult
 import com.instructure.teacher.mobius.common.ui.UpdateInit
 import com.spotify.mobius.First
 import com.spotify.mobius.Next
@@ -29,29 +30,54 @@ class SyllabusUpdate : UpdateInit<SyllabusModel, SyllabusEvent, SyllabusEffect>(
 
     override fun update(model: SyllabusModel, event: SyllabusEvent): Next<SyllabusModel, SyllabusEffect> {
         return when (event) {
-            SyllabusEvent.PullToRefresh -> Next.next(model.copy(isLoading = true), setOf<SyllabusEffect>(SyllabusEffect.LoadData(model.courseId, true)))
-            is SyllabusEvent.DataLoaded -> {
-                Next.next(model.copy(
-                    isLoading = false,
-                    course = event.course,
-                    events = event.events,
-                    syllabus = event.course.dataOrNull?.let { ScheduleItem.createSyllabus(it.name, it.syllabusBody) },
-                    permissions = event.permissionsResult,
-                    summaryAllowed = event.summaryAllowed
-                ))
+            is SyllabusEvent.PullToRefresh -> handlePullToRefresh(model)
+            is SyllabusEvent.DataLoaded -> handleDataLoaded(model, event)
+            is SyllabusEvent.SyllabusItemClicked -> handleSyllabusItemClicked(model, event)
+            is SyllabusEvent.EditClicked -> handleEditClicked(model)
+            is SyllabusEvent.SyllabusUpdatedEvent -> handleSyllabusUpdatedEvent(model, event)
+        }
+    }
+
+    private fun handlePullToRefresh(model: SyllabusModel): Next<SyllabusModel, SyllabusEffect> {
+        return Next.next(model.copy(isLoading = true), setOf<SyllabusEffect>(SyllabusEffect.LoadData(model.courseId, true)))
+    }
+
+    private fun handleDataLoaded(model: SyllabusModel, event: SyllabusEvent.DataLoaded): Next<SyllabusModel, SyllabusEffect> {
+        return Next.next(model.copy(
+            isLoading = false,
+            course = event.course,
+            events = event.events,
+            syllabus = event.course.dataOrNull?.let { ScheduleItem.createSyllabus(it.name, it.syllabusBody) },
+            permissions = event.permissionsResult,
+            summaryAllowed = event.summaryAllowed
+        ))
+    }
+
+    private fun handleSyllabusItemClicked(model: SyllabusModel, event: SyllabusEvent.SyllabusItemClicked): Next<SyllabusModel, SyllabusEffect> {
+        val item = model.events!!.dataOrThrow.find { it.itemId == event.itemId }!!
+        return Next.dispatch(setOf(
+            when {
+                item.assignment != null -> SyllabusEffect.ShowAssignmentView(item.assignment!!, model.course!!.dataOrThrow)
+                else -> SyllabusEffect.ShowScheduleItemView(item, model.course!!.dataOrThrow)
             }
-            is SyllabusEvent.SyllabusItemClicked -> {
-                val item = model.events!!.dataOrThrow.find { it.itemId == event.itemId }!!
-                Next.dispatch(setOf(
-                        when {
-                            item.assignment != null -> SyllabusEffect.ShowAssignmentView(item.assignment!!, model.course!!.dataOrThrow)
-                            else -> SyllabusEffect.ShowScheduleItemView(item, model.course!!.dataOrThrow)
-                        }
-                ))
-            }
-            is SyllabusEvent.EditClicked -> {
-                Next.dispatch(setOf(SyllabusEffect.OpenEditSyllabus(model.course!!.dataOrThrow, model.summaryAllowed)))
-            }
+        ))
+    }
+
+    private fun handleEditClicked(model: SyllabusModel): Next<SyllabusModel, SyllabusEffect> {
+        return Next.dispatch(setOf(SyllabusEffect.OpenEditSyllabus(model.course!!.dataOrThrow, model.summaryAllowed)))
+    }
+
+    private fun handleSyllabusUpdatedEvent(model: SyllabusModel, event: SyllabusEvent.SyllabusUpdatedEvent): Next<SyllabusModel, SyllabusEffect> {
+        return if (model.summaryAllowed == event.summaryAllowed) {
+            val course = model.course?.dataOrNull?.copy(syllabusBody = event.content)
+            val syllabus = ScheduleItem.createSyllabus(course?.name, event.content)
+            val courseResult = course?.let {
+                DataResult.Success(course)
+            } ?: DataResult.Fail()
+
+            Next.next(model.copy(course = courseResult, syllabus = syllabus))
+        } else {
+            Next.next(model.copy(isLoading = true), setOf<SyllabusEffect>(SyllabusEffect.LoadData(model.courseId, true)))
         }
     }
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusUpdate.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusUpdate.kt
@@ -36,7 +36,8 @@ class SyllabusUpdate : UpdateInit<SyllabusModel, SyllabusEvent, SyllabusEffect>(
                     course = event.course,
                     events = event.events,
                     syllabus = event.course.dataOrNull?.let { ScheduleItem.createSyllabus(it.name, it.syllabusBody) },
-                    permissions = event.permissionsResult
+                    permissions = event.permissionsResult,
+                    summaryAllowed = event.summaryAllowed
                 ))
             }
             is SyllabusEvent.SyllabusItemClicked -> {
@@ -47,6 +48,9 @@ class SyllabusUpdate : UpdateInit<SyllabusModel, SyllabusEvent, SyllabusEffect>(
                             else -> SyllabusEffect.ShowScheduleItemView(item, model.course!!.dataOrThrow)
                         }
                 ))
+            }
+            is SyllabusEvent.EditClicked -> {
+                Next.dispatch(setOf(SyllabusEffect.OpenEditSyllabus(model.course!!.dataOrThrow, model.summaryAllowed)))
             }
         }
     }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusUpdate.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusUpdate.kt
@@ -68,7 +68,7 @@ class SyllabusUpdate : UpdateInit<SyllabusModel, SyllabusEvent, SyllabusEffect>(
     }
 
     private fun handleSyllabusUpdatedEvent(model: SyllabusModel, event: SyllabusEvent.SyllabusUpdatedEvent): Next<SyllabusModel, SyllabusEffect> {
-        return if (model.summaryAllowed == event.summaryAllowed) {
+        return if (model.summaryAllowed == event.summaryAllowed && event.content.isNotEmpty()) {
             val course = model.course?.dataOrNull?.copy(syllabusBody = event.content)
             val syllabus = ScheduleItem.createSyllabus(course?.name, event.content)
             val courseResult = course?.let {

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusUpdate.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusUpdate.kt
@@ -32,10 +32,11 @@ class SyllabusUpdate : UpdateInit<SyllabusModel, SyllabusEvent, SyllabusEffect>(
             SyllabusEvent.PullToRefresh -> Next.next(model.copy(isLoading = true), setOf<SyllabusEffect>(SyllabusEffect.LoadData(model.courseId, true)))
             is SyllabusEvent.DataLoaded -> {
                 Next.next(model.copy(
-                        isLoading = false,
-                        course = event.course,
-                        events = event.events,
-                        syllabus = event.course.dataOrNull?.let { ScheduleItem.createSyllabus(it.name, it.syllabusBody) }
+                    isLoading = false,
+                    course = event.course,
+                    events = event.events,
+                    syllabus = event.course.dataOrNull?.let { ScheduleItem.createSyllabus(it.name, it.syllabusBody) },
+                    permissions = event.permissionsResult
                 ))
             }
             is SyllabusEvent.SyllabusItemClicked -> {

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusEffectHandler.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusEffectHandler.kt
@@ -27,7 +27,9 @@ class EditSyllabusEffectHandler : EffectHandler<EditSyllabusView, EditSyllabusEv
         when (effect) {
             is EditSyllabusEffect.SaveData -> saveData(effect)
             EditSyllabusEffect.CloseEdit -> view?.closeEditSyllabus()
+            EditSyllabusEffect.ShowSaveSuccess -> view?.showSaveSuccess()
             EditSyllabusEffect.ShowSaveError -> view?.showSaveError()
+            EditSyllabusEffect.ShowCloseConfirmationDialog -> view?.showCloseConfirmationDialog()
         }.exhaustive
     }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusEffectHandler.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusEffectHandler.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.teacher.features.syllabus.edit
+
+import com.instructure.teacher.mobius.common.ui.EffectHandler
+
+class EditSyllabusEffectHandler : EffectHandler<EditSyllabusView, EditSyllabusEvent, EditSyllabusEffect>() {
+
+    override fun accept(value: EditSyllabusEffect) {
+
+    }
+
+}

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusEffectHandler.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusEffectHandler.kt
@@ -36,11 +36,12 @@ class EditSyllabusEffectHandler : EffectHandler<EditSyllabusView, EditSyllabusEv
             val id = effect.course.id
             val syllabusBody = effect.newContent
             val editedCourse = CourseManager.editCourseSyllabusAsync(id, syllabusBody).await()
+            val courseSettings = CourseManager.editCourseSettingsAsync(id, effect.summaryAllowed).await()
 
-            if (editedCourse.isFail) {
+            if (editedCourse.isFail || courseSettings.isFail) {
                 consumer.accept(EditSyllabusEvent.SyllabusSaveError)
             } else {
-                consumer.accept(EditSyllabusEvent.SyllabusSaveSuccess)
+                consumer.accept(EditSyllabusEvent.SyllabusSaveSuccess(syllabusBody, effect.summaryAllowed))
             }
         }
     }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusFragment.kt
@@ -22,6 +22,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.instructure.canvasapi2.models.Course
+import com.instructure.pandautils.interfaces.NavigationCallbacks
 import com.instructure.pandautils.utils.*
 import com.instructure.teacher.mobius.common.ui.EffectHandler
 import com.instructure.teacher.mobius.common.ui.MobiusFragment
@@ -30,7 +31,7 @@ import com.instructure.teacher.mobius.common.ui.UpdateInit
 
 private const val SUMMARY_ALLOWED = "summaryAllowed"
 
-class EditSyllabusFragment : MobiusFragment<EditSyllabusModel, EditSyllabusEvent, EditSyllabusEffect, EditSyllabusView, EditSyllabusViewState>() {
+class EditSyllabusFragment : MobiusFragment<EditSyllabusModel, EditSyllabusEvent, EditSyllabusEffect, EditSyllabusView, EditSyllabusViewState>(), NavigationCallbacks {
 
     private val course by ParcelableArg<Course>()
     private val summaryAllowed: Boolean by BooleanArg(key = SUMMARY_ALLOWED)
@@ -39,7 +40,8 @@ class EditSyllabusFragment : MobiusFragment<EditSyllabusModel, EditSyllabusEvent
 
     override fun makeUpdate(): UpdateInit<EditSyllabusModel, EditSyllabusEvent, EditSyllabusEffect> = EditSyllabusUpdate()
 
-    override fun makeView(inflater: LayoutInflater, parent: ViewGroup): EditSyllabusView = EditSyllabusView(inflater, parent) { MediaUploadUtils.showPickImageDialog(this) }
+    override fun makeView(inflater: LayoutInflater, parent: ViewGroup): EditSyllabusView =
+        EditSyllabusView(requireFragmentManager(), inflater, parent) { MediaUploadUtils.showPickImageDialog(this) }
 
     override fun makePresenter(): Presenter<EditSyllabusModel, EditSyllabusViewState> = EditSyllabusPresenter()
 
@@ -73,4 +75,8 @@ class EditSyllabusFragment : MobiusFragment<EditSyllabusModel, EditSyllabusEvent
             return extras
         }
     }
+
+    override fun onHandleBackPressed() = view.onHandleBackPressed()
+
+    override fun onHandleClose() = false
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusFragment.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.teacher.features.syllabus.edit
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import com.instructure.canvasapi2.models.Course
+import com.instructure.pandautils.utils.BooleanArg
+import com.instructure.pandautils.utils.Const
+import com.instructure.pandautils.utils.ParcelableArg
+import com.instructure.teacher.mobius.common.ui.EffectHandler
+import com.instructure.teacher.mobius.common.ui.MobiusFragment
+import com.instructure.teacher.mobius.common.ui.Presenter
+import com.instructure.teacher.mobius.common.ui.UpdateInit
+
+private const val SUMMARY_ALLOWED = "summaryAllowed"
+
+class EditSyllabusFragment : MobiusFragment<EditSyllabusModel, EditSyllabusEvent, EditSyllabusEffect, EditSyllabusView, EditSyllabusViewState>() {
+
+    private val course by ParcelableArg<Course>()
+    private val summaryAllowed: Boolean by BooleanArg(key = SUMMARY_ALLOWED)
+
+    override fun makeEffectHandler(): EffectHandler<EditSyllabusView, EditSyllabusEvent, EditSyllabusEffect> = EditSyllabusEffectHandler()
+
+    override fun makeUpdate(): UpdateInit<EditSyllabusModel, EditSyllabusEvent, EditSyllabusEffect> = EditSyllabusUpdate()
+
+    override fun makeView(inflater: LayoutInflater, parent: ViewGroup): EditSyllabusView = EditSyllabusView(inflater, parent)
+
+    override fun makePresenter(): Presenter<EditSyllabusModel, EditSyllabusViewState> = EditSyllabusPresenter()
+
+    override fun makeInitModel(): EditSyllabusModel = EditSyllabusModel(course, summaryAllowed)
+
+    companion object {
+
+        fun newInstance(bundle: Bundle): EditSyllabusFragment {
+            return EditSyllabusFragment().apply {
+                arguments = bundle
+            }
+        }
+
+        fun createArgs(course: Course, summaryAllowed: Boolean): Bundle {
+            val extras = Bundle()
+            extras.putParcelable(Const.COURSE, course)
+            extras.putBoolean(SUMMARY_ALLOWED, summaryAllowed)
+            return extras
+        }
+    }
+}

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusFragment.kt
@@ -60,6 +60,10 @@ class EditSyllabusFragment : MobiusFragment<EditSyllabusModel, EditSyllabusEvent
         }
     }
 
+    override fun onHandleBackPressed() = view.onHandleBackPressed()
+
+    override fun onHandleClose() = false
+
     companion object {
 
         fun newInstance(bundle: Bundle): EditSyllabusFragment {
@@ -75,8 +79,4 @@ class EditSyllabusFragment : MobiusFragment<EditSyllabusModel, EditSyllabusEvent
             return extras
         }
     }
-
-    override fun onHandleBackPressed() = view.onHandleBackPressed()
-
-    override fun onHandleClose() = false
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusFragment.kt
@@ -64,6 +64,11 @@ class EditSyllabusFragment : MobiusFragment<EditSyllabusModel, EditSyllabusEvent
 
     override fun onHandleClose() = false
 
+    override fun onPause() {
+        view.saveState()
+        super.onPause()
+    }
+
     companion object {
 
         fun newInstance(bundle: Bundle): EditSyllabusFragment {

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusFragment.kt
@@ -16,13 +16,13 @@
  */
 package com.instructure.teacher.features.syllabus.edit
 
+import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.instructure.canvasapi2.models.Course
-import com.instructure.pandautils.utils.BooleanArg
-import com.instructure.pandautils.utils.Const
-import com.instructure.pandautils.utils.ParcelableArg
+import com.instructure.pandautils.utils.*
 import com.instructure.teacher.mobius.common.ui.EffectHandler
 import com.instructure.teacher.mobius.common.ui.MobiusFragment
 import com.instructure.teacher.mobius.common.ui.Presenter
@@ -39,11 +39,24 @@ class EditSyllabusFragment : MobiusFragment<EditSyllabusModel, EditSyllabusEvent
 
     override fun makeUpdate(): UpdateInit<EditSyllabusModel, EditSyllabusEvent, EditSyllabusEffect> = EditSyllabusUpdate()
 
-    override fun makeView(inflater: LayoutInflater, parent: ViewGroup): EditSyllabusView = EditSyllabusView(inflater, parent)
+    override fun makeView(inflater: LayoutInflater, parent: ViewGroup): EditSyllabusView = EditSyllabusView(inflater, parent) { MediaUploadUtils.showPickImageDialog(this) }
 
     override fun makePresenter(): Presenter<EditSyllabusModel, EditSyllabusViewState> = EditSyllabusPresenter()
 
     override fun makeInitModel(): EditSyllabusModel = EditSyllabusModel(course, summaryAllowed)
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        if (resultCode == Activity.RESULT_OK) {
+            // Get the image Uri
+            when (requestCode) {
+                RequestCodes.PICK_IMAGE_GALLERY -> data?.data
+                RequestCodes.CAMERA_PIC_REQUEST -> MediaUploadUtils.handleCameraPicResult(requireActivity(), null)
+                else -> null
+            }?.let { imageUri ->
+                view.uploadRceImage(imageUri, requireActivity(), course)
+            }
+        }
+    }
 
     companion object {
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusModels.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusModels.kt
@@ -21,13 +21,16 @@ import com.instructure.canvasapi2.models.Course
 sealed class EditSyllabusEvent {
     data class SaveClicked(val content: String, val summaryAllowed: Boolean) : EditSyllabusEvent()
     data class SyllabusSaveSuccess(val content: String, val summaryAllowed: Boolean) : EditSyllabusEvent()
+    data class BackClicked(val content: String, val summaryAllowed: Boolean) : EditSyllabusEvent()
     object SyllabusSaveError : EditSyllabusEvent()
 }
 
 sealed class EditSyllabusEffect {
     data class SaveData(val course: Course, val newContent: String, val summaryAllowed: Boolean) : EditSyllabusEffect()
     object CloseEdit : EditSyllabusEffect()
+    object ShowSaveSuccess : EditSyllabusEffect()
     object ShowSaveError : EditSyllabusEffect()
+    object ShowCloseConfirmationDialog : EditSyllabusEffect()
 }
 
 data class EditSyllabusModel(val course: Course, val summaryAllowed: Boolean, val isSaving: Boolean = false)

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusModels.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusModels.kt
@@ -19,11 +19,15 @@ package com.instructure.teacher.features.syllabus.edit
 import com.instructure.canvasapi2.models.Course
 
 sealed class EditSyllabusEvent {
-    object SaveClicked : EditSyllabusEvent()
+    data class SaveClicked(val content: String, val summaryAllowed: Boolean) : EditSyllabusEvent()
+    object SyllabusSaveSuccess : EditSyllabusEvent()
+    object SyllabusSaveError : EditSyllabusEvent()
 }
 
 sealed class EditSyllabusEffect {
-    data class SaveData(val course: Course) : EditSyllabusEffect()
+    data class SaveData(val course: Course, val newContent: String, val summaryAllowed: Boolean) : EditSyllabusEffect()
+    object CloseEdit : EditSyllabusEffect()
+    object ShowSaveError : EditSyllabusEffect()
 }
 
-data class EditSyllabusModel(val course: Course, val summaryAllowed: Boolean)
+data class EditSyllabusModel(val course: Course, val summaryAllowed: Boolean, val isSaving: Boolean = false)

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusModels.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusModels.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.teacher.features.syllabus.edit
+
+import com.instructure.canvasapi2.models.Course
+
+sealed class EditSyllabusEvent {
+    object SaveClicked : EditSyllabusEvent()
+}
+
+sealed class EditSyllabusEffect {
+    data class SaveData(val course: Course) : EditSyllabusEffect()
+}
+
+data class EditSyllabusModel(val course: Course, val summaryAllowed: Boolean)

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusModels.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusModels.kt
@@ -20,7 +20,7 @@ import com.instructure.canvasapi2.models.Course
 
 sealed class EditSyllabusEvent {
     data class SaveClicked(val content: String, val summaryAllowed: Boolean) : EditSyllabusEvent()
-    object SyllabusSaveSuccess : EditSyllabusEvent()
+    data class SyllabusSaveSuccess(val content: String, val summaryAllowed: Boolean) : EditSyllabusEvent()
     object SyllabusSaveError : EditSyllabusEvent()
 }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusModels.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusModels.kt
@@ -22,6 +22,7 @@ sealed class EditSyllabusEvent {
     data class SaveClicked(val content: String, val summaryAllowed: Boolean) : EditSyllabusEvent()
     data class SyllabusSaveSuccess(val content: String, val summaryAllowed: Boolean) : EditSyllabusEvent()
     data class BackClicked(val content: String, val summaryAllowed: Boolean) : EditSyllabusEvent()
+    data class SaveState(val content: String, val summaryAllowed: Boolean) : EditSyllabusEvent()
     object SyllabusSaveError : EditSyllabusEvent()
 }
 
@@ -33,4 +34,4 @@ sealed class EditSyllabusEffect {
     object ShowCloseConfirmationDialog : EditSyllabusEffect()
 }
 
-data class EditSyllabusModel(val course: Course, val summaryAllowed: Boolean, val isSaving: Boolean = false)
+data class EditSyllabusModel(val course: Course, val summaryAllowed: Boolean, val isSaving: Boolean = false, val isChanged: Boolean = false)

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusPresenter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusPresenter.kt
@@ -22,6 +22,9 @@ import com.instructure.teacher.mobius.common.ui.Presenter
 class EditSyllabusPresenter : Presenter<EditSyllabusModel, EditSyllabusViewState> {
 
     override fun present(model: EditSyllabusModel, context: Context): EditSyllabusViewState {
-        return EditSyllabusViewState.Loaded(model.course.syllabusBody, model.summaryAllowed)
+        return when {
+            model.isSaving -> EditSyllabusViewState.Saving
+            else -> EditSyllabusViewState.Loaded(model.course.syllabusBody, model.summaryAllowed)
+        }
     }
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusPresenter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusPresenter.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.teacher.features.syllabus.edit
+
+import android.content.Context
+import com.instructure.teacher.mobius.common.ui.Presenter
+
+class EditSyllabusPresenter : Presenter<EditSyllabusModel, EditSyllabusViewState> {
+
+    override fun present(model: EditSyllabusModel, context: Context): EditSyllabusViewState {
+        return EditSyllabusViewState.Loaded(model.course.syllabusBody, model.summaryAllowed)
+    }
+}

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusUpdate.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusUpdate.kt
@@ -16,6 +16,8 @@
  */
 package com.instructure.teacher.features.syllabus.edit
 
+import com.instructure.teacher.events.SyllabusUpdatedEvent
+import com.instructure.teacher.events.post
 import com.instructure.teacher.mobius.common.ui.UpdateInit
 import com.spotify.mobius.First
 import com.spotify.mobius.Next
@@ -53,6 +55,7 @@ class EditSyllabusUpdate : UpdateInit<EditSyllabusModel, EditSyllabusEvent, Edit
 
     private fun handleSyllabusSaved(model: EditSyllabusModel, event: EditSyllabusEvent.SyllabusSaveSuccess): Next<EditSyllabusModel, EditSyllabusEffect> {
         val course = model.course.copy(syllabusBody = event.content)
+        SyllabusUpdatedEvent().post()
         return Next.next(model.copy(isSaving = false, course = course, summaryAllowed = event.summaryAllowed), setOf(EditSyllabusEffect.CloseEdit, EditSyllabusEffect.ShowSaveSuccess))
     }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusUpdate.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusUpdate.kt
@@ -34,19 +34,20 @@ class EditSyllabusUpdate : UpdateInit<EditSyllabusModel, EditSyllabusEvent, Edit
             is EditSyllabusEvent.SyllabusSaveSuccess -> handleSyllabusSaved(model, event)
             is EditSyllabusEvent.SyllabusSaveError -> handleSyllabusSaveError(model)
             is EditSyllabusEvent.BackClicked -> handleBackClick(model, event)
+            is EditSyllabusEvent.SaveState -> handleSaveInstanceState(model, event)
         }
     }
 
     private fun handleBackClick(model: EditSyllabusModel, event: EditSyllabusEvent.BackClicked): Next<EditSyllabusModel, EditSyllabusEffect> {
         return if (isSyllabusChanged(model, event)) {
-            Next.dispatch(setOf(EditSyllabusEffect.CloseEdit))
-        } else {
             Next.dispatch(setOf(EditSyllabusEffect.ShowCloseConfirmationDialog))
+        } else {
+            Next.dispatch(setOf(EditSyllabusEffect.CloseEdit))
         }
     }
 
     private fun isSyllabusChanged(model: EditSyllabusModel, event: EditSyllabusEvent.BackClicked): Boolean {
-        return model.summaryAllowed == event.summaryAllowed && model.course.syllabusBody == event.content
+        return model.summaryAllowed != event.summaryAllowed || model.course.syllabusBody != event.content || model.isChanged
     }
 
     private fun handleSaveClicked(model: EditSyllabusModel, event: EditSyllabusEvent.SaveClicked): Next<EditSyllabusModel, EditSyllabusEffect> {
@@ -61,5 +62,11 @@ class EditSyllabusUpdate : UpdateInit<EditSyllabusModel, EditSyllabusEvent, Edit
 
     private fun handleSyllabusSaveError(model: EditSyllabusModel): Next<EditSyllabusModel, EditSyllabusEffect> {
         return Next.next(model.copy(isSaving = false), setOf(EditSyllabusEffect.ShowSaveError))
+    }
+
+    private fun handleSaveInstanceState(model: EditSyllabusModel, event: EditSyllabusEvent.SaveState): Next<EditSyllabusModel, EditSyllabusEffect> {
+        val course = model.course.copy(syllabusBody = event.content)
+        val isChanged = model.summaryAllowed == event.summaryAllowed && model.course.syllabusBody == event.content
+        return Next.next(model.copy(course = course, summaryAllowed = event.summaryAllowed, isChanged = isChanged))
     }
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusUpdate.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusUpdate.kt
@@ -56,7 +56,7 @@ class EditSyllabusUpdate : UpdateInit<EditSyllabusModel, EditSyllabusEvent, Edit
 
     private fun handleSyllabusSaved(model: EditSyllabusModel, event: EditSyllabusEvent.SyllabusSaveSuccess): Next<EditSyllabusModel, EditSyllabusEffect> {
         val course = model.course.copy(syllabusBody = event.content)
-        SyllabusUpdatedEvent().post()
+        SyllabusUpdatedEvent(event.content, event.summaryAllowed).post()
         return Next.next(model.copy(isSaving = false, course = course, summaryAllowed = event.summaryAllowed), setOf(EditSyllabusEffect.CloseEdit, EditSyllabusEffect.ShowSaveSuccess))
     }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusUpdate.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusUpdate.kt
@@ -29,7 +29,7 @@ class EditSyllabusUpdate : UpdateInit<EditSyllabusModel, EditSyllabusEvent, Edit
     override fun update(model: EditSyllabusModel, event: EditSyllabusEvent): Next<EditSyllabusModel, EditSyllabusEffect> {
         return when(event) {
             is EditSyllabusEvent.SaveClicked -> handleSaveClicked(model, event)
-            is EditSyllabusEvent.SyllabusSaveSuccess -> handleSyllabusSaved(model)
+            is EditSyllabusEvent.SyllabusSaveSuccess -> handleSyllabusSaved(model, event)
             is EditSyllabusEvent.SyllabusSaveError -> handleSyllabusSaveError(model)
         }
     }
@@ -38,8 +38,9 @@ class EditSyllabusUpdate : UpdateInit<EditSyllabusModel, EditSyllabusEvent, Edit
         return Next.next(model.copy(isSaving = true), setOf(EditSyllabusEffect.SaveData(model.course, event.content, event.summaryAllowed)))
     }
 
-    private fun handleSyllabusSaved(model: EditSyllabusModel): Next<EditSyllabusModel, EditSyllabusEffect> {
-        return Next.next(model.copy(isSaving = false), setOf(EditSyllabusEffect.CloseEdit))
+    private fun handleSyllabusSaved(model: EditSyllabusModel, event: EditSyllabusEvent.SyllabusSaveSuccess): Next<EditSyllabusModel, EditSyllabusEffect> {
+        val course = model.course.copy(syllabusBody = event.content)
+        return Next.next(model.copy(isSaving = false, course = course, summaryAllowed = event.summaryAllowed), setOf(EditSyllabusEffect.CloseEdit))
     }
 
     private fun handleSyllabusSaveError(model: EditSyllabusModel): Next<EditSyllabusModel, EditSyllabusEffect> {

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusUpdate.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusUpdate.kt
@@ -27,11 +27,24 @@ class EditSyllabusUpdate : UpdateInit<EditSyllabusModel, EditSyllabusEvent, Edit
     }
 
     override fun update(model: EditSyllabusModel, event: EditSyllabusEvent): Next<EditSyllabusModel, EditSyllabusEffect> {
-        return when(event) {
+        return when (event) {
             is EditSyllabusEvent.SaveClicked -> handleSaveClicked(model, event)
             is EditSyllabusEvent.SyllabusSaveSuccess -> handleSyllabusSaved(model, event)
             is EditSyllabusEvent.SyllabusSaveError -> handleSyllabusSaveError(model)
+            is EditSyllabusEvent.BackClicked -> handleBackClick(model, event)
         }
+    }
+
+    private fun handleBackClick(model: EditSyllabusModel, event: EditSyllabusEvent.BackClicked): Next<EditSyllabusModel, EditSyllabusEffect> {
+        return if (isSyllabusChanged(model, event)) {
+            Next.dispatch(setOf(EditSyllabusEffect.CloseEdit))
+        } else {
+            Next.dispatch(setOf(EditSyllabusEffect.ShowCloseConfirmationDialog))
+        }
+    }
+
+    private fun isSyllabusChanged(model: EditSyllabusModel, event: EditSyllabusEvent.BackClicked): Boolean {
+        return model.summaryAllowed == event.summaryAllowed && model.course.syllabusBody == event.content
     }
 
     private fun handleSaveClicked(model: EditSyllabusModel, event: EditSyllabusEvent.SaveClicked): Next<EditSyllabusModel, EditSyllabusEffect> {
@@ -40,7 +53,7 @@ class EditSyllabusUpdate : UpdateInit<EditSyllabusModel, EditSyllabusEvent, Edit
 
     private fun handleSyllabusSaved(model: EditSyllabusModel, event: EditSyllabusEvent.SyllabusSaveSuccess): Next<EditSyllabusModel, EditSyllabusEffect> {
         val course = model.course.copy(syllabusBody = event.content)
-        return Next.next(model.copy(isSaving = false, course = course, summaryAllowed = event.summaryAllowed), setOf(EditSyllabusEffect.CloseEdit))
+        return Next.next(model.copy(isSaving = false, course = course, summaryAllowed = event.summaryAllowed), setOf(EditSyllabusEffect.CloseEdit, EditSyllabusEffect.ShowSaveSuccess))
     }
 
     private fun handleSyllabusSaveError(model: EditSyllabusModel): Next<EditSyllabusModel, EditSyllabusEffect> {

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusUpdate.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusUpdate.kt
@@ -34,20 +34,8 @@ class EditSyllabusUpdate : UpdateInit<EditSyllabusModel, EditSyllabusEvent, Edit
             is EditSyllabusEvent.SyllabusSaveSuccess -> handleSyllabusSaved(model, event)
             is EditSyllabusEvent.SyllabusSaveError -> handleSyllabusSaveError(model)
             is EditSyllabusEvent.BackClicked -> handleBackClick(model, event)
-            is EditSyllabusEvent.SaveState -> handleSaveInstanceState(model, event)
+            is EditSyllabusEvent.SaveState -> handleSaveState(model, event)
         }
-    }
-
-    private fun handleBackClick(model: EditSyllabusModel, event: EditSyllabusEvent.BackClicked): Next<EditSyllabusModel, EditSyllabusEffect> {
-        return if (isSyllabusChanged(model, event)) {
-            Next.dispatch(setOf(EditSyllabusEffect.ShowCloseConfirmationDialog))
-        } else {
-            Next.dispatch(setOf(EditSyllabusEffect.CloseEdit))
-        }
-    }
-
-    private fun isSyllabusChanged(model: EditSyllabusModel, event: EditSyllabusEvent.BackClicked): Boolean {
-        return model.summaryAllowed != event.summaryAllowed || model.course.syllabusBody != event.content || model.isChanged
     }
 
     private fun handleSaveClicked(model: EditSyllabusModel, event: EditSyllabusEvent.SaveClicked): Next<EditSyllabusModel, EditSyllabusEffect> {
@@ -64,9 +52,21 @@ class EditSyllabusUpdate : UpdateInit<EditSyllabusModel, EditSyllabusEvent, Edit
         return Next.next(model.copy(isSaving = false), setOf(EditSyllabusEffect.ShowSaveError))
     }
 
-    private fun handleSaveInstanceState(model: EditSyllabusModel, event: EditSyllabusEvent.SaveState): Next<EditSyllabusModel, EditSyllabusEffect> {
+    private fun handleBackClick(model: EditSyllabusModel, event: EditSyllabusEvent.BackClicked): Next<EditSyllabusModel, EditSyllabusEffect> {
+        return if (isSyllabusChanged(model, event.content, event.summaryAllowed)) {
+            Next.dispatch(setOf(EditSyllabusEffect.ShowCloseConfirmationDialog))
+        } else {
+            Next.dispatch(setOf(EditSyllabusEffect.CloseEdit))
+        }
+    }
+
+    private fun isSyllabusChanged(model: EditSyllabusModel, content: String, summaryAllowed: Boolean): Boolean {
+        return model.summaryAllowed != summaryAllowed || model.course.syllabusBody != content || model.isChanged
+    }
+
+    private fun handleSaveState(model: EditSyllabusModel, event: EditSyllabusEvent.SaveState): Next<EditSyllabusModel, EditSyllabusEffect> {
         val course = model.course.copy(syllabusBody = event.content)
-        val isChanged = model.summaryAllowed == event.summaryAllowed && model.course.syllabusBody == event.content
+        val isChanged = isSyllabusChanged(model, event.content, event.summaryAllowed)
         return Next.next(model.copy(course = course, summaryAllowed = event.summaryAllowed, isChanged = isChanged))
     }
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusUpdate.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusUpdate.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.teacher.features.syllabus.edit
+
+import com.instructure.teacher.mobius.common.ui.UpdateInit
+import com.spotify.mobius.First
+import com.spotify.mobius.Next
+
+class EditSyllabusUpdate : UpdateInit<EditSyllabusModel, EditSyllabusEvent, EditSyllabusEffect>() {
+
+    override fun performInit(model: EditSyllabusModel): First<EditSyllabusModel, EditSyllabusEffect> {
+        return First.first(model.copy())
+    }
+
+    override fun update(model: EditSyllabusModel, event: EditSyllabusEvent): Next<EditSyllabusModel, EditSyllabusEffect> {
+        return Next.next(model.copy())
+    }
+}

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusUpdate.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusUpdate.kt
@@ -27,6 +27,22 @@ class EditSyllabusUpdate : UpdateInit<EditSyllabusModel, EditSyllabusEvent, Edit
     }
 
     override fun update(model: EditSyllabusModel, event: EditSyllabusEvent): Next<EditSyllabusModel, EditSyllabusEffect> {
-        return Next.next(model.copy())
+        return when(event) {
+            is EditSyllabusEvent.SaveClicked -> handleSaveClicked(model, event)
+            is EditSyllabusEvent.SyllabusSaveSuccess -> handleSyllabusSaved(model)
+            is EditSyllabusEvent.SyllabusSaveError -> handleSyllabusSaveError(model)
+        }
+    }
+
+    private fun handleSaveClicked(model: EditSyllabusModel, event: EditSyllabusEvent.SaveClicked): Next<EditSyllabusModel, EditSyllabusEffect> {
+        return Next.next(model.copy(isSaving = true), setOf(EditSyllabusEffect.SaveData(model.course, event.content, event.summaryAllowed)))
+    }
+
+    private fun handleSyllabusSaved(model: EditSyllabusModel): Next<EditSyllabusModel, EditSyllabusEffect> {
+        return Next.next(model.copy(isSaving = false), setOf(EditSyllabusEffect.CloseEdit))
+    }
+
+    private fun handleSyllabusSaveError(model: EditSyllabusModel): Next<EditSyllabusModel, EditSyllabusEffect> {
+        return Next.next(model.copy(isSaving = false), setOf(EditSyllabusEffect.ShowSaveError))
     }
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusView.kt
@@ -16,42 +16,94 @@
  */
 package com.instructure.teacher.features.syllabus.edit
 
+import android.app.Activity
+import android.graphics.Color
+import android.net.Uri
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.TextView
+import android.widget.Toast
+import androidx.fragment.app.FragmentActivity
+import com.instructure.canvasapi2.models.Course
 import com.instructure.pandautils.discussions.DiscussionUtils
-import com.instructure.pandautils.utils.ThemePrefs
+import com.instructure.pandautils.utils.*
 import com.instructure.pandautils.views.CanvasWebView
 import com.instructure.teacher.R
 import com.instructure.teacher.mobius.common.ui.MobiusView
+import com.instructure.teacher.utils.setupCloseButton
+import com.instructure.teacher.utils.setupMenu
+import com.instructure.teacher.utils.withRequireNetwork
 import com.spotify.mobius.functions.Consumer
 import kotlinx.android.synthetic.main.fragment_edit_syllabus.*
 
-class EditSyllabusView(inflater: LayoutInflater, parent: ViewGroup) : MobiusView<EditSyllabusViewState, EditSyllabusEvent>(R.layout.fragment_edit_syllabus, inflater, parent) {
+class EditSyllabusView(inflater: LayoutInflater, parent: ViewGroup, uploadImageCallback: () -> Unit) : MobiusView<EditSyllabusViewState, EditSyllabusEvent>(R.layout.fragment_edit_syllabus, inflater, parent) {
+
+    private val placeHolderList = mutableListOf<Placeholder>()
+
+    private val saveMenuButton get() = toolbar.menu.findItem(R.id.menuSaveSyllabus)
+    private val saveMenuView: TextView? get() = rootView?.findViewById(R.id.menuSaveSyllabus)
+
+    private var consumer: Consumer<EditSyllabusEvent>? = null
+
 
     init {
         contentRCEView?.hideEditorToolbar()
-//        contentRCEView?.actionUploadImageCallback = { MediaUploadUtils.showPickImageDialog(this) }
+        contentRCEView?.actionUploadImageCallback = uploadImageCallback
+        setupToolbar()
+    }
+
+    fun setupToolbar() {
+        val activity = context as? FragmentActivity
+        toolbar.setupCloseButton {
+            activity?.onBackPressed()
+        }
+        toolbar.setupMenu(R.menu.menu_edit_syllabus) { menuItem ->
+            when (menuItem.itemId) {
+                R.id.menuSaveSyllabus -> activity?.withRequireNetwork { savePage() }
+            }
+        }
+        ViewStyler.themeToolbarBottomSheet(activity!!, context.resources.getBoolean(com.instructure.pandautils.R.bool.isDeviceTablet), toolbar, Color.BLACK, false)
+        saveMenuView?.setTextColor(ThemePrefs.buttonColor)
+    }
+
+    private fun savePage() {
+        consumer?.accept(EditSyllabusEvent.SaveClicked(contentRCEView.html, showSummarySwitch.isChecked))
     }
 
     override fun onConnect(output: Consumer<EditSyllabusEvent>) {
-
+        consumer = output
     }
 
     override fun render(state: EditSyllabusViewState) {
-        renderContent((state as EditSyllabusViewState.Loaded).content ?: "")
+        when (state) {
+            is EditSyllabusViewState.Loaded -> renderLoadedContent(state)
+            is EditSyllabusViewState.Saving -> renderSavingState()
+        }
+    }
+
+    private fun renderLoadedContent(state: EditSyllabusViewState.Loaded) {
+        savingProgressBar.setGone()
+        saveMenuButton.isVisible = true
+        saveMenuView?.setTextColor(ThemePrefs.buttonColor)
+        renderContent(state.content ?: "")
         showSummarySwitch.isChecked = state.showSummary
     }
 
-    override fun onDispose() {
+    private fun renderSavingState() {
+        savingProgressBar.setVisible()
+        saveMenuButton.isVisible = false
+    }
 
+    override fun onDispose() {
+        consumer = null
     }
 
     private fun renderContent(content: String) {
         if (CanvasWebView.containsLTI(content, "UTF-8")) {
             contentRCEView?.setHtml(DiscussionUtils.createLTIPlaceHolders(context, content) { _, placeholder ->
-//                placeHolderList.add(placeholder)
+                placeHolderList.add(placeholder)
             },
-                context.getString(R.string.pageDetails),
+                context.getString(R.string.pageDetails), // TODO Strings
                 context.getString(R.string.rce_empty_description),
                 ThemePrefs.brandColor, ThemePrefs.buttonColor
             )
@@ -63,5 +115,19 @@ class EditSyllabusView(inflater: LayoutInflater, parent: ViewGroup) : MobiusView
                 ThemePrefs.brandColor, ThemePrefs.buttonColor
             )
         }
+    }
+
+    fun uploadRceImage(imageUri: Uri, activity: Activity, course: Course) {
+        MediaUploadUtils.uploadRceImageJob(imageUri, course, activity) { text, alt -> contentRCEView?.insertImage(text, alt) }
+    }
+
+    fun closeEditSyllabus() {
+        context.toast("Save success", Toast.LENGTH_SHORT) // TODO String
+        val activity = context as? FragmentActivity
+        activity?.onBackPressed()
+    }
+
+    fun showSaveError() {
+        context.toast("Save error", Toast.LENGTH_SHORT) // TODO String
     }
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusView.kt
@@ -53,13 +53,12 @@ class EditSyllabusView(val fragmentManager: FragmentManager, inflater: LayoutInf
         contentRCEView?.hideEditorToolbar()
         contentRCEView?.actionUploadImageCallback = uploadImageCallback
         setupToolbar()
+        showSummarySwitch.applyTheme()
     }
 
     fun setupToolbar() {
         val activity = context as? FragmentActivity
-        toolbar.setupCloseButton {
-            activity?.onBackPressed()
-        }
+        toolbar.setupCloseButton { activity?.onBackPressed() }
         toolbar.setupMenu(R.menu.menu_edit_syllabus) { menuItem ->
             when (menuItem.itemId) {
                 R.id.menuSaveSyllabus -> activity?.withRequireNetwork { savePage() }
@@ -94,6 +93,7 @@ class EditSyllabusView(val fragmentManager: FragmentManager, inflater: LayoutInf
 
     private fun renderSavingState() {
         savingProgressBar.setVisible()
+        savingProgressBar.announceForAccessibility(context.getString(R.string.saving))
         saveMenuButton.isVisible = false
     }
 
@@ -106,14 +106,14 @@ class EditSyllabusView(val fragmentManager: FragmentManager, inflater: LayoutInf
             contentRCEView?.setHtml(DiscussionUtils.createLTIPlaceHolders(context, content) { _, placeholder ->
                 placeHolderList.add(placeholder)
             },
-                context.getString(R.string.pageDetails), // TODO Strings
+                context.getString(R.string.editSyllabusContentAccessibilityLabel),
                 context.getString(R.string.rce_empty_description),
                 ThemePrefs.brandColor, ThemePrefs.buttonColor
             )
         } else {
             contentRCEView?.setHtml(
                 content,
-                context.getString(R.string.pageDetails),
+                context.getString(R.string.editSyllabusContentAccessibilityLabel),
                 context.getString(R.string.rce_empty_description),
                 ThemePrefs.brandColor, ThemePrefs.buttonColor
             )
@@ -131,11 +131,11 @@ class EditSyllabusView(val fragmentManager: FragmentManager, inflater: LayoutInf
     }
 
     fun showSaveSuccess() {
-        context.toast("Save success", Toast.LENGTH_SHORT) // TODO String
+        context.toast(R.string.syllabusSuccessfullyUpdated, Toast.LENGTH_SHORT)
     }
 
     fun showSaveError() {
-        context.toast("Save error", Toast.LENGTH_SHORT) // TODO String
+        context.toast(R.string.errorSavingSyllabus, Toast.LENGTH_SHORT)
     }
 
     fun showCloseConfirmationDialog() {

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusView.kt
@@ -24,7 +24,9 @@ import android.view.ViewGroup
 import android.widget.TextView
 import android.widget.Toast
 import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentManager
 import com.instructure.canvasapi2.models.Course
+import com.instructure.pandautils.dialogs.UnsavedChangesExitDialog
 import com.instructure.pandautils.discussions.DiscussionUtils
 import com.instructure.pandautils.utils.*
 import com.instructure.pandautils.views.CanvasWebView
@@ -36,7 +38,8 @@ import com.instructure.teacher.utils.withRequireNetwork
 import com.spotify.mobius.functions.Consumer
 import kotlinx.android.synthetic.main.fragment_edit_syllabus.*
 
-class EditSyllabusView(inflater: LayoutInflater, parent: ViewGroup, uploadImageCallback: () -> Unit) : MobiusView<EditSyllabusViewState, EditSyllabusEvent>(R.layout.fragment_edit_syllabus, inflater, parent) {
+class EditSyllabusView(val fragmentManager: FragmentManager, inflater: LayoutInflater, parent: ViewGroup, uploadImageCallback: () -> Unit)
+    : MobiusView<EditSyllabusViewState, EditSyllabusEvent>(R.layout.fragment_edit_syllabus, inflater, parent) {
 
     private val placeHolderList = mutableListOf<Placeholder>()
 
@@ -44,7 +47,7 @@ class EditSyllabusView(inflater: LayoutInflater, parent: ViewGroup, uploadImageC
     private val saveMenuView: TextView? get() = rootView?.findViewById(R.id.menuSaveSyllabus)
 
     private var consumer: Consumer<EditSyllabusEvent>? = null
-
+    private var shouldClose = false
 
     init {
         contentRCEView?.hideEditorToolbar()
@@ -122,12 +125,31 @@ class EditSyllabusView(inflater: LayoutInflater, parent: ViewGroup, uploadImageC
     }
 
     fun closeEditSyllabus() {
-        context.toast("Save success", Toast.LENGTH_SHORT) // TODO String
+        shouldClose = true
         val activity = context as? FragmentActivity
         activity?.onBackPressed()
     }
 
+    fun showSaveSuccess() {
+        context.toast("Save success", Toast.LENGTH_SHORT) // TODO String
+    }
+
     fun showSaveError() {
         context.toast("Save error", Toast.LENGTH_SHORT) // TODO String
+    }
+
+    fun showCloseConfirmationDialog() {
+        UnsavedChangesExitDialog.show(fragmentManager) {
+            closeEditSyllabus()
+        }
+    }
+
+    fun onHandleBackPressed(): Boolean {
+        return if (shouldClose) {
+            false
+        } else {
+            consumer?.accept(EditSyllabusEvent.BackClicked(contentRCEView.html, showSummarySwitch.isChecked))
+            true
+        }
     }
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusView.kt
@@ -152,4 +152,8 @@ class EditSyllabusView(val fragmentManager: FragmentManager, inflater: LayoutInf
             true
         }
     }
+
+    fun saveState() {
+        consumer?.accept(EditSyllabusEvent.SaveState(contentRCEView.html, showSummarySwitch.isChecked))
+    }
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusView.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.teacher.features.syllabus.edit
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import com.instructure.pandautils.discussions.DiscussionUtils
+import com.instructure.pandautils.utils.ThemePrefs
+import com.instructure.pandautils.views.CanvasWebView
+import com.instructure.teacher.R
+import com.instructure.teacher.mobius.common.ui.MobiusView
+import com.spotify.mobius.functions.Consumer
+import kotlinx.android.synthetic.main.fragment_edit_syllabus.*
+
+class EditSyllabusView(inflater: LayoutInflater, parent: ViewGroup) : MobiusView<EditSyllabusViewState, EditSyllabusEvent>(R.layout.fragment_edit_syllabus, inflater, parent) {
+
+    init {
+        contentRCEView?.hideEditorToolbar()
+//        contentRCEView?.actionUploadImageCallback = { MediaUploadUtils.showPickImageDialog(this) }
+    }
+
+    override fun onConnect(output: Consumer<EditSyllabusEvent>) {
+
+    }
+
+    override fun render(state: EditSyllabusViewState) {
+        renderContent((state as EditSyllabusViewState.Loaded).content ?: "")
+        showSummarySwitch.isChecked = state.showSummary
+    }
+
+    override fun onDispose() {
+
+    }
+
+    private fun renderContent(content: String) {
+        if (CanvasWebView.containsLTI(content, "UTF-8")) {
+            contentRCEView?.setHtml(DiscussionUtils.createLTIPlaceHolders(context, content) { _, placeholder ->
+//                placeHolderList.add(placeholder)
+            },
+                context.getString(R.string.pageDetails),
+                context.getString(R.string.rce_empty_description),
+                ThemePrefs.brandColor, ThemePrefs.buttonColor
+            )
+        } else {
+            contentRCEView?.setHtml(
+                content,
+                context.getString(R.string.pageDetails),
+                context.getString(R.string.rce_empty_description),
+                ThemePrefs.brandColor, ThemePrefs.buttonColor
+            )
+        }
+    }
+}

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusViewState.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusViewState.kt
@@ -18,4 +18,5 @@ package com.instructure.teacher.features.syllabus.edit
 
 sealed class EditSyllabusViewState {
     data class Loaded(val content: String? = null, val showSummary: Boolean = false) : EditSyllabusViewState()
+    object Saving : EditSyllabusViewState()
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusViewState.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusViewState.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.teacher.features.syllabus.edit
+
+sealed class EditSyllabusViewState {
+    data class Loaded(val content: String? = null, val showSummary: Boolean = false) : EditSyllabusViewState()
+}

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/ui/SyllabusFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/ui/SyllabusFragment.kt
@@ -40,6 +40,16 @@ class SyllabusFragment : MobiusFragment<SyllabusModel, SyllabusEvent, SyllabusEf
 
     override fun makeInitModel() = SyllabusModel(canvasContext.id)
 
+    override fun onStart() {
+        super.onStart()
+        view.registerEventBus()
+    }
+
+    override fun onStop() {
+        view.unregisterEventBus()
+        super.onStop()
+    }
+
     companion object {
         fun newInstance(canvasContext: CanvasContext?) = if (isValidRoute(canvasContext)) createFragmentWithCanvasContext(canvasContext) else null
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/ui/SyllabusView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/ui/SyllabusView.kt
@@ -118,7 +118,8 @@ class SyllabusView(val canvasContext: CanvasContext, inflater: LayoutInflater, p
         // We need to do this again after changing the edit button to visible to make it the correct color.
         ViewStyler.themeToolbar(context as Activity, toolbar, canvasContext)
 
-        val hasBoth = state.eventsState != null && state.syllabus != null
+        val showSummary = state.showSummary && state.eventsState != null
+        val hasBoth = showSummary && state.syllabus != null
         syllabusTabLayout.setVisible(hasBoth)
         syllabusPager.canSwipe = hasBoth
 
@@ -190,7 +191,7 @@ class SyllabusView(val canvasContext: CanvasContext, inflater: LayoutInflater, p
     @Subscribe(threadMode = ThreadMode.MAIN, sticky = true)
     fun onSyllabusUpdated(event: SyllabusUpdatedEvent) {
         event.once(javaClass.simpleName) {
-            consumer?.accept(SyllabusEvent.PullToRefresh)
+            consumer?.accept(SyllabusEvent.SyllabusUpdatedEvent(event.content, event.summaryAllowed))
         }
     }
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/ui/SyllabusView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/ui/SyllabusView.kt
@@ -32,6 +32,7 @@ import com.instructure.teacher.features.syllabus.SyllabusEvent
 import com.instructure.teacher.fragments.AssignmentDetailsFragment
 import com.instructure.teacher.mobius.common.ui.MobiusView
 import com.instructure.teacher.router.RouteMatcher
+import com.instructure.teacher.utils.setupMenu
 import com.spotify.mobius.functions.Consumer
 import kotlinx.android.synthetic.main.fragment_syllabus.*
 import kotlinx.android.synthetic.main.fragment_syllabus_events.*
@@ -60,7 +61,10 @@ class SyllabusView(val canvasContext: CanvasContext, inflater: LayoutInflater, p
     }
 
     init {
+        toolbar.setupMenu(R.menu.menu_edit_generic) { openEditSyllabus() }
+        setEditVisibility(false)
         ViewStyler.themeToolbar(context as Activity, toolbar, canvasContext)
+
         syllabusTabLayout.setBackgroundColor(ColorKeeper.getOrGenerateColor(canvasContext))
 
         toolbar.setupAsBackButton { (context as? Activity)?.onBackPressed() }
@@ -69,6 +73,11 @@ class SyllabusView(val canvasContext: CanvasContext, inflater: LayoutInflater, p
 
         syllabusPager.adapter = SyllabusTabAdapter(canvasContext, getTabTitles())
         syllabusTabLayout.setupWithViewPager(syllabusPager, true)
+    }
+
+    private fun setEditVisibility(isVisible: Boolean) {
+        val editItem = toolbar.menu?.findItem(R.id.menu_edit)
+        editItem?.isVisible = isVisible
     }
 
     private fun getTabTitles(): List<String> {
@@ -99,6 +108,8 @@ class SyllabusView(val canvasContext: CanvasContext, inflater: LayoutInflater, p
     private fun renderLoadedState(state: SyllabusViewState.Loaded) {
         swipeRefreshLayout.isRefreshing = false
 
+        setEditVisibility(state.canEdit)
+
         val hasBoth = state.eventsState != null && state.syllabus != null
         syllabusTabLayout.setVisible(hasBoth)
         syllabusPager.canSwipe = hasBoth
@@ -107,6 +118,10 @@ class SyllabusView(val canvasContext: CanvasContext, inflater: LayoutInflater, p
 
         if (state.syllabus != null) syllabusWebView?.loadHtml(state.syllabus, context.getString(com.instructure.pandares.R.string.syllabus))
         if (state.eventsState != null) renderEvents(state.eventsState)
+    }
+
+    private fun openEditSyllabus() {
+        // TODO Open edit
     }
 
     private fun renderEvents(eventsState: EventsViewState) {

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/ui/SyllabusView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/ui/SyllabusView.kt
@@ -115,6 +115,8 @@ class SyllabusView(val canvasContext: CanvasContext, inflater: LayoutInflater, p
         swipeRefreshLayout.isRefreshing = false
 
         setEditVisibility(state.canEdit)
+        // We need to do this again after changing the edit button to visible to make it the correct color.
+        ViewStyler.themeToolbar(context as Activity, toolbar, canvasContext)
 
         val hasBoth = state.eventsState != null && state.syllabus != null
         syllabusTabLayout.setVisible(hasBoth)

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/ui/SyllabusView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/ui/SyllabusView.kt
@@ -28,6 +28,7 @@ import com.instructure.canvasapi2.utils.exhaustive
 import com.instructure.interactions.router.Route
 import com.instructure.pandautils.utils.*
 import com.instructure.teacher.R
+import com.instructure.teacher.events.SyllabusUpdatedEvent
 import com.instructure.teacher.features.calendar.event.CalendarEventFragment
 import com.instructure.teacher.features.syllabus.SyllabusEvent
 import com.instructure.teacher.features.syllabus.edit.EditSyllabusFragment
@@ -39,6 +40,9 @@ import com.spotify.mobius.functions.Consumer
 import kotlinx.android.synthetic.main.fragment_syllabus.*
 import kotlinx.android.synthetic.main.fragment_syllabus_events.*
 import kotlinx.android.synthetic.main.fragment_syllabus_webview.*
+import org.greenrobot.eventbus.EventBus
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
 
 private const val SYLLABUS_TAB_POSITION = 0
 private const val SUMMARY_TAB_POSITION = 1
@@ -170,5 +174,21 @@ class SyllabusView(val canvasContext: CanvasContext, inflater: LayoutInflater, p
     fun openEditSyllabus(course: Course, summaryAllowed: Boolean) {
         val fragmentArgs = EditSyllabusFragment.createArgs(course, summaryAllowed)
         RouteMatcher.route(context, Route(EditSyllabusFragment::class.java, course, fragmentArgs))
+    }
+
+    fun registerEventBus() {
+        EventBus.getDefault().register(this)
+    }
+
+    fun unregisterEventBus() {
+        EventBus.getDefault().unregister(this)
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN, sticky = true)
+    fun onSyllabusUpdated(event: SyllabusUpdatedEvent) {
+        event.once(javaClass.simpleName) {
+            consumer?.accept(SyllabusEvent.PullToRefresh)
+        }
     }
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/ui/SyllabusView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/ui/SyllabusView.kt
@@ -22,6 +22,7 @@ import android.view.ViewGroup
 import com.google.android.material.tabs.TabLayout
 import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.CanvasContext
+import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.models.ScheduleItem
 import com.instructure.canvasapi2.utils.exhaustive
 import com.instructure.interactions.router.Route
@@ -29,6 +30,7 @@ import com.instructure.pandautils.utils.*
 import com.instructure.teacher.R
 import com.instructure.teacher.features.calendar.event.CalendarEventFragment
 import com.instructure.teacher.features.syllabus.SyllabusEvent
+import com.instructure.teacher.features.syllabus.edit.EditSyllabusFragment
 import com.instructure.teacher.fragments.AssignmentDetailsFragment
 import com.instructure.teacher.mobius.common.ui.MobiusView
 import com.instructure.teacher.router.RouteMatcher
@@ -61,7 +63,7 @@ class SyllabusView(val canvasContext: CanvasContext, inflater: LayoutInflater, p
     }
 
     init {
-        toolbar.setupMenu(R.menu.menu_edit_generic) { openEditSyllabus() }
+        toolbar.setupMenu(R.menu.menu_edit_generic) { consumer?.accept(SyllabusEvent.EditClicked) }
         setEditVisibility(false)
         ViewStyler.themeToolbar(context as Activity, toolbar, canvasContext)
 
@@ -120,10 +122,6 @@ class SyllabusView(val canvasContext: CanvasContext, inflater: LayoutInflater, p
         if (state.eventsState != null) renderEvents(state.eventsState)
     }
 
-    private fun openEditSyllabus() {
-        // TODO Open edit
-    }
-
     private fun renderEvents(eventsState: EventsViewState) {
         with(eventsState) {
             syllabusEmptyView?.setVisible(visibility.empty)
@@ -167,5 +165,10 @@ class SyllabusView(val canvasContext: CanvasContext, inflater: LayoutInflater, p
     fun showScheduleItemView(scheduleItem: ScheduleItem, canvasContext: CanvasContext) {
         val route = Route(CalendarEventFragment::class.java, canvasContext, CalendarEventFragment.createArgs(canvasContext, scheduleItem))
         RouteMatcher.route(context, route)
+    }
+
+    fun openEditSyllabus(course: Course, summaryAllowed: Boolean) {
+        val fragmentArgs = EditSyllabusFragment.createArgs(course, summaryAllowed)
+        RouteMatcher.route(context, Route(EditSyllabusFragment::class.java, course, fragmentArgs))
     }
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/ui/SyllabusViewState.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/ui/SyllabusViewState.kt
@@ -21,7 +21,8 @@ sealed class SyllabusViewState {
 
     data class Loaded(
             val syllabus: String? = null,
-            val eventsState: EventsViewState? = null
+            val eventsState: EventsViewState? = null,
+            val canEdit: Boolean = false
     ) : SyllabusViewState()
 }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/ui/SyllabusViewState.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/ui/SyllabusViewState.kt
@@ -22,7 +22,8 @@ sealed class SyllabusViewState {
     data class Loaded(
             val syllabus: String? = null,
             val eventsState: EventsViewState? = null,
-            val canEdit: Boolean = false
+            val canEdit: Boolean = false,
+            val showSummary: Boolean = false
     ) : SyllabusViewState()
 }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/router/RouteResolver.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/router/RouteResolver.kt
@@ -14,6 +14,7 @@ import com.instructure.teacher.features.calendar.event.CalendarEventFragment
 import com.instructure.teacher.features.files.search.FileSearchFragment
 import com.instructure.teacher.features.modules.list.ui.ModuleListFragment
 import com.instructure.teacher.features.postpolicies.ui.PostPolicyFragment
+import com.instructure.teacher.features.syllabus.edit.EditSyllabusFragment
 import com.instructure.teacher.features.syllabus.ui.SyllabusFragment
 import com.instructure.teacher.fragments.*
 import instructure.rceditor.RCEFragment
@@ -168,6 +169,8 @@ object RouteResolver {
             fragment = CreateOrEditPageDetailsFragment.newInstance(route.arguments)
         } else if (SyllabusFragment::class.java.isAssignableFrom(cls)) {
             fragment = SyllabusFragment.newInstance(canvasContext ?: route.canvasContext)
+        } else if (EditSyllabusFragment::class.java.isAssignableFrom(cls)) {
+            fragment = EditSyllabusFragment.newInstance(route.arguments)
         } else if (CalendarEventFragment::class.java.isAssignableFrom(cls)) {
             fragment = CalendarEventFragment.newInstance(route.arguments)
         } else if (FullscreenInternalWebViewFragment::class.java.isAssignableFrom(cls)) {

--- a/apps/teacher/src/main/res/layout/fragment_edit_syllabus.xml
+++ b/apps/teacher/src/main/res/layout/fragment_edit_syllabus.xml
@@ -120,7 +120,7 @@
                 android:layout_centerVertical="true"
                 android:layout_marginEnd="10dp"
                 android:backgroundTint="@color/teacher_colorPrimary"
-                android:maxWidth="48dp"
+                android:minWidth="48dp"
                 android:minHeight="48dp"
                 app:layout_constraintBaseline_toBaselineOf="@id/showSummaryLabel"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/apps/teacher/src/main/res/layout/fragment_edit_syllabus.xml
+++ b/apps/teacher/src/main/res/layout/fragment_edit_syllabus.xml
@@ -31,7 +31,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:navigationIcon="@drawable/ic_back_arrow"
         app:theme="@style/ToolBarStyle"
-        app:title="Edit Syllabus"
+        app:title="@string/editSyllabusTitle"
         app:titleTextColor="@color/black" >
 
         <ProgressBar
@@ -60,7 +60,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="10dp"
                 android:layout_marginTop="10dp"
-                android:text="@string/description"
+                android:text="@string/editSyllabusContent"
                 android:textColor="@color/defaultTextGray"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -93,7 +93,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="10dp"
                 android:layout_marginTop="16dp"
-                android:text="Detail"
+                android:text="@string/editSyllabusDetails"
                 android:textColor="@color/defaultTextGray"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/divider" />
@@ -105,8 +105,8 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="10dp"
                 android:layout_marginTop="8dp"
-                android:labelFor="@+id/frontPageSwitch"
-                android:text="Show course summary"
+                android:labelFor="@+id/showSummarySwitch"
+                android:text="@string/editSyllabusShowCourseSummary"
                 android:textSize="16sp"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/detailsLabel" />

--- a/apps/teacher/src/main/res/layout/fragment_edit_syllabus.xml
+++ b/apps/teacher/src/main/res/layout/fragment_edit_syllabus.xml
@@ -14,11 +14,12 @@
   ~     along with this program.  If not, see <http://www.gnu.org/licenses/>.
   ~
   -->
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
@@ -31,82 +32,101 @@
         app:navigationIcon="@drawable/ic_back_arrow"
         app:theme="@style/ToolBarStyle"
         app:title="Edit Syllabus"
-        app:titleTextColor="@color/black" />
+        app:titleTextColor="@color/black" >
 
-    <TextView
-        android:id="@+id/contentLabel"
-        style="@style/TextFont.Medium"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:text="@string/description"
-        android:textColor="@color/defaultTextGray"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/toolbar" />
+        <ProgressBar
+            android:id="@+id/savingProgressBar"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_gravity="end"
+            android:layout_marginEnd="16dp"
+            android:visibility="gone"/>
 
-    <instructure.rceditor.RCETextEditorView
-        android:id="@+id/contentRCEView"
+    </androidx.appcompat.widget.Toolbar>
+
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="@dimen/rce_view_min_height"
-        android:layout_marginBottom="8dp"
-        android:layout_marginStart="6dp"
-        android:layout_marginEnd="6dp"
-        app:rce_controls_margin_end="12dp"
-        app:rce_controls_margin_start="12dp"
-        app:rce_editor_padding="12dp"
-        app:layout_constraintTop_toBottomOf="@id/contentLabel"
-        app:layout_constraintStart_toStartOf="parent"/>
+        android:layout_height="match_parent">
 
-    <include
-        android:id="@+id/divider"
-        layout="@layout/view_divider"
-        android:layout_width="match_parent"
-        android:layout_height="0.5dp"
-        app:layout_constraintTop_toBottomOf="@id/contentRCEView"
-        app:layout_constraintStart_toStartOf="parent"
-        android:layout_marginStart="8dp"
-        android:layout_marginEnd="8dp"
-        tools:layout_editor_absoluteX="-6dp"
-        tools:layout_editor_absoluteY="394dp" />
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="6dp">
 
-    <TextView
-        android:id="@+id/detailsLabel"
-        style="@style/TextFont.Medium"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:text="Detail"
-        android:textColor="@color/defaultTextGray"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/divider" />
+            <TextView
+                android:id="@+id/contentLabel"
+                style="@style/TextFont.Medium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="10dp"
+                android:text="@string/description"
+                android:textColor="@color/defaultTextGray"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
-        android:id="@+id/showSummaryLabel"
-        style="@style/TextFont.Medium"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:labelFor="@+id/frontPageSwitch"
-        android:text="Show course summary"
-        android:textSize="16sp"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="8dp"
-        app:layout_constraintTop_toBottomOf="@id/detailsLabel"
-        app:layout_constraintStart_toStartOf="parent"/>
+            <instructure.rceditor.RCETextEditorView
+                android:id="@+id/contentRCEView"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/rce_view_min_height"
+                android:layout_marginBottom="8dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/contentLabel"
+                app:rce_controls_margin_end="12dp"
+                app:rce_controls_margin_start="12dp"
+                app:rce_editor_padding="12dp" />
 
-    <androidx.appcompat.widget.SwitchCompat
-        android:id="@+id/showSummarySwitch"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:minHeight="48dp"
-        android:maxWidth="48dp"
-        android:layout_alignParentEnd="true"
-        android:layout_centerVertical="true"
-        android:backgroundTint="@color/teacher_colorPrimary"
-        android:layout_marginEnd="16dp"
-        app:layout_constraintBaseline_toBaselineOf="@id/showSummaryLabel"
-        app:layout_constraintEnd_toEndOf="parent"
-        tools:checked="true"/>
+            <include
+                android:id="@+id/divider"
+                layout="@layout/view_divider"
+                android:layout_width="match_parent"
+                android:layout_height="0.5dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/contentRCEView"
+                tools:layout_editor_absoluteX="-6dp"
+                tools:layout_editor_absoluteY="394dp" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+            <TextView
+                android:id="@+id/detailsLabel"
+                style="@style/TextFont.Medium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="16dp"
+                android:text="Detail"
+                android:textColor="@color/defaultTextGray"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/divider" />
+
+            <TextView
+                android:id="@+id/showSummaryLabel"
+                style="@style/TextFont.Medium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="8dp"
+                android:labelFor="@+id/frontPageSwitch"
+                android:text="Show course summary"
+                android:textSize="16sp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/detailsLabel" />
+
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/showSummarySwitch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentEnd="true"
+                android:layout_centerVertical="true"
+                android:layout_marginEnd="10dp"
+                android:backgroundTint="@color/teacher_colorPrimary"
+                android:maxWidth="48dp"
+                android:minHeight="48dp"
+                app:layout_constraintBaseline_toBaselineOf="@id/showSummaryLabel"
+                app:layout_constraintEnd_toEndOf="parent"
+                tools:checked="true" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </ScrollView>
+
+</LinearLayout>

--- a/apps/teacher/src/main/res/layout/fragment_edit_syllabus.xml
+++ b/apps/teacher/src/main/res/layout/fragment_edit_syllabus.xml
@@ -17,6 +17,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/editSyllabusPage"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">

--- a/apps/teacher/src/main/res/layout/fragment_edit_syllabus.xml
+++ b/apps/teacher/src/main/res/layout/fragment_edit_syllabus.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (C)  - present Instructure, Inc.
+  ~
+  ~     This program is free software: you can redistribute it and/or modify
+  ~     it under the terms of the GNU General Public License as published by
+  ~     the Free Software Foundation, version 3 of the License.
+  ~
+  ~     This program is distributed in the hope that it will be useful,
+  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~     GNU General Public License for more details.
+  ~
+  ~     You should have received a copy of the GNU General Public License
+  ~     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  ~
+  -->
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/white"
+        android:elevation="6dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navigationIcon="@drawable/ic_back_arrow"
+        app:theme="@style/ToolBarStyle"
+        app:title="Edit Syllabus"
+        app:titleTextColor="@color/black" />
+
+    <TextView
+        android:id="@+id/contentLabel"
+        style="@style/TextFont.Medium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:text="@string/description"
+        android:textColor="@color/defaultTextGray"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar" />
+
+    <instructure.rceditor.RCETextEditorView
+        android:id="@+id/contentRCEView"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/rce_view_min_height"
+        android:layout_marginBottom="8dp"
+        android:layout_marginStart="6dp"
+        android:layout_marginEnd="6dp"
+        app:rce_controls_margin_end="12dp"
+        app:rce_controls_margin_start="12dp"
+        app:rce_editor_padding="12dp"
+        app:layout_constraintTop_toBottomOf="@id/contentLabel"
+        app:layout_constraintStart_toStartOf="parent"/>
+
+    <include
+        android:id="@+id/divider"
+        layout="@layout/view_divider"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        app:layout_constraintTop_toBottomOf="@id/contentRCEView"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        tools:layout_editor_absoluteX="-6dp"
+        tools:layout_editor_absoluteY="394dp" />
+
+    <TextView
+        android:id="@+id/detailsLabel"
+        style="@style/TextFont.Medium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:text="Detail"
+        android:textColor="@color/defaultTextGray"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/divider" />
+
+    <TextView
+        android:id="@+id/showSummaryLabel"
+        style="@style/TextFont.Medium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:labelFor="@+id/frontPageSwitch"
+        android:text="Show course summary"
+        android:textSize="16sp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintTop_toBottomOf="@id/detailsLabel"
+        app:layout_constraintStart_toStartOf="parent"/>
+
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/showSummarySwitch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:minHeight="48dp"
+        android:maxWidth="48dp"
+        android:layout_alignParentEnd="true"
+        android:layout_centerVertical="true"
+        android:backgroundTint="@color/teacher_colorPrimary"
+        android:layout_marginEnd="16dp"
+        app:layout_constraintBaseline_toBaselineOf="@id/showSummaryLabel"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:checked="true"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/teacher/src/main/res/menu/menu_edit_syllabus.xml
+++ b/apps/teacher/src/main/res/menu/menu_edit_syllabus.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (C)  - present Instructure, Inc.
+  ~
+  ~     This program is free software: you can redistribute it and/or modify
+  ~     it under the terms of the GNU General Public License as published by
+  ~     the Free Software Foundation, version 3 of the License.
+  ~
+  ~     This program is distributed in the hope that it will be useful,
+  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~     GNU General Public License for more details.
+  ~
+  ~     You should have received a copy of the GNU General Public License
+  ~     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  ~
+  -->
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/menuSaveSyllabus"
+        android:title="@string/save"
+        app:showAsAction="always" />
+
+</menu>

--- a/apps/teacher/src/main/res/values/strings.xml
+++ b/apps/teacher/src/main/res/values/strings.xml
@@ -888,4 +888,14 @@
     <string name="gauge">Gauge</string>
     <string name="ltiLaunchFailure">This LTI tool could not be loaded at this time.</string>
     <string name="downloading">Downloading…</string>
+
+    <!-- Edit Syllabus -->
+    <string name="syllabusSuccessfullyUpdated">Syllabus successfully updated.</string>
+    <string name="errorSavingSyllabus">An error occurred trying to save the syllabus. Try again.</string>
+    <string name="editSyllabusTitle">Edit Syllabus</string>
+    <string name="editSyllabusContent">Content</string>
+    <string name="editSyllabusDetails">Details</string>
+    <string name="editSyllabusShowCourseSummary">Show course summary</string>
+    <string name="editSyllabusContentAccessibilityLabel">Syllabus content</string>
+
 </resources>

--- a/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/SyllabusEffectHandlerTest.kt
+++ b/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/SyllabusEffectHandlerTest.kt
@@ -19,10 +19,7 @@ package com.instructure.teacher.features.syllabus
 import com.instructure.canvasapi2.apis.CalendarEventAPI
 import com.instructure.canvasapi2.managers.CalendarEventManager
 import com.instructure.canvasapi2.managers.CourseManager
-import com.instructure.canvasapi2.models.Assignment
-import com.instructure.canvasapi2.models.Course
-import com.instructure.canvasapi2.models.CourseSettings
-import com.instructure.canvasapi2.models.ScheduleItem
+import com.instructure.canvasapi2.models.*
 import com.instructure.canvasapi2.utils.DataResult
 import com.instructure.canvasapi2.utils.toApiString
 import com.instructure.teacher.features.syllabus.ui.SyllabusView
@@ -48,6 +45,8 @@ class SyllabusEffectHandlerTest {
         connect(eventConsumer)
     }
 
+    private val permissions = CanvasContextPermission(canManageContent = true)
+
     private lateinit var course: Course
 
     @ExperimentalCoroutinesApi
@@ -72,7 +71,7 @@ class SyllabusEffectHandlerTest {
         effectHandler.accept(SyllabusEffect.LoadData(COURSE_ID, false))
 
         // Then
-        val expectedEvent = SyllabusEvent.DataLoaded(DataResult.Fail(), DataResult.Fail())
+        val expectedEvent = SyllabusEvent.DataLoaded(DataResult.Fail(), DataResult.Fail(), DataResult.Fail())
         verify(timeout = 100) {
             eventConsumer.accept(expectedEvent)
         }
@@ -90,6 +89,9 @@ class SyllabusEffectHandlerTest {
         every { CourseManager.getCourseSettingsAsync(COURSE_ID, false) } returns mockk {
             coEvery { await() } returns DataResult.Success(CourseSettings(courseSummary = true))
         }
+        every { CourseManager.getPermissionsAsync(any(), any(), any()) } returns mockk {
+            coEvery { await() } returns DataResult.Success(permissions)
+        }
 
         mockkObject(CalendarEventManager)
         every { CalendarEventManager.getCalendarEventsExhaustiveAsync(any(), any(), any(), any(), any(), any()) } returns mockk {
@@ -100,7 +102,7 @@ class SyllabusEffectHandlerTest {
         effectHandler.accept(SyllabusEffect.LoadData(COURSE_ID, false))
 
         // Then
-        val expectedEvent = SyllabusEvent.DataLoaded(DataResult.Success(course), DataResult.Fail())
+        val expectedEvent = SyllabusEvent.DataLoaded(DataResult.Success(course), DataResult.Fail(), DataResult.Success(permissions))
         verify(timeout = 100) {
             eventConsumer.accept(expectedEvent)
         }
@@ -133,6 +135,9 @@ class SyllabusEffectHandlerTest {
         every { CourseManager.getCourseSettingsAsync(COURSE_ID, false) } returns mockk {
             coEvery { await() } returns DataResult.Success(CourseSettings(courseSummary = true))
         }
+        every { CourseManager.getPermissionsAsync(any(), any(), any()) } returns mockk {
+            coEvery { await() } returns DataResult.Success(permissions)
+        }
 
         mockkObject(CalendarEventManager)
         every { CalendarEventManager.getCalendarEventsExhaustiveAsync(any(), CalendarEventAPI.CalendarEventType.ASSIGNMENT, any(), any(), any(), any()) } returns mockk {
@@ -152,7 +157,7 @@ class SyllabusEffectHandlerTest {
             sortedEvents.add(calendarEvents[i])
         }
 
-        val expectedEvent = SyllabusEvent.DataLoaded(DataResult.Success(course), DataResult.Success(sortedEvents))
+        val expectedEvent = SyllabusEvent.DataLoaded(DataResult.Success(course), DataResult.Success(sortedEvents), DataResult.Success(permissions))
         verify(timeout = 100) {
             eventConsumer.accept(expectedEvent)
         }
@@ -172,6 +177,9 @@ class SyllabusEffectHandlerTest {
         every { CourseManager.getCourseSettingsAsync(COURSE_ID, false) } returns mockk {
             coEvery { await() } returns DataResult.Success(CourseSettings(courseSummary = true))
         }
+        every { CourseManager.getPermissionsAsync(any(), any(), any()) } returns mockk {
+            coEvery { await() } returns DataResult.Success(permissions)
+        }
 
         mockkObject(CalendarEventManager)
         every { CalendarEventManager.getCalendarEventsExhaustiveAsync(any(), CalendarEventAPI.CalendarEventType.ASSIGNMENT, any(), any(), any(), any()) } returns mockk {
@@ -185,7 +193,7 @@ class SyllabusEffectHandlerTest {
         effectHandler.accept(SyllabusEffect.LoadData(COURSE_ID, false))
 
         // Then
-        val expectedEvent = SyllabusEvent.DataLoaded(DataResult.Success(course), DataResult.Success(assignments))
+        val expectedEvent = SyllabusEvent.DataLoaded(DataResult.Success(course), DataResult.Success(assignments), DataResult.Success(permissions))
         verify(timeout = 100) {
             eventConsumer.accept(expectedEvent)
         }
@@ -205,6 +213,9 @@ class SyllabusEffectHandlerTest {
         every { CourseManager.getCourseSettingsAsync(COURSE_ID, false) } returns mockk {
             coEvery { await() } returns DataResult.Success(CourseSettings(courseSummary = true))
         }
+        every { CourseManager.getPermissionsAsync(any(), any(), any()) } returns mockk {
+            coEvery { await() } returns DataResult.Success(permissions)
+        }
 
         mockkObject(CalendarEventManager)
         every { CalendarEventManager.getCalendarEventsExhaustiveAsync(any(), CalendarEventAPI.CalendarEventType.ASSIGNMENT, any(), any(), any(), any()) } returns mockk {
@@ -218,7 +229,7 @@ class SyllabusEffectHandlerTest {
         effectHandler.accept(SyllabusEffect.LoadData(COURSE_ID, false))
 
         // Then
-        val expectedEvent = SyllabusEvent.DataLoaded(DataResult.Success(course), DataResult.Success(calendarEvents))
+        val expectedEvent = SyllabusEvent.DataLoaded(DataResult.Success(course), DataResult.Success(calendarEvents), DataResult.Success(permissions))
         verify(timeout = 100) {
             eventConsumer.accept(expectedEvent)
         }
@@ -239,6 +250,9 @@ class SyllabusEffectHandlerTest {
         every { CourseManager.getCourseWithSyllabusAsync(COURSE_ID, false) } returns mockk {
             coEvery { await() } returns DataResult.Success(course)
         }
+        every { CourseManager.getPermissionsAsync(any(), any(), any()) } returns mockk {
+            coEvery { await() } returns DataResult.Success(permissions)
+        }
 
         mockkObject(CalendarEventManager)
         every { CalendarEventManager.getCalendarEventsExhaustiveAsync(any(), CalendarEventAPI.CalendarEventType.ASSIGNMENT, any(), any(), any(), any()) } returns mockk {
@@ -252,7 +266,7 @@ class SyllabusEffectHandlerTest {
         effectHandler.accept(SyllabusEffect.LoadData(COURSE_ID, false))
 
         // Then
-        val expectedEvent = SyllabusEvent.DataLoaded(DataResult.Success(course), DataResult.Success(emptyList()))
+        val expectedEvent = SyllabusEvent.DataLoaded(DataResult.Success(course), DataResult.Success(emptyList()), DataResult.Success(permissions))
         verify(timeout = 100) {
             eventConsumer.accept(expectedEvent)
         }

--- a/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/SyllabusEffectHandlerTest.kt
+++ b/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/SyllabusEffectHandlerTest.kt
@@ -71,7 +71,7 @@ class SyllabusEffectHandlerTest {
         effectHandler.accept(SyllabusEffect.LoadData(COURSE_ID, false))
 
         // Then
-        val expectedEvent = SyllabusEvent.DataLoaded(DataResult.Fail(), DataResult.Fail(), DataResult.Fail())
+        val expectedEvent = SyllabusEvent.DataLoaded(DataResult.Fail(), DataResult.Fail(), DataResult.Fail(), true)
         verify(timeout = 100) {
             eventConsumer.accept(expectedEvent)
         }
@@ -102,7 +102,7 @@ class SyllabusEffectHandlerTest {
         effectHandler.accept(SyllabusEffect.LoadData(COURSE_ID, false))
 
         // Then
-        val expectedEvent = SyllabusEvent.DataLoaded(DataResult.Success(course), DataResult.Fail(), DataResult.Success(permissions))
+        val expectedEvent = SyllabusEvent.DataLoaded(DataResult.Success(course), DataResult.Fail(), DataResult.Success(permissions), true)
         verify(timeout = 100) {
             eventConsumer.accept(expectedEvent)
         }
@@ -157,7 +157,7 @@ class SyllabusEffectHandlerTest {
             sortedEvents.add(calendarEvents[i])
         }
 
-        val expectedEvent = SyllabusEvent.DataLoaded(DataResult.Success(course), DataResult.Success(sortedEvents), DataResult.Success(permissions))
+        val expectedEvent = SyllabusEvent.DataLoaded(DataResult.Success(course), DataResult.Success(sortedEvents), DataResult.Success(permissions), true)
         verify(timeout = 100) {
             eventConsumer.accept(expectedEvent)
         }
@@ -193,7 +193,7 @@ class SyllabusEffectHandlerTest {
         effectHandler.accept(SyllabusEffect.LoadData(COURSE_ID, false))
 
         // Then
-        val expectedEvent = SyllabusEvent.DataLoaded(DataResult.Success(course), DataResult.Success(assignments), DataResult.Success(permissions))
+        val expectedEvent = SyllabusEvent.DataLoaded(DataResult.Success(course), DataResult.Success(assignments), DataResult.Success(permissions), true)
         verify(timeout = 100) {
             eventConsumer.accept(expectedEvent)
         }
@@ -229,7 +229,7 @@ class SyllabusEffectHandlerTest {
         effectHandler.accept(SyllabusEffect.LoadData(COURSE_ID, false))
 
         // Then
-        val expectedEvent = SyllabusEvent.DataLoaded(DataResult.Success(course), DataResult.Success(calendarEvents), DataResult.Success(permissions))
+        val expectedEvent = SyllabusEvent.DataLoaded(DataResult.Success(course), DataResult.Success(calendarEvents), DataResult.Success(permissions), true)
         verify(timeout = 100) {
             eventConsumer.accept(expectedEvent)
         }
@@ -301,6 +301,19 @@ class SyllabusEffectHandlerTest {
         // Then
         verify(timeout = 100) {
             view.showScheduleItemView(scheduleItem, course)
+        }
+
+        confirmVerified(view)
+    }
+
+    @Test
+    fun `OpenEditSyllabus results in opening the edit syllabus screen`() {
+        // When
+        effectHandler.accept(SyllabusEffect.OpenEditSyllabus(course, true))
+
+        // Then
+        verify(timeout = 100) {
+            view.openEditSyllabus(course, true)
         }
 
         confirmVerified(view)

--- a/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/SyllabusPresenterTest.kt
+++ b/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/SyllabusPresenterTest.kt
@@ -198,14 +198,15 @@ class SyllabusPresenterTest {
         val model = baseModel.copy(
             course = DataResult.Success(baseCourse),
             events = DataResult.Success(baseEvents),
-            syllabus = ScheduleItem.createSyllabus("Title", syllabusBody)
+            syllabus = ScheduleItem.createSyllabus("Title", syllabusBody),
+            summaryAllowed = true
         )
 
         // When
         val syllabusViewState = syllabusPresenter.present(model, context)
 
         // Then
-        val expectedState = SyllabusViewState.Loaded(syllabus = syllabusBody, eventsState = EventsViewState.Loaded(baseEventsViewState))
+        val expectedState = SyllabusViewState.Loaded(syllabus = syllabusBody, eventsState = EventsViewState.Loaded(baseEventsViewState), showSummary = true)
         assertEquals(expectedState, syllabusViewState)
     }
 

--- a/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/SyllabusPresenterTest.kt
+++ b/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/SyllabusPresenterTest.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.instructure.canvasapi2.models.Assignment
+import com.instructure.canvasapi2.models.CanvasContextPermission
 import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.models.ScheduleItem
 import com.instructure.canvasapi2.utils.DataResult
@@ -195,9 +196,9 @@ class SyllabusPresenterTest {
         // Given
         val syllabusBody = "Syllabus body"
         val model = baseModel.copy(
-                course = DataResult.Success(baseCourse),
-                events = DataResult.Success(baseEvents),
-                syllabus = ScheduleItem.createSyllabus("Title", syllabusBody)
+            course = DataResult.Success(baseCourse),
+            events = DataResult.Success(baseEvents),
+            syllabus = ScheduleItem.createSyllabus("Title", syllabusBody)
         )
 
         // When
@@ -205,6 +206,63 @@ class SyllabusPresenterTest {
 
         // Then
         val expectedState = SyllabusViewState.Loaded(syllabus = syllabusBody, eventsState = EventsViewState.Loaded(baseEventsViewState))
+        assertEquals(expectedState, syllabusViewState)
+    }
+
+    @Test
+    fun `Should return loaded state with possibility to edit if user has the permission to edit`() {
+        // Given
+        val syllabusBody = "Syllabus body"
+        val model = baseModel.copy(
+            course = DataResult.Success(baseCourse),
+            events = DataResult.Success(baseEvents),
+            syllabus = ScheduleItem.createSyllabus("Title", syllabusBody),
+            permissions = DataResult.Success(CanvasContextPermission(canManageContent = true))
+        )
+
+        // When
+        val syllabusViewState = syllabusPresenter.present(model, context)
+
+        // Then
+        val expectedState = SyllabusViewState.Loaded(syllabus = syllabusBody, eventsState = EventsViewState.Loaded(baseEventsViewState), canEdit = true)
+        assertEquals(expectedState, syllabusViewState)
+    }
+
+    @Test
+    fun `Should return loaded state without possibility to edit if user does not have the permission to edit`() {
+        // Given
+        val syllabusBody = "Syllabus body"
+        val model = baseModel.copy(
+            course = DataResult.Success(baseCourse),
+            events = DataResult.Success(baseEvents),
+            syllabus = ScheduleItem.createSyllabus("Title", syllabusBody),
+            permissions = DataResult.Success(CanvasContextPermission(canManageContent = false))
+        )
+
+        // When
+        val syllabusViewState = syllabusPresenter.present(model, context)
+
+        // Then
+        val expectedState = SyllabusViewState.Loaded(syllabus = syllabusBody, eventsState = EventsViewState.Loaded(baseEventsViewState), canEdit = false)
+        assertEquals(expectedState, syllabusViewState)
+    }
+
+    @Test
+    fun `Should return loaded state without possibility to edit if permissions fail`() {
+        // Given
+        val syllabusBody = "Syllabus body"
+        val model = baseModel.copy(
+            course = DataResult.Success(baseCourse),
+            events = DataResult.Success(baseEvents),
+            syllabus = ScheduleItem.createSyllabus("Title", syllabusBody),
+            permissions = DataResult.Fail()
+        )
+
+        // When
+        val syllabusViewState = syllabusPresenter.present(model, context)
+
+        // Then
+        val expectedState = SyllabusViewState.Loaded(syllabus = syllabusBody, eventsState = EventsViewState.Loaded(baseEventsViewState), canEdit = false)
         assertEquals(expectedState, syllabusViewState)
     }
 }

--- a/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/SyllabusUpdateTest.kt
+++ b/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/SyllabusUpdateTest.kt
@@ -184,4 +184,19 @@ class SyllabusUpdateTest {
                 UpdateSpec.assertThatNext(NextMatchers.hasModel(expectedModel))
             )
     }
+
+    @Test
+    fun `SyllabusUpdatedEvent should load data if summary allowed was not changed but content is empty`() {
+        val expectedModel = initModel.copy(isLoading = true)
+
+        updateSpec
+            .given(initModel)
+            .whenEvent(SyllabusEvent.SyllabusUpdatedEvent(summaryAllowed = false, content = ""))
+            .then(
+                UpdateSpec.assertThatNext(
+                    NextMatchers.hasModel(expectedModel),
+                    matchesEffects<SyllabusModel, SyllabusEffect>(SyllabusEffect.LoadData(course.id, true))
+                )
+            )
+    }
 }

--- a/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/SyllabusUpdateTest.kt
+++ b/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/SyllabusUpdateTest.kt
@@ -140,4 +140,18 @@ class SyllabusUpdateTest {
                 UpdateSpec.assertThatNext(matchesEffects<SyllabusModel, SyllabusEffect>(SyllabusEffect.ShowScheduleItemView(events.data[0], course)))
             )
     }
+
+    @Test
+    fun `EditClicked event should dispatch OpenEditSyllabus`() {
+        val courseResult = DataResult.Success(course)
+
+        val initModel = initModel.copy(course = courseResult, summaryAllowed = true)
+
+        updateSpec
+            .given(initModel)
+            .whenEvent(SyllabusEvent.EditClicked)
+            .then(
+                UpdateSpec.assertThatNext(matchesEffects<SyllabusModel, SyllabusEffect>(SyllabusEffect.OpenEditSyllabus(course, true)))
+            )
+    }
 }

--- a/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/SyllabusUpdateTest.kt
+++ b/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/SyllabusUpdateTest.kt
@@ -154,4 +154,34 @@ class SyllabusUpdateTest {
                 UpdateSpec.assertThatNext(matchesEffects<SyllabusModel, SyllabusEffect>(SyllabusEffect.OpenEditSyllabus(course, true)))
             )
     }
+
+    @Test
+    fun `SyllabusUpdatedEvent should load data if summary allowed was changed`() {
+        val expectedModel = initModel.copy(isLoading = true)
+        updateSpec
+            .given(initModel)
+            .whenEvent(SyllabusEvent.SyllabusUpdatedEvent(summaryAllowed = true, content = "Web Content"))
+            .then(
+                UpdateSpec.assertThatNext(
+                    NextMatchers.hasModel(expectedModel),
+                    matchesEffects<SyllabusModel, SyllabusEffect>(SyllabusEffect.LoadData(course.id, true))
+                )
+            )
+    }
+
+    @Test
+    fun `SyllabusUpdatedEvent should create new model with updated syllabus if summary allowed was not changed`() {
+        val givenModel = initModel.copy(course = DataResult.Success(course))
+
+        val courseResult = DataResult.Success(course.copy(syllabusBody = "New Syllabus Body"))
+        val syllabus = ScheduleItem.createSyllabus(course.name, "New Syllabus Body")
+        val expectedModel = initModel.copy(course = courseResult, syllabus = syllabus)
+
+        updateSpec
+            .given(givenModel)
+            .whenEvent(SyllabusEvent.SyllabusUpdatedEvent(summaryAllowed = false, content = "New Syllabus Body"))
+            .then(
+                UpdateSpec.assertThatNext(NextMatchers.hasModel(expectedModel))
+            )
+    }
 }

--- a/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/SyllabusUpdateTest.kt
+++ b/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/SyllabusUpdateTest.kt
@@ -17,6 +17,7 @@
 package com.instructure.teacher.features.syllabus
 
 import com.instructure.canvasapi2.models.Assignment
+import com.instructure.canvasapi2.models.CanvasContextPermission
 import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.models.ScheduleItem
 import com.instructure.canvasapi2.utils.DataResult
@@ -80,12 +81,13 @@ class SyllabusUpdateTest {
         val events = DataResult.Success(List(4) {
             ScheduleItem(itemId = it.toString())
         })
+        val permissionsResult = DataResult.Success(CanvasContextPermission(canManageContent = true))
 
-        val expectedModel = initModel.copy(isLoading = false, course = course, events = events, syllabus = syllabus)
+        val expectedModel = initModel.copy(isLoading = false, course = course, events = events, syllabus = syllabus, permissions = permissionsResult)
 
         updateSpec
             .given(initModel.copy(isLoading = true))
-            .whenEvent(SyllabusEvent.DataLoaded(course, events))
+            .whenEvent(SyllabusEvent.DataLoaded(course, events, permissionsResult))
             .then(
                 UpdateSpec.assertThatNext(NextMatchers.hasModel(expectedModel))
             )
@@ -96,11 +98,13 @@ class SyllabusUpdateTest {
         val initModel = initModel.copy(isLoading = true, course = DataResult.Success(course), events = DataResult.Success(emptyList()), syllabus = ScheduleItem.createSyllabus(null, null))
 
         val course = DataResult.Fail()
-        val expectedModel = initModel.copy(isLoading = false, course = course, events = course, syllabus = null)
+        val permissionsResult = DataResult.Success(CanvasContextPermission(canManageContent = true))
+
+        val expectedModel = initModel.copy(isLoading = false, course = course, events = course, syllabus = null, permissions = permissionsResult)
 
         updateSpec
             .given(initModel)
-            .whenEvent(SyllabusEvent.DataLoaded(course, course))
+            .whenEvent(SyllabusEvent.DataLoaded(course, course, permissionsResult))
             .then(
                 UpdateSpec.assertThatNext(NextMatchers.hasModel(expectedModel))
             )

--- a/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusEffectHandlerTest.kt
+++ b/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusEffectHandlerTest.kt
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.teacher.features.syllabus.edit
+
+import com.instructure.canvasapi2.managers.CourseManager
+import com.instructure.canvasapi2.models.Course
+import com.instructure.canvasapi2.models.CourseSettings
+import com.instructure.canvasapi2.utils.DataResult
+import com.spotify.mobius.functions.Consumer
+import io.mockk.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.test.setMain
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.Executors
+
+private const val COURSE_ID: Long = 1L
+
+class EditSyllabusEffectHandlerTest {
+
+    private val editSyllabusView: EditSyllabusView = mockk(relaxed = true)
+    private val eventConsumer: Consumer<EditSyllabusEvent> = mockk(relaxed = true)
+
+    private val effectHandler = EditSyllabusEffectHandler().apply {
+        view = this@EditSyllabusEffectHandlerTest.editSyllabusView
+        connect(eventConsumer)
+    }
+
+    private lateinit var course: Course
+
+    @ExperimentalCoroutinesApi
+    @Before
+    fun setup() {
+        Dispatchers.setMain(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
+        course = Course(id = COURSE_ID)
+    }
+
+    @Test
+    fun `Save Data should produce error event if edit course request fails`() {
+        // Given
+        val newSyllabusBody = "Edited Syllabus"
+
+        mockkObject(CourseManager)
+        every { CourseManager.editCourseSyllabusAsync(COURSE_ID, newSyllabusBody) } returns mockk {
+            coEvery { await() } returns DataResult.Fail()
+        }
+        every { CourseManager.editCourseSettingsAsync(COURSE_ID, true) } returns mockk {
+            coEvery { await() } returns DataResult.Success(CourseSettings(courseSummary = true))
+        }
+
+        // When
+        effectHandler.accept(EditSyllabusEffect.SaveData(course, newSyllabusBody, true))
+
+        // Then
+        val expectedEvent = EditSyllabusEvent.SyllabusSaveError
+        verify(timeout = 100) {
+            eventConsumer.accept(expectedEvent)
+        }
+
+        confirmVerified(eventConsumer)
+    }
+
+    @Test
+    fun `Save Data should produce error event if edit course settings request fails`() {
+        // Given
+        val newSyllabusBody = "Edited Syllabus"
+
+        mockkObject(CourseManager)
+        every { CourseManager.editCourseSyllabusAsync(COURSE_ID, newSyllabusBody) } returns mockk {
+            coEvery { await() } returns DataResult.Success(course.copy(syllabusBody = newSyllabusBody))
+        }
+        every { CourseManager.editCourseSettingsAsync(COURSE_ID, true) } returns mockk {
+            coEvery { await() } returns DataResult.Fail()
+        }
+
+        // When
+        effectHandler.accept(EditSyllabusEffect.SaveData(course, newSyllabusBody, true))
+
+        // Then
+        val expectedEvent = EditSyllabusEvent.SyllabusSaveError
+        verify(timeout = 100) {
+            eventConsumer.accept(expectedEvent)
+        }
+
+        confirmVerified(eventConsumer)
+    }
+
+    @Test
+    fun `Save Data should produce save success event if both requests are successful`() {
+        // Given
+        val newSyllabusBody = "Edited Syllabus"
+
+        mockkObject(CourseManager)
+        every { CourseManager.editCourseSyllabusAsync(COURSE_ID, newSyllabusBody) } returns mockk {
+            coEvery { await() } returns DataResult.Success(course.copy(syllabusBody = newSyllabusBody))
+        }
+        every { CourseManager.editCourseSettingsAsync(COURSE_ID, true) } returns mockk {
+            coEvery { await() } returns DataResult.Success(CourseSettings(courseSummary = true))
+        }
+
+        // When
+        effectHandler.accept(EditSyllabusEffect.SaveData(course, newSyllabusBody, true))
+
+        // Then
+        val expectedEvent = EditSyllabusEvent.SyllabusSaveSuccess(newSyllabusBody, true)
+        verify(timeout = 100) {
+            eventConsumer.accept(expectedEvent)
+        }
+
+        confirmVerified(eventConsumer)
+    }
+
+    @Test
+    fun `CloseEdit results in closing the edit syllabus screen`() {
+        // When
+        effectHandler.accept(EditSyllabusEffect.CloseEdit)
+
+        // Then
+        verify(timeout = 100) {
+            editSyllabusView.closeEditSyllabus()
+        }
+
+        confirmVerified(editSyllabusView)
+    }
+
+    @Test
+    fun `ShowSaveSuccess results in showing save success message`() {
+        // When
+        effectHandler.accept(EditSyllabusEffect.ShowSaveSuccess)
+
+        // Then
+        verify(timeout = 100) {
+            editSyllabusView.showSaveSuccess()
+        }
+
+        confirmVerified(editSyllabusView)
+    }
+
+    @Test
+    fun `ShowSaveError results in showing save error message`() {
+        // When
+        effectHandler.accept(EditSyllabusEffect.ShowSaveError)
+
+        // Then
+        verify(timeout = 100) {
+            editSyllabusView.showSaveError()
+        }
+
+        confirmVerified(editSyllabusView)
+    }
+
+    @Test
+    fun `ShowCloseConfirmationDialog results in showing close confirmation dialog`() {
+        // When
+        effectHandler.accept(EditSyllabusEffect.ShowCloseConfirmationDialog)
+
+        // Then
+        verify(timeout = 100) {
+            editSyllabusView.showCloseConfirmationDialog()
+        }
+
+        confirmVerified(editSyllabusView)
+    }
+}

--- a/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusPresenterTest.kt
+++ b/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusPresenterTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.teacher.features.syllabus.edit
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.instructure.canvasapi2.models.Course
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class EditSyllabusPresenterTest {
+
+    private val presenter = EditSyllabusPresenter()
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun `Should return saving state if received model is saving`() {
+        // Given
+        val model = EditSyllabusModel(Course(syllabusBody = "syllabus"), summaryAllowed = true, isSaving = true)
+
+        // When
+        val viewState = presenter.present(model, context)
+
+        // Then
+        assertEquals(EditSyllabusViewState.Saving, viewState)
+    }
+
+    @Test
+    fun `Should return loaded state with correct data if received model is not saving`() {
+        // Given
+        val model = EditSyllabusModel(Course(syllabusBody = "syllabus"), summaryAllowed = true, isSaving = false)
+
+        // When
+        val viewState = presenter.present(model, context)
+
+        // Then
+        val expectedViewState = EditSyllabusViewState.Loaded("syllabus", true)
+        assertEquals(expectedViewState, viewState)
+    }
+}

--- a/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusUpdateTest.kt
+++ b/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/edit/EditSyllabusUpdateTest.kt
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.teacher.features.syllabus.edit
+
+import com.instructure.canvasapi2.models.Course
+import com.instructure.teacher.events.SyllabusUpdatedEvent
+import com.instructure.teacher.unit.utils.matchesEffects
+import com.spotify.mobius.test.FirstMatchers
+import com.spotify.mobius.test.InitSpec
+import com.spotify.mobius.test.NextMatchers
+import com.spotify.mobius.test.UpdateSpec
+import org.greenrobot.eventbus.EventBus
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class EditSyllabusUpdateTest {
+
+    private val initSpec = InitSpec(EditSyllabusUpdate()::init)
+    private val updateSpec = UpdateSpec(EditSyllabusUpdate()::update)
+
+    private lateinit var initModel: EditSyllabusModel
+    private lateinit var course: Course
+
+    @Before
+    fun setup() {
+        course = Course(id = 1234L, name = "Course Name", syllabusBody = "This is a syllabus")
+        initModel = EditSyllabusModel(course, true)
+    }
+
+    @Test
+    fun `Init should set init model and has no side effect`() {
+        initSpec
+            .whenInit(initModel)
+            .then(
+                InitSpec.assertThatFirst(
+                    FirstMatchers.hasModel(initModel),
+                    FirstMatchers.hasNoEffects())
+            )
+    }
+
+    @Test
+    fun `SaveClicked event should set the model to saving and save data`() {
+        val content = "New syllabus"
+        val summaryAllowed = false
+
+        val expectedModel = initModel.copy(isSaving = true)
+        updateSpec
+            .given(initModel)
+            .whenEvent(EditSyllabusEvent.SaveClicked(content, summaryAllowed))
+            .then(
+                UpdateSpec.assertThatNext(
+                    NextMatchers.hasModel(expectedModel),
+                    matchesEffects<EditSyllabusModel, EditSyllabusEffect>(EditSyllabusEffect.SaveData(course, content, summaryAllowed))
+                )
+            )
+    }
+
+    @Test
+    fun `Save success event should create model with the saved data, close edit and show success message`() {
+        val content = "New syllabus"
+        val summaryAllowed = false
+
+        val givenModel = initModel.copy(isSaving = true)
+        val expectedModel = givenModel.copy(isSaving = false, course = course.copy(syllabusBody = content), summaryAllowed = summaryAllowed)
+        updateSpec
+            .given(givenModel)
+            .whenEvent(EditSyllabusEvent.SyllabusSaveSuccess(content, summaryAllowed))
+            .then(
+                UpdateSpec.assertThatNext(
+                    NextMatchers.hasModel(expectedModel),
+                    matchesEffects<EditSyllabusModel, EditSyllabusEffect>(EditSyllabusEffect.CloseEdit, EditSyllabusEffect.ShowSaveSuccess)
+                )
+            )
+
+        val stickyEvent = EventBus.getDefault().getStickyEvent(SyllabusUpdatedEvent::class.java)
+        assertEquals(stickyEvent.content, content)
+        assertEquals(stickyEvent.summaryAllowed, summaryAllowed)
+    }
+
+    @Test
+    fun `Save error event should show error message and set saving to false`() {
+        val givenModel = initModel.copy(isSaving = true)
+        val expectedModel = givenModel.copy(isSaving = false)
+        updateSpec
+            .given(givenModel)
+            .whenEvent(EditSyllabusEvent.SyllabusSaveError)
+            .then(
+                UpdateSpec.assertThatNext(
+                    NextMatchers.hasModel(expectedModel),
+                    matchesEffects<EditSyllabusModel, EditSyllabusEffect>(EditSyllabusEffect.ShowSaveError)
+                )
+            )
+    }
+
+    @Test
+    fun `Back click event should close edit if nothing was changed`() {
+        updateSpec
+            .given(initModel)
+            .whenEvent(EditSyllabusEvent.BackClicked(initModel.course.syllabusBody!!, initModel.summaryAllowed))
+            .then(
+                UpdateSpec.assertThatNext(
+                    matchesEffects<EditSyllabusModel, EditSyllabusEffect>(EditSyllabusEffect.CloseEdit)
+                )
+            )
+    }
+
+    @Test
+    fun `Back click event should show exit confirmation if summary allowed was changed`() {
+        val summaryAllowed = false
+
+        updateSpec
+            .given(initModel)
+            .whenEvent(EditSyllabusEvent.BackClicked(initModel.course.syllabusBody!!, summaryAllowed))
+            .then(
+                UpdateSpec.assertThatNext(
+                    matchesEffects<EditSyllabusModel, EditSyllabusEffect>(EditSyllabusEffect.ShowCloseConfirmationDialog)
+                )
+            )
+    }
+
+    @Test
+    fun `Back click event should show exit confirmation if syllabus content was changed`() {
+        val content = "new syllabus"
+
+        updateSpec
+            .given(initModel)
+            .whenEvent(EditSyllabusEvent.BackClicked(content, initModel.summaryAllowed))
+            .then(
+                UpdateSpec.assertThatNext(
+                    matchesEffects<EditSyllabusModel, EditSyllabusEffect>(EditSyllabusEffect.ShowCloseConfirmationDialog)
+                )
+            )
+    }
+
+    @Test
+    fun `Back click event should show exit confirmation if model was changed previously`() {
+        updateSpec
+            .given(initModel.copy(isChanged = true))
+            .whenEvent(EditSyllabusEvent.BackClicked(initModel.course.syllabusBody!!, initModel.summaryAllowed))
+            .then(
+                UpdateSpec.assertThatNext(
+                    matchesEffects<EditSyllabusModel, EditSyllabusEffect>(EditSyllabusEffect.ShowCloseConfirmationDialog)
+                )
+            )
+    }
+
+    @Test
+    fun `Save state event should create model with the changed data`() {
+        val content = "New syllabus"
+        val summaryAllowed = false
+
+        val expectedModel = initModel.copy(course = course.copy(syllabusBody = content), summaryAllowed = summaryAllowed, isChanged = true)
+        updateSpec
+            .given(initModel)
+            .whenEvent(EditSyllabusEvent.SaveState(content, summaryAllowed))
+            .then(
+                UpdateSpec.assertThatNext(
+                    NextMatchers.hasModel(expectedModel)
+                )
+            )
+    }
+}

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/CustomActions.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/CustomActions.kt
@@ -16,13 +16,14 @@
  */
 package com.instructure.canvas.espresso
 
+import android.app.Activity
 import android.os.SystemClock
 import android.os.SystemClock.sleep
-import android.util.Log
 import android.view.InputDevice
 import android.view.MotionEvent
 import android.view.View
 import android.widget.EditText
+import androidx.annotation.StringRes
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.test.espresso.Espresso.onView
@@ -30,23 +31,19 @@ import androidx.test.espresso.PerformException
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.ViewInteraction
-import androidx.test.espresso.action.CoordinatesProvider
-import androidx.test.espresso.action.GeneralClickAction
-import androidx.test.espresso.action.Press
-import androidx.test.espresso.action.Tap
-import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.action.*
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.RootMatchers.withDecorView
 import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.espresso.util.HumanReadables
 import androidx.viewpager.widget.ViewPager
 import com.instructure.espresso.assertDisplayed
 import com.instructure.espresso.swipeUp
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers
-import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.*
 
 //
 // This is a repo for generally useful Espresso actions
@@ -318,13 +315,21 @@ class SetViewPagerCurrentItemAction(private val pageNumber: Int) : ViewAction {
 
         if (pageNumber >= adapter.count) throw PerformException.Builder()
                 .withActionDescription(this.description)
-                .withViewDescription(HumanReadables.describe(view))
-                .withCause(IndexOutOfBoundsException("Requested page $pageNumber in ViewPager of size ${adapter.count}"))
-                .build()
+            .withViewDescription(HumanReadables.describe(view))
+            .withCause(IndexOutOfBoundsException("Requested page $pageNumber in ViewPager of size ${adapter.count}"))
+            .build()
 
         pager.setCurrentItem(pageNumber, false)
 
         uiController.loopMainThreadUntilIdle()
     }
 
+}
+
+fun checkToastText(text: String, activity: Activity) {
+    onView(withText(text)).inRoot(withDecorView(not(`is`(activity.window.decorView)))).check(matches(isDisplayed()))
+}
+
+fun checkToastText(@StringRes stringRes: Int, activity: Activity) {
+    onView(withText(stringRes)).inRoot(withDecorView(not(`is`(activity.window.decorView)))).check(matches(isDisplayed()))
 }

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/endpoints/CourseEndpoints.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/endpoints/CourseEndpoints.kt
@@ -112,6 +112,20 @@ object CourseEndpoint : Endpoint(
                         val settings = data.courseSettings[courseId] ?: CourseSettings()
                         request.successResponse(settings)
                     }
+
+                    PUT {
+                        val courseId = pathVars.courseId
+                        val settings = data.courseSettings[courseId] ?: CourseSettings()
+
+                        // Handle course settings change, if present
+                        val newSyllabusSummaryVisibility = request.url().queryParameter("syllabus_course_summary")
+                        if (newSyllabusSummaryVisibility != null) {
+                            settings.courseSummary = newSyllabusSummaryVisibility.toBoolean()
+                        }
+
+                        // Return the updated course
+                        request.successResponse(settings)
+                    }
                 }
         ),
 
@@ -146,6 +160,12 @@ object CourseEndpoint : Endpoint(
                         "wiki" -> Course.HomePage.HOME_WIKI
                         else -> Course.HomePage.HOME_MODULES
                     }
+                }
+
+                // Handle course syllabus change, if present
+                val newSyllabusBody = request.url().queryParameter("course[syllabus_body]")
+                if (newSyllabusBody != null) {
+                    course.syllabusBody = newSyllabusBody
                 }
 
                 // Return the updated course

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/endpoints/CourseEndpoints.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/endpoints/CourseEndpoints.kt
@@ -18,39 +18,10 @@ package com.instructure.canvas.espresso.mockCanvas.endpoints
 
 import android.util.Log
 import com.google.gson.Gson
-import com.instructure.canvas.espresso.mockCanvas.Endpoint
-import com.instructure.canvas.espresso.mockCanvas.MockCanvas
-import com.instructure.canvas.espresso.mockCanvas.addDiscussionTopicToCourse
-import com.instructure.canvas.espresso.mockCanvas.addFileToCourse
-import com.instructure.canvas.espresso.mockCanvas.addQuizSubmission
-import com.instructure.canvas.espresso.mockCanvas.addReplyToDiscussion
-import com.instructure.canvas.espresso.mockCanvas.endpoint
-import com.instructure.canvas.espresso.mockCanvas.utils.AuthModel
-import com.instructure.canvas.espresso.mockCanvas.utils.DontCareAuthModel
-import com.instructure.canvas.espresso.mockCanvas.utils.LongId
-import com.instructure.canvas.espresso.mockCanvas.utils.PathVars
-import com.instructure.canvas.espresso.mockCanvas.utils.Segment
-import com.instructure.canvas.espresso.mockCanvas.utils.StringId
-import com.instructure.canvas.espresso.mockCanvas.utils.UserId
-import com.instructure.canvas.espresso.mockCanvas.utils.grabJsonFromMultiPartBody
-import com.instructure.canvas.espresso.mockCanvas.utils.noContentResponse
-import com.instructure.canvas.espresso.mockCanvas.utils.successPaginatedResponse
-import com.instructure.canvas.espresso.mockCanvas.utils.successResponse
-import com.instructure.canvas.espresso.mockCanvas.utils.unauthorizedResponse
-import com.instructure.canvas.espresso.mockCanvas.utils.user
-import com.instructure.canvasapi2.models.Attachment
-import com.instructure.canvasapi2.models.Course
-import com.instructure.canvasapi2.models.CourseSettings
-import com.instructure.canvasapi2.models.DiscussionEntry
-import com.instructure.canvasapi2.models.DiscussionParticipant
-import com.instructure.canvasapi2.models.DiscussionTopicHeader
-import com.instructure.canvasapi2.models.GradingPeriod
-import com.instructure.canvasapi2.models.GradingPeriodResponse
-import com.instructure.canvasapi2.models.LaunchDefinition
-import com.instructure.canvasapi2.models.Quiz
-import com.instructure.canvasapi2.models.QuizSubmission
-import com.instructure.canvasapi2.models.QuizSubmissionResponse
-import com.instructure.canvasapi2.models.QuizSubmissionTime
+import com.instructure.canvas.espresso.mockCanvas.*
+import com.instructure.canvas.espresso.mockCanvas.utils.*
+import com.instructure.canvasapi2.models.*
+import com.instructure.canvasapi2.models.postmodels.UpdateCourseWrapper
 import com.instructure.canvasapi2.utils.globalName
 import com.instructure.canvasapi2.utils.toApiString
 import okio.Buffer
@@ -163,7 +134,8 @@ object CourseEndpoint : Endpoint(
                 }
 
                 // Handle course syllabus change, if present
-                val newSyllabusBody = request.url().queryParameter("course[syllabus_body]")
+                val updateCourseWrapper = getJsonFromRequestBody<UpdateCourseWrapper>(request.body())
+                val newSyllabusBody = updateCourseWrapper?.course?.syllabusBody
                 if (newSyllabusBody != null) {
                     course.syllabusBody = newSyllabusBody
                 }

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/utils/RequestUtils.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/utils/RequestUtils.kt
@@ -23,6 +23,7 @@ import com.instructure.canvas.espresso.mockCanvas.MockCanvas
 import com.instructure.canvasapi2.models.User
 import okhttp3.*
 import okio.Buffer
+import okio.IOException
 
 /**
  * Creates a successful response for this [Request] with a response code of 200 and response [body] serialized to json
@@ -213,13 +214,24 @@ private fun grabJsonFieldFromBuffer(buffer: Buffer, jsonObject: JsonObject): Boo
         }
         else{
             fieldValue = fieldStringValue.toDoubleOrNull()
-            if(fieldValue != null) {
+            if (fieldValue != null) {
                 jsonObject.addProperty(fieldName, fieldValue as Double)
-            }
-            else {
+            } else {
                 jsonObject.addProperty(fieldName, fieldStringValue)
             }
         }
     }
     return true
+}
+
+inline fun <reified T> getJsonFromRequestBody(requestBody: RequestBody?): T? {
+    val jsonString = try {
+        val buffer = Buffer()
+        requestBody?.writeTo(buffer)
+        buffer.readUtf8()
+    } catch (e: IOException) {
+        return null
+    }
+
+    return Gson().fromJson(jsonString, T::class.java)
 }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CourseAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CourseAPI.kt
@@ -52,6 +52,9 @@ object CourseAPI {
         @GET("courses/{courseId}/settings")
         fun getCourseSettings(@Path("courseId") courseId: Long): Call<CourseSettings>
 
+        @PUT("courses/{course_id}/settings")
+        fun updateCourseSettings(@Path("course_id") courseId: Long, @QueryMap params: Map<String, Boolean>): Call<CourseSettings>
+
         @GET("courses/{courseId}?include[]=syllabus_body&include[]=term&include[]=license&include[]=is_public&include[]=permissions")
         fun getCourseWithSyllabus(@Path("courseId") courseId: Long): Call<Course>
 
@@ -172,6 +175,10 @@ object CourseAPI {
 
     fun getCourseSettings(courseId: Long, adapter: RestBuilder, callback: StatusCallback<CourseSettings>, params: RestParams) {
         callback.addCall(adapter.build(CoursesInterface::class.java, params).getCourseSettings(courseId)).enqueue(callback)
+    }
+
+    fun updateCourseSettings(courseId: Long, queryParams: Map<String, Boolean>, adapter: RestBuilder, callback: StatusCallback<CourseSettings>, params: RestParams) {
+        callback.addCall(adapter.build(CoursesInterface::class.java, params).updateCourseSettings(courseId, queryParams)).enqueue(callback)
     }
 
     fun getCourseWithSyllabus(courseId: Long, adapter: RestBuilder, callback: StatusCallback<Course>, params: RestParams) {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CourseAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CourseAPI.kt
@@ -52,9 +52,8 @@ object CourseAPI {
         @GET("courses/{courseId}/settings")
         fun getCourseSettings(@Path("courseId") courseId: Long): Call<CourseSettings>
 
-        @FormUrlEncoded
         @PUT("courses/{course_id}/settings")
-        fun updateCourseSettings(@Path("course_id") courseId: Long, @FieldMap params: Map<String, Boolean>): Call<CourseSettings>
+        fun updateCourseSettings(@Path("course_id") courseId: Long, @QueryMap params: Map<String, Boolean>): Call<CourseSettings>
 
         @GET("courses/{courseId}?include[]=syllabus_body&include[]=term&include[]=license&include[]=is_public&include[]=permissions")
         fun getCourseWithSyllabus(@Path("courseId") courseId: Long): Call<Course>
@@ -81,9 +80,8 @@ object CourseAPI {
         @DELETE("users/self/favorites/courses/{courseId}")
         fun removeCourseFromFavorites(@Path("courseId") courseId: Long): Call<Favorite>
 
-        @FormUrlEncoded
         @PUT("courses/{course_id}")
-        fun updateCourse(@Path("course_id") courseId: Long, @FieldMap params: Map<String, String>): Call<Course>
+        fun updateCourse(@Path("course_id") courseId: Long, @QueryMap params: Map<String, String>): Call<Course>
 
         @GET("courses/{courseId}/groups?include[]=users")
         fun getFirstPageGroups(@Path("courseId") courseId: Long): Call<List<Group>>
@@ -179,8 +177,8 @@ object CourseAPI {
         callback.addCall(adapter.build(CoursesInterface::class.java, params).getCourseSettings(courseId)).enqueue(callback)
     }
 
-    fun updateCourseSettings(courseId: Long, bodyFields: Map<String, Boolean>, adapter: RestBuilder, callback: StatusCallback<CourseSettings>, params: RestParams) {
-        callback.addCall(adapter.build(CoursesInterface::class.java, params).updateCourseSettings(courseId, bodyFields)).enqueue(callback)
+    fun updateCourseSettings(courseId: Long, queryParams: Map<String, Boolean>, adapter: RestBuilder, callback: StatusCallback<CourseSettings>, params: RestParams) {
+        callback.addCall(adapter.build(CoursesInterface::class.java, params).updateCourseSettings(courseId, queryParams)).enqueue(callback)
     }
 
     fun getCourseWithSyllabus(courseId: Long, adapter: RestBuilder, callback: StatusCallback<Course>, params: RestParams) {
@@ -213,8 +211,8 @@ object CourseAPI {
      * @param courseId The id for the course
      * @param params   A map of the fields to change and the values they will change to
      */
-    fun updateCourse(courseId: Long, bodyFields: Map<String, String>, adapter: RestBuilder, callback: StatusCallback<Course>, params: RestParams) {
-        callback.addCall(adapter.build(CoursesInterface::class.java, params).updateCourse(courseId, bodyFields)).enqueue(callback)
+    fun updateCourse(courseId: Long, queryParams: Map<String, String>, adapter: RestBuilder, callback: StatusCallback<Course>, params: RestParams) {
+        callback.addCall(adapter.build(CoursesInterface::class.java, params).updateCourse(courseId, queryParams)).enqueue(callback)
     }
 
     fun getFirstPageGroups(courseId: Long, adapter: RestBuilder, callback: StatusCallback<List<Group>>, params: RestParams) {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CourseAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CourseAPI.kt
@@ -179,8 +179,8 @@ object CourseAPI {
         callback.addCall(adapter.build(CoursesInterface::class.java, params).getCourseSettings(courseId)).enqueue(callback)
     }
 
-    fun updateCourseSettings(courseId: Long, queryParams: Map<String, Boolean>, adapter: RestBuilder, callback: StatusCallback<CourseSettings>, params: RestParams) {
-        callback.addCall(adapter.build(CoursesInterface::class.java, params).updateCourseSettings(courseId, queryParams)).enqueue(callback)
+    fun updateCourseSettings(courseId: Long, bodyFields: Map<String, Boolean>, adapter: RestBuilder, callback: StatusCallback<CourseSettings>, params: RestParams) {
+        callback.addCall(adapter.build(CoursesInterface::class.java, params).updateCourseSettings(courseId, bodyFields)).enqueue(callback)
     }
 
     fun getCourseWithSyllabus(courseId: Long, adapter: RestBuilder, callback: StatusCallback<Course>, params: RestParams) {
@@ -213,8 +213,8 @@ object CourseAPI {
      * @param courseId The id for the course
      * @param params   A map of the fields to change and the values they will change to
      */
-    fun updateCourse(courseId: Long, queryParams: Map<String, String>, adapter: RestBuilder, callback: StatusCallback<Course>, params: RestParams) {
-        callback.addCall(adapter.build(CoursesInterface::class.java, params).updateCourse(courseId, queryParams)).enqueue(callback)
+    fun updateCourse(courseId: Long, bodyFields: Map<String, String>, adapter: RestBuilder, callback: StatusCallback<Course>, params: RestParams) {
+        callback.addCall(adapter.build(CoursesInterface::class.java, params).updateCourse(courseId, bodyFields)).enqueue(callback)
     }
 
     fun getFirstPageGroups(courseId: Long, adapter: RestBuilder, callback: StatusCallback<List<Group>>, params: RestParams) {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CourseAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CourseAPI.kt
@@ -20,6 +20,7 @@ import com.instructure.canvasapi2.StatusCallback
 import com.instructure.canvasapi2.builders.RestBuilder
 import com.instructure.canvasapi2.builders.RestParams
 import com.instructure.canvasapi2.models.*
+import com.instructure.canvasapi2.models.postmodels.UpdateCourseWrapper
 import com.instructure.canvasapi2.utils.APIHelper
 import retrofit2.Call
 import retrofit2.Response
@@ -82,6 +83,9 @@ object CourseAPI {
 
         @PUT("courses/{course_id}")
         fun updateCourse(@Path("course_id") courseId: Long, @QueryMap params: Map<String, String>): Call<Course>
+
+        @PUT("courses/{course_id}")
+        fun updateCourse(@Path("course_id") courseId: Long, @Body body: UpdateCourseWrapper): Call<Course>
 
         @GET("courses/{courseId}/groups?include[]=users")
         fun getFirstPageGroups(@Path("courseId") courseId: Long): Call<List<Group>>
@@ -213,6 +217,10 @@ object CourseAPI {
      */
     fun updateCourse(courseId: Long, queryParams: Map<String, String>, adapter: RestBuilder, callback: StatusCallback<Course>, params: RestParams) {
         callback.addCall(adapter.build(CoursesInterface::class.java, params).updateCourse(courseId, queryParams)).enqueue(callback)
+    }
+
+    fun updateCourse(courseId: Long, body: UpdateCourseWrapper, adapter: RestBuilder, callback: StatusCallback<Course>, params: RestParams) {
+        callback.addCall(adapter.build(CoursesInterface::class.java, params).updateCourse(courseId, body)).enqueue(callback)
     }
 
     fun getFirstPageGroups(courseId: Long, adapter: RestBuilder, callback: StatusCallback<List<Group>>, params: RestParams) {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CourseAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CourseAPI.kt
@@ -52,8 +52,9 @@ object CourseAPI {
         @GET("courses/{courseId}/settings")
         fun getCourseSettings(@Path("courseId") courseId: Long): Call<CourseSettings>
 
+        @FormUrlEncoded
         @PUT("courses/{course_id}/settings")
-        fun updateCourseSettings(@Path("course_id") courseId: Long, @QueryMap params: Map<String, Boolean>): Call<CourseSettings>
+        fun updateCourseSettings(@Path("course_id") courseId: Long, @FieldMap params: Map<String, Boolean>): Call<CourseSettings>
 
         @GET("courses/{courseId}?include[]=syllabus_body&include[]=term&include[]=license&include[]=is_public&include[]=permissions")
         fun getCourseWithSyllabus(@Path("courseId") courseId: Long): Call<Course>
@@ -80,8 +81,9 @@ object CourseAPI {
         @DELETE("users/self/favorites/courses/{courseId}")
         fun removeCourseFromFavorites(@Path("courseId") courseId: Long): Call<Favorite>
 
+        @FormUrlEncoded
         @PUT("courses/{course_id}")
-        fun updateCourse(@Path("course_id") courseId: Long, @QueryMap params: Map<String, String>): Call<Course>
+        fun updateCourse(@Path("course_id") courseId: Long, @FieldMap params: Map<String, String>): Call<Course>
 
         @GET("courses/{courseId}/groups?include[]=users")
         fun getFirstPageGroups(@Path("courseId") courseId: Long): Call<List<Group>>

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/CourseManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/CourseManager.kt
@@ -21,14 +21,15 @@ import com.instructure.canvasapi2.apis.CourseAPI
 import com.instructure.canvasapi2.builders.RestBuilder
 import com.instructure.canvasapi2.builders.RestParams
 import com.instructure.canvasapi2.models.*
+import com.instructure.canvasapi2.models.postmodels.UpdateCourseBody
+import com.instructure.canvasapi2.models.postmodels.UpdateCourseWrapper
 import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.canvasapi2.utils.DataResult
 import com.instructure.canvasapi2.utils.ExhaustiveListCallback
 import com.instructure.canvasapi2.utils.weave.apiAsync
 import kotlinx.coroutines.Deferred
 import java.io.IOException
-import java.util.ArrayList
-import java.util.HashMap
+import java.util.*
 
 object CourseManager {
 
@@ -208,16 +209,16 @@ object CourseManager {
     }
 
     private fun editCourseSyllabus(courseId: Long, syllabusBody: String, callback: StatusCallback<Course>) {
-        val queryParams = HashMap<String, String>()
-        queryParams["course[syllabus_body]"] = syllabusBody
+        val updateCourseBody = UpdateCourseBody(syllabusBody)
+        val updateCourseWrapper = UpdateCourseWrapper(updateCourseBody)
 
         val adapter = RestBuilder(callback)
         val params = RestParams(isForceReadFromNetwork = true)
 
-        CourseAPI.updateCourse(courseId, queryParams, adapter, callback, params)
+        CourseAPI.updateCourse(courseId, updateCourseWrapper, adapter, callback, params)
     }
 
-    fun getCoursesWithEnrollmentType(forceNetwork: Boolean, callback: StatusCallback<List<Course>>, type: String) {
+    private fun getCoursesWithEnrollmentType(forceNetwork: Boolean, callback: StatusCallback<List<Course>>, type: String) {
         val adapter = RestBuilder(callback)
         val params = RestParams(isForceReadFromNetwork = forceNetwork)
 

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/CourseManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/CourseManager.kt
@@ -132,6 +132,20 @@ object CourseManager {
         CourseAPI.getCourseSettings(courseId, adapter, it, params)
     }
 
+    fun editCourseSettingsAsync(courseId: Long, summaryAllowed: Boolean): Deferred<DataResult<CourseSettings>> {
+        return apiAsync { editCourseSettings(courseId, summaryAllowed, it) }
+    }
+
+    private fun editCourseSettings(courseId: Long, summaryAllowed: Boolean, callback: StatusCallback<CourseSettings>) {
+        val queryParams = HashMap<String, Boolean>()
+        queryParams["syllabus_course_summary"] = summaryAllowed
+
+        val adapter = RestBuilder(callback)
+        val params = RestParams(isForceReadFromNetwork = true)
+
+        CourseAPI.updateCourseSettings(courseId, queryParams, adapter, callback, params)
+    }
+
     fun getCourseWithGrade(courseId: Long, callback: StatusCallback<Course>, forceNetwork: Boolean) {
         val adapter = RestBuilder(callback)
         val params = RestParams(isForceReadFromNetwork = forceNetwork)

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/CourseManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/CourseManager.kt
@@ -137,13 +137,13 @@ object CourseManager {
     }
 
     private fun editCourseSettings(courseId: Long, summaryAllowed: Boolean, callback: StatusCallback<CourseSettings>) {
-        val queryParams = HashMap<String, Boolean>()
-        queryParams["syllabus_course_summary"] = summaryAllowed
+        val bodyFields = HashMap<String, Boolean>()
+        bodyFields["syllabus_course_summary"] = summaryAllowed
 
         val adapter = RestBuilder(callback)
         val params = RestParams(isForceReadFromNetwork = true)
 
-        CourseAPI.updateCourseSettings(courseId, queryParams, adapter, callback, params)
+        CourseAPI.updateCourseSettings(courseId, bodyFields, adapter, callback, params)
     }
 
     fun getCourseWithGrade(courseId: Long, callback: StatusCallback<Course>, forceNetwork: Boolean) {
@@ -179,13 +179,13 @@ object CourseManager {
     }
 
     fun editCourseName(courseId: Long, newCourseName: String, callback: StatusCallback<Course>, forceNetwork: Boolean) {
-        val queryParams = HashMap<String, String>()
-        queryParams["course[name]"] = newCourseName
+        val bodyFields = HashMap<String, String>()
+        bodyFields["course[name]"] = newCourseName
 
         val adapter = RestBuilder(callback)
         val params = RestParams(isForceReadFromNetwork = forceNetwork)
 
-        CourseAPI.updateCourse(courseId, queryParams, adapter, callback, params)
+        CourseAPI.updateCourse(courseId, bodyFields, adapter, callback, params)
     }
 
     fun editCourseHomePage(
@@ -194,13 +194,13 @@ object CourseManager {
         forceNetwork: Boolean,
         callback: StatusCallback<Course>
     ) {
-        val queryParams = HashMap<String, String>()
-        queryParams["course[default_view]"] = newHomePage
+        val bodyFields = HashMap<String, String>()
+        bodyFields["course[default_view]"] = newHomePage
 
         val adapter = RestBuilder(callback)
         val params = RestParams(isForceReadFromNetwork = forceNetwork)
 
-        CourseAPI.updateCourse(courseId, queryParams, adapter, callback, params)
+        CourseAPI.updateCourse(courseId, bodyFields, adapter, callback, params)
     }
 
     fun editCourseSyllabusAsync(courseId: Long, syllabusBody: String): Deferred<DataResult<Course>> {
@@ -208,13 +208,13 @@ object CourseManager {
     }
 
     private fun editCourseSyllabus(courseId: Long, syllabusBody: String, callback: StatusCallback<Course>) {
-        val queryParams = HashMap<String, String>()
-        queryParams["course[syllabus_body]"] = syllabusBody
+        val bodyFields = HashMap<String, String>()
+        bodyFields["course[syllabus_body]"] = syllabusBody
 
         val adapter = RestBuilder(callback)
         val params = RestParams(isForceReadFromNetwork = true)
 
-        CourseAPI.updateCourse(courseId, queryParams, adapter, callback, params)
+        CourseAPI.updateCourse(courseId, bodyFields, adapter, callback, params)
     }
 
     fun getCoursesWithEnrollmentType(forceNetwork: Boolean, callback: StatusCallback<List<Course>>, type: String) {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/CourseManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/CourseManager.kt
@@ -137,13 +137,13 @@ object CourseManager {
     }
 
     private fun editCourseSettings(courseId: Long, summaryAllowed: Boolean, callback: StatusCallback<CourseSettings>) {
-        val bodyFields = HashMap<String, Boolean>()
-        bodyFields["syllabus_course_summary"] = summaryAllowed
+        val queryParams = HashMap<String, Boolean>()
+        queryParams["syllabus_course_summary"] = summaryAllowed
 
         val adapter = RestBuilder(callback)
         val params = RestParams(isForceReadFromNetwork = true)
 
-        CourseAPI.updateCourseSettings(courseId, bodyFields, adapter, callback, params)
+        CourseAPI.updateCourseSettings(courseId, queryParams, adapter, callback, params)
     }
 
     fun getCourseWithGrade(courseId: Long, callback: StatusCallback<Course>, forceNetwork: Boolean) {
@@ -179,13 +179,13 @@ object CourseManager {
     }
 
     fun editCourseName(courseId: Long, newCourseName: String, callback: StatusCallback<Course>, forceNetwork: Boolean) {
-        val bodyFields = HashMap<String, String>()
-        bodyFields["course[name]"] = newCourseName
+        val queryParams = HashMap<String, String>()
+        queryParams["course[name]"] = newCourseName
 
         val adapter = RestBuilder(callback)
         val params = RestParams(isForceReadFromNetwork = forceNetwork)
 
-        CourseAPI.updateCourse(courseId, bodyFields, adapter, callback, params)
+        CourseAPI.updateCourse(courseId, queryParams, adapter, callback, params)
     }
 
     fun editCourseHomePage(
@@ -194,13 +194,13 @@ object CourseManager {
         forceNetwork: Boolean,
         callback: StatusCallback<Course>
     ) {
-        val bodyFields = HashMap<String, String>()
-        bodyFields["course[default_view]"] = newHomePage
+        val queryParams = HashMap<String, String>()
+        queryParams["course[default_view]"] = newHomePage
 
         val adapter = RestBuilder(callback)
         val params = RestParams(isForceReadFromNetwork = forceNetwork)
 
-        CourseAPI.updateCourse(courseId, bodyFields, adapter, callback, params)
+        CourseAPI.updateCourse(courseId, queryParams, adapter, callback, params)
     }
 
     fun editCourseSyllabusAsync(courseId: Long, syllabusBody: String): Deferred<DataResult<Course>> {
@@ -208,13 +208,13 @@ object CourseManager {
     }
 
     private fun editCourseSyllabus(courseId: Long, syllabusBody: String, callback: StatusCallback<Course>) {
-        val bodyFields = HashMap<String, String>()
-        bodyFields["course[syllabus_body]"] = syllabusBody
+        val queryParams = HashMap<String, String>()
+        queryParams["course[syllabus_body]"] = syllabusBody
 
         val adapter = RestBuilder(callback)
         val params = RestParams(isForceReadFromNetwork = true)
 
-        CourseAPI.updateCourse(courseId, bodyFields, adapter, callback, params)
+        CourseAPI.updateCourse(courseId, queryParams, adapter, callback, params)
     }
 
     fun getCoursesWithEnrollmentType(forceNetwork: Boolean, callback: StatusCallback<List<Course>>, type: String) {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/CourseManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/CourseManager.kt
@@ -22,8 +22,10 @@ import com.instructure.canvasapi2.builders.RestBuilder
 import com.instructure.canvasapi2.builders.RestParams
 import com.instructure.canvasapi2.models.*
 import com.instructure.canvasapi2.utils.ApiPrefs
+import com.instructure.canvasapi2.utils.DataResult
 import com.instructure.canvasapi2.utils.ExhaustiveListCallback
 import com.instructure.canvasapi2.utils.weave.apiAsync
+import kotlinx.coroutines.Deferred
 import java.io.IOException
 import java.util.ArrayList
 import java.util.HashMap
@@ -183,6 +185,20 @@ object CourseManager {
 
         val adapter = RestBuilder(callback)
         val params = RestParams(isForceReadFromNetwork = forceNetwork)
+
+        CourseAPI.updateCourse(courseId, queryParams, adapter, callback, params)
+    }
+
+    fun editCourseSyllabusAsync(courseId: Long, syllabusBody: String): Deferred<DataResult<Course>> {
+        return apiAsync { editCourseSyllabus(courseId, syllabusBody, it) }
+    }
+
+    private fun editCourseSyllabus(courseId: Long, syllabusBody: String, callback: StatusCallback<Course>) {
+        val queryParams = HashMap<String, String>()
+        queryParams["course[syllabus_body]"] = syllabusBody
+
+        val adapter = RestBuilder(callback)
+        val params = RestParams(isForceReadFromNetwork = true)
 
         CourseAPI.updateCourse(courseId, queryParams, adapter, callback, params)
     }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/CanvasContextPermission.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/CanvasContextPermission.kt
@@ -43,7 +43,9 @@ data class CanvasContextPermission(
         @SerializedName(CREATE_ANNOUNCEMENT)
         val canCreateAnnouncement: Boolean = false,
         @SerializedName(STUDENT_VIEW)
-        val canUseStudentView: Boolean = false
+        val canUseStudentView: Boolean = false,
+        @SerializedName(MANAGE_CONTENT)
+        val canManageContent: Boolean = false
 ) : Parcelable {
     companion object {
         const val BECOME_USER = "become_user"
@@ -58,5 +60,6 @@ data class CanvasContextPermission(
         const val VIEW_ALL_GRADES = "view_all_grades"
         const val VIEW_ANALYTICS = "view_analytics"
         const val STUDENT_VIEW = "use_student_view"
+        const val MANAGE_CONTENT = "manage_content"
     }
 }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Course.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Course.kt
@@ -37,7 +37,7 @@ data class Course(
         @SerializedName("end_at")
         val endAt: String? = null,
         @SerializedName("syllabus_body")
-        val syllabusBody: String? = null,
+        var syllabusBody: String? = null,
         @SerializedName("hide_final_grades")
         val hideFinalGrades: Boolean = false,
         @SerializedName("is_public")

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/postmodels/UpdateCourseBody.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/postmodels/UpdateCourseBody.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2020 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.canvasapi2.models.postmodels
+
+import com.google.gson.annotations.SerializedName
+
+data class UpdateCourseWrapper(val course: UpdateCourseBody)
+
+data class UpdateCourseBody(@SerializedName("syllabus_body") val syllabusBody: String)


### PR DESCRIPTION
The feature is ready, but I still need to add some interaction tests. It can be reviewed already, but please don't merge.

Test Plan: 
- Test editing the syllabus with a teacher.
- Test if teacher assistants does not have permission to edit syllabus, if this is turned off in the Canvas settings.
- Test success cases: in this case if the syllabus is succesfully edited, the user should return to the syllabus screen and it should be updated.
- Test error case: We should se an error message and remain on the screen.
- Test if going back without saving triggers confirmation dialog.

refs: MBL-14864
affects: Teacher
release note: Added the possibility to edit course syllabus.