### PR TITLE
[Student][MBL-15057] Cant view documents embedded by students in a discussion

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/DiscussionDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/DiscussionDetailsFragment.kt
@@ -366,7 +366,7 @@ class DiscussionDetailsFragment : ParentFragment(), Bookmarkable {
         CookieManager.getInstance().acceptThirdPartyCookies(webView)
         webView.canvasWebViewClientCallback = object : CanvasWebView.CanvasWebViewClientCallback {
             override fun routeInternallyCallback(url: String) {
-                if (!RouteMatcher.canRouteInternally(requireActivity(), url, ApiPrefs.domain, true)) {
+                if (!RouteMatcher.canRouteInternally(requireActivity(), url, ApiPrefs.domain, routeIfPossible = true, allowUnsupported = false)) {
                     RouteMatcher.route(requireContext(), InternalWebviewFragment.makeRoute(url, url, false, ""))
                 }
             }


### PR DESCRIPTION
Test plan: In the ticket

refs: MBL-15057
affects: Student
release note: Fixed a bug where documents linked in discussion replies cannot be opened.