### PR TITLE
[MBL-15400][Student] Student Annotation submission type

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/AssignmentDetailsRenderTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/AssignmentDetailsRenderTest.kt
@@ -419,12 +419,13 @@ class AssignmentDetailsRenderTest : StudentRenderTest() {
                 "online_text_entry",
                 "online_url",
                 "media_recording",
-                "attendance"
+                "attendance",
+                "student_annotation"
             )
         )
         val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
         loadPageWithModel(model)
-        val expected = "External Tool, File Upload, Text Entry, Website URL, Media Recording, Attendance"
+        val expected = "External Tool, File Upload, Text Entry, Website URL, Media Recording, Attendance, Student Annotation"
         assignmentDetailsRenderPage.assertDisplaysSubmissionTypes(expected)
     }
 
@@ -758,7 +759,8 @@ class AssignmentDetailsRenderTest : StudentRenderTest() {
         0,
         0,
         0,
-        null
+        null,
+        1
     )
 
     private fun loadPageWithModel(model: AssignmentDetailsModel) {

--- a/apps/student/src/main/db/com/instructure/student/1.sqm
+++ b/apps/student/src/main/db/com/instructure/student/1.sqm
@@ -1,0 +1,17 @@
+ --
+ -- Copyright (C) 2019 - present Instructure, Inc.
+ --
+ --     Licensed under the Apache License, Version 2.0 (the "License");
+ --     you may not use this file except in compliance with the License.
+ --     You may obtain a copy of the License at
+ --
+ --     http://www.apache.org/licenses/LICENSE-2.0
+ --
+ --     Unless required by applicable law or agreed to in writing, software
+ --     distributed under the License is distributed on an "AS IS" BASIS,
+ --     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ --     See the License for the specific language governing permissions and
+ --     limitations under the License.
+ --
+
+ALTER TABLE submission ADD COLUMN annotatableAttachmentId INTEGER;

--- a/apps/student/src/main/db/com/instructure/student/Submission.sq
+++ b/apps/student/src/main/db/com/instructure/student/Submission.sq
@@ -16,7 +16,6 @@
 
 import com.instructure.canvasapi2.models.CanvasContext;
 import com.instructure.student.db.sqlColAdapters.Date;
-import com.instructure.student.db.sqlColAdapters.ErrorColAdapter;
 
 CREATE TABLE submission (
     id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
@@ -32,7 +31,8 @@ CREATE TABLE submission (
     -- Used for progress
     currentFile INTEGER NOT NULL DEFAULT 0,
     fileCount INTEGER NOT NULL DEFAULT 0,
-    progress REAL
+    progress REAL,
+    annotatableAttachmentId INTEGER
 );
 
 insertOnlineTextSubmission:
@@ -50,6 +50,10 @@ VALUES (?, ?, ?, ?, ?, ?, "online_upload");
 insertMediaUploadSubmission:
 INSERT INTO submission (assignmentName, assignmentId, assignmentGroupCategoryId, canvasContext, userId, lastActivityDate, submissionType)
 VALUES (?, ?, ?, ?, ?, ?, "media_recording");
+
+insertStudentAnnotationSubmission:
+INSERT INTO submission (annotatableAttachmentId, assignmentName, assignmentId, canvasContext, userId, lastActivityDate, submissionType)
+VALUES (?, ?, ?, ?, ?, ?, "student_annotation");
 
 getAllSubmissions:
 SELECT *

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsEffectHandler.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/AssignmentDetailsEffectHandler.kt
@@ -129,7 +129,7 @@ class AssignmentDetailsEffectHandler(val context: Context, val assignmentId: Lon
                     Assignment.SubmissionType.ONLINE_UPLOAD -> view?.showFileUploadView(effect.assignment)
                     Assignment.SubmissionType.ONLINE_TEXT_ENTRY -> view?.showOnlineTextEntryView(effect.assignment.id, effect.assignment.name)
                     Assignment.SubmissionType.ONLINE_URL -> view?.showOnlineUrlEntryView(effect.assignment.id, effect.assignment.name, effect.course)
-                    Assignment.SubmissionType.STUDENT_ANNOTATION -> view?.showStudentAnnotationView(effect.assignment.htmlUrl ?: "")
+                    Assignment.SubmissionType.STUDENT_ANNOTATION -> view?.showStudentAnnotationView(effect.assignment)
                     Assignment.SubmissionType.EXTERNAL_TOOL, Assignment.SubmissionType.BASIC_LTI_LAUNCH -> view?.showLTIView(effect.course, effect.assignment.name ?: "", effect.ltiTool)
                     else -> view?.showMediaRecordingView(effect.assignment) // Assignment.SubmissionType.MEDIA_RECORDING
                 }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/annnotation/AnnotationSubmissionUploadFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/annnotation/AnnotationSubmissionUploadFragment.kt
@@ -58,7 +58,7 @@ class AnnotationSubmissionUploadFragment : Fragment() {
 
         viewModel.pdfUrl.observe(viewLifecycleOwner, {
             binding.annotationSubmissionViewContainer.addView(
-                PdfStudentSubmissionView(requireActivity(), it)
+                PdfStudentSubmissionView(requireActivity(), it, true)
             )
         })
 

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/annnotation/AnnotationSubmissionUploadFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/annnotation/AnnotationSubmissionUploadFragment.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2021 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.student.mobius.assignmentDetails.submission.annnotation
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import com.instructure.canvasapi2.models.CanvasContext
+import com.instructure.interactions.router.Route
+import com.instructure.pandautils.utils.*
+import com.instructure.student.R
+import com.instructure.student.databinding.FragmentAnnotationSubmissionUploadBinding
+import com.instructure.student.mobius.assignmentDetails.submissionDetails.content.AnnotationSubmissionViewModel
+import com.instructure.student.mobius.assignmentDetails.submissionDetails.content.PdfStudentSubmissionView
+import com.instructure.student.mobius.common.ui.SubmissionService
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class AnnotationSubmissionUploadFragment : Fragment() {
+
+    private var submissionId by LongArg(key = SUBMISSION_ID)
+    private var annotatableAttachmentId by LongArg(key = ANNOTATABLE_ATTACHMENT_ID)
+    private var assignmentId by LongArg(key = Const.ASSIGNMENT_ID)
+    private var canvasContext by ParcelableArg<CanvasContext>(key = Const.CANVAS_CONTEXT)
+    private var assignmentName by StringArg(key = Const.ASSIGNMENT_NAME)
+
+    private val viewModel: AnnotationSubmissionViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val binding = FragmentAnnotationSubmissionUploadBinding.inflate(inflater, container, false)
+
+        binding.lifecycleOwner = this
+        binding.viewModel = viewModel
+
+        viewModel.loadAnnotatedPdfUrl(submissionId)
+
+        viewModel.pdfUrl.observe(viewLifecycleOwner, {
+            binding.annotationSubmissionViewContainer.addView(
+                PdfStudentSubmissionView(requireActivity(), it)
+            )
+        })
+
+        binding.annotationSubmissionToolbar.setupAsBackButton { requireActivity().onBackPressed() }
+        binding.annotationSubmissionToolbar.setMenu(R.menu.menu_submit_generic) {
+            when (it.itemId) {
+                R.id.menuSubmit -> {
+                    SubmissionService.startStudentAnnotationSubmission(requireContext(), canvasContext, assignmentId, assignmentName, annotatableAttachmentId)
+                    requireActivity().onBackPressed()
+                }
+            }
+        }
+
+        return binding.root
+    }
+
+    companion object {
+
+        private const val ANNOTATABLE_ATTACHMENT_ID = "annotatable_attachment_id"
+        private const val SUBMISSION_ID = "submission_id"
+
+        fun newInstance(route: Route): AnnotationSubmissionUploadFragment {
+            return AnnotationSubmissionUploadFragment().withArgs(route.arguments)
+        }
+
+        fun makeRoute(
+            canvasContext: CanvasContext,
+            annotatableAttachmentId: Long,
+            submissionId: Long,
+            assignmentId: Long,
+            assignmentName: String
+        ): Route {
+            val bundle = Bundle().apply {
+                putParcelable(Const.CANVAS_CONTEXT, canvasContext)
+                putLong(ANNOTATABLE_ATTACHMENT_ID, annotatableAttachmentId)
+                putLong(SUBMISSION_ID, submissionId)
+                putLong(Const.ASSIGNMENT_ID, assignmentId)
+                putString(Const.ASSIGNMENT_NAME, assignmentName)
+            }
+            return Route(AnnotationSubmissionUploadFragment::class.java, canvasContext, bundle)
+        }
+    }
+}

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/annnotation/AnnotationSubmissionUploadFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/annnotation/AnnotationSubmissionUploadFragment.kt
@@ -16,10 +16,12 @@
  */
 package com.instructure.student.mobius.assignmentDetails.submission.annnotation
 
+import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.instructure.canvasapi2.models.CanvasContext
@@ -27,7 +29,6 @@ import com.instructure.interactions.router.Route
 import com.instructure.pandautils.utils.*
 import com.instructure.student.R
 import com.instructure.student.databinding.FragmentAnnotationSubmissionUploadBinding
-import com.instructure.student.mobius.assignmentDetails.submissionDetails.content.AnnotationSubmissionViewModel
 import com.instructure.student.mobius.assignmentDetails.submissionDetails.content.PdfStudentSubmissionView
 import com.instructure.student.mobius.common.ui.SubmissionService
 import dagger.hilt.android.AndroidEntryPoint
@@ -61,8 +62,14 @@ class AnnotationSubmissionUploadFragment : Fragment() {
             )
         })
 
-        binding.annotationSubmissionToolbar.setupAsBackButton { requireActivity().onBackPressed() }
-        binding.annotationSubmissionToolbar.setMenu(R.menu.menu_submit_generic) {
+        setUpToolbar(binding.annotationSubmissionToolbar)
+
+        return binding.root
+    }
+
+    private fun setUpToolbar(toolbar: Toolbar) {
+        toolbar.setupAsBackButton { requireActivity().onBackPressed() }
+        toolbar.setMenu(R.menu.menu_submit_generic) {
             when (it.itemId) {
                 R.id.menuSubmit -> {
                     SubmissionService.startStudentAnnotationSubmission(requireContext(), canvasContext, assignmentId, assignmentName, annotatableAttachmentId)
@@ -70,8 +77,7 @@ class AnnotationSubmissionUploadFragment : Fragment() {
                 }
             }
         }
-
-        return binding.root
+        ViewStyler.themeToolbarBottomSheet(requireActivity(), false, toolbar, Color.BLACK, false)
     }
 
     companion object {

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/annnotation/AnnotationSubmissionViewModel.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/annnotation/AnnotationSubmissionViewModel.kt
@@ -14,7 +14,7 @@
  *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-package com.instructure.student.mobius.assignmentDetails.submissionDetails.content
+package com.instructure.student.mobius.assignmentDetails.submission.annnotation
 
 import android.content.res.Resources
 import androidx.lifecycle.LiveData

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/annnotation/AnnotationSubmissionViewModel.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/annnotation/AnnotationSubmissionViewModel.kt
@@ -51,7 +51,7 @@ class AnnotationSubmissionViewModel @Inject constructor(
                 val docSession = canvaDocsManager.createCanvaDocSessionAsync(submissionId, attempt)
                     .await().dataOrThrow
                 val sessionUrl = docSession.canvadocsSessionUrl
-                if (sessionUrl != null) {
+                if (sessionUrl != null && sessionUrl.isNotEmpty()) {
                     _pdfUrl.value = sessionUrl
                     _state.value = ViewState.Success
                 } else {

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsModels.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsModels.kt
@@ -89,5 +89,5 @@ sealed class SubmissionDetailsContentType {
     data class UrlContent(val url: String, val previewUrl: String?) : SubmissionDetailsContentType()
     data class DiscussionContent(val previewUrl: String?) : SubmissionDetailsContentType()
     object LockedContent : SubmissionDetailsContentType()
-    object StudentAnnotationContent : SubmissionDetailsContentType()
+    data class StudentAnnotationContent(val subissionId: Long, val submissionAttempt: Long) : SubmissionDetailsContentType()
 }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsUpdate.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsUpdate.kt
@@ -200,7 +200,7 @@ class SubmissionDetailsUpdate : UpdateInit<SubmissionDetailsModel, SubmissionDet
                 // Discussion Submission
                 Assignment.SubmissionType.DISCUSSION_TOPIC -> SubmissionDetailsContentType.DiscussionContent(submission.previewUrl)
 
-                Assignment.SubmissionType.STUDENT_ANNOTATION -> SubmissionDetailsContentType.StudentAnnotationContent
+                Assignment.SubmissionType.STUDENT_ANNOTATION -> SubmissionDetailsContentType.StudentAnnotationContent(submission.id, submission.attempt)
                 else -> SubmissionDetailsContentType.UnsupportedContent(assignment?.id ?: -1)
             }
         }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/AnnotationSubmissionViewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/AnnotationSubmissionViewFragment.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2021 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.student.mobius.assignmentDetails.submissionDetails.content
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import com.instructure.pandautils.utils.LongArg
+import com.instructure.student.databinding.FragmentAnnotationSubmissionViewBinding
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class AnnotationSubmissionViewFragment : Fragment() {
+
+    private var submissionId by LongArg()
+    private var submissionAttempt by LongArg()
+
+    private val viewModel: AnnotationSubmissionViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val binding = FragmentAnnotationSubmissionViewBinding.inflate(inflater, container, false)
+
+        binding.lifecycleOwner = this
+        binding.viewModel = viewModel
+
+        viewModel.loadAnnotatedPdfUrl(submissionId, submissionAttempt)
+
+        viewModel.pdfUrl.observe(viewLifecycleOwner, {
+            binding.annotationSubmissionViewContainer.addView(PdfStudentSubmissionView(requireActivity(), it))
+        })
+
+        return binding.root
+    }
+
+    companion object {
+        fun newInstance(submissionId: Long, submissionAttempt: Long): AnnotationSubmissionViewFragment {
+            return AnnotationSubmissionViewFragment().apply {
+                this.submissionId = submissionId
+                this.submissionAttempt = submissionAttempt
+            }
+        }
+    }
+}

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/AnnotationSubmissionViewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/AnnotationSubmissionViewFragment.kt
@@ -24,6 +24,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.instructure.pandautils.utils.LongArg
 import com.instructure.student.databinding.FragmentAnnotationSubmissionViewBinding
+import com.instructure.student.mobius.assignmentDetails.submission.annnotation.AnnotationSubmissionViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/AnnotationSubmissionViewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/AnnotationSubmissionViewFragment.kt
@@ -44,7 +44,7 @@ class AnnotationSubmissionViewFragment : Fragment() {
         binding.lifecycleOwner = this
         binding.viewModel = viewModel
 
-        viewModel.loadAnnotatedPdfUrl(submissionId, submissionAttempt)
+        viewModel.loadAnnotatedPdfUrl(submissionId, submissionAttempt.toString())
 
         viewModel.pdfUrl.observe(viewLifecycleOwner, {
             binding.annotationSubmissionViewContainer.addView(PdfStudentSubmissionView(requireActivity(), it))

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/AnnotationSubmissionViewModel.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/AnnotationSubmissionViewModel.kt
@@ -28,6 +28,8 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+private const val DRAFT_ATTEMPT = "draft"
+
 @HiltViewModel
 class AnnotationSubmissionViewModel @Inject constructor(
     private val canvaDocsManager: CanvaDocsManager,
@@ -42,7 +44,7 @@ class AnnotationSubmissionViewModel @Inject constructor(
         get() = _pdfUrl
     private val _pdfUrl = MutableLiveData<String>()
 
-    fun loadAnnotatedPdfUrl(submissionId: Long, attempt: Long) {
+    fun loadAnnotatedPdfUrl(submissionId: Long, attempt: String = DRAFT_ATTEMPT) {
         _state.value = ViewState.Loading
         viewModelScope.launch {
             try {

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/AnnotationSubmissionViewModel.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/AnnotationSubmissionViewModel.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2021 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.student.mobius.assignmentDetails.submissionDetails.content
+
+import android.content.res.Resources
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.instructure.canvasapi2.managers.CanvaDocsManager
+import com.instructure.pandautils.mvvm.ViewState
+import com.instructure.student.R
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class AnnotationSubmissionViewModel @Inject constructor(
+    private val canvaDocsManager: CanvaDocsManager,
+    private val resources: Resources
+) : ViewModel() {
+
+    val state: LiveData<ViewState>
+        get() = _state
+    private val _state = MutableLiveData<ViewState>()
+
+    val pdfUrl: LiveData<String>
+        get() = _pdfUrl
+    private val _pdfUrl = MutableLiveData<String>()
+
+    fun loadAnnotatedPdfUrl(submissionId: Long, attempt: Long) {
+        _state.value = ViewState.Loading
+        viewModelScope.launch {
+            try {
+                val docSession = canvaDocsManager.createCanvaDocSessionAsync(submissionId, attempt)
+                    .await().dataOrThrow
+                val sessionUrl = docSession.canvadocsSessionUrl
+                if (sessionUrl != null) {
+                    _pdfUrl.value = sessionUrl
+                    _state.value = ViewState.Success
+                } else {
+                    _state.value =
+                        ViewState.Error(resources.getString(R.string.failedToLoadSubmission))
+                }
+            } catch (e: Exception) {
+                _state.value = ViewState.Error(resources.getString(R.string.failedToLoadSubmission))
+            }
+        }
+    }
+}

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/PdfStudentSubmissionView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/PdfStudentSubmissionView.kt
@@ -60,7 +60,8 @@ import java.util.ArrayList
 @SuppressLint("ViewConstructor")
 class PdfStudentSubmissionView(
         context: Context,
-        private val pdfUrl: String
+        private val pdfUrl: String,
+        private val studentAnnotation: Boolean = false
 ) : PdfSubmissionView(context), AnnotationManager.OnAnnotationCreationModeChangeListener, AnnotationManager.OnAnnotationEditingModeChangeListener {
 
     private var initJob: Job? = null
@@ -142,12 +143,16 @@ class PdfStudentSubmissionView(
     }
 
     override fun attachDocListener() {
-        // Modify the session data permissions to make sure students can't annotate already submitted assignments
-        if (docSession.annotationMetadata?.canWrite() == true) {
-            docSession.annotationMetadata?.permissions = "read"
+        // We need to add this flag, because we want to show the toolbar in the student annotation, but hide when
+        // we open an already submitted file submission with a teacher's annotations.
+        if (!studentAnnotation) {
+            // Modify the session data permissions to make sure students can't annotate already submitted assignments
+            if (docSession.annotationMetadata?.canWrite() == true) {
+                docSession.annotationMetadata?.permissions = "read"
+            }
+            // Default is to have top inset, remove this since there will be no toolbar
+            pdfFragment?.setInsets(0, 0, 0, 0)
         }
-        // Default is to have top inset, remove this since there will be no toolbar
-        pdfFragment?.setInsets(0, 0, 0, 0)
         super.attachDocListener()
     }
 

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/emptySubmission/SubmissionDetailsEmptyContentEffectHandler.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/emptySubmission/SubmissionDetailsEmptyContentEffectHandler.kt
@@ -67,7 +67,7 @@ class SubmissionDetailsEmptyContentEffectHandler(val context: Context, val assig
                     Assignment.SubmissionType.ONLINE_UPLOAD -> view?.showFileUploadView(effect.assignment)
                     Assignment.SubmissionType.ONLINE_TEXT_ENTRY -> view?.showOnlineTextEntryView(effect.assignment.id, effect.assignment.name)
                     Assignment.SubmissionType.ONLINE_URL -> view?.showOnlineUrlEntryView(effect.assignment.id, effect.assignment.name, effect.course)
-                    Assignment.SubmissionType.STUDENT_ANNOTATION -> view?.showStudentAnnotationView(effect.assignment.htmlUrl ?: "")
+                    Assignment.SubmissionType.STUDENT_ANNOTATION -> view?.showStudentAnnotationView(effect.assignment)
                     Assignment.SubmissionType.EXTERNAL_TOOL, Assignment.SubmissionType.BASIC_LTI_LAUNCH -> view?.showLTIView(effect.course, title = effect.assignment.name ?: "", ltiTool = effect.ltiTool)
                     else -> view?.showMediaRecordingView() // e.g. Assignment.SubmissionType.MEDIA_RECORDING
                 }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/emptySubmission/ui/SubmissionDetailsEmptyContentView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/emptySubmission/ui/SubmissionDetailsEmptyContentView.kt
@@ -28,11 +28,18 @@ import android.widget.Toast
 import com.instructure.canvasapi2.models.*
 import com.instructure.canvasapi2.utils.AnalyticsEventConstants
 import com.instructure.canvasapi2.utils.ApiPrefs
-import com.instructure.pandautils.utils.*
+import com.instructure.pandautils.utils.ThemePrefs
+import com.instructure.pandautils.utils.onClick
+import com.instructure.pandautils.utils.setHidden
+import com.instructure.pandautils.utils.setVisible
 import com.instructure.pandautils.views.RecordingMediaType
 import com.instructure.student.R
 import com.instructure.student.activity.InternalWebViewActivity
-import com.instructure.student.fragment.*
+import com.instructure.student.fragment.BasicQuizViewFragment
+import com.instructure.student.fragment.DiscussionDetailsFragment
+import com.instructure.student.fragment.LtiLaunchFragment
+import com.instructure.student.fragment.StudioWebViewFragment
+import com.instructure.student.mobius.assignmentDetails.submission.annnotation.AnnotationSubmissionUploadFragment
 import com.instructure.student.mobius.assignmentDetails.submission.picker.PickerSubmissionMode
 import com.instructure.student.mobius.assignmentDetails.submission.picker.ui.PickerSubmissionUploadFragment
 import com.instructure.student.mobius.assignmentDetails.submission.text.ui.TextSubmissionUploadFragment
@@ -46,7 +53,6 @@ import com.spotify.mobius.functions.Consumer
 import kotlinx.android.synthetic.main.dialog_submission_picker.*
 import kotlinx.android.synthetic.main.dialog_submission_picker_media.*
 import kotlinx.android.synthetic.main.fragment_submission_details_empty_content.*
-import kotlinx.android.synthetic.main.fragment_submission_details_empty_content.submitButton
 
 class SubmissionDetailsEmptyContentView(
     val canvasContext: CanvasContext,
@@ -105,7 +111,7 @@ class SubmissionDetailsEmptyContentView(
                 showStudioUploadView(assignment, ltiToolUrl!!, ltiToolName!!)
             }
             setupDialogRow(dialog, dialog.submissionEntryStudentAnnotation, visibilities.studentAnnotation) {
-                showStudentAnnotationView(assignment.htmlUrl ?: "")
+                showStudentAnnotationView(assignment)
             }
         }
         dialog.show()
@@ -221,9 +227,21 @@ class SubmissionDetailsEmptyContentView(
         (context as Activity).runOnUiThread { (context as Activity).onBackPressed() }
     }
 
-    fun showStudentAnnotationView(assignmentUrl: String) {
+    fun showStudentAnnotationView(assignment: Assignment) {
         logEvent(AnalyticsEventConstants.SUBMIT_STUDENT_ANNOTATION_SELECTED)
-        RouteMatcher.route(context,
-            UnsupportedFeatureFragment.makeRoute(canvasContext, unsupportedDescription = context.getString(R.string.studentAnnotationUnsupportedDescription), url = assignmentUrl))
+
+        val submissionId = assignment.submission?.id
+        if (submissionId != null) {
+            RouteMatcher.route(
+                context,
+                AnnotationSubmissionUploadFragment.makeRoute(
+                    canvasContext,
+                    assignment.annotatableAttachmentId,
+                    submissionId,
+                    assignment.id,
+                    assignment.name ?: ""
+                )
+            )
+        }
     }
 }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/ui/SubmissionDetailsView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/ui/SubmissionDetailsView.kt
@@ -291,7 +291,7 @@ class SubmissionDetailsView(
             SubmissionDetailsContentType.NoneContent -> SubmissionMessageFragment.newInstance(title = R.string.noOnlineSubmissions,  subtitle = R.string.noneContentMessage)
             SubmissionDetailsContentType.OnPaperContent -> SubmissionMessageFragment.newInstance(title = R.string.noOnlineSubmissions, subtitle = R.string.onPaperContentMessage)
             SubmissionDetailsContentType.LockedContent -> SubmissionMessageFragment.newInstance(title = R.string.submissionDetailsAssignmentLocked, subtitle = R.string.could_not_route_locked)
-            SubmissionDetailsContentType.StudentAnnotationContent -> SubmissionMessageFragment.newInstance(title = R.string.unsupportedSubmissionType, message = R.string.studentAnnotationUnsupportedMessage)
+            is SubmissionDetailsContentType.StudentAnnotationContent -> AnnotationSubmissionViewFragment.newInstance(type.subissionId, type.submissionAttempt)
             is SubmissionDetailsContentType.UnsupportedContent -> {
                 // Users shouldn't get here, but we'll handle the case and send up some analytics if they do
                 val bundle = Bundle().apply {

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/AssignmentDetailsView.kt
@@ -46,6 +46,7 @@ import com.instructure.student.activity.InternalWebViewActivity
 import com.instructure.student.activity.ShareFileSubmissionTarget
 import com.instructure.student.fragment.*
 import com.instructure.student.mobius.assignmentDetails.AssignmentDetailsEvent
+import com.instructure.student.mobius.assignmentDetails.submission.annnotation.AnnotationSubmissionUploadFragment
 import com.instructure.student.mobius.assignmentDetails.submission.file.ui.UploadStatusSubmissionFragment
 import com.instructure.student.mobius.assignmentDetails.submission.picker.PickerSubmissionMode
 import com.instructure.student.mobius.assignmentDetails.submission.picker.ui.PickerSubmissionUploadFragment
@@ -278,7 +279,7 @@ class AssignmentDetailsView(
                 showStudioUploadView(assignment, ltiToolUrl!!, ltiToolName!!)
             }
             setupDialogRow(dialog, dialog.submissionEntryStudentAnnotation, visibilities.studentAnnotation) {
-                showStudentAnnotationView(assignment.htmlUrl ?: "")
+                showStudentAnnotationView(assignment)
             }
         }
         dialog.show()
@@ -401,10 +402,22 @@ class AssignmentDetailsView(
         RouteMatcher.route(context, StudioWebViewFragment.makeRoute(canvasContext, ltiUrl, studioLtiToolName, true, assignment))
     }
 
-    fun showStudentAnnotationView(assignmentUrl: String) {
+    fun showStudentAnnotationView(assignment: Assignment) {
         logEvent(AnalyticsEventConstants.SUBMIT_STUDENT_ANNOTATION_SELECTED)
-        RouteMatcher.route(context,
-            UnsupportedFeatureFragment.makeRoute(canvasContext, unsupportedDescription = context.getString(R.string.studentAnnotationUnsupportedDescription), url = assignmentUrl))
+
+        val submissionId = assignment.submission?.id
+        if (submissionId != null) {
+            RouteMatcher.route(
+                context,
+                AnnotationSubmissionUploadFragment.makeRoute(
+                    canvasContext,
+                    assignment.annotatableAttachmentId,
+                    submissionId,
+                    assignment.id,
+                    assignment.name ?: ""
+                )
+            )
+        }
     }
 
     fun showQuizOrDiscussionView(url: String) {

--- a/apps/student/src/main/java/com/instructure/student/router/RouteResolver.kt
+++ b/apps/student/src/main/java/com/instructure/student/router/RouteResolver.kt
@@ -10,6 +10,7 @@ import com.instructure.student.features.dashboard.edit.EditDashboardFragment
 import com.instructure.student.features.elementary.course.ElementaryCourseFragment
 import com.instructure.student.features.files.search.FileSearchFragment
 import com.instructure.student.fragment.*
+import com.instructure.student.mobius.assignmentDetails.submission.annnotation.AnnotationSubmissionUploadFragment
 import com.instructure.student.mobius.assignmentDetails.submission.file.ui.UploadStatusSubmissionFragment
 import com.instructure.student.mobius.assignmentDetails.submission.picker.ui.PickerSubmissionUploadFragment
 import com.instructure.student.mobius.assignmentDetails.submission.text.ui.TextSubmissionUploadFragment
@@ -117,6 +118,7 @@ object RouteResolver {
             cls.isA<UploadStatusSubmissionFragment>() -> UploadStatusSubmissionFragment.newInstance(route)
             cls.isA<AnnotationCommentListFragment>() -> AnnotationCommentListFragment.newInstance(route)
             cls.isA<NothingToSeeHereFragment>() -> NothingToSeeHereFragment.newInstance()
+            cls.isA<AnnotationSubmissionUploadFragment>() -> AnnotationSubmissionUploadFragment.newInstance(route)
             cls.isA<InternalWebviewFragment>() -> InternalWebviewFragment.newInstance(route) // Keep this at the end
             else -> null
         }

--- a/apps/student/src/main/res/layout/dialog_submission_picker.xml
+++ b/apps/student/src/main/res/layout/dialog_submission_picker.xml
@@ -136,7 +136,7 @@
             style="@style/TextFont.Regular"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/studentAnnotationUnsupported"
+            android:text="@string/submissionTypeStudentAnnotation"
             android:textSize="16sp"/>
 
     </LinearLayout>

--- a/apps/student/src/main/res/layout/fragment_annotation_submission_upload.xml
+++ b/apps/student/src/main/res/layout/fragment_annotation_submission_upload.xml
@@ -20,7 +20,7 @@
     <data>
         <variable
             name="viewModel"
-            type="com.instructure.student.mobius.assignmentDetails.submissionDetails.content.AnnotationSubmissionViewModel" />
+            type="com.instructure.student.mobius.assignmentDetails.submission.annnotation.AnnotationSubmissionViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/apps/student/src/main/res/layout/fragment_annotation_submission_upload.xml
+++ b/apps/student/src/main/res/layout/fragment_annotation_submission_upload.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (C)  - present Instructure, Inc.
+  ~
+  ~     This program is free software: you can redistribute it and/or modify
+  ~     it under the terms of the GNU General Public License as published by
+  ~     the Free Software Foundation, version 3 of the License.
+  ~
+  ~     This program is distributed in the hope that it will be useful,
+  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~     GNU General Public License for more details.
+  ~
+  ~     You should have received a copy of the GNU General Public License
+  ~     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  ~
+  -->
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <variable
+            name="viewModel"
+            type="com.instructure.student.mobius.assignmentDetails.submissionDetails.content.AnnotationSubmissionViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/annotationSubmissionToolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?android:attr/actionBarSize"
+            android:elevation="6dp"
+            app:title="@string/studentAnnotationToolbarTitle"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <FrameLayout
+            android:id="@+id/annotationSubmissionViewContainer"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toBottomOf="@id/annotationSubmissionToolbar"
+            app:layout_constraintBottom_toBottomOf="parent">
+
+            <com.instructure.pandautils.views.EmptyView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:emptyViewState="@{viewModel.state}"/>
+
+        </FrameLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/apps/student/src/main/res/layout/fragment_annotation_submission_view.xml
+++ b/apps/student/src/main/res/layout/fragment_annotation_submission_view.xml
@@ -20,7 +20,7 @@
     <data>
         <variable
             name="viewModel"
-            type="com.instructure.student.mobius.assignmentDetails.submissionDetails.content.AnnotationSubmissionViewModel" />
+            type="com.instructure.student.mobius.assignmentDetails.submission.annnotation.AnnotationSubmissionViewModel" />
     </data>
 
     <FrameLayout

--- a/apps/student/src/main/res/layout/fragment_annotation_submission_view.xml
+++ b/apps/student/src/main/res/layout/fragment_annotation_submission_view.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (C)  - present Instructure, Inc.
+  ~
+  ~     This program is free software: you can redistribute it and/or modify
+  ~     it under the terms of the GNU General Public License as published by
+  ~     the Free Software Foundation, version 3 of the License.
+  ~
+  ~     This program is distributed in the hope that it will be useful,
+  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~     GNU General Public License for more details.
+  ~
+  ~     You should have received a copy of the GNU General Public License
+  ~     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  ~
+  -->
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <variable
+            name="viewModel"
+            type="com.instructure.student.mobius.assignmentDetails.submissionDetails.content.AnnotationSubmissionViewModel" />
+    </data>
+
+    <FrameLayout
+        android:id="@+id/annotationSubmissionViewContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.instructure.pandautils.views.EmptyView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:emptyViewState="@{viewModel.state}"/>
+
+    </FrameLayout>
+</layout>

--- a/apps/student/src/main/res/layout/fragment_submission_details_empty_content.xml
+++ b/apps/student/src/main/res/layout/fragment_submission_details_empty_content.xml
@@ -96,8 +96,8 @@
         android:text="@string/submitAssignment"
         android:visibility="invisible"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="@id/textRight"
-        app:layout_constraintRight_toRightOf="@id/textLeft" />
+        app:layout_constraintEnd_toStartOf="@id/textRight"
+        app:layout_constraintStart_toEndOf="@id/textLeft" />
 
     <com.instructure.pandautils.views.FloatingRecordingView
         android:id="@+id/floatingRecordingView"

--- a/apps/student/src/test/java/com/instructure/student/mobius/assignmentDetails/submission/annnotation/AnnotationSubmissionViewModelTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/mobius/assignmentDetails/submission/annnotation/AnnotationSubmissionViewModelTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2021 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.student.mobius.assignmentDetails.submission.annnotation
+
+import android.content.res.Resources
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import com.instructure.canvasapi2.managers.CanvaDocsManager
+import com.instructure.canvasapi2.models.canvadocs.CanvaDocSessionResponseBody
+import com.instructure.canvasapi2.utils.DataResult
+import com.instructure.pandautils.mvvm.ViewState
+import com.instructure.student.R
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.*
+import org.junit.Assert.*
+
+@ExperimentalCoroutinesApi
+class AnnotationSubmissionViewModelTest {
+
+    private lateinit var viewModel: AnnotationSubmissionViewModel
+
+    @get:Rule
+    var instantExecutorRule = InstantTaskExecutorRule()
+
+    private val lifecycleOwner: LifecycleOwner = mockk(relaxed = true)
+    private val lifecycleRegistry = LifecycleRegistry(lifecycleOwner)
+
+    private val canvaDocsManager: CanvaDocsManager = mockk(relaxed = true)
+    private val resources: Resources = mockk(relaxed = true)
+
+    private val testDispatcher = TestCoroutineDispatcher()
+
+    @Before
+    fun setUp() {
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+        Dispatchers.setMain(testDispatcher)
+
+        every { resources.getString(R.string.failedToLoadSubmission) } returns "Error"
+        viewModel = AnnotationSubmissionViewModel(canvaDocsManager, resources)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        testDispatcher.cleanupTestCoroutines()
+    }
+
+    @Test
+    fun `Error response doesnt update pdf url and produces error`() {
+        // Given
+        every { canvaDocsManager.createCanvaDocSessionAsync(any(), any()) } returns mockk() {
+            coEvery { await() } returns DataResult.Fail()
+        }
+
+        // When
+        viewModel.state.observe(lifecycleOwner, {})
+        viewModel.loadAnnotatedPdfUrl(1)
+
+        // Then
+        assertNull(viewModel.pdfUrl.value)
+        assertEquals(ViewState.Error("Error"), viewModel.state.value)
+    }
+
+    @Test
+    fun `Empty session url doesnt update pdf url and produces error`() {
+        // Given
+        val canvaDocSession = CanvaDocSessionResponseBody("", "")
+        every { canvaDocsManager.createCanvaDocSessionAsync(any(), any()) } returns mockk() {
+            coEvery { await() } returns DataResult.Success(canvaDocSession)
+        }
+
+        // When
+        viewModel.state.observe(lifecycleOwner, {})
+        viewModel.loadAnnotatedPdfUrl(1)
+
+        // Then
+        assertNull(viewModel.pdfUrl.value)
+        assertEquals(ViewState.Error("Error"), viewModel.state.value)
+    }
+
+    @Test
+    fun `Valid session url response updates pdf url`() {
+        // Given
+        val canvaDocSession = CanvaDocSessionResponseBody("", "https://myschool.com/annotatedFile.pdf")
+        every { canvaDocsManager.createCanvaDocSessionAsync(any(), any()) } returns mockk() {
+            coEvery { await() } returns DataResult.Success(canvaDocSession)
+        }
+
+        // When
+        viewModel.state.observe(lifecycleOwner, {})
+        viewModel.loadAnnotatedPdfUrl(1)
+
+        // Then
+        assertEquals("https://myschool.com/annotatedFile.pdf", viewModel.pdfUrl.value)
+        assertEquals(ViewState.Success, viewModel.state.value)
+    }
+}

--- a/apps/student/src/test/java/com/instructure/student/test/SubmissionServiceTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/SubmissionServiceTest.kt
@@ -75,7 +75,7 @@ class SubmissionServiceTest : Assert() {
     }
 
 
-@Test
+    @Test
     fun `startTextSubmission starts the service with an intent`() {
         val text = "stuff"
         val intent = slot<Intent>()
@@ -189,5 +189,18 @@ class SubmissionServiceTest : Assert() {
         // Assert deleted
         assertNull(commentDb.getCommentById(commentId).executeAsOneOrNull())
         assertEquals(0, fileDb.getFilesForPendingComment(commentId).executeAsList().size)
+    }
+
+    @Test
+    fun `Student annotation submission starts the service with an intent`() {
+        val annotatableAttachmentId = 123L
+        val intent = slot<Intent>()
+
+        every { context.startService(capture(intent)) } returns null
+
+        SubmissionService.startStudentAnnotationSubmission(context, canvasContext, assignmentId, assignmentName, annotatableAttachmentId)
+
+        assertEquals(SubmissionService.Action.STUDENT_ANNOTATION.name, intent.captured.action)
+        assertTrue(intent.captured.hasExtra(Const.SUBMISSION_ID))
     }
 }

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsEffectHandlerTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsEffectHandlerTest.kt
@@ -132,7 +132,8 @@ class AssignmentDetailsEffectHandlerTest : Assert() {
             userId = userId,
             currentFile = 0,
             fileCount = 0,
-            progress = null
+            progress = null,
+            annotatableAttachmentId = null
         )
     }
 
@@ -870,12 +871,11 @@ class AssignmentDetailsEffectHandlerTest : Assert() {
     @Test
     fun `ShowCreateSubmissionView with student annotation submissionType shows student annotation view`() {
         val submissionType = Assignment.SubmissionType.STUDENT_ANNOTATION
-        assignment = assignment.copy(htmlUrl = "www.instructure.com")
 
         connection.accept(AssignmentDetailsEffect.ShowCreateSubmissionView(submissionType, course, assignment))
 
         verify(timeout = 100) {
-            view.showStudentAnnotationView("www.instructure.com")
+            view.showStudentAnnotationView(assignment)
         }
         confirmVerified(view)
     }
@@ -883,11 +883,12 @@ class AssignmentDetailsEffectHandlerTest : Assert() {
     @Test
     fun `ShowCreateSubmissionView with mediaRecording submissionType calls showMediaRecordingView`() {
         val submissionType = Assignment.SubmissionType.MEDIA_RECORDING
+        val assignmentWithStudentAnnotation = assignment.copy(annotatableAttachmentId = 123L)
 
-        connection.accept(AssignmentDetailsEffect.ShowCreateSubmissionView(submissionType, course, assignment))
+        connection.accept(AssignmentDetailsEffect.ShowCreateSubmissionView(submissionType, course, assignmentWithStudentAnnotation))
 
         verify(timeout = 100) {
-            view.showMediaRecordingView(assignment)
+            view.showMediaRecordingView(assignmentWithStudentAnnotation)
         }
         confirmVerified(view)
     }

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsPresenterTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsPresenterTest.kt
@@ -580,7 +580,8 @@ class AssignmentDetailsPresenterTest : Assert() {
             userId = 0,
             currentFile = 0,
             fileCount = 0,
-            progress = null
+            progress = null,
+            annotatableAttachmentId = null
         )
         val assignment = baseAssignment.copy(
             submission = baseSubmission.copy(
@@ -611,7 +612,8 @@ class AssignmentDetailsPresenterTest : Assert() {
             userId = 0,
             currentFile = 0,
             fileCount = 0,
-            progress = null
+            progress = null,
+            annotatableAttachmentId = null
         )
         val assignment = baseAssignment.copy(
             submission = baseSubmission.copy(
@@ -639,7 +641,8 @@ class AssignmentDetailsPresenterTest : Assert() {
             userId = 0,
             currentFile = 0,
             fileCount = 0,
-            progress = null
+            progress = null,
+            annotatableAttachmentId = null
         )
         val assignment = baseAssignment.copy(
             submission = baseSubmission.copy(
@@ -667,7 +670,8 @@ class AssignmentDetailsPresenterTest : Assert() {
             userId = 0,
             currentFile = 0,
             fileCount = 0,
-            progress = null
+            progress = null,
+            annotatableAttachmentId = null
         )
         val model = baseModel.copy(
             assignmentResult = DataResult.Success(baseAssignment),
@@ -692,7 +696,8 @@ class AssignmentDetailsPresenterTest : Assert() {
             userId = 0,
             currentFile = 0,
             fileCount = 0,
-            progress = null
+            progress = null,
+            annotatableAttachmentId = null
         )
         val model = baseModel.copy(
             assignmentResult = DataResult.Success(baseAssignment),

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsUpdateTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsUpdateTest.kt
@@ -81,7 +81,8 @@ class AssignmentDetailsUpdateTest : Assert() {
             userId = userId,
             currentFile = 0,
             fileCount = 0,
-            progress = null
+            progress = null,
+            annotatableAttachmentId = null
         )
     }
 

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/submissionDetails/SubmissionDetailsEmptyContentEffectHandlerTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/submissionDetails/SubmissionDetailsEmptyContentEffectHandlerTest.kt
@@ -369,12 +369,12 @@ class SubmissionDetailsEmptyContentEffectHandlerTest : Assert() {
     @Test
     fun `ShowCreateSubmissionView with student annotation submissionType shows student annotation view`() {
         val submissionType = Assignment.SubmissionType.STUDENT_ANNOTATION
-        assignment = assignment.copy(htmlUrl = "www.instructure.com")
+        val assignmentWithStudentAnnotation = assignment.copy(annotatableAttachmentId = 123L)
 
-        connection.accept(SubmissionDetailsEmptyContentEffect.ShowCreateSubmissionView(submissionType, course, assignment))
+        connection.accept(SubmissionDetailsEmptyContentEffect.ShowCreateSubmissionView(submissionType, course, assignmentWithStudentAnnotation))
 
         verify(timeout = 100) {
-            view.showStudentAnnotationView("www.instructure.com")
+            view.showStudentAnnotationView(assignmentWithStudentAnnotation)
         }
         confirmVerified(view)
     }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CanvaDocsAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CanvaDocsAPI.kt
@@ -22,15 +22,12 @@ import com.instructure.canvasapi2.builders.RestParams
 import com.instructure.canvasapi2.models.canvadocs.CanvaDocAnnotation
 import com.instructure.canvasapi2.models.canvadocs.CanvaDocAnnotationResponse
 import com.instructure.canvasapi2.models.DocSession
+import com.instructure.canvasapi2.models.canvadocs.CanvaDocSessionRequestBody
+import com.instructure.canvasapi2.models.canvadocs.CanvaDocSessionResponseBody
 
 import okhttp3.ResponseBody
 import retrofit2.Call
-import retrofit2.http.Body
-import retrofit2.http.DELETE
-import retrofit2.http.GET
-import retrofit2.http.PUT
-import retrofit2.http.Path
-import retrofit2.http.Url
+import retrofit2.http.*
 
 object CanvaDocsAPI {
 
@@ -46,6 +43,9 @@ object CanvaDocsAPI {
 
         @DELETE("/1/sessions/{sessionId}/annotations/{annotationId}")
         fun deleteAnnotation(@Path("sessionId") sessionId: String, @Path("annotationId") annotationId: String): Call<ResponseBody>
+
+        @POST("canvadoc_session")
+        fun createCanvaDocSession(@Body body: CanvaDocSessionRequestBody): Call<CanvaDocSessionResponseBody>
     }
 
     fun getCanvaDoc(
@@ -81,5 +81,13 @@ object CanvaDocsAPI {
             params: RestParams,
             callback: StatusCallback<ResponseBody>) {
         callback.addCall(adapter.build(CanvaDocsInterFace::class.java, params).deleteAnnotation(sessionId, annotationId)).enqueue(callback)
+    }
+
+    fun createCanvaDocSession(
+        body: CanvaDocSessionRequestBody,
+        adapter: RestBuilder,
+        params: RestParams,
+        callback: StatusCallback<CanvaDocSessionResponseBody>) {
+        callback.addCall(adapter.build(CanvaDocsInterFace::class.java, params).createCanvaDocSession(body)).enqueue(callback)
     }
 }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/SubmissionAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/SubmissionAPI.kt
@@ -20,10 +20,7 @@ package com.instructure.canvasapi2.apis
 import com.instructure.canvasapi2.StatusCallback
 import com.instructure.canvasapi2.builders.RestBuilder
 import com.instructure.canvasapi2.builders.RestParams
-import com.instructure.canvasapi2.models.LTITool
-import com.instructure.canvasapi2.models.RubricCriterionAssessment
-import com.instructure.canvasapi2.models.Submission
-import com.instructure.canvasapi2.models.SubmissionSummary
+import com.instructure.canvasapi2.models.*
 import retrofit2.Call
 import retrofit2.http.*
 
@@ -108,6 +105,14 @@ object SubmissionAPI {
                 @Query("submission[submission_type]") submissionType: String,
                 @Query("submission[file_ids][]") attachments: List<Long>): Call<Submission>
 
+        @POST("{contextId}/assignments/{assignmentId}/submissions")
+        fun postStudentAnnotationSubmission(
+            @Path("contextId") contextId: Long,
+            @Path("assignmentId") assignmentId: Long,
+            @Field("submission_type") submissionType: String,
+            @Field("annotatable_attachment_id") annotatableAttachmentId: Long
+        ): Call<Submission>
+
         @GET
         fun getLtiFromAuthenticationUrl(@Url url: String): Call<LTITool>
 
@@ -186,6 +191,24 @@ object SubmissionAPI {
         } catch (e: Exception) {
             null
         }
+    }
+
+    fun postStudentAnnotationSubmission(
+        canvasContextId: Long,
+        assignmentId: Long,
+        annotatableAttachmentId: Long,
+        adapter: RestBuilder,
+        params: RestParams,
+        callback: StatusCallback<Submission>
+    ) {
+        callback.addCall(
+            adapter.build(SubmissionInterface::class.java, params).postStudentAnnotationSubmission(
+                canvasContextId,
+                assignmentId,
+                Assignment.SubmissionType.STUDENT_ANNOTATION.apiString,
+                annotatableAttachmentId
+            )
+        ).enqueue(callback)
     }
 
     private fun generateRubricAssessmentQueryMap(rubricAssessment: Map<String, RubricCriterionAssessment>): Map<String, String> {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/SubmissionAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/SubmissionAPI.kt
@@ -105,12 +105,13 @@ object SubmissionAPI {
                 @Query("submission[submission_type]") submissionType: String,
                 @Query("submission[file_ids][]") attachments: List<Long>): Call<Submission>
 
+        @FormUrlEncoded
         @POST("{contextId}/assignments/{assignmentId}/submissions")
         fun postStudentAnnotationSubmission(
             @Path("contextId") contextId: Long,
             @Path("assignmentId") assignmentId: Long,
-            @Field("submission_type") submissionType: String,
-            @Field("annotatable_attachment_id") annotatableAttachmentId: Long
+            @Field("submission[submission_type]") submissionType: String,
+            @Field("submission[annotatable_attachment_id]") annotatableAttachmentId: Long
         ): Call<Submission>
 
         @GET

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/di/ApiModule.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/di/ApiModule.kt
@@ -76,6 +76,11 @@ object ApiModule {
     }
 
     @Provides
+    fun provideCanvaDocsManager(): CanvaDocsManager {
+        return CanvaDocsManager
+    }
+
+    @Provides
     @Singleton
     fun provideHelpLinksApi(): HelpLinksAPI {
         return HelpLinksAPI

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/CanvaDocsManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/CanvaDocsManager.kt
@@ -69,11 +69,11 @@ object CanvaDocsManager {
         CanvaDocsAPI.deleteAnnotation(sessionId, annotationId, adapter, params, callback)
     }
 
-    fun createCanvaDocSessionAsync(submissionId: Long, attempt: Long) = apiAsync<CanvaDocSessionResponseBody> { createCanvaDocSession(submissionId, attempt, it) }
+    fun createCanvaDocSessionAsync(submissionId: Long, attempt: String) = apiAsync<CanvaDocSessionResponseBody> { createCanvaDocSession(submissionId, attempt, it) }
 
     private fun createCanvaDocSession(
         submissionId: Long,
-        attempt: Long,
+        attempt: String,
         callback: StatusCallback<CanvaDocSessionResponseBody>
     ) {
         val adapter = RestBuilder(callback)
@@ -81,7 +81,7 @@ object CanvaDocsManager {
         CanvaDocsAPI.createCanvaDocSession(
             CanvaDocSessionRequestBody(
                 submissionId.toString(),
-                attempt.toString()
+                attempt
             ), adapter, params, callback
         )
     }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/CanvaDocsManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/CanvaDocsManager.kt
@@ -22,7 +22,10 @@ import com.instructure.canvasapi2.builders.RestParams
 import com.instructure.canvasapi2.models.DocSession
 import com.instructure.canvasapi2.models.canvadocs.CanvaDocAnnotation
 import com.instructure.canvasapi2.models.canvadocs.CanvaDocAnnotationResponse
+import com.instructure.canvasapi2.models.canvadocs.CanvaDocSessionRequestBody
+import com.instructure.canvasapi2.models.canvadocs.CanvaDocSessionResponseBody
 import com.instructure.canvasapi2.utils.ApiPrefs
+import com.instructure.canvasapi2.utils.weave.apiAsync
 import okhttp3.ResponseBody
 
 object CanvaDocsManager {
@@ -66,4 +69,20 @@ object CanvaDocsManager {
         CanvaDocsAPI.deleteAnnotation(sessionId, annotationId, adapter, params, callback)
     }
 
+    fun createCanvaDocSessionAsync(submissionId: Long, attempt: Long) = apiAsync<CanvaDocSessionResponseBody> { createCanvaDocSession(submissionId, attempt, it) }
+
+    private fun createCanvaDocSession(
+        submissionId: Long,
+        attempt: Long,
+        callback: StatusCallback<CanvaDocSessionResponseBody>
+    ) {
+        val adapter = RestBuilder(callback)
+        val params = RestParams(domain = ApiPrefs.fullDomain)
+        CanvaDocsAPI.createCanvaDocSession(
+            CanvaDocSessionRequestBody(
+                submissionId.toString(),
+                attempt.toString()
+            ), adapter, params, callback
+        )
+    }
 }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/SubmissionManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/SubmissionManager.kt
@@ -266,4 +266,31 @@ object SubmissionManager {
         )
     }
 
+    fun postStudentAnnotationSubmissionAsync(
+        canvasContext: CanvasContext,
+        assignmentId: Long,
+        annotatableAttachmentId: Long
+    ) = apiAsync<Submission> {
+        postStudentAnnotationSubmission(canvasContext, assignmentId, annotatableAttachmentId, it)
+    }
+
+    private fun postStudentAnnotationSubmission(
+        canvasContext: CanvasContext,
+        assignmentId: Long,
+        annotatableAttachmentId: Long,
+        callback: StatusCallback<Submission>
+    ) {
+        val adapter = RestBuilder(callback)
+        val params = RestParams(canvasContext = canvasContext)
+
+        SubmissionAPI.postStudentAnnotationSubmission(
+            canvasContext.id,
+            assignmentId,
+            annotatableAttachmentId,
+            adapter,
+            params,
+            callback
+        )
+    }
+
 }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Assignment.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Assignment.kt
@@ -105,7 +105,9 @@ data class Assignment(
         val plannerOverride: PlannerOverride? = null,
         var isStudioEnabled: Boolean = false,
         @SerializedName("in_closed_grading_period")
-        val inClosedGradingPeriod: Boolean = false
+        val inClosedGradingPeriod: Boolean = false,
+        @SerializedName("annotatable_attachment_id")
+        val annotatableAttachmentId: Long = 0
 ) : CanvasModel<Assignment>() {
     override val comparisonDate get() = dueDate
     override val comparisonString get() = dueAt

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/canvadocs/CanvaDocSession.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/canvadocs/CanvaDocSession.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2021 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.canvasapi2.models.canvadocs
+
+import com.google.gson.annotations.SerializedName
+
+data class CanvaDocSessionRequestBody(
+    @SerializedName("submission_id")
+    val submussionId: String,
+    @SerializedName("submission_attempt")
+    val submissionAttempt: String
+)
+
+data class CanvaDocSessionResponseBody(
+    @SerializedName("annotation_context_launch_id")
+    val annotationContextLaunchId: String? = null,
+    @SerializedName("canvadocs_session_url")
+    val canvadocsSessionUrl: String? = null
+)

--- a/libs/pandares/src/main/res/values-ar/strings.xml
+++ b/libs/pandares/src/main/res/values-ar/strings.xml
@@ -1269,9 +1269,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">استجابات هذا الطالب مخفية لأن هذه المهمة مجهولة الاسم.</string>
 
-    <string name="studentAnnotationUnsupported">التعليق التوضيحي للطالب (غير مدعوم)</string>
-    <string name="studentAnnotationUnsupportedDescription">التعليق التوضيحي للطالب غير مدعوم حاليًا على الأجهزة المحمولة.</string>
-    <string name="unsupportedSubmissionType">نوع إرسال غير مدعوم</string>
-    <string name="studentAnnotationUnsupportedMessage">لا يمكن عرض الإرسال، لأن التعليق التوضيحي للطالب غير مدعوم حاليًا على الأجهزة المحمولة.</string>
     <string name="schedule_marked_as_done">قمت بتمييزه بأنه تم.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-b+da+instk12/strings.xml
+++ b/libs/pandares/src/main/res/values-b+da+instk12/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">Elevens svar er skjult, fordi denne opgave er anonym.</string>
 
-    <string name="studentAnnotationUnsupported">Elevers anmærkninger (ikke understøttet)</string>
-    <string name="studentAnnotationUnsupportedDescription">Elevers anmærkninger understøttes i øjeblikket ikke på mobil.</string>
-    <string name="unsupportedSubmissionType">Ikke-understøttet afleveringsform</string>
-    <string name="studentAnnotationUnsupportedMessage">Aflevering kan ikke vises, fordi elevers anmærkninger i øjeblikket ikke understøttes på mobil.</string>
     <string name="schedule_marked_as_done">Du har markeret det som udført.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-b+en+AU+unimelb/strings.xml
+++ b/libs/pandares/src/main/res/values-b+en+AU+unimelb/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">This student\'s responses are hidden because this assignment is anonymous.</string>
 
-    <string name="studentAnnotationUnsupported">Student Annotation (Unsupported)</string>
-    <string name="studentAnnotationUnsupportedDescription">Student Annotation is currently not supported on mobile.</string>
-    <string name="unsupportedSubmissionType">Unsupported Submission Type</string>
-    <string name="studentAnnotationUnsupportedMessage">Submission cannot be displayed, because Student Annotation is currently not supported on mobile.</string>
     <string name="schedule_marked_as_done">You\'ve marked it as done.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-b+nb+instk12/strings.xml
+++ b/libs/pandares/src/main/res/values-b+nb+instk12/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">Denne elevens svar er skjult fordi denne oppgaven er anonym.</string>
 
-    <string name="studentAnnotationUnsupported">Elevmerknad (ikke støttet)</string>
-    <string name="studentAnnotationUnsupportedDescription">Elevmerknader støttes for øyeblikket ikke på mobil.</string>
-    <string name="unsupportedSubmissionType">Ustøttet innleveringstype</string>
-    <string name="studentAnnotationUnsupportedMessage">Innlevering kan ikke vises fordi Elevmerknader for øyeblikket ikke støttes på mobil.</string>
     <string name="schedule_marked_as_done">Du har merket det som fullført.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-b+sv+instk12/strings.xml
+++ b/libs/pandares/src/main/res/values-b+sv+instk12/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">Den här elevens svar är dolda eftersom uppgiften är anonym.</string>
 
-    <string name="studentAnnotationUnsupported">Elevnotering (stöds inte)</string>
-    <string name="studentAnnotationUnsupportedDescription">Elevnotering stöds för närvarande inte på mobila enheter.</string>
-    <string name="unsupportedSubmissionType">Inlämningstyp som inte stöds</string>
-    <string name="studentAnnotationUnsupportedMessage">Inlämningen kan inte visas eftersom elevnotering inte stöds på mobila enheter.</string>
     <string name="schedule_marked_as_done">Du har markerat den som färdig.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-ca/strings.xml
+++ b/libs/pandares/src/main/res/values-ca/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">Les respostes d\'aquest estudiant estan amagades perquè la tasca és anònima.</string>
 
-    <string name="studentAnnotationUnsupported">Anotació de l’estudiant (no admesa)</string>
-    <string name="studentAnnotationUnsupportedDescription">En aquest moment, no s\'admet l’anotació de l\'estudiant al dispositiu mòbil.</string>
-    <string name="unsupportedSubmissionType">Tipus de entrega no admès</string>
-    <string name="studentAnnotationUnsupportedMessage">No es pot mostrar l’entrega, perquè en aquest moment no s\'admet l’anotació de l\'estudiant al dispositiu mòbil.</string>
     <string name="schedule_marked_as_done">L’heu marcat com a fet.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-cy/strings.xml
+++ b/libs/pandares/src/main/res/values-cy/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">Mae atebion y myfyriwr hwn wedi’u cuddio gan fod yr aseiniad hwn yn ddienw.</string>
 
-    <string name="studentAnnotationUnsupported">Anodiad gan Fyfyriwr (Anghydnaws)</string>
-    <string name="studentAnnotationUnsupportedDescription">Does dim modd delio ag anodiadau gan fyfyrwyr ar ddyfeisiau symudol ar hyn o bryd.</string>
-    <string name="unsupportedSubmissionType">Math o Gyflwyniad Anghydnaws</string>
-    <string name="studentAnnotationUnsupportedMessage">Does dim modd dangos y cyflwyniad, oherwydd does dim modd delio ag anodiadau gan fyfyrwyr ar ddyfeisiau symudol ar hyn o bryd.</string>
     <string name="schedule_marked_as_done">Rydych chi wedi’i farcio fel wedi’i orffen.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-da/strings.xml
+++ b/libs/pandares/src/main/res/values-da/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">Den studerendes svar er skjult, fordi denne opgave er anonym.</string>
 
-    <string name="studentAnnotationUnsupported">Studerendes anmærkninger (ikke understøttet)</string>
-    <string name="studentAnnotationUnsupportedDescription">Studerendes anmærkninger understøttes i øjeblikket ikke på mobil.</string>
-    <string name="unsupportedSubmissionType">Ikke-understøttet afleveringsform</string>
-    <string name="studentAnnotationUnsupportedMessage">Aflevering kan ikke vises, fordi studerendes anmærkninger i øjeblikket ikke understøttes på mobil.</string>
     <string name="schedule_marked_as_done">Du har markeret det som udført.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-de/strings.xml
+++ b/libs/pandares/src/main/res/values-de/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">Die Antworten dieses Studenten sind ausgeblendet, weil diese Aufgabe anonym ist.</string>
 
-    <string name="studentAnnotationUnsupported">Studentenanmerkung (Nicht unterstützt)</string>
-    <string name="studentAnnotationUnsupportedDescription">Studentenanmerkungen werden derzeit auf Mobilgeräten nicht unterstützt.</string>
-    <string name="unsupportedSubmissionType">Nicht unterstützte Abgabeart</string>
-    <string name="studentAnnotationUnsupportedMessage">Abgabe kann nicht angezeigt werden, weil Studentenanmerkungen derzeit auf Mobilgeräten nicht unterstützt werden.</string>
     <string name="schedule_marked_as_done">Sie haben es es als erledigt markiert.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-en-rAU/strings.xml
+++ b/libs/pandares/src/main/res/values-en-rAU/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">This student\'s responses are hidden because this assignment is anonymous.</string>
 
-    <string name="studentAnnotationUnsupported">Student Annotation (Unsupported)</string>
-    <string name="studentAnnotationUnsupportedDescription">Student Annotation is currently not supported on mobile.</string>
-    <string name="unsupportedSubmissionType">Unsupported Submission Type</string>
-    <string name="studentAnnotationUnsupportedMessage">Submission cannot be displayed, because Student Annotation is currently not supported on mobile.</string>
     <string name="schedule_marked_as_done">You\'ve marked it as done.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-en-rCA/strings.xml
+++ b/libs/pandares/src/main/res/values-en-rCA/strings.xml
@@ -1215,9 +1215,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">This student\'s responses are hidden because this assignment is anonymous.</string>
 
-    <string name="studentAnnotationUnsupported">Student Annotation (Unsupported)</string>
-    <string name="studentAnnotationUnsupportedDescription">Student Annotation is currently not supported on mobile.</string>
-    <string name="unsupportedSubmissionType">Unsupported Submission Type</string>
-    <string name="studentAnnotationUnsupportedMessage">Submission cannot be displayed, because Student Annotation is currently not supported on mobile.</string>
     <string name="schedule_marked_as_done">You\'ve marked it as done.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-en-rCY/strings.xml
+++ b/libs/pandares/src/main/res/values-en-rCY/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">This student\'s responses are hidden because this assignment is anonymous.</string>
 
-    <string name="studentAnnotationUnsupported">Student Annotation (Unsupported)</string>
-    <string name="studentAnnotationUnsupportedDescription">Student Annotation is currently not supported on mobile.</string>
-    <string name="unsupportedSubmissionType">Unsupported Submission Type</string>
-    <string name="studentAnnotationUnsupportedMessage">Submission cannot be displayed, because Student Annotation is currently not supported on mobile.</string>
     <string name="schedule_marked_as_done">You\'ve marked it as done.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-en-rGB/strings.xml
+++ b/libs/pandares/src/main/res/values-en-rGB/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">This student\'s responses are hidden because this assignment is anonymous.</string>
 
-    <string name="studentAnnotationUnsupported">Student Annotation (Unsupported)</string>
-    <string name="studentAnnotationUnsupportedDescription">Student Annotation is currently not supported on mobile.</string>
-    <string name="unsupportedSubmissionType">Unsupported Submission Type</string>
-    <string name="studentAnnotationUnsupportedMessage">Submission cannot be displayed, because Student Annotation is currently not supported on mobile.</string>
     <string name="schedule_marked_as_done">You\'ve marked it as done.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-es/strings.xml
+++ b/libs/pandares/src/main/res/values-es/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">Las respuestas del estudiante están ocultas porque esta tarea es anónima.</string>
 
-    <string name="studentAnnotationUnsupported">Anotación del estudiante (no admitida)</string>
-    <string name="studentAnnotationUnsupportedDescription">La anotación del estudiante actualmente no se admite en el móvil.</string>
-    <string name="unsupportedSubmissionType">Tipo de entrega no admitida</string>
-    <string name="studentAnnotationUnsupportedMessage">La entrega no se puede mostrar porque la Anotación del estudiante actualmente no se admite en el móvil.</string>
     <string name="schedule_marked_as_done">Lo marcó como terminado.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-fi/strings.xml
+++ b/libs/pandares/src/main/res/values-fi/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">Tämän opiskelijan vastaukset on kätketty, koska tehtävä on nimetön.</string>
 
-    <string name="studentAnnotationUnsupported">Opiskelijan huomautusasiakirjat (tukematon)</string>
-    <string name="studentAnnotationUnsupportedDescription">Opiskelijan huomautuksia ei tällä hetkellä tueta matkapuhelimessa.</string>
-    <string name="unsupportedSubmissionType">Lähetystyyppiä ei tueta</string>
-    <string name="studentAnnotationUnsupportedMessage">Lähetystä ei voida näyttää, koska opiskelijan huomautuksia ei tällä hetkellä tueta matkapuhelimessa.</string>
     <string name="schedule_marked_as_done">Olet merkinnyt sen tehdyksi.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-fr-rCA/strings.xml
+++ b/libs/pandares/src/main/res/values-fr-rCA/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">Les réponses de cet étudiant sont masquées du fait que cette tâche est anonyme.</string>
 
-    <string name="studentAnnotationUnsupported">Annotation d’étudiant (non pris en charge)</string>
-    <string name="studentAnnotationUnsupportedDescription">L’annotation d’étudiant n’est actuellement pas prise en charge sur les mobiles.</string>
-    <string name="unsupportedSubmissionType">Type d’envoi non pris en charge</string>
-    <string name="studentAnnotationUnsupportedMessage">L’envoi ne peut pas être affiché, car l’annotation d’étudiant n’est actuellement pas prise en charge sur mobile.</string>
     <string name="schedule_marked_as_done">Vous l’avez marqué comme terminé.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-fr/strings.xml
+++ b/libs/pandares/src/main/res/values-fr/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">Les réponses de cet élève sont masquées car ce travail est anonyme.</string>
 
-    <string name="studentAnnotationUnsupported">Annotation de l\'élève (non prise en charge)</string>
-    <string name="studentAnnotationUnsupportedDescription">L\'annotation des élèves n\'est actuellement pas prise en charge sur les téléphones mobiles.</string>
-    <string name="unsupportedSubmissionType">Type de soumission non pris en charge</string>
-    <string name="studentAnnotationUnsupportedMessage">La soumission ne peut pas être affichée, car l\'annotation de l\'élève n\'est actuellement pas prise en charge sur les téléphones mobiles.</string>
     <string name="schedule_marked_as_done">Vous avez tout indiqué comme terminé.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-ht/strings.xml
+++ b/libs/pandares/src/main/res/values-ht/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">Repons elèv sa a kache paske devwa sa a anonim.</string>
 
-    <string name="studentAnnotationUnsupported">Nòt Elèv (Pa sipòte)</string>
-    <string name="studentAnnotationUnsupportedDescription">Nòt Elèv yo pa disponib sou mobil.</string>
-    <string name="unsupportedSubmissionType">Tip Soumisyon Pa Sipòte</string>
-    <string name="studentAnnotationUnsupportedMessage">Soumisyon an pa kapab afiche paske Nòt Elèv yo pa disponib sou mobil.</string>
     <string name="schedule_marked_as_done">Ou te make li konplè.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-is/strings.xml
+++ b/libs/pandares/src/main/res/values-is/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">Svör nemanda eru falin því þetta verkefni er nafnlaust.</string>
 
-    <string name="studentAnnotationUnsupported">Athugasemd nemanda (Enginn stuðningur)</string>
-    <string name="studentAnnotationUnsupportedDescription">Ekki er stuðningur við athugasemd nemanda á farsímum.</string>
-    <string name="unsupportedSubmissionType">Gerð skila ekki studd</string>
-    <string name="studentAnnotationUnsupportedMessage">Ekki hægt að birta skil því ekki er stuðningur við athugasemd nemanda á farsímum.</string>
     <string name="schedule_marked_as_done">Þú hefur merkt þetta sem lokið.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-it/strings.xml
+++ b/libs/pandares/src/main/res/values-it/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">Le risposte di questo studente sono nascoste perché questo compito è anonimo.</string>
 
-    <string name="studentAnnotationUnsupported">Annotazione studente (non supportata)</string>
-    <string name="studentAnnotationUnsupportedDescription">L’annotazione studente non è attualmente supportata sui dispositivi mobili.</string>
-    <string name="unsupportedSubmissionType">Tipo di consegna non supportato</string>
-    <string name="studentAnnotationUnsupportedMessage">Impossibile visualizzare consegna perché l’annotazione studente non è attualmente supportata sui dispositivi mobili.</string>
     <string name="schedule_marked_as_done">È stato contrassegnato come fatto.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-ja/strings.xml
+++ b/libs/pandares/src/main/res/values-ja/strings.xml
@@ -1200,9 +1200,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">この課題は匿名であるため、この学生の応答は表示されません。</string>
 
-    <string name="studentAnnotationUnsupported">学生の注釈（サポートされていません）</string>
-    <string name="studentAnnotationUnsupportedDescription">現在、学生の注釈はモバイルではサポートされていません。</string>
-    <string name="unsupportedSubmissionType">サポートされていない提出タイプ</string>
-    <string name="studentAnnotationUnsupportedMessage">現在、学生の注釈はモバイルでサポートされていないため、提出物を表示できません。</string>
     <string name="schedule_marked_as_done">「終了」としてマークしました。</string>
 </resources>

--- a/libs/pandares/src/main/res/values-mi/strings.xml
+++ b/libs/pandares/src/main/res/values-mi/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">Kei te hunahia ngā whakautu a tēnei ākonga no te mea he ingoamuna tēnei whakataunga.</string>
 
-    <string name="studentAnnotationUnsupported">Ākonga Tuhipoka (Kaore e tautokotia)</string>
-    <string name="studentAnnotationUnsupportedDescription">Ākonga Tuhipoka kaore i te tautokotia i tēnei wā i runga i te waea haerere.</string>
-    <string name="unsupportedSubmissionType">Kaore i Tautokotia tēnei Momo Tapaetanga</string>
-    <string name="studentAnnotationUnsupportedMessage">Kaore e taea te whakaatu atu i te tāpaetanga no te mea Ākonga Tuhipoka kaore i te tautokotia i tēnei wā i runga i te waea haerere.</string>
     <string name="schedule_marked_as_done">Kua tohua e koe kua oti.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-nb/strings.xml
+++ b/libs/pandares/src/main/res/values-nb/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">Denne studentens svar er skjult fordi denne oppgaven er anonym.</string>
 
-    <string name="studentAnnotationUnsupported">Studentmerknad (ikke støttet)</string>
-    <string name="studentAnnotationUnsupportedDescription">Studentmerknader støttes for øyeblikket ikke på mobil.</string>
-    <string name="unsupportedSubmissionType">Ustøttet innleveringstype</string>
-    <string name="studentAnnotationUnsupportedMessage">Innlevering kan ikke vises fordi Studentmerknader for øyeblikket ikke støttes på mobil.</string>
     <string name="schedule_marked_as_done">Du har merket det som fullført.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-nl/strings.xml
+++ b/libs/pandares/src/main/res/values-nl/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">De antwoorden van deze cursist zijn verborgen omdat deze opdracht anoniem is.</string>
 
-    <string name="studentAnnotationUnsupported">Cursistaantekening (niet ondersteund)</string>
-    <string name="studentAnnotationUnsupportedDescription">Cursistaantekening wordt momenteel niet ondersteund op mobiel apparaat.</string>
-    <string name="unsupportedSubmissionType">Niet-ondersteund inleveringstype</string>
-    <string name="studentAnnotationUnsupportedMessage">Inlevering kan niet worden weergegeven omdat cursistaantekening momenteel niet wordt ondersteund op mobiel apparaat.</string>
     <string name="schedule_marked_as_done">Je hebt het als klaar gemarkeerd.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-pl/strings.xml
+++ b/libs/pandares/src/main/res/values-pl/strings.xml
@@ -1242,9 +1242,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">Odpowiedzi tego uczestnika są ukryte, ponieważ to zadanie jest anonimowe.</string>
 
-    <string name="studentAnnotationUnsupported">Adnotacja uczestnika (nieobsługiwana)</string>
-    <string name="studentAnnotationUnsupportedDescription">Adnotacja uczestnika nie jest obecnie obsługiwana na urządzeniach przenośnych.</string>
-    <string name="unsupportedSubmissionType">Nieobsługiwany typ zgłoszenia</string>
-    <string name="studentAnnotationUnsupportedMessage">Przesyłki nie można wyświetlić, ponieważ Adnotacja uczestnika nie jest obecnie obsługiwana na urządzeniach przenośnych.</string>
     <string name="schedule_marked_as_done">Oznaczono je jako gotowe.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-pt-rBR/strings.xml
+++ b/libs/pandares/src/main/res/values-pt-rBR/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">As respostas deste aluno estão ocultas porque esta tarefa é anônima.</string>
 
-    <string name="studentAnnotationUnsupported">Anotação do aluno (não compatível)</string>
-    <string name="studentAnnotationUnsupportedDescription">Atualmente, a anotação do aluno não é compatível com dispositivos móveis.</string>
-    <string name="unsupportedSubmissionType">Tipo de envio não suportado</string>
-    <string name="studentAnnotationUnsupportedMessage">O envio não pode ser exibido, porque a Anotação do Aluno não é compatível com dispositivos móveis.</string>
     <string name="schedule_marked_as_done">Você marcou como concluído.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-pt-rPT/strings.xml
+++ b/libs/pandares/src/main/res/values-pt-rPT/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">As respostas deste aluno são ocultas porque esta tarefa é anónima.</string>
 
-    <string name="studentAnnotationUnsupported">Anotação do aluno (Sem suporte)</string>
-    <string name="studentAnnotationUnsupportedDescription">A anotação do aluno não é actualmente suportada em telemóvel.</string>
-    <string name="unsupportedSubmissionType">Tipo de apresentação não suportada</string>
-    <string name="studentAnnotationUnsupportedMessage">A submissão não pode ser exibida, porque a Anotação do aluno não é atualmente suportada em telemóvel.</string>
     <string name="schedule_marked_as_done">Marcou-o como feito.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-ru/strings.xml
+++ b/libs/pandares/src/main/res/values-ru/strings.xml
@@ -1242,9 +1242,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">Ответы студентов скрыты, поскольку это задание анонимно.</string>
 
-    <string name="studentAnnotationUnsupported">Аннотация учащегося (не поддерживается)</string>
-    <string name="studentAnnotationUnsupportedDescription">В настоящее время функция Аннотация учащегося не поддерживается на мобильных устройствах.</string>
-    <string name="unsupportedSubmissionType">Неподдерживаемый тип отправки</string>
-    <string name="studentAnnotationUnsupportedMessage">Невозможно отобразить отправку, так как Аннотация учащегося в настоящее время не поддерживается на мобильном устройстве.</string>
     <string name="schedule_marked_as_done">Вы отметили это как выполненное.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-sl/strings.xml
+++ b/libs/pandares/src/main/res/values-sl/strings.xml
@@ -1215,9 +1215,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">Odgovori tega študenta so skriti, ker je ta naloga anonimna.</string>
 
-    <string name="studentAnnotationUnsupported">Opomba študenta (ni podprto)</string>
-    <string name="studentAnnotationUnsupportedDescription">Opomba študenta v mobilnem prikazu trenutno ni podprta.</string>
-    <string name="unsupportedSubmissionType">Nepodprta vrsta oddaje</string>
-    <string name="studentAnnotationUnsupportedMessage">Oddaje ni mogoče prikazati, ker funkcija Opomba študenta v mobilnem prikazu trenutno ni podprta.</string>
     <string name="schedule_marked_as_done">To ste označili kot končano.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-sv/strings.xml
+++ b/libs/pandares/src/main/res/values-sv/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">Den här studentens svar är dolda eftersom uppgiften är anonym.</string>
 
-    <string name="studentAnnotationUnsupported">Studentnotering (stöds inte)</string>
-    <string name="studentAnnotationUnsupportedDescription">Studentnotering stöds för närvarande inte på mobila enheter.</string>
-    <string name="unsupportedSubmissionType">Inlämningstyp som inte stöds</string>
-    <string name="studentAnnotationUnsupportedMessage">Inlämningen kan inte visas eftersom studentnotering inte stöds på mobila enheter.</string>
     <string name="schedule_marked_as_done">Du har markerat den som färdig.</string>
 </resources>

--- a/libs/pandares/src/main/res/values-th/strings.xml
+++ b/libs/pandares/src/main/res/values-th/strings.xml
@@ -1214,9 +1214,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">การตอบกลับของผู้เรียนรายนี้ถูกซ่อนไว้เนื่องจากภารกิจไม่เปิดเผยตัว</string>
 
-    <string name="studentAnnotationUnsupported">หมายเหตุกำกับของผู้เรียน (ไม่รองรับ)</string>
-    <string name="studentAnnotationUnsupportedDescription">หมายเหตุกำกับของผู้เรียนปัจจุบันไม่รองรับสำหรับอุปกรณ์พกพา</string>
-    <string name="unsupportedSubmissionType">ประเภทการจัดส่งที่ไม่รองรับ</string>
-    <string name="studentAnnotationUnsupportedMessage">ไม่สามารถแสดงผลงานจัดส่งได้เนื่องจากหมายเหตุกำกับของผู้เรียนปัจจุบันไม่รองรับกับอุปกรณ์พกพา</string>
     <string name="schedule_marked_as_done">คุณกำกับว่าเสร็จสิ้นแล้ว</string>
 </resources>

--- a/libs/pandares/src/main/res/values-zh-rHK/strings.xml
+++ b/libs/pandares/src/main/res/values-zh-rHK/strings.xml
@@ -1200,9 +1200,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">這名學生的回覆已隱藏，因為此作業為匿名狀態。</string>
 
-    <string name="studentAnnotationUnsupported">學生註釋（不支援）</string>
-    <string name="studentAnnotationUnsupportedDescription">流動電話目前不支援學生註釋。</string>
-    <string name="unsupportedSubmissionType">不支援提交項目類型</string>
-    <string name="studentAnnotationUnsupportedMessage">提交項目無法顯示，因為流動電話目前不支援學生註釋。</string>
     <string name="schedule_marked_as_done">您已將其標示為完成。</string>
 </resources>

--- a/libs/pandares/src/main/res/values-zh/strings.xml
+++ b/libs/pandares/src/main/res/values-zh/strings.xml
@@ -1200,9 +1200,5 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">该学生的回答已隐藏，因为该作业已匿名。</string>
 
-    <string name="studentAnnotationUnsupported">学生注释（不支持）</string>
-    <string name="studentAnnotationUnsupportedDescription">目前在移动设备上不支持学生注释。</string>
-    <string name="unsupportedSubmissionType">不受支持的提交项类型</string>
-    <string name="studentAnnotationUnsupportedMessage">无法显示提交项，因为目前在移动设备上不支持学生注释。</string>
     <string name="schedule_marked_as_done">您已将其标记为“完成”。</string>
 </resources>

--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -1227,4 +1227,5 @@
 
     <string name="somethingWentWrong">Something went wrong</string>
     <string name="failedToLoadQuiz">Failed to load quiz</string>
+    <string name="failedToLoadSubmission">Failed to load submission</string>
 </resources>

--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -1228,4 +1228,6 @@
     <string name="somethingWentWrong">Something went wrong</string>
     <string name="failedToLoadQuiz">Failed to load quiz</string>
     <string name="failedToLoadSubmission">Failed to load submission</string>
+    <string name="studentAnnotationToolbarTitle">Student Annotation</string>
+    <string name="submissionTypeStudentAnnotation">Student Annotation</string>
 </resources>

--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -1215,10 +1215,6 @@
 
     <string name="speedGraderAnonymousSubmissionMessage">This student\'s responses are hidden because this assignment is anonymous.</string>
 
-    <string name="studentAnnotationUnsupported">Student Annotation (Unsupported)</string>
-    <string name="studentAnnotationUnsupportedDescription">Student Annotation is currently not supported on mobile.</string>
-    <string name="unsupportedSubmissionType">Unsupported Submission Type</string>
-    <string name="studentAnnotationUnsupportedMessage">Submission cannot be displayed, because Student Annotation is currently not supported on mobile.</string>
     <string name="schedule_marked_as_done">You\'ve marked it as done.</string>
     <string name="error_saving_assignment_closed_grading_period">Cannot change the due date when due in a closed grading period.</string>
     <string name="a11y_content_description_schedule_jump_to_today">Jump to Today</string>


### PR DESCRIPTION
Test plan:
- Verify that the student annotation submission type is working. If there are more submission type the user should see it as an option and selecting it will redirect to the submission screen. If it's the only submission type, the user should be redirected without showing the dialog.
- Verify that the student can view the already submitted student annotation submission, but cannot modify it.
- Verify that the student cannot modify teacher's annotations on a file upload submission.
- Test the DB schema migration. Install an older version of the app, then update the app with the build from this branch. Verify that the submissions db doesn't break.

refs: MBL-15400
affects: Student
release note: Added support for student annotation submission type