### PR TITLE
[MBL-15837][Student] Filtering Dashboard based on sections and terms

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/adapter/DashboardRecyclerAdapter.kt
+++ b/apps/student/src/main/java/com/instructure/student/adapter/DashboardRecyclerAdapter.kt
@@ -135,6 +135,7 @@ class DashboardRecyclerAdapter(
 
             // Map not null is needed because the dashboard api can return unpublished courses
             val visibleCourses = dashboardCards.mapNotNull { mCourseMap[it.id] }
+                    .filter { it.isCurrentEnrolment() }
 
             // Filter groups
             val allActiveGroups = groups.filter { group -> group.isActive(mCourseMap[group.courseId])}

--- a/apps/student/src/main/java/com/instructure/student/features/dashboard/edit/EditDashboardViewModel.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/dashboard/edit/EditDashboardViewModel.kt
@@ -320,7 +320,7 @@ class EditDashboardViewModel @Inject constructor(private val courseManager: Cour
 
     private fun getCurrentCourses(courses: List<Course>): List<EditDashboardCourseItemViewModel> {
         favoriteCourseMap.clear()
-        val currentCourses = courses.filter { it.hasActiveEnrollment() && it.isBetweenValidDateRange() }
+        val currentCourses = courses.filter { it.hasActiveEnrollment() && it.isCurrentEnrolment() }
         favoriteCourseMap.putAll(currentCourses.filter { it.isFavorite }.associateBy { it.id })
         return currentCourses.map {
             EditDashboardCourseItemViewModel(
@@ -336,7 +336,7 @@ class EditDashboardViewModel @Inject constructor(private val courseManager: Cour
     }
 
     private fun getPastCourses(courses: List<Course>): List<EditDashboardCourseItemViewModel> {
-        val pastCourses = courses.filter { it.term?.endDate?.before(Date()) ?: false || it.endDate?.before(Date()) ?: false || it.isCompleted() }
+        val pastCourses = courses.filter { it.isPastEnrolment() }
         return pastCourses.map {
             EditDashboardCourseItemViewModel(
                     id = it.id,
@@ -351,7 +351,7 @@ class EditDashboardViewModel @Inject constructor(private val courseManager: Cour
     }
 
     private fun getFutureCourses(courses: List<Course>): List<EditDashboardCourseItemViewModel> {
-        val futureCourses = courses.filter { it.term?.startDate?.after(Date()) ?: false || it.startDate?.after(Date()) ?: false || it.isCreationPending()}
+        val futureCourses = courses.filter { it.isFutureEnrolment() }
         favoriteCourseMap.putAll(futureCourses.filter { it.isFavorite }.associateBy { it.id })
         return futureCourses.map {
             EditDashboardCourseItemViewModel(

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Course.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Course.kt
@@ -19,6 +19,7 @@ package com.instructure.canvasapi2.models
 
 import com.google.gson.annotations.SerializedName
 import com.instructure.canvasapi2.utils.Logger
+import com.instructure.canvasapi2.utils.isCreationPending
 import com.instructure.canvasapi2.utils.isNullOrEmpty
 import com.instructure.canvasapi2.utils.toDate
 import kotlinx.android.parcel.Parcelize
@@ -169,7 +170,7 @@ data class Course(
                         noFinalGrade(enrollment.finalGrade, enrollment.finalScore))
             }
 
-    fun getCourseGradeForGradingPeriodSpecificEnrollment(enrollment: Enrollment) : CourseGrade {
+    fun getCourseGradeForGradingPeriodSpecificEnrollment(enrollment: Enrollment): CourseGrade {
         return CourseGrade(
                 enrollment.currentPeriodComputedCurrentGrade(),
                 enrollment.currentPeriodComputedCurrentScore(),
@@ -245,6 +246,57 @@ data class Course(
         return isValidEndAt && isValidStartAt
     }
 
+    fun isPastEnrolment(): Boolean {
+        val now = Date()
+        if (accessRestrictedByDate) return false
+        if (workflowState == WorkflowState.COMPLETED) return true
+
+        return if (restrictEnrollmentsToCourseDate) {
+            endDate?.before(now) ?: false
+        } else {
+            return if (sections.isEmpty()) {
+                term?.endDate?.before(now) ?: false
+            } else {
+                sections.any { section -> section.endDate?.before(now) ?: false }
+            }
+        }
+    }
+
+    fun isFutureEnrolment(): Boolean {
+        val now = Date()
+        if (accessRestrictedByDate) return false
+        if (workflowState == WorkflowState.COMPLETED) return false
+
+        if (isCreationPending()) return true
+
+        return if (restrictEnrollmentsToCourseDate) {
+            startDate?.after(now) ?: false
+        } else {
+            return if (sections.isEmpty()) {
+                term?.startDate?.after(now) ?: false
+            } else {
+                sections.any { section -> section.startDate?.after(now) ?: false }
+            }
+        }
+    }
+
+    fun isCurrentEnrolment(): Boolean {
+        val now = Date()
+        if (accessRestrictedByDate) return false
+
+        if (workflowState == WorkflowState.COMPLETED) return false
+
+        return if (restrictEnrollmentsToCourseDate) {
+            isWithinDates(startAt.toDate(), endAt.toDate(), now)
+        } else {
+            if (sections.isEmpty()) {
+                isWithinDates(term?.startDate, term?.endDate, now)
+            } else {
+                sections.any { section -> isWithinDates(section.startAt.toDate(), section.endAt.toDate(), now) }
+            }
+        }
+    }
+
     /**
      * Get home page label returns the fragment identifier.
      *
@@ -265,29 +317,60 @@ data class Course(
             }
 
     enum class HomePage(val apiString: String) {
-        @SerializedName("feed") HOME_FEED("feed"),
-        @SerializedName("wiki") HOME_WIKI("wiki"),
-        @SerializedName("modules") HOME_MODULES("modules"),
-        @SerializedName("assignments") HOME_ASSIGNMENTS("assignments"),
-        @SerializedName("syllabus") HOME_SYLLABUS("syllabus")
+        @SerializedName("feed")
+        HOME_FEED("feed"),
+
+        @SerializedName("wiki")
+        HOME_WIKI("wiki"),
+
+        @SerializedName("modules")
+        HOME_MODULES("modules"),
+
+        @SerializedName("assignments")
+        HOME_ASSIGNMENTS("assignments"),
+
+        @SerializedName("syllabus")
+        HOME_SYLLABUS("syllabus")
     }
 
     enum class License(val apiString: String, val prettyString: String) {
-        @SerializedName("private") PRIVATE_COPYRIGHTED("private", "Private (Copyrighted)"),
-        @SerializedName("cc_by_nc_nd") CC_ATTRIBUTION_NON_COMMERCIAL_NO_DERIVATIVE("cc_by_nc_nd", "CC Attribution Non-Commercial No Derivatives"),
-        @SerializedName("c_by_nc_sa") CC_ATTRIBUTION_NON_COMMERCIAL_SHARE_ALIKE("c_by_nc_sa", "CC Attribution Non-Commercial Share Alike"),
-        @SerializedName("c_by_nc") CC_ATTRIBUTION_NON_COMMERCIAL("cc_by_nc", "CC Attribution Non-Commercial"),
-        @SerializedName("cc_by_nd") CC_ATTRIBUTION_NO_DERIVATIVE("cc_by_nd", "CC Attribution No Derivatives"),
-        @SerializedName("cc_by_sa") CC_ATTRIBUTION_SHARE_ALIKE("cc_by_sa", "CC Attribution Share Alike"),
-        @SerializedName("cc_by") CC_ATTRIBUTION("cc_by", "CC Attribution"),
-        @SerializedName("public_domain") PUBLIC_DOMAIN("public_domain", "Public Domain")
+        @SerializedName("private")
+        PRIVATE_COPYRIGHTED("private", "Private (Copyrighted)"),
+
+        @SerializedName("cc_by_nc_nd")
+        CC_ATTRIBUTION_NON_COMMERCIAL_NO_DERIVATIVE("cc_by_nc_nd", "CC Attribution Non-Commercial No Derivatives"),
+
+        @SerializedName("c_by_nc_sa")
+        CC_ATTRIBUTION_NON_COMMERCIAL_SHARE_ALIKE("c_by_nc_sa", "CC Attribution Non-Commercial Share Alike"),
+
+        @SerializedName("c_by_nc")
+        CC_ATTRIBUTION_NON_COMMERCIAL("cc_by_nc", "CC Attribution Non-Commercial"),
+
+        @SerializedName("cc_by_nd")
+        CC_ATTRIBUTION_NO_DERIVATIVE("cc_by_nd", "CC Attribution No Derivatives"),
+
+        @SerializedName("cc_by_sa")
+        CC_ATTRIBUTION_SHARE_ALIKE("cc_by_sa", "CC Attribution Share Alike"),
+
+        @SerializedName("cc_by")
+        CC_ATTRIBUTION("cc_by", "CC Attribution"),
+
+        @SerializedName("public_domain")
+        PUBLIC_DOMAIN("public_domain", "Public Domain")
     }
 
     enum class WorkflowState(val apiString: String) {
-        @SerializedName("unpublished") UNPUBLISHED("unpublished"),
-        @SerializedName("available") AVAILABLE("available"),
-        @SerializedName("completed") COMPLETED("completed"),
-        @SerializedName("deleted") DELETED("deleted")
+        @SerializedName("unpublished")
+        UNPUBLISHED("unpublished"),
+
+        @SerializedName("available")
+        AVAILABLE("available"),
+
+        @SerializedName("completed")
+        COMPLETED("completed"),
+
+        @SerializedName("deleted")
+        DELETED("deleted")
 
     }
 }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Section.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Section.kt
@@ -42,4 +42,6 @@ data class Section(
     override val type get() = CanvasContext.Type.SECTION
 
     val endDate get() = endAt.toDate()
+
+    val startDate get() = startAt.toDate()
 }


### PR DESCRIPTION
refs: MBL-15837
affects: Student
release note: Fixed a bug where courses with closed sections would show up as current enrolments.

test plan: Smoke test the Dashboard and Edit Dashboard screens with different terms and sections. See ticket for more info.