### PR TITLE
[MBL-15769][Student] Messages won't update after reply deleted.

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/InboxConversationFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/InboxConversationFragment.kt
@@ -321,6 +321,7 @@ class InboxConversationFragment : ParentFragment() {
             adapter.remove(message)
             if (adapter.size() > 0) {
                 toast(R.string.deleted)
+                onConversationUpdated(false)
             } else {
                 onConversationUpdated(true)
             }


### PR DESCRIPTION
Test plan: in the ticket

refs: MBL-15769
affects: Student
release note: Fixed a bug where inbox didn't refresh after deleting a reply.