### PR TITLE
[MBL-14996][Teacher] Loading indicator fix

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/CourseBrowserFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/CourseBrowserFragment.kt
@@ -134,6 +134,9 @@ class CourseBrowserFragment : BaseSyncFragment<
         courseBrowserSubtitle.text = (presenter.canvasContext as? Course)?.term?.name ?: ""
         mCourseBrowserHeader.setTitleAndSubtitle(presenter.canvasContext.name ?: "", (presenter.canvasContext as? Course)?.term?.name ?: "")
         setupToolbar()
+        if (!presenter.isEmpty) {
+            checkIfEmpty()
+        }
     }
 
     override fun onPause() {


### PR DESCRIPTION
refs: MBL-14996
affects: Teacher
release note: Fixed a bug with the loading indication on the Course details screen.

test plan: Steps to reproduce is in the ticket. If you navigate back to the CourseBrowser screen the loading indicator should not be visible.