### PR TITLE
[Student][Teacher][MBL-15881] Some Android devices don't recognize available apps that can open external files

### DIFF
--- a/apps/student/src/main/AndroidManifest.xml
+++ b/apps/student/src/main/AndroidManifest.xml
@@ -383,6 +383,7 @@
         </intent>
         <intent>
             <action android:name="android.intent.action.VIEW" />
+            <data android:mimeType="*/*" />
         </intent>
     </queries>
 </manifest>

--- a/apps/teacher/src/main/AndroidManifest.xml
+++ b/apps/teacher/src/main/AndroidManifest.xml
@@ -252,6 +252,7 @@
         </intent>
         <intent>
             <action android:name="android.intent.action.VIEW" />
+            <data android:mimeType="*/*" />
         </intent>
     </queries>
 


### PR DESCRIPTION
Test plan: See ticket. Should be also tested in the Teacher app, because it had the same issue. With this fix the teacher works as well, but doesn't have the loading screen when opening a file (never had).

refs: MBL-15881
affects: Student, Teacher
release note: Fixed a bug where some linked files wouldn't open the associated apps.