### PR TITLE
[MBL-15835][Student] - Change student e2e tests locale to en instead of en_US

### DIFF
--- a/apps/student/flank_e2e.yml
+++ b/apps/student/flank_e2e.yml
@@ -17,7 +17,7 @@ gcloud:
   device:
   - model: NexusLowRes
     version: 25
-    locale: en_US
+    locale: en
     orientation: portrait
 
 flank:

--- a/apps/student/flank_e2e.yml
+++ b/apps/student/flank_e2e.yml
@@ -17,7 +17,7 @@ gcloud:
   device:
   - model: NexusLowRes
     version: 25
-    locale: en
+    locale: en_GB
     orientation: portrait
 
 flank:


### PR DESCRIPTION
Change student e2e tests locale to en instead of en_US. (Hoping that the timezone will also change by this)

refs: MBL-15835
affects: Student
release note: none