### PR TITLE
[MBL-14785][Parent] Routing set up for grades page

### DIFF
--- a/apps/flutter_parent/lib/router/panda_router.dart
+++ b/apps/flutter_parent/lib/router/panda_router.dart
@@ -28,6 +28,7 @@ import 'package:flutter_parent/screens/assignments/assignment_details_screen.dar
 import 'package:flutter_parent/screens/calendar/calendar_screen.dart';
 import 'package:flutter_parent/screens/calendar/calendar_widget/calendar_widget.dart';
 import 'package:flutter_parent/screens/courses/details/course_details_screen.dart';
+import 'package:flutter_parent/screens/courses/details/course_grades_screen.dart';
 import 'package:flutter_parent/screens/courses/routing_shell/course_routing_shell_screen.dart';
 import 'package:flutter_parent/screens/dashboard/dashboard_screen.dart';
 import 'package:flutter_parent/screens/domain_search/domain_search_screen.dart';
@@ -98,6 +99,8 @@ class PandaRouter {
   static String frontPage(String courseId) => '/courses/$courseId/pages/first-page';
 
   static String frontPageWiki(String courseId) => '/courses/$courseId/wiki';
+
+  static String gradesPage(String courseId) => '/courses/$courseId/grades';
 
   static String help() => '/help';
 
@@ -187,6 +190,7 @@ class PandaRouter {
       router.define(eventDetails(':${_RouterKeys.courseId}', ':${_RouterKeys.eventId}'), handler: _eventDetailsHandler);
       router.define(frontPage(':${_RouterKeys.courseId}'), handler: _frontPageHandler);
       router.define(frontPageWiki(':${_RouterKeys.courseId}'), handler: _frontPageHandler);
+      router.define(gradesPage(':${_RouterKeys.courseId}'), handler: _gradesPageHandler);
       router.define(help(), handler: _helpHandler);
       router.define(institutionAnnouncementDetails(':${_RouterKeys.accountNotificationId}'),
           handler: _institutionAnnouncementDetailsHandler);
@@ -285,6 +289,10 @@ class PandaRouter {
 
   static Handler _frontPageHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
     return CourseRoutingShellScreen(params[_RouterKeys.courseId][0], CourseShellType.frontPage);
+  });
+
+  static Handler _gradesPageHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {
+    return CourseDetailsScreen(params[_RouterKeys.courseId][0]);
   });
 
   static Handler _helpHandler = Handler(handlerFunc: (BuildContext context, Map<String, List<String>> params) {

--- a/apps/flutter_parent/test/router/panda_router_test.dart
+++ b/apps/flutter_parent/test/router/panda_router_test.dart
@@ -25,6 +25,7 @@ import 'package:flutter_parent/screens/announcements/announcement_details_screen
 import 'package:flutter_parent/screens/assignments/assignment_details_screen.dart';
 import 'package:flutter_parent/screens/calendar/calendar_screen.dart';
 import 'package:flutter_parent/screens/calendar/calendar_widget/calendar_widget.dart';
+import 'package:flutter_parent/screens/courses/details/course_details_interactor.dart';
 import 'package:flutter_parent/screens/courses/details/course_details_screen.dart';
 import 'package:flutter_parent/screens/courses/routing_shell/course_routing_shell_screen.dart';
 import 'package:flutter_parent/screens/dashboard/dashboard_screen.dart';
@@ -417,6 +418,15 @@ void main() {
 
     test('returns course details ', () {
       final url = 'https://test.instructure.com/courses/123';
+      final widget = _getWidgetFromRoute(
+        _rootWithUrl(url),
+      );
+
+      expect(widget, isA<CourseDetailsScreen>());
+    });
+
+    test('returns course details for grades', () {
+      final url = 'https://test.instructure.com/courses/123/grades';
       final widget = _getWidgetFromRoute(
         _rootWithUrl(url),
       );


### PR DESCRIPTION
refs: MBL-14785
affects: Parent
release note: Links for grades now open inside the app.

test plan: Navigate to the course grades > Send a message from that page > Open inbox > Click link in the message > The link should route inside the app