### PR TITLE
[MBL-15415][Student] Mark done no longer available for locked assignment

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/CourseModuleProgressionFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/CourseModuleProgressionFragment.kt
@@ -31,10 +31,7 @@ import androidx.viewpager.widget.ViewPager
 import com.instructure.canvasapi2.StatusCallback
 import com.instructure.canvasapi2.managers.ModuleManager
 import com.instructure.canvasapi2.models.*
-import com.instructure.canvasapi2.utils.ApiType
-import com.instructure.canvasapi2.utils.LinkHeaders
-import com.instructure.canvasapi2.utils.Logger
-import com.instructure.canvasapi2.utils.isRtl
+import com.instructure.canvasapi2.utils.*
 import com.instructure.canvasapi2.utils.weave.WeaveJob
 import com.instructure.canvasapi2.utils.weave.awaitApi
 import com.instructure.canvasapi2.utils.weave.catch
@@ -325,7 +322,7 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
             markDoneWrapper.setGone()
         } else {
             val completionRequirement = item.completionRequirement
-            if (completionRequirement != null && ModuleItem.MUST_MARK_DONE == completionRequirement.type) {
+            if (completionRequirement != null && ModuleItem.MUST_MARK_DONE == completionRequirement.type && !item.isLocked()) {
                 markDoneWrapper.setVisible()
                 markDoneCheckbox.isChecked = completionRequirement.completed
             } else {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/ModelExtensions.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/ModelExtensions.kt
@@ -56,6 +56,8 @@ fun Course.isCreationPending(): Boolean = enrollments?.any { it.enrollmentState 
 fun Course.isNotDeleted(): Boolean = workflowState != Course.WorkflowState.DELETED
 fun Course.isPublished(): Boolean = workflowState != Course.WorkflowState.UNPUBLISHED
 
+fun ModuleItem.isLocked(): Boolean = moduleDetails?.lockedForUser ?: false || moduleDetails?.lockExplanation.isValid() && moduleDetails?.lockDate?.before(Date()) == true && moduleDetails.unlockDate?.after(Date()) == true
+
 fun MediaComment.asAttachment() = Attachment().also {
     it.contentType = contentType ?: ""
     it.displayName = displayName


### PR DESCRIPTION
refs: MBL-15415
affects: Student
release note: Fixed a bug where the mark done checkbox was available for locked assignments.

test plan: See ticket. Keep in mind you will need to disable the K5 feature flag to use the user in the ticket.