### PR TITLE
[Student][MBL-15790] K5 modules routing

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/CourseModuleProgressionFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/CourseModuleProgressionFragment.kt
@@ -767,7 +767,7 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
                     putSerializable(MODULE_ITEMS, CourseModulesStore.moduleListItems)
                     putParcelableArrayList(MODULE_OBJECTS, CourseModulesStore.moduleObjects)
                 }
-                moduleItemId = route.queryParamsHash[RouterParams.MODULE_ITEM_ID] ?: ""
+                moduleItemId = route.queryParamsHash[RouterParams.MODULE_ITEM_ID] ?: route.paramsHash[RouterParams.MODULE_ITEM_ID] ?: ""
             } else null
 
             CourseModulesStore.moduleListItems = null
@@ -779,5 +779,6 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
         private fun validRoute(route: Route): Boolean = route.canvasContext != null
             && (CourseModulesStore.moduleObjects != null && CourseModulesStore.moduleListItems != null)
             || route.queryParamsHash.keys.any { it == RouterParams.MODULE_ITEM_ID }
+            || route.paramsHash.keys.any { it == RouterParams.MODULE_ITEM_ID }
     }
 }

--- a/apps/student/src/main/java/com/instructure/student/router/RouteMatcher.kt
+++ b/apps/student/src/main/java/com/instructure/student/router/RouteMatcher.kt
@@ -100,7 +100,7 @@ object RouteMatcher : BaseRouteMatcher() {
         } else {
             routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/modules"), ModuleListFragment::class.java))
         }
-        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/modules/items/:${RouterParams.MODULE_ITEM_ID}"), ModuleListFragment::class.java)) // Just route to modules list. API does not have a way to fetch a module item without knowing the module id (even though web canvas can do it)
+        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/modules/items/:${RouterParams.MODULE_ITEM_ID}"), ModuleListFragment::class.java, CourseModuleProgressionFragment::class.java))
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/modules/:${RouterParams.MODULE_ID}"), ModuleListFragment::class.java))
 
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/pages/:${RouterParams.PAGE_ID}"), ModuleListFragment::class.java, CourseModuleProgressionFragment::class.java, listOf(":${RouterParams.MODULE_ITEM_ID}")))


### PR DESCRIPTION
Test plan: Bug description in the ticket. Also smoke test module item opening from the standard modules page and module item opening from links.

refs: MBL-15790
affects: Student
release note: Fixed a bug where links from the elementary subject modules don't open.