### PR TITLE
[MBL-15809] - Fix breaking teacher UI e2e tests

### DIFF
--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/ModulesE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/ModulesE2ETest.kt
@@ -93,7 +93,7 @@ class ModulesE2ETest : TeacherTest() {
                 teacherToken = teacher.token
         )
 
-        modulesPage.navigateBack()
+        Espresso.pressBack()
         courseBrowserPage.refresh()
         courseBrowserPage.openModulesTab()
         modulesPage.refresh()

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/PagesE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/PagesE2ETest.kt
@@ -1,8 +1,8 @@
 package com.instructure.teacher.ui.e2e
 
+import androidx.test.espresso.Espresso
 import androidx.test.espresso.web.webdriver.Locator
 import com.instructure.canvas.espresso.E2E
-import com.instructure.canvas.espresso.Stub
 import com.instructure.dataseeding.api.PagesApi
 import com.instructure.panda_annotations.FeatureCategory
 import com.instructure.panda_annotations.Priority
@@ -73,15 +73,15 @@ class PagesE2ETest : TeacherTest() {
 
         pageListPage.openPage(pageTitle = publishedPage.title)
         editPageDetailsPage.runTextChecks(WebViewTextCheck(Locator.ID, "header1", "Regular Page Text"))
-        editPageDetailsPage.navigateBack()
+        Espresso.pressBack()
 
         pageListPage.openPage(pageTitle = frontPage.title)
         editPageDetailsPage.runTextChecks(WebViewTextCheck(Locator.ID, "header1", "Front Page Text"))
-        editPageDetailsPage.navigateBack()
+        Espresso.pressBack()
 
         pageListPage.openPage(pageTitle = unpublishedPage.title)
         editPageDetailsPage.runTextChecks(WebViewTextCheck(Locator.ID, "header1", "Unpublished Page Text"))
-        editPageDetailsPage.navigateBack()
+        Espresso.pressBack()
 
     }
 
@@ -112,7 +112,7 @@ class PagesE2ETest : TeacherTest() {
         val editedUnpublishedPageName = "Page still unpublished"
         editPageDetailsPage.editPageName(editedPageName = editedUnpublishedPageName)
         editPageDetailsPage.savePage()
-        editPageDetailsPage.navigateBack()
+        Espresso.pressBack()
         pageListPage.assertPageIsUnpublished(editedUnpublishedPageName)
     }
 
@@ -142,7 +142,7 @@ class PagesE2ETest : TeacherTest() {
         editPageDetailsPage.openEdit()
         editPageDetailsPage.toggleFrontPage()
         editPageDetailsPage.savePage()
-        editPageDetailsPage.navigateBack()
+        Espresso.pressBack()
         pageListPage.assertFrontPageDisplayed(pageTitle = publishedPage.title)
     }
 
@@ -169,14 +169,14 @@ class PagesE2ETest : TeacherTest() {
         editPageDetailsPage.openEdit()
         editPageDetailsPage.togglePublished()
         editPageDetailsPage.savePage()
-        editPageDetailsPage.navigateBack()
+        Espresso.pressBack()
         pageListPage.assertPageIsPublished(pageTitle = unpublishedPage.title)
     }
 
     @E2E
     @Test
     @TestMetaData(Priority.P0, FeatureCategory.PAGES, TestCategory.E2E)
-    fun testUnableToUnpublishFrontPage() {
+    fun testUnableToUnpublishFrontPageE2E() {
         val data = seedData(students = 1, teachers = 1, courses = 1)
         val teacher = data.teachersList[0]
         val course = data.coursesList[0]
@@ -202,7 +202,7 @@ class PagesE2ETest : TeacherTest() {
         editPageDetailsPage.unableToSaveUnpublishedFrontPage()
         editPageDetailsPage.togglePublished()
         editPageDetailsPage.savePage()
-        editPageDetailsPage.navigateBack()
+        Espresso.pressBack()
         pageListPage.assertFrontPageDisplayed(pageTitle = frontPage.title)
         pageListPage.assertPageIsPublished(pageTitle = frontPage.title)
     }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/PeopleE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/PeopleE2ETest.kt
@@ -16,6 +16,7 @@
  */
 package com.instructure.teacher.ui.e2e
 
+import androidx.test.espresso.Espresso
 import com.instructure.canvas.espresso.E2E
 import com.instructure.dataseeding.api.SubmissionsApi
 import com.instructure.dataseeding.model.SubmissionType
@@ -83,14 +84,14 @@ class PeopleE2ETest: TeacherTest() {
         courseBrowserPage.openPeopleTab()
         peopleListPage.clickPerson(teacher)
         studentContextPage.assertDisplaysCourseInfo(course)
-        studentContextPage.navigateBack()
+        Espresso.pressBack()
 
         peopleListPage.clickPerson(notGradedStudent)
         studentContextPage.assertDisplaysStudentInfo(notGradedStudent)
         studentContextPage.assertDisplaysCourseInfo(course)
         studentContextPage.assertStudentGrade("--")
         studentContextPage.assertStudentSubmission("--")
-        studentContextPage.navigateBack()
+        Espresso.pressBack()
 
         peopleListPage.clickPerson(gradedStudent)
         studentContextPage.assertDisplaysStudentInfo(gradedStudent)

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/SpeedGraderE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/SpeedGraderE2ETest.kt
@@ -16,6 +16,7 @@
  */
 package com.instructure.teacher.ui.e2e
 
+import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast
@@ -49,6 +50,7 @@ class SpeedGraderE2ETest : TeacherTest() {
     @Test
     @TestMetaData(Priority.P0, FeatureCategory.GRADES, TestCategory.E2E)
     fun testSpeedGraderE2E() {
+
         val data = seedData(teachers = 1, courses = 1, students = 3, favoriteCourses = 1)
         val teacher = data.teachersList[0]
         val course = data.coursesList[0]
@@ -63,7 +65,7 @@ class SpeedGraderE2ETest : TeacherTest() {
                 teacherToken = teacher.token,
                 pointsPossible = 15.0
         )
-        val sub = seedAssignmentSubmission(
+        seedAssignmentSubmission(
                 submissionSeeds = listOf(SubmissionsApi.SubmissionSeedInfo(
                         amount = 1,
                         submissionType = SubmissionType.ONLINE_TEXT_ENTRY
@@ -73,7 +75,7 @@ class SpeedGraderE2ETest : TeacherTest() {
                 studentToken = student.token
         )
 
-        val gradedSubmission = seedAssignmentSubmission(
+        seedAssignmentSubmission(
                 submissionSeeds = listOf(SubmissionsApi.SubmissionSeedInfo(
                         amount = 1,
                         submissionType = SubmissionType.ONLINE_TEXT_ENTRY
@@ -102,10 +104,12 @@ class SpeedGraderE2ETest : TeacherTest() {
         assignmentDetailsPage.assertNotSubmitted(actual = 1, outOf = 3)
         assignmentDetailsPage.openNotSubmittedSubmissions()
         assignmentSubmissionListPage.assertHasStudentSubmission(canvasUser = noSubStudent)
-        assignmentSubmissionListPage.navigateBack()
+        Espresso.pressBack()
+
         assignmentDetailsPage.openGradedSubmissions()
         assignmentSubmissionListPage.assertHasStudentSubmission(canvasUser = gradedStudent)
-        assignmentSubmissionListPage.navigateBack()
+        Espresso.pressBack()
+
         assignmentDetailsPage.openSubmissionsPage()
         assignmentSubmissionListPage.clickSubmission(student)
         speedGraderPage.assertDisplaysTextSubmissionViewWithStudentName(studentName = student.name)
@@ -114,7 +118,7 @@ class SpeedGraderE2ETest : TeacherTest() {
         val grade = "10"
         speedGraderGradePage.enterNewGrade(grade)
         speedGraderGradePage.assertHasGrade(grade)
-        speedGraderGradePage.navigateBack()
+        Espresso.pressBack()
         refresh()
 
         assignmentSubmissionListPage.clickFilterButton()

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/AssignmentSubmissionListPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/AssignmentSubmissionListPage.kt
@@ -163,9 +163,4 @@ class AssignmentSubmissionListPage : BasePage() {
     fun clickFilterDialogOk() {
         waitForViewWithText(android.R.string.ok).click()
     }
-
-    fun navigateBack() {
-        onView(Matchers.allOf((withParent(R.id.assignmentSubmissionListToolbar) + ViewMatchers.withContentDescription("Navigate up")), ViewMatchers.isDisplayed())).click()
-
-    }
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/DashboardPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/DashboardPage.kt
@@ -75,10 +75,6 @@ class DashboardPage : BasePage() {
         onView(withId(R.id.menu_edit_favorite_courses)).click()
     }
 
-    fun navigateBack(toolbarId: Int = R.id.toolbar) {
-        onView(withParent(toolbarId) + withContentDescription("Navigate up")).click()
-    }
-
     fun openCourse(courseName: String) {
         onView(withText(courseName)).click()
     }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/EditPageDetailsPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/EditPageDetailsPage.kt
@@ -37,10 +37,6 @@ class EditPageDetailsPage : BasePage() {
         }
     }
 
-    fun navigateBack() {
-        onView(allOf((withParent(R.id.toolbar) + withContentDescription("Navigate up")), isDisplayed())).click()
-    }
-
     fun openEdit() {
         onView(withId(R.id.menu_edit)).click()
     }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/ModulesPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/ModulesPage.kt
@@ -28,10 +28,6 @@ class ModulesPage : BasePage() {
         onView(allOf(withId(R.id.moduleName), withText(moduleTitle))).assertDisplayed()
     }
 
-    fun navigateBack() {
-        onView(withParent(R.id.toolbar) + withContentDescription("Navigate up")).click()
-    }
-
     fun refresh() {
         onView(allOf(withId(R.id.swipeRefreshLayout), withAncestor(R.id.moduleList))).swipeDown()
     }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/SpeedGraderGradePage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/SpeedGraderGradePage.kt
@@ -52,10 +52,6 @@ class SpeedGraderGradePage : BasePage() {
         confirmDialogButton.click()
     }
 
-    fun navigateBack() {
-        onView(Matchers.allOf((withParent(R.id.speedGraderToolbar) + withContentDescription("Navigate up")), ViewMatchers.isDisplayed())).click()
-    }
-
     fun assertGradeDialog() {
         customizeGradeTitle.assertDisplayed()
     }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/StudentContextPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/StudentContextPage.kt
@@ -56,8 +56,4 @@ class StudentContextPage : BasePage(R.id.studentContextPage) {
     fun assertStudentSubmission(submittedCount: String) {
         onView(withId(R.id.submittedCount)).assertHasText(submittedCount)
     }
-
-    fun navigateBack() {
-        onView(withParent(R.id.toolbar) + withContentDescription("Navigate up")).click()
-    }
 }


### PR DESCRIPTION
Fix breaking Teacher UI E2E tests - cut off navigateBack() function because of UI change. We are using Espresso.pressBack() instead of it yet.


refs: MBL-15809
affects: Student
release note: none