### PR TITLE
[MBL-15684][Student] Self-enroll links in the RCE are unresponsive

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/router/RouteMatcher.kt
+++ b/apps/student/src/main/java/com/instructure/student/router/RouteMatcher.kt
@@ -199,6 +199,8 @@ object RouteMatcher : BaseRouteMatcher() {
         //Single Detail Pages (Typically routing from To-dos (may not be handling every use case)
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/assignments/:${RouterParams.ASSIGNMENT_ID}"), AssignmentDetailsFragment::class.java, null))
 
+        routes.add(Route("/enroll/.*", RouteContext.DO_NOT_ROUTE))
+
         // Catch all (when nothing has matched, these take over)
         // Note: Catch all only happens with supported domains such as instructure.com
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/.*"), UnsupportedFeatureFragment::class.java)) // course_id fetches the course context


### PR DESCRIPTION
Test plan: Test user and course linked in the ticket.

refs: MBL-15684
affects: Student
release note: Fixed self enrolment link opening.