### PR TITLE
[MBL-15884][Student] Concluded courses no longer appear in grades widget

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/widget/GradesViewWidgetService.kt
+++ b/apps/student/src/main/java/com/instructure/student/widget/GradesViewWidgetService.kt
@@ -119,7 +119,7 @@ class GradesViewWidgetService : BaseRemoteViewsService(), Serializable {
                 try {
                     // Force network so we always get the latest data for grades
                     setData(CourseManager.getCoursesSynchronous(true).filter
-                    { it.isFavorite && !it.accessRestrictedByDate && !it.isInvited() })
+                    { it.isFavorite && it.isCurrentEnrolment() && !it.isInvited() })
                 } catch (e: Throwable) {
                     Logger.e("Could not load " + this::class.java.simpleName + " widget. " + e.message)
                 }


### PR DESCRIPTION
refs: MBL-15884
affects: Student
release note: Fixed a bug where concluded courses would still be visible in the Grades widget.

test plan:
1. Create a Course with an assignment
2. Submit to the course
3. Grade the submission
4. Enable the Grades widget, verify the grade is visible.
5. Conclude the course
6. Verify the grade is no longer visible in the widget.