### PR TITLE
[MBL-15059][Teacher] Fixed tablet tests

### DIFF
--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/AssignmentSubmissionListPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/AssignmentSubmissionListPage.kt
@@ -95,7 +95,7 @@ class AssignmentSubmissionListPage : BasePage() {
     }
 
     fun clickSubmission(student: User) {
-        refresh()
+        waitForMatcherWithRefreshes(withId(R.id.submissionsRecyclerView))
         scrollRecyclerView(R.id.submissionsRecyclerView, student.name)
         waitForViewWithText(student.name).click()
     }


### PR DESCRIPTION
Fixed npe on tablet view due to tabbed layout when trying to invoke refresh method

refs: MBL-15059
affects: Teacher
release note: Extended test matrix

test plan: Bitrise tablet workflow