### PR TITLE
[MBL-15434][Teacher] Free draw annotations disappear after submission swipes

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/activities/SpeedGraderActivity.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/activities/SpeedGraderActivity.kt
@@ -24,7 +24,6 @@ import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
 import android.os.Bundle
-import android.os.PersistableBundle
 import android.util.TypedValue
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
@@ -126,6 +125,7 @@ class SpeedGraderActivity : BasePresenterActivity<SpeedGraderPresenter, SpeedGra
             override fun onPageScrollStateChanged(state: Int) {}
             override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {}
             override fun onPageSelected(position: Int) {
+                adapter.updateAnnotations(position)
                 previousSelection = currentSelection
                 currentSelection = position
                 if (adapter.hasUnsavedChanges(previousSelection)) {

--- a/apps/teacher/src/main/java/com/instructure/teacher/adapters/SubmissionContentAdapter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/adapters/SubmissionContentAdapter.kt
@@ -64,4 +64,8 @@ class SubmissionContentAdapter(
     fun invalidateSubmissionCache() {
         mStudentSubmissions.onEach { it.isCached = false }
     }
+
+    fun updateAnnotations(position: Int) {
+        mContentMap[position]?.updateAnnotations()
+    }
 }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/CanvaDocsManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/CanvaDocsManager.kt
@@ -39,7 +39,7 @@ object CanvaDocsManager {
         callback: StatusCallback<CanvaDocAnnotationResponse>
     ) {
         val adapter = RestBuilder(callback)
-        val params = RestParams(domain = canvaDocDomain, apiVersion = "")
+        val params = RestParams(domain = canvaDocDomain, apiVersion = "", isForceReadFromNetwork = true)
         CanvaDocsAPI.getAnnotations(sessionId, adapter, params, callback)
     }
 


### PR DESCRIPTION
Test plan: In the ticket

refs: MBL-15434
affects: Teacher
release note: Fixed a bug, where annotations weren't visible when going back to the previous document in Speed Grader.