### PR TITLE
[MBL-15850][Teacher] Changed the status indicator logic to match Student

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/holders/DiscussionListHolder.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/holders/DiscussionListHolder.kt
@@ -85,7 +85,7 @@ class DiscussionListHolder(view: View) : RecyclerView.ViewHolder(view) {
         val unreadDisplayCount = if (discussionTopicHeader.unreadCount > 99) context.getString(R.string.max_count)
                                  else discussionTopicHeader.unreadCount.toString()
 
-        statusIndicator.setVisible(discussionTopicHeader.status == DiscussionTopicHeader.ReadState.UNREAD)
+        statusIndicator.setVisible(discussionTopicHeader.unreadCount != 0)
 
         readUnreadCounts.text = context.getString(R.string.discussions_unread_replies_blank,
                                 context.getString(R.string.discussions_replies, entryCount.toString()),


### PR DESCRIPTION
refs: MBL-15850
affects: Teacher
release note: Fixed a bug where the unread indicator would not disappear.

test plan: See if the indicator is working as intended.