### PR TITLE
[MBL-15812][Student] Current grading period is not applied to Elementary Themed Dashboards

### DIFF
--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/UserAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/UserAPI.kt
@@ -96,7 +96,7 @@ object UserAPI {
         fun generatePairingCode(): Call<PairingCode>
         //endregion
 
-        @GET("users/self/missing_submissions?include[]=planner_overrides")
+        @GET("users/self/missing_submissions?include[]=planner_overrides&filter[]=submittable&filter[]=current_grading_period")
         fun getMissingSubmissions(): Call<List<Assignment>>
 
         @GET


### PR DESCRIPTION
Test plan: In the ticket.

refs: MBL-15812
affects: Student
release note: Fixed a bug where missing assignments were shown for all grading periods instead of current.