### PR TITLE
[MBL-15265][Teacher] Content disabled when sliding panel open

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/view/SubmissionContentView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/view/SubmissionContentView.kt
@@ -599,16 +599,19 @@ class SubmissionContentView(
                         SlidingUpPanelLayout.PanelState.ANCHORED -> {
                             submissionVersionsButton?.isClickable = true
                             postPanelEvent(newState, 0.5f)
+                            contentRoot.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
                         }
                         SlidingUpPanelLayout.PanelState.EXPANDED -> {
                             submissionVersionsButton?.isClickable = false
                             postPanelEvent(newState, 1.0f)
+                            contentRoot.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
                         }
                         SlidingUpPanelLayout.PanelState.COLLAPSED -> {
                                 submissionVersionsButton?.isClickable = true
                             //fix for rotating when the panel is collapsed
                             pdfFragment?.notifyLayoutChanged()
                             postPanelEvent(newState, 0.0f)
+                            contentRoot.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
                         }
                     }
                 }


### PR DESCRIPTION
refs: MBL-15265
affects: Teacher
release note: none

test plan: See ticket. The content should not be focusable by the screen reader when the panel is open.