### PR TITLE
[MBL-15145][Teacher] Remove exit confirmation on saved page

### DIFF
--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/PagesE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/PagesE2ETest.kt
@@ -83,8 +83,6 @@ class PagesE2ETest : TeacherTest() {
 
     }
 
-    //TODO remove Stub annotation once MBL-15145 is done
-    @Stub
     @E2E
     @Test
     @TestMetaData(Priority.P0, FeatureCategory.PAGES, TestCategory.E2E)
@@ -116,8 +114,6 @@ class PagesE2ETest : TeacherTest() {
         pageListPage.assertPageIsUnpublished(editedUnpublishedPageName)
     }
 
-    //TODO remove Stub annotation once MBL-15145 is done
-    @Stub
     @E2E
     @Test
     @TestMetaData(Priority.P0, FeatureCategory.PAGES, TestCategory.E2E)
@@ -148,8 +144,6 @@ class PagesE2ETest : TeacherTest() {
         pageListPage.assertFrontPageDisplayed(pageTitle = publishedPage.title)
     }
 
-    //TODO remove Stub annotation once MBL-15145 is done
-    @Stub
     @E2E
     @Test
     @TestMetaData(Priority.P0, FeatureCategory.PAGES, TestCategory.E2E)
@@ -177,8 +171,6 @@ class PagesE2ETest : TeacherTest() {
         pageListPage.assertPageIsPublished(pageTitle = unpublishedPage.title)
     }
 
-    //TODO remove Stub annotation once MBL-15145 is done
-    @Stub
     @E2E
     @Test
     @TestMetaData(Priority.P0, FeatureCategory.PAGES, TestCategory.E2E)

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/CreateOrEditPageDetailsFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/CreateOrEditPageDetailsFragment.kt
@@ -101,14 +101,14 @@ class CreateOrEditPageDetailsFragment :
 
     private fun shouldAllowExit() : Boolean {
         // Check if this is a new page and has changes
-        if(presenter?.page?.id == 0L &&
+        if(presenter.page.id == 0L &&
                 !pageRCEView?.html.isValid() &&
                 !pageNameEditText.text.toString().isValid()) {
             return true
         }
         // Check if edited page has changes
-        if(presenter?.page?.id != 0L &&
-                presenter?.page?.body ?: "" == pageRCEView?.html &&
+        if(presenter.page.id != 0L &&
+                presenter.page.body ?: "" == pageRCEView?.html &&
                 mPage?.title ?: "" == pageNameEditText.text.toString() &&
                 mPage?.frontPage == frontPageSwitch.isChecked &&
                 mPage?.published == publishSwitch.isChecked) {
@@ -294,6 +294,7 @@ class CreateOrEditPageDetailsFragment :
         } else {
             toast(R.string.pageSuccessfullyCreated)
         }
+        forceQuit = true
         pageNameEditText.hideKeyboard() // Close the keyboard
         requireActivity().onBackPressed() // Close this fragment
     }


### PR DESCRIPTION
refs: MBL-15145
affects: Teacher
release note: Exit confirmation no longer appears after saving a page.

test plan: Go to Pages > Create or Edit a page > After clicking save the exit confirmation should not be visible.