### PR TITLE
[Student][MBL-15598] Bottom bar navigation

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
@@ -760,7 +760,11 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
             ft.addToBackStack(fragment::class.java.name)
             fragment.show(ft, fragment::class.java.name)
         } else {
-            addFullScreenFragment(fragment)
+            if (fragment != null && fragment::class.java.name in getBottomNavFragmentNames() && isBottomNavFragment(currentFragment)) {
+                selectBottomNavFragment(fragment::class.java)
+            } else {
+                addFullScreenFragment(fragment)
+            }
         }
     }
 
@@ -897,7 +901,7 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
             }
         }
 
-    private fun isBottomNavFragment(fragment: Fragment) = fragment.arguments?.getBoolean(BOTTOM_NAV_SCREEN) == true
+    private fun isBottomNavFragment(fragment: Fragment?) = fragment?.arguments?.getBoolean(BOTTOM_NAV_SCREEN) == true
 
     private fun getBottomNavFragmentNames() = navigationBehavior.bottomNavBarFragments.map { it.name }
 

--- a/apps/student/src/main/java/com/instructure/student/fragment/FlutterCalendarFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/FlutterCalendarFragment.kt
@@ -109,7 +109,9 @@ class FlutterCalendarFragment : FlutterFragment() {
 
         // Perform onBackPressed on the FlutterFragment, which will attempt to pop the current route and update
         // the 'shouldPop' value for future use.
-        onBackPressed()
+        if (!shouldPop) {
+            onBackPressed()
+        }
 
         // If 'shouldPop' was true it means we just popped a CalendarScreen in Flutter and that we should also
         // allow this fragment to be popped

--- a/apps/student/src/main/java/com/instructure/student/mobius/elementary/ElementaryDashboardFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/elementary/ElementaryDashboardFragment.kt
@@ -94,9 +94,6 @@ class ElementaryDashboardFragment : ParentFragment() {
                 }
             }
         })
-
-        dashboardPager.setCurrentItem(DashboardStateStore.currentPage, false)
-        dashboardTabLayout.getTabAt(DashboardStateStore.currentPage)?.select()
     }
 
     override fun onHiddenChanged(hidden: Boolean) {
@@ -114,9 +111,4 @@ class ElementaryDashboardFragment : ParentFragment() {
 
         fun makeRoute(canvasContext: CanvasContext?) = Route(ElementaryDashboardFragment::class.java, canvasContext)
     }
-}
-
-object DashboardStateStore {
-
-    var currentPage: Int = 0
 }

--- a/libs/interactions/src/main/java/com/instructure/interactions/Navigation.kt
+++ b/libs/interactions/src/main/java/com/instructure/interactions/Navigation.kt
@@ -25,7 +25,6 @@ interface Navigation {
     val currentFragment: Fragment?
 
     fun popCurrentFragment()
-    fun updateCalendarStartDay()
     fun addBookmark()
     fun canBookmark(): Boolean
 


### PR DESCRIPTION
Test plan: Test the in app navigation thoroughly. Bottom navigation screens should only be added to the backstack once, and keep their state even when going back to a previous tab.

refs: MBL-15598
affects: Student
release note: Improved bottom menu navigation.