### PR TITLE
[MBL-15129][Student] Assignments added to a module locked in the app, when the term has ended but overwritten by course end date

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsPresenter.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsPresenter.kt
@@ -178,7 +178,7 @@ object AssignmentDetailsPresenter : Presenter<AssignmentDetailsModel, Assignment
         visibilities.allowedAttempts = assignment.allowedAttempts != -1L
         visibilities.submitButtonEnabled = assignment.allowedAttempts == -1L || (assignment.submission?.attempt?.let{ it < assignment.allowedAttempts } ?: true)
 
-        if (isObserver || !course.isReadOnlyForCurrentDate()) {
+        if (isObserver || !course.isBetweenValidDateRange()) {
             // Observers shouldn't see the submit button
             // OR if the course is soft concluded
             visibilities.submitButton = false

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/emptySubmission/SubmissionDetailsEmptyContentPresenter.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/emptySubmission/SubmissionDetailsEmptyContentPresenter.kt
@@ -75,7 +75,7 @@ object SubmissionDetailsEmptyContentPresenter : Presenter<SubmissionDetailsEmpty
     }
 
     private fun allowedToSubmit(assignment: Assignment, course: Course): Boolean {
-        return if (!course.isReadOnlyForCurrentDate()) {
+        return if (!course.isBetweenValidDateRange()) {
             // Don't show submit if the course is soft concluded
             return false
         } else if (assignment.turnInType == Assignment.TurnInType.ONLINE || assignment.turnInType == Assignment.TurnInType.EXTERNAL_TOOL) {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Course.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Course.kt
@@ -206,24 +206,18 @@ data class Course(
      *
      * Useful for setting content to read-only, such as submissions
      */
-    fun isReadOnlyForCurrentDate(): Boolean {
+    fun isBetweenValidDateRange(): Boolean {
         val now = Date()
         if (accessRestrictedByDate) return false
 
         if (workflowState == "completed") return false
 
-        val isValidForCourse = isWithinDates(
-                startAt.toDate(),
-                endAt.toDate(),
-                now
-        )
-
-        return if (restrictEnrollmentsToCourseDate && !isValidForCourse) {
-            false
+        return if (restrictEnrollmentsToCourseDate) {
+            isWithinDates(startAt.toDate(), endAt.toDate(), now)
         } else {
             val isValidForTerm = isWithinDates(term?.startDate, term?.endDate, now)
 
-            if(isValidForTerm) {
+            if (isValidForTerm) {
                 // check the sections
                 if (sections.isEmpty()) {
                     true


### PR DESCRIPTION
Test plan: In the ticket.

refs: MBL-15129
affects: Student
release note: Fixed a bug where assignments show as locked before the end date of the course.