### PR TITLE
[MBL-15760] - Refactor, reorder k5 grades interaction tests and implement a new test case

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/GradesInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/GradesInteractionTest.kt
@@ -136,20 +136,6 @@ class GradesInteractionTest : StudentTest() {
         gradesPage.assertCourseShownWithGrades(notGradedCourse.name, "0%")
     }
 
-    @Test
-    @TestMetaData(Priority.P1, FeatureCategory.K5_DASHBOARD, TestCategory.INTERACTION)
-    fun testasdf() {
-        val data = createMockData(courseCount = 2, withGradingPeriods = true)
-        goToGradesTab(data)
-
-        gradesPage.assertSelectedGradingPeriod(gradesPage.getStringFromResource(R.string.currentGradingPeriod))
-        gradesPage.clickGradingPeriodSelector()
-
-        val gradingPeriod = data.courseGradingPeriods.values.first().first()
-        gradesPage.selectGradingPeriod(gradingPeriod.title!!)
-        gradesPage.assertSelectedGradingPeriod(gradingPeriod.title!!)
-    }
-
     private fun createMockData(
         courseCount: Int = 0,
         withGradingPeriods: Boolean = false,


### PR DESCRIPTION
refactor and reorder existing k5 grades interaction tests and implement a new test case.

refs: MBL-15760
affects: Student
release note: none
