### PR TITLE
[MBL-15719][Parent] Omit userId from enrolments call

### DIFF
--- a/apps/flutter_parent/lib/network/api/enrollments_api.dart
+++ b/apps/flutter_parent/lib/network/api/enrollments_api.dart
@@ -41,7 +41,7 @@ class EnrollmentsApi {
     final dio = canvasDio(forceRefresh: forceRefresh);
     final params = {
       'state': ['active', 'completed'], // current_and_concluded state not supported for observers
-      'user_id': studentId,
+      //'user_id': studentId, <-- add this back when the api is fixed
       if (gradingPeriodId?.isNotEmpty == true)
         'grading_period_id': gradingPeriodId,
     };

--- a/apps/flutter_parent/lib/screens/courses/details/course_details_model.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_details_model.dart
@@ -98,6 +98,8 @@ class CourseDetailsModel extends BaseModel {
     final enrollmentsFuture = _interactor()
         .loadEnrollmentsForGradingPeriod(courseId, student.id, _nextGradingPeriod?.id, forceRefresh: forceRefresh)
         ?.then((enrollments) {
+      enrollments = enrollments
+          .where((element) => element.userId == student.id).toList();
       return enrollments.length > 0 ? enrollments.first : null;
     })?.catchError((_) => null); // Some 'legacy' parents can't read grades for students, so catch and return null
 

--- a/apps/flutter_parent/test/screens/courses/course_details_model_test.dart
+++ b/apps/flutter_parent/test/screens/courses/course_details_model_test.dart
@@ -150,7 +150,8 @@ void main() {
       // Initial setup
       final termEnrollment = Enrollment((b) => b
         ..id = '10'
-        ..enrollmentState = 'active');
+        ..enrollmentState = 'active'
+        ..userId = _studentId);
       final gradingPeriods = [
         GradingPeriod((b) => b
           ..id = '123'

--- a/apps/flutter_parent/test/screens/courses/course_grades_screen_test.dart
+++ b/apps/flutter_parent/test/screens/courses/course_grades_screen_test.dart
@@ -325,7 +325,8 @@ void main() {
       ];
       final enrollment = Enrollment((b) => b
         ..enrollmentState = 'active'
-        ..grades = _mockGrade(currentScore: 1.2345));
+        ..grades = _mockGrade(currentScore: 1.2345)
+        ..userId = _studentId);
 
       final model = CourseDetailsModel(_student, _courseId);
       model.course = _mockCourse();
@@ -349,7 +350,8 @@ void main() {
       ];
       final enrollment = Enrollment((b) => b
         ..enrollmentState = 'active'
-        ..grades = _mockGrade(currentGrade: grade));
+        ..grades = _mockGrade(currentGrade: grade)
+        ..userId = _studentId);
       final model = CourseDetailsModel(_student, _courseId);
       model.course = _mockCourse();
       when(interactor.loadAssignmentGroups(_courseId, _studentId, null)).thenAnswer((_) async => groups);


### PR DESCRIPTION
refs: MBL-15719
affects: Parent
release note: Fixed a bug where total grades were not visible for past and future enrolments.

test plan: See ticket.