### PR TITLE
[MBL-15661][Student] File upload screen | Text overlaps the image when empty

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/ui/PickerSubmissionUploadView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/ui/PickerSubmissionUploadView.kt
@@ -102,9 +102,9 @@ class PickerSubmissionUploadView(inflater: LayoutInflater, parent: ViewGroup, va
 
     private fun renderEmpty() {
         pickerEmptyView.setVisible(true)
-        pickerEmptyView.setListEmpty()
         pickerEmptyView.setImageVisible(true)
         pickerEmptyView.setEmptyViewImage(context.getDrawableCompat(R.drawable.ic_panda_choosefile))
+        pickerEmptyView.setListEmpty()
         pickerEmptyView.setTitleText(R.string.chooseFile)
         pickerEmptyView.setMessageText(
             if (mode.isForComment) R.string.chooseFileForCommentSubtext else R.string.chooseFileSubtext


### PR DESCRIPTION
Test plan: See ticket

refs: MBL-15661
affects: Student
release note: Fixed a visual bug on file upload submission.