### PR TITLE
[MBL-15826][Student/Teacher] Zoom links not opening on Android 11

### DIFF
--- a/apps/student/src/main/AndroidManifest.xml
+++ b/apps/student/src/main/AndroidManifest.xml
@@ -374,6 +374,7 @@
     </application>
 
     <queries>
+        <package android:name="us.zoom.videomeetings" />
         <intent>
             <action android:name="android.media.action.IMAGE_CAPTURE" />
         </intent>

--- a/apps/teacher/src/main/AndroidManifest.xml
+++ b/apps/teacher/src/main/AndroidManifest.xml
@@ -243,6 +243,7 @@
 
     <queries>
         <package android:name="com.instructure.candroid" />
+        <package android:name="us.zoom.videomeetings" />
         <intent>
             <action android:name="android.media.action.IMAGE_CAPTURE" />
         </intent>


### PR DESCRIPTION
Test plan: In the ticket

refs: MBL-15826
affects: Teacher, Student
release note: Fixed zoom links not opening on Android 11