### PR TITLE
[MBL-15097][Student] Remove a11y focus behind sliding panel if anchored

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/ui/SubmissionDetailsView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/ui/SubmissionDetailsView.kt
@@ -121,7 +121,7 @@ class SubmissionDetailsView(
             ) {
                 when (newState) {
                     SlidingUpPanelLayout.PanelState.ANCHORED -> {
-                        submissionContent.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
+                        submissionContent.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
                     }
                     SlidingUpPanelLayout.PanelState.EXPANDED -> {
                         submissionContent.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS


### PR DESCRIPTION
refs: MBL-15097
affects: Student
release note: None

test plan: Go to submissions & rubric > Using talkback navigate through the screen >
1. If the sliding panel is collapsed the details should be focusable
2. If the sliding panel is anchored or expanded the details should NOT be focusable