### PR TITLE
[MBL-15097][Student] Remove focus for views under SlidingPanel

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/ui/SubmissionDetailsView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/ui/SubmissionDetailsView.kt
@@ -118,7 +118,19 @@ class SubmissionDetailsView(
                 panel: View?,
                 previousState: SlidingUpPanelLayout.PanelState?,
                 newState: SlidingUpPanelLayout.PanelState?
-            ) = Unit
+            ) {
+                when (newState) {
+                    SlidingUpPanelLayout.PanelState.ANCHORED -> {
+                        submissionContent.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
+                    }
+                    SlidingUpPanelLayout.PanelState.EXPANDED -> {
+                        submissionContent.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
+                    }
+                    SlidingUpPanelLayout.PanelState.COLLAPSED -> {
+                        submissionContent.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
+                    }
+                }
+            }
 
             override fun onPanelSlide(panel: View?, offset: Float) {
                 val maxHeight = contentWrapper.height


### PR DESCRIPTION
refs: MBL-15097
affects: Student
release note: Accessibility bugfix

test plan: Using TalkBack navigate through the submission details page. If the SlidingPanel is full screen the content behind the panel should not be focusable.