### PR TITLE
[MBL-15657][Teacher] C4E for Student View

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/activity/StudentViewStarterActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/StudentViewStarterActivity.kt
@@ -40,6 +40,7 @@ class StudentViewStarterActivity : AppCompatActivity() {
         val clientId = extras.getString(Const.CLIENT_ID, ApiPrefs.clientId)
         val clientSecret = extras.getString(Const.CLIENT_SECRET, ApiPrefs.clientSecret)
         val courseId = extras.getLong(Const.COURSE_ID)
+        val isElementary = extras.getBoolean(Const.IS_ELEMENTARY, false)
 
         MasqueradeHelper.startMasquerading(
             masqueradingUserId = -1, // This will be retrieved when we get the test user
@@ -48,7 +49,8 @@ class StudentViewStarterActivity : AppCompatActivity() {
             masqueradeToken = token,
             masqueradeClientId = clientId,
             masqueradeClientSecret = clientSecret,
-            courseId = courseId
+            courseId = courseId,
+            isElementary = isElementary
         )
     }
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/CourseBrowserFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/CourseBrowserFragment.kt
@@ -366,6 +366,7 @@ class CourseBrowserFragment : BaseSyncFragment<
             putExtra(Const.DOMAIN, ApiPrefs.domain)
             putExtra(Const.CLIENT_ID, ApiPrefs.clientId)
             putExtra(Const.CLIENT_SECRET, ApiPrefs.clientSecret)
+            putExtra(Const.IS_ELEMENTARY, ApiPrefs.user?.k5User ?: false)
             flags = Intent.FLAG_ACTIVITY_NEW_TASK
         }
 

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/MasqueradeHelper.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/MasqueradeHelper.kt
@@ -66,7 +66,8 @@ object MasqueradeHelper {
         masqueradeToken: String = "",
         masqueradeClientId: String = ApiPrefs.clientId,
         masqueradeClientSecret: String = ApiPrefs.clientSecret,
-        courseId: Long? = null) {
+        courseId: Long? = null,
+        isElementary: Boolean = false) {
         // Check to see if they're trying to switch domain as site admin, or masquerading as a test student from
         // a different domain
         if (!masqueradingDomain.isNullOrBlank()) {
@@ -81,6 +82,7 @@ object MasqueradeHelper {
             ApiPrefs.accessToken = masqueradeToken
             ApiPrefs.clientId = masqueradeClientId
             ApiPrefs.clientSecret = masqueradeClientSecret
+            ApiPrefs.canvasForElementary = isElementary
         }
 
         try {
@@ -135,8 +137,9 @@ object MasqueradeHelper {
         GlobalScope.launch {
             try {
                 val canvasForElementaryFlag = getCanvasForElementaryFlag()
-                startupIntent.putExtra("canvas_for_elementary", canvasForElementaryFlag)
+                startupIntent.putExtra("canvas_for_elementary", canvasForElementaryFlag || ApiPrefs.canvasForElementary)
             } catch (e: Exception) {
+                startupIntent.putExtra("canvas_for_elementary", ApiPrefs.canvasForElementary)
                 // No-op
             } finally {
                 // Delays process rebirth long enough for all the shared preferences to be saved and caches to be cleared.

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/Const.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/Const.kt
@@ -168,4 +168,5 @@ object Const {
     const val INTENT_ACTION_STUDENT_VIEW = "com.instructure.student.STUDENT_VIEW"
     const val CLIENT_ID = "clientId"
     const val CLIENT_SECRET = "clientSecret"
+    const val IS_ELEMENTARY = "isElementary"
 }


### PR DESCRIPTION
refs: MBL-15657
affects: Teacher
release note: Student view now opens Canvas for Elementary courses with the correct design.

test plan: You have to install both apps

1. Login with a C4E teacher -> When using student view the elementary dashboard and subject pages should be visible.
2. Login with a non-C4E teacher -> When using student view the original dashboard and subject pages should be visible.