### PR TITLE
[Parent][MBL-15747] Sent mail from course page only displays in inbox after refresh

### DIFF
--- a/apps/flutter_parent/lib/l10n/app_localizations.dart
+++ b/apps/flutter_parent/lib/l10n/app_localizations.dart
@@ -1657,4 +1657,7 @@ class AppLocalizations {
 
   String get lockedForUserTitle =>
       Intl.message('Locked', desc: 'title for locked alerts');
+
+  String get messageSent =>
+      Intl.message('Message sent', desc: 'confirmation message on the screen when the user succesfully sends a message');
 }

--- a/apps/flutter_parent/lib/network/utils/dio_config.dart
+++ b/apps/flutter_parent/lib/network/utils/dio_config.dart
@@ -202,7 +202,7 @@ class DioConfig {
     if (path == null) {
       return DioCacheManager(CacheConfig(baseUrl: baseUrl)).clearAll();
     } else {
-      return DioCacheManager(CacheConfig(baseUrl: baseUrl)).deleteByPrimaryKey(path);
+      return DioCacheManager(CacheConfig(baseUrl: baseUrl)).deleteByPrimaryKey(path, requestMethod: 'GET');
     }
   }
 }

--- a/apps/flutter_parent/lib/screens/inbox/create_conversation/create_conversation_screen.dart
+++ b/apps/flutter_parent/lib/screens/inbox/create_conversation/create_conversation_screen.dart
@@ -150,6 +150,8 @@ class _CreateConversationScreenState extends State<CreateConversationScreen> wit
       }
       await _interactor.createConversation(widget.courseId, recipientIds, _subjectText, _bodyText, attachmentIds);
       Navigator.of(context).pop(true); // 'true' indicates upload was successful
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(L10n(context).messageSent)));
     } catch (e) {
       setState(() => _sending = false);
       _scaffoldKey.currentState.showSnackBar(


### PR DESCRIPTION
Test plan: in the ticket

refs: MBL-15747
affects: Parent
release note: Fixed a bug where inbox wouldn't update after sending a message.