### PR TITLE
[MBL-15522][Student] Hide K5 tabs

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/ElementaryDashboardInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/ElementaryDashboardInteractionTest.kt
@@ -26,6 +26,7 @@ import com.instructure.panda_annotations.TestCategory
 import com.instructure.panda_annotations.TestMetaData
 import com.instructure.student.ui.utils.StudentTest
 import com.instructure.student.ui.utils.tokenLoginElementary
+import com.instructure.student.util.FeatureFlagPrefs
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Test
 
@@ -88,6 +89,7 @@ class ElementaryDashboardInteractionTest : StudentTest() {
         // We have to add this delay to be sure that the remote config is already fetched before we want to override remote config values.
         Thread.sleep(3000)
         RemoteConfigPrefs.putString(RemoteConfigParam.K5_DESIGN.rc_name, "true")
+        FeatureFlagPrefs.showInProgressK5Tabs = true
 
         val data = MockCanvas.init(
             studentCount = 1,

--- a/apps/student/src/main/java/com/instructure/student/mobius/elementary/ElementaryDashboardFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/elementary/ElementaryDashboardFragment.kt
@@ -24,12 +24,10 @@ import com.google.android.material.tabs.TabLayout
 import com.instructure.canvasapi2.models.CanvasContext
 import com.instructure.interactions.router.Route
 import com.instructure.pandautils.features.elementary.ElementaryDashboardPagerAdapter
-import com.instructure.pandautils.utils.Const
-import com.instructure.pandautils.utils.ParcelableArg
-import com.instructure.pandautils.utils.isTablet
-import com.instructure.pandautils.utils.makeBundle
+import com.instructure.pandautils.utils.*
 import com.instructure.student.R
 import com.instructure.student.fragment.ParentFragment
+import com.instructure.student.util.FeatureFlagPrefs
 import kotlinx.android.synthetic.main.fragment_course_grid.toolbar
 import kotlinx.android.synthetic.main.fragment_elementary_dashboard.*
 
@@ -49,6 +47,13 @@ class ElementaryDashboardFragment : ParentFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        if (!FeatureFlagPrefs.showInProgressK5Tabs) {
+            dashboardTabLayout.removeTabAt(3)
+            dashboardTabLayout.removeTabAt(2)
+            dashboardTabLayout.removeTabAt(1)
+        }
+
         dashboardPager.adapter = ElementaryDashboardPagerAdapter(canvasContext, childFragmentManager)
         dashboardTabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
             override fun onTabReselected(tab: TabLayout.Tab?) = Unit

--- a/apps/student/src/main/java/com/instructure/student/util/FeatureFlagPrefs.kt
+++ b/apps/student/src/main/java/com/instructure/student/util/FeatureFlagPrefs.kt
@@ -15,7 +15,10 @@
  */
 package com.instructure.student.util
 
+import com.instructure.canvasapi2.utils.FeatureFlagPref
 import com.instructure.canvasapi2.utils.PrefManager
 
 object FeatureFlagPrefs : PrefManager("feature_flags") {
+
+    var showInProgressK5Tabs by FeatureFlagPref("Show K5 in progress tabs")
 }


### PR DESCRIPTION
Test plan: Login with a K5 user and verify that only the Homeroom tab is visible. Verify that the feature flag can be changed in developer settings.

refs: MBL-15522
affects: Student
release note: none