### PR TITLE
[MBL-15686][Student] Annotation on submitted work (pdf file)

### DIFF
--- a/libs/annotations/src/main/java/com/instructure/annotations/PdfSubmissionView.kt
+++ b/libs/annotations/src/main/java/com/instructure/annotations/PdfSubmissionView.kt
@@ -559,6 +559,8 @@ abstract class PdfSubmissionView(context: Context) : FrameLayout(context), Annot
     //region Annotation Manipulation
     @Suppress("EXPERIMENTAL_FEATURE_WARNING")
     fun createNewAnnotation(annotation: Annotation) {
+        if (docSession.annotationMetadata?.canWrite() != true) return
+
         // This is a new annotation; Post it
         commentsButton.isEnabled = false
 
@@ -593,6 +595,8 @@ abstract class PdfSubmissionView(context: Context) : FrameLayout(context), Annot
 
     @Suppress("EXPERIMENTAL_FEATURE_WARNING")
     private fun updateAnnotation(annotation: Annotation) {
+        if (docSession.annotationMetadata?.canWrite() != true) return
+
         // Don't want to update if we just created a stamp.
         if(annotation.type == AnnotationType.STAMP && !stampRaceFlag) return
         // Annotation modified; Update it


### PR DESCRIPTION
Test plan:
- Submit a PDF file that has annotations created by a 3rd party app
- Verify that after moving these annotations the annotations won't be saved to CanvaDoc session

refs: MBL-15686
affects: Student
release note: Fixed a bug where students could modify PDF annotations in some cases.