### PR TITLE
[Student][MBL-15895] K5 Grades not showing correct values

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/elementary/grades/GradesViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/elementary/grades/GradesViewModel.kt
@@ -124,14 +124,15 @@ class GradesViewModel @Inject constructor(
         return courses
             .map {
                 val enrollment = it.enrollments?.first()
+                val grades = it.getCourseGrade(false)
                 GradeRowItemViewModel(resources,
                     GradeRowViewData(
                         it.id,
                         it.name,
                         getCourseColor(it),
                         it.imageUrl ?: "",
-                        if (it.hideFinalGrades) 0.0 else enrollment?.computedCurrentScore,
-                        createGradeText(enrollment?.computedCurrentScore, enrollment?.computedCurrentGrade, it.hideFinalGrades, enrollment?.currentGradingPeriodId ?: 0L != 0L))
+                        if (it.hideFinalGrades) 0.0 else grades?.currentScore,
+                        createGradeText(grades?.currentScore, grades?.currentGrade, it.hideFinalGrades, enrollment?.currentGradingPeriodId ?: 0L != 0L))
                 ) { gradeRowClicked(it) }
             }
     }

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/elementary/grades/GradesViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/elementary/grades/GradesViewModelTest.kt
@@ -351,7 +351,7 @@ class GradesViewModelTest {
         gradingPeriods: List<GradingPeriod>? = null,
         hideFinalGrades: Boolean = false
     ): Course {
-        val enrollment = Enrollment(id = 123, computedCurrentScore = score, computedCurrentGrade = grade)
+        val enrollment = Enrollment(id = 123, computedCurrentScore = score, computedCurrentGrade = grade, type = Enrollment.EnrollmentType.Student)
         return Course(
             id = id,
             name = name,


### PR DESCRIPTION
Test plan: Compare K5 grades page with the web. Test user included in the ticket.

refs: MBL-15895
affects: Student
release note: Fixed a bug where grades where shown for the wrong grading period on the homeroom grades screen.