### PR TITLE
[MBL-15533][Student] Students are able to generate pairing codes when self-registration is disabled

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/SettingsInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/SettingsInteractionTest.kt
@@ -115,6 +115,7 @@ class SettingsInteractionTest : StudentTest() {
     fun testPairObserver_refreshCode() {
         setUpAndSignIn()
 
+        ApiPrefs.canGeneratePairingCode = true
         dashboardPage.launchSettingsPage()
         settingsPage.launchPairObserverPage()
 

--- a/apps/student/src/main/java/com/instructure/student/activity/CallbackActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/CallbackActivity.kt
@@ -75,6 +75,10 @@ abstract class CallbackActivity : ParentActivity(), InboxFragment.OnUnreadCountI
                 }
             }
 
+            val termsOfService = awaitApi<TermsOfService> { UserManager.getTermsOfService(it, true) }
+            ApiPrefs.canGeneratePairingCode = termsOfService.selfRegistrationType == SelfRegistration.ALL
+                || termsOfService.selfRegistrationType == SelfRegistration.OBSERVER
+
             // Grab colors
             if (ColorKeeper.hasPreviouslySynced) {
                 UserManager.getColors(userColorsCallback, true)

--- a/apps/student/src/main/java/com/instructure/student/fragment/ApplicationSettingsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/ApplicationSettingsFragment.kt
@@ -83,12 +83,14 @@ class ApplicationSettingsFragment : ParentFragment() {
         legal.onClick { LegalDialogStyled().show(requireFragmentManager(), LegalDialogStyled.TAG) }
         pinAndFingerprint.setGone() // TODO: Wire up once implemented
 
-        pairObserver.setVisible()
-        pairObserver.onClick {
-            if (APIHelper.hasNetworkConnection()) {
-                addFragment(PairObserverFragment.newInstance())
-            } else {
-                NoInternetConnectionDialog.show(requireFragmentManager())
+        if (ApiPrefs.canGeneratePairingCode == true) {
+            pairObserver.setVisible()
+            pairObserver.onClick {
+                if (APIHelper.hasNetworkConnection()) {
+                    addFragment(PairObserverFragment.newInstance())
+                } else {
+                    NoInternetConnectionDialog.show(requireFragmentManager())
+                }
             }
         }
 

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/TermsOfService.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/TermsOfService.kt
@@ -28,5 +28,13 @@ data class TermsOfService(
         val passive: Boolean = false,
         @SerializedName("account_id")
         val accountId: Long = 0,
-        val content: String? = null
+        val content: String? = null,
+        @SerializedName("self_registration_type")
+        val selfRegistrationType: SelfRegistration? = null
 ) : Parcelable
+
+enum class SelfRegistration(val apiString: String) {
+        @SerializedName("all") ALL("all"),
+        @SerializedName("observer") OBSERVER("observer"),
+        @SerializedName("none") NONE("none"),
+}

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/ApiPrefs.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/ApiPrefs.kt
@@ -86,6 +86,9 @@ object ApiPrefs : PrefManager(PREFERENCE_FILE_NAME) {
     internal var masqueradeDomain by StringPref()
     internal var masqueradeUser: User? by GsonPref(User::class.java, null, "masq-user")
 
+    // Used to determine if a student can generate a pairing code, saved during splash
+    var canGeneratePairingCode by NBooleanPref()
+
     var domain: String
         get() = if (isMasquerading || isStudentView) masqueradeDomain else originalDomain
         set(newDomain) {


### PR DESCRIPTION
Test plan: In the ticket

refs: MBL-15533
affects: Student
release note: Fixed a bug where students could generate pairing code, when it's disabled.