### PR TITLE
[MBL-13876][Student][Teacher] University is getting Cleartext errors.

### DIFF
--- a/libs/pandautils/src/main/res/xml/network_security_config.xml
+++ b/libs/pandautils/src/main/res/xml/network_security_config.xml
@@ -15,6 +15,7 @@
   ~
   -->
 <network-security-config>
+    <base-config cleartextTrafficPermitted="true" />
     <debug-overrides>
         <trust-anchors>
             <certificates src="user"/>


### PR DESCRIPTION
Test plan: In the ticket. To test this flow you need to enter the whole Canvas instance url and click next instead of selecting the name of the University, because currently that flow redirects to saml authentication.

refs: MBL-14876
affects: Student, Teacher
release note: - 