### PR TITLE
[MBL-15815][Teacher] Student Annotation prevent teachers updating assignments

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/EditAssignmentDetailsFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/EditAssignmentDetailsFragment.kt
@@ -430,8 +430,6 @@ class EditAssignmentDetailsFragment : BaseFragment() {
             val type = "none"
             val submissionList = listOf(type)
             postData.submissionTypes = submissionList
-        } else {
-            postData.submissionTypes = mAssignment.submissionTypesRaw
         }
 
         // if we want to set the type as not graded, we don't want a submission type or points possible


### PR DESCRIPTION
refs: MBL-15815
affects: Teacher
release note: Fixed a bug where assignments with student annotation submission type couldn't be edited