### PR TITLE
[MBL-15770][Student][Teacher] Unexpected error after put an empty input text in student annotation

### DIFF
--- a/libs/annotations/src/main/java/com/instructure/annotations/PdfSubmissionView.kt
+++ b/libs/annotations/src/main/java/com/instructure/annotations/PdfSubmissionView.kt
@@ -982,7 +982,7 @@ abstract class PdfSubmissionView(context: Context) : FrameLayout(context), Annot
 
             val annotation = if (pdfFragment?.selectedAnnotations?.size ?: 0 > 0) pdfFragment?.selectedAnnotations?.get(0)
                     ?: return else return
-            if (cancelled && annotation.contents.isNullOrEmpty()) {
+            if ((cancelled && annotation.contents.isNullOrEmpty()) || text.isEmpty()) {
                 // Remove the annotation
                 pdfFragment?.document?.annotationProvider?.removeAnnotationFromPage(annotation)
                 pdfFragment?.notifyAnnotationHasChanged(annotation)


### PR DESCRIPTION
Test plan: Bug description in the ticket. OK button should work just like the Cancel button on empty input, when creating text annotations. On editing it should remove the annotation when the user enters an empty text. Test on Teacher and Student app as well.

refs: MBL-15770
affects: Student, Teacher
release note: none