### PR TITLE
[MBL-9773][Student] Module navigation buttons are not included when accessing module items from links

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
@@ -688,7 +688,7 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
                 val contextId = Route.extractCourseId(route)
                 if (contextId != 0L) {
                     when {
-                        RouteContext.FILE == route.routeContext -> {
+                        RouteContext.FILE == route.routeContext && route.secondaryClass != CourseModuleProgressionFragment::class.java -> {
                             if (route.queryParamsHash.containsKey(RouterParams.VERIFIER) && route.queryParamsHash.containsKey(RouterParams.DOWNLOAD_FRD)) {
                                 if(route.uri != null) openMedia(CanvasContext.getGenericContext(CanvasContext.Type.COURSE, contextId, ""), route.uri.toString())
                             }
@@ -763,7 +763,7 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
             if (fragment != null && fragment::class.java.name in getBottomNavFragmentNames() && isBottomNavFragment(currentFragment)) {
                 selectBottomNavFragment(fragment::class.java)
             } else {
-                addFullScreenFragment(fragment)
+                addFullScreenFragment(fragment, route.removePreviousScreen)
             }
         }
     }
@@ -785,14 +785,19 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
         bottomNavScreensStack.push(fragmentClass.name)
     }
 
-    private fun addFullScreenFragment(fragment: Fragment?) {
+    private fun addFullScreenFragment(fragment: Fragment?, removePreviousFragment: Boolean = false) {
         if (fragment == null) {
             Logger.e("NavigationActivity:addFullScreenFragment() - Could not route null Fragment.")
             return
         }
 
         val ft = supportFragmentManager.beginTransaction()
-        ft.setCustomAnimations(R.anim.fade_in_quick, R.anim.fade_out_quick)
+        if (removePreviousFragment) {
+            supportFragmentManager.popBackStackImmediate()
+        } else {
+            ft.setCustomAnimations(R.anim.fade_in_quick, R.anim.fade_out_quick)
+        }
+
         currentFragment?.let { ft.hide(it) }
         ft.add(R.id.fullscreen, fragment, fragment::class.java.name)
         ft.addToBackStack(fragment::class.java.name)

--- a/apps/student/src/main/java/com/instructure/student/fragment/CourseModuleProgressionFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/CourseModuleProgressionFragment.kt
@@ -715,6 +715,7 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
 
     private fun loadModuleProgression(bundle: Bundle?) {
         if(assetId.isBlank()) {
+            bottomBarModule.setVisible()
             setViewInfo(bundle)
             setButtonListeners()
             updateBottomNavBarButtons()

--- a/apps/student/src/main/java/com/instructure/student/fragment/CourseModuleProgressionFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/CourseModuleProgressionFragment.kt
@@ -47,6 +47,8 @@ import com.instructure.pandautils.utils.*
 import com.instructure.student.R
 import com.instructure.student.events.ModuleUpdatedEvent
 import com.instructure.student.events.post
+import com.instructure.student.mobius.assignmentDetails.ui.AssignmentDetailsFragment
+import com.instructure.student.router.RouteMatcher
 import com.instructure.student.util.Const
 import com.instructure.student.util.CourseModulesStore
 import com.instructure.student.util.ModuleProgressionUtility
@@ -70,7 +72,9 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
     private var childPos: Int by IntArg(key = CHILD_POSITION)
     private var modules: ArrayList<ModuleObject> by ParcelableArrayListArg(key = MODULE_OBJECTS)
     private var items: ArrayList<ArrayList<ModuleItem>> by SerializableArg(key = MODULE_ITEMS, default = ArrayList())
-    private var moduleItemId: String by StringArg(key = ITEM_ID)
+    private var assetId: String by StringArg(key = ASSET_ID)
+    private var assetType: String by StringArg(key = ASSET_TYPE, default = ModuleItemAsset.MODULE_ITEM.assetType)
+    private var route: Route by ParcelableArg(key = ROUTE)
 
     // Default number will get reset
     private var itemsCount = 3
@@ -106,7 +110,7 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        loadModuleProgression(moduleItemId, savedInstanceState)
+        loadModuleProgression(savedInstanceState)
     }
 
     override fun onDestroyView() {
@@ -211,7 +215,6 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
     }
 
     private fun setViewInfo(bundle: Bundle?) {
-
         // Figure out the total size so the adapter knows how many items it will have
         var size = 0
         for (i in items.indices) { size += items[i].size }
@@ -390,6 +393,7 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
 
             //prev_item/next_item buttons may now need to be visible (if we were on a module item that was the last in its group but
             //now we have info about the next_item module, we want the user to be able to navigate there)
+            bottomBarModule.setVisible()
             updateBottomNavBarButtons()
         } catch { }
     }
@@ -709,20 +713,25 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
     }
     //endregion
 
-    private fun loadModuleProgression(moduleItemId: String, bundle: Bundle?) {
-        if(moduleItemId.isBlank()) {
+    private fun loadModuleProgression(bundle: Bundle?) {
+        if(assetId.isBlank()) {
             setViewInfo(bundle)
             setButtonListeners()
             updateBottomNavBarButtons()
             return
         }
 
+        progressBar.setVisible()
         routeModuleProgressionJob = tryWeave {
-            val moduleItemSequence = awaitApi<ModuleItemSequence> { ModuleManager.getModuleItemSequence(canvasContext, ModuleManager.MODULE_ASSET_MODULE_ITEM, moduleItemId, it, true) }
+            val moduleItemSequence = awaitApi<ModuleItemSequence> { ModuleManager.getModuleItemSequence(canvasContext, assetType, assetId, it, true) }
             // Make sure that there is a sequence
-            if (moduleItemSequence.items!!.isNotEmpty()) {
+            val sequenceItems = moduleItemSequence.items ?: emptyArray()
+            if (sequenceItems.isNotEmpty()) {
                 // Get the current module item. we'll use the id of this down below
-                val current = moduleItemSequence.items!!.firstOrNull { it.current!!.id == moduleItemId.toLong() }?.current ?: moduleItemSequence.items!![0].current
+                val current = when {
+                   assetType == ModuleItemAsset.MODULE_ITEM.assetType -> sequenceItems.firstOrNull { it.current!!.id == assetId.toLong() }?.current ?: sequenceItems[0].current
+                   else -> sequenceItems[0].current
+                }
                 val moduleItems = awaitApi<List<ModuleItem>> { ModuleManager.getAllModuleItems(canvasContext, current!!.moduleId, it, true) }
                 val unfilteredItems = ArrayList<ArrayList<ModuleItem>>(1).apply { add(ArrayList(moduleItems)) }
                 modules = ArrayList<ModuleObject>(1).apply { moduleItemSequence.modules!!.firstOrNull { it.id == current?.moduleId }?.let { add(it) } }
@@ -730,23 +739,36 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
                 groupPos = moduleHelper.newGroupPosition
                 childPos = moduleHelper.newChildPosition
                 items = moduleHelper.strippedModuleItems
+            } else {
+                progressBar.setGone()
+                val moduleItemAsset = ModuleItemAsset.fromAssetType(assetType)
+                if (moduleItemAsset != ModuleItemAsset.MODULE_ITEM) {
+                    val newRoute = route.copy(secondaryClass = moduleItemAsset.routeClass, removePreviousScreen = true)
+                    RouteMatcher.route(requireContext(), newRoute)
+                    return@tryWeave
+                }
             }
 
+            progressBar.setGone()
+            bottomBarModule.setVisible()
             setViewInfo(bundle)
             setButtonListeners()
         } catch {
+            progressBar.setGone()
             Logger.e("Error routing modules: " + it.message)
         }
     }
 
     companion object {
 
-        const val MODULE_ITEMS = "module_item"
-        const val MODULE_OBJECTS = "module_objects"
-        const val MODULE_POSITION = "module_position"
-        const val GROUP_POSITION = "group_position"
-        const val CHILD_POSITION = "child_position"
-        const val ITEM_ID = "item_id"
+        private const val MODULE_ITEMS = "module_item"
+        private const val MODULE_OBJECTS = "module_objects"
+        private const val MODULE_POSITION = "module_position"
+        private const val GROUP_POSITION = "group_position"
+        private const val CHILD_POSITION = "child_position"
+        private const val ASSET_ID = "asset_id"
+        private const val ASSET_TYPE = "asset_type"
+        private const val ROUTE = "route"
 
 
         //we don't want to add subheaders or external tools into the list. subheaders don't do anything and we
@@ -766,11 +788,15 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
 
         fun newInstance(route: Route): CourseModuleProgressionFragment? {
             val fragment = if (validRoute(route)) CourseModuleProgressionFragment().apply {
-                arguments = route.arguments.apply {
+                arguments = Bundle().apply {
+                    putAll(route.arguments)
                     putSerializable(MODULE_ITEMS, CourseModulesStore.moduleListItems)
                     putParcelableArrayList(MODULE_OBJECTS, CourseModulesStore.moduleObjects)
+                    putParcelable(ROUTE, route)
                 }
-                moduleItemId = route.queryParamsHash[RouterParams.MODULE_ITEM_ID] ?: route.paramsHash[RouterParams.MODULE_ITEM_ID] ?: ""
+                val asset = getAssetTypeAndId(route)
+                assetType = asset.first.assetType
+                assetId = asset.second
             } else null
 
             CourseModulesStore.moduleListItems = null
@@ -779,9 +805,40 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
             return fragment
         }
 
+        private fun getAssetTypeAndId(route: Route): Pair<ModuleItemAsset, String> {
+            val queryParams = route.queryParamsHash
+            val params = route.paramsHash
+            if (queryParams.containsKey(RouterParams.MODULE_ITEM_ID)) {
+                return Pair(ModuleItemAsset.MODULE_ITEM, queryParams[RouterParams.MODULE_ITEM_ID] ?: "")
+            }
+
+            ModuleItemAsset.values().forEach {
+                if (params.containsKey(it.assetIdParamName)) {
+                    return Pair(it, params[it.assetIdParamName] ?: "")
+                }
+            }
+
+            return Pair(ModuleItemAsset.MODULE_ITEM, "")
+        }
+
         private fun validRoute(route: Route): Boolean = route.canvasContext != null
             && (CourseModulesStore.moduleObjects != null && CourseModulesStore.moduleListItems != null)
             || route.queryParamsHash.keys.any { it == RouterParams.MODULE_ITEM_ID }
-            || route.paramsHash.keys.any { it == RouterParams.MODULE_ITEM_ID }
+            || route.paramsHash.keys.any { isModuleItemAsset(it) }
+
+        private fun isModuleItemAsset(paramName: String) = ModuleItemAsset.values().find { it.assetIdParamName == paramName } != null
+    }
+}
+
+enum class ModuleItemAsset(val assetType: String, val assetIdParamName: String, val routeClass: Class<out Fragment>? = null) {
+    MODULE_ITEM("ModuleItem", RouterParams.MODULE_ITEM_ID),
+    PAGE("Page", RouterParams.PAGE_ID, PageDetailsFragment::class.java),
+    QUIZ("Quiz", RouterParams.QUIZ_ID, BasicQuizViewFragment::class.java),
+    DISCUSSION("Discussion", RouterParams.MESSAGE_ID, DiscussionDetailsFragment::class.java),
+    ASSIGNMENT("Assignment", RouterParams.ASSIGNMENT_ID, AssignmentDetailsFragment::class.java),
+    FILE("File", RouterParams.FILE_ID, FileDetailsFragment::class.java);
+
+    companion object {
+        fun fromAssetType(assetType: String): ModuleItemAsset = values().find { it.assetType == assetType } ?: MODULE_ITEM
     }
 }

--- a/apps/student/src/main/java/com/instructure/student/fragment/QuizListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/QuizListFragment.kt
@@ -134,7 +134,9 @@ class QuizListFragment : ParentFragment(), Bookmarkable {
         if (navigation != null) {
             /* The quiz list endpoint is currently missing the quiz question types, so we'll route using the quiz url
             which should pull the full quiz details including the question types. */
-            if (!RouteMatcher.canRouteInternally(requireActivity(), quiz.htmlUrl!!, ApiPrefs.domain, true)) {
+            if (RouteMatcher.canRouteInternally(requireActivity(), quiz.htmlUrl!!, ApiPrefs.domain, false)) {
+                RouteMatcher.routeUrl(requireContext(), quiz.htmlUrl!!, ApiPrefs.domain, secondaryClass = BasicQuizViewFragment::class.java)
+            } else {
                 RouteMatcher.route(requireContext(), BasicQuizViewFragment.makeRoute(canvasContext, quiz, quiz.url!!))
             }
         }

--- a/apps/student/src/main/java/com/instructure/student/router/RouteMatcher.kt
+++ b/apps/student/src/main/java/com/instructure/student/router/RouteMatcher.kt
@@ -130,17 +130,17 @@ object RouteMatcher : BaseRouteMatcher() {
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/files/folder/:${RouterParams.FOLDER_NAME}"), RouteContext.FILE))
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/files/:${RouterParams.FILE_ID}/download"), RouteContext.FILE)) // trigger webview's download listener
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/files/:${RouterParams.FILE_ID}/preview"), RouteContext.FILE))
-        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/files/:${RouterParams.FILE_ID}"), RouteContext.FILE))
+        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/files/:${RouterParams.FILE_ID}"), RouteContext.FILE, CourseModuleProgressionFragment::class.java))
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/files/folder(\\/.*)*/:${RouterParams.FILE_ID}"), RouteContext.FILE))
         routes.add(Route("/files/folder(\\/.*)*/:${RouterParams.FILE_ID}", RouteContext.FILE))
 
         // Discussions
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/discussion_topics"), DiscussionListFragment::class.java))
-        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/discussion_topics/:${RouterParams.MESSAGE_ID}"), DiscussionListFragment::class.java, DiscussionDetailsFragment::class.java))
+        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/discussion_topics/:${RouterParams.MESSAGE_ID}"), DiscussionListFragment::class.java, CourseModuleProgressionFragment::class.java))
 
         // Pages
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/pages"), PageListFragment::class.java))
-        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/pages/:${RouterParams.PAGE_ID}"), PageListFragment::class.java, PageDetailsFragment::class.java))
+        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/pages/:${RouterParams.PAGE_ID}"), PageListFragment::class.java, CourseModuleProgressionFragment::class.java))
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/wiki"), PageListFragment::class.java))
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/wiki/:${RouterParams.PAGE_ID}"), PageListFragment::class.java, PageDetailsFragment::class.java))
 
@@ -153,7 +153,7 @@ object RouteMatcher : BaseRouteMatcher() {
 
         // Quiz
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/quizzes"), QuizListFragment::class.java))
-        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/quizzes/:${RouterParams.QUIZ_ID}"), QuizListFragment::class.java, BasicQuizViewFragment::class.java))
+        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/quizzes/:${RouterParams.QUIZ_ID}"), QuizListFragment::class.java, CourseModuleProgressionFragment::class.java))
 
 
         // Calendar
@@ -165,9 +165,9 @@ object RouteMatcher : BaseRouteMatcher() {
 
         // Assignments
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/assignments"), AssignmentListFragment::class.java))
-        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/assignments/:${RouterParams.ASSIGNMENT_ID}"), AssignmentListFragment::class.java, AssignmentDetailsFragment::class.java))
-        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/assignments/:${RouterParams.ASSIGNMENT_ID}"), NotificationListFragment::class.java, AssignmentDetailsFragment::class.java))
-        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/assignments/:${RouterParams.ASSIGNMENT_ID}"), CalendarFragment::class.java, AssignmentDetailsFragment::class.java))
+        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/assignments/:${RouterParams.ASSIGNMENT_ID}"), AssignmentListFragment::class.java, CourseModuleProgressionFragment::class.java))
+        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/assignments/:${RouterParams.ASSIGNMENT_ID}"), NotificationListFragment::class.java, CourseModuleProgressionFragment::class.java))
+        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/assignments/:${RouterParams.ASSIGNMENT_ID}"), CalendarFragment::class.java, CourseModuleProgressionFragment::class.java))
 
         // Studio
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/external_tools/:${RouterParams.EXTERNAL_ID}/resource_selection"), StudioWebViewFragment::class.java))
@@ -264,28 +264,41 @@ object RouteMatcher : BaseRouteMatcher() {
                 handleWebViewUrl(context, route.uri.toString())
             }
         } else if (route.routeContext == RouteContext.FILE || route.primaryClass?.isAssignableFrom(FileListFragment::class.java) == true && route.queryParamsHash.containsKey(RouterParams.PREVIEW)) {
-            if (route.queryParamsHash.containsKey(RouterParams.VERIFIER) && route.queryParamsHash.containsKey(RouterParams.DOWNLOAD_FRD)) {
-                if (route.uri != null) {
-                    openMedia(context as FragmentActivity, route.uri.toString())
-                } else if (route.uri != null) {
-                    openMedia(context as FragmentActivity, route.uri!!.toString())
+            when {
+                route.secondaryClass == CourseModuleProgressionFragment::class.java -> handleFullscreenRoute(context, route)
+                route.queryParamsHash.containsKey(RouterParams.VERIFIER) && route.queryParamsHash.containsKey(RouterParams.DOWNLOAD_FRD) -> {
+                    if (route.removePreviousScreen) {
+                        val fragmentManager = (context as? FragmentActivity)?.supportFragmentManager
+                        fragmentManager?.popBackStackImmediate()
+                    }
+                    if (route.uri != null) {
+                        openMedia(context as FragmentActivity, route.uri.toString())
+                    } else if (route.uri != null) {
+                        openMedia(context as FragmentActivity, route.uri!!.toString())
+                    }
                 }
-            }  else if (route.paramsHash.containsKey(RouterParams.FOLDER_NAME) && !route.queryParamsHash.containsKey(RouterParams.PREVIEW)) {
-                // Preview query params are caught under the same route matcher with the :folder_name param, make sure we're not catching preview urls here as well
-                // Route to the FileListFragment but to the folder - To route we need to modify the route a bit.
-                if (!route.paramsHash.containsKey(RouterParams.COURSE_ID)) {
-                    route.canvasContext = ApiPrefs.user
+                route.paramsHash.containsKey(RouterParams.FOLDER_NAME) && !route.queryParamsHash.containsKey(RouterParams.PREVIEW) -> {
+                    // Preview query params are caught under the same route matcher with the :folder_name param, make sure we're not catching preview urls here as well
+                    // Route to the FileListFragment but to the folder - To route we need to modify the route a bit.
+                    if (!route.paramsHash.containsKey(RouterParams.COURSE_ID)) {
+                        route.canvasContext = ApiPrefs.user
+                    }
+                    route.routeContext = RouteContext.UNKNOWN
+                    route.primaryClass = FileListFragment::class.java
+                    handleFullscreenRoute(context, route)
                 }
-                route.routeContext = RouteContext.UNKNOWN
-                route.primaryClass = FileListFragment::class.java
-                handleFullscreenRoute(context, route)
-            } else {
-                val isGroupRoute = "groups" == route.uri?.pathSegments?.get(0)
-                handleSpecificFile(
+                else -> {
+                    if (route.removePreviousScreen) {
+                        val fragmentManager = (context as? FragmentActivity)?.supportFragmentManager
+                        fragmentManager?.popBackStackImmediate()
+                    }
+                    val isGroupRoute = "groups" == route.uri?.pathSegments?.get(0)
+                    handleSpecificFile(
                         context as FragmentActivity,
                         (if (route.queryParamsHash.containsKey(RouterParams.PREVIEW)) route.queryParamsHash[RouterParams.PREVIEW] else route.paramsHash[RouterParams.FILE_ID]) ?: "",
                         route,
                         isGroupRoute)
+                }
             }
         } else if (route.routeContext == RouteContext.MEDIA) {
             handleMediaRoute(context, route)

--- a/apps/student/src/main/java/com/instructure/student/router/RouteMatcher.kt
+++ b/apps/student/src/main/java/com/instructure/student/router/RouteMatcher.kt
@@ -137,10 +137,12 @@ object RouteMatcher : BaseRouteMatcher() {
         // Discussions
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/discussion_topics"), DiscussionListFragment::class.java))
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/discussion_topics/:${RouterParams.MESSAGE_ID}"), DiscussionListFragment::class.java, CourseModuleProgressionFragment::class.java))
+        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/discussion_topics/:${RouterParams.MESSAGE_ID}"), DiscussionListFragment::class.java, DiscussionDetailsFragment::class.java))
 
         // Pages
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/pages"), PageListFragment::class.java))
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/pages/:${RouterParams.PAGE_ID}"), PageListFragment::class.java, CourseModuleProgressionFragment::class.java))
+        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/pages/:${RouterParams.PAGE_ID}"), PageListFragment::class.java, PageDetailsFragment::class.java))
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/wiki"), PageListFragment::class.java))
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/wiki/:${RouterParams.PAGE_ID}"), PageListFragment::class.java, PageDetailsFragment::class.java))
 
@@ -154,6 +156,7 @@ object RouteMatcher : BaseRouteMatcher() {
         // Quiz
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/quizzes"), QuizListFragment::class.java))
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/quizzes/:${RouterParams.QUIZ_ID}"), QuizListFragment::class.java, CourseModuleProgressionFragment::class.java))
+        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/quizzes/:${RouterParams.QUIZ_ID}"), QuizListFragment::class.java, BasicQuizViewFragment::class.java))
 
 
         // Calendar
@@ -168,6 +171,9 @@ object RouteMatcher : BaseRouteMatcher() {
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/assignments/:${RouterParams.ASSIGNMENT_ID}"), AssignmentListFragment::class.java, CourseModuleProgressionFragment::class.java))
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/assignments/:${RouterParams.ASSIGNMENT_ID}"), NotificationListFragment::class.java, CourseModuleProgressionFragment::class.java))
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/assignments/:${RouterParams.ASSIGNMENT_ID}"), CalendarFragment::class.java, CourseModuleProgressionFragment::class.java))
+        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/assignments/:${RouterParams.ASSIGNMENT_ID}"), AssignmentListFragment::class.java, AssignmentDetailsFragment::class.java))
+        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/assignments/:${RouterParams.ASSIGNMENT_ID}"), NotificationListFragment::class.java, AssignmentDetailsFragment::class.java))
+        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/assignments/:${RouterParams.ASSIGNMENT_ID}"), CalendarFragment::class.java, AssignmentDetailsFragment::class.java))
 
         // Studio
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/external_tools/:${RouterParams.EXTERNAL_ID}/resource_selection"), StudioWebViewFragment::class.java))

--- a/apps/student/src/main/java/com/instructure/student/router/RouteMatcher.kt
+++ b/apps/student/src/main/java/com/instructure/student/router/RouteMatcher.kt
@@ -233,7 +233,7 @@ object RouteMatcher : BaseRouteMatcher() {
         routeUrl(context, url, ApiPrefs.domain, extras)
     }
 
-    fun routeUrl(context: Context, url: String, domain: String, extras: Bundle? = null) {
+    fun routeUrl(context: Context, url: String, domain: String, extras: Bundle? = null, secondaryClass: Class<out Fragment>? = null) {
         /* Possible activity types we can navigate too: Unknown Link, InitActivity, Master/Detail, Fullscreen, WebView, ViewMedia */
 
         //Find the best route
@@ -256,6 +256,10 @@ object RouteMatcher : BaseRouteMatcher() {
         if (route?.getContextType() == CanvasContext.Type.GROUP && route.primaryClass == PeopleListFragment::class.java && route.secondaryClass == PeopleDetailsFragment::class.java ) {
             route.primaryClass = null
             route.secondaryClass = PeopleListFragment::class.java
+        }
+
+        if (secondaryClass != null) {
+            route?.secondaryClass = secondaryClass
         }
 
         route(context, route)

--- a/apps/student/src/main/res/layout/course_module_progression.xml
+++ b/apps/student/src/main/res/layout/course_module_progression.xml
@@ -29,6 +29,16 @@
         android:layout_height="match_parent"
         android:layout_above="@+id/markDoneWrapper" />
 
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignTop="@id/viewPager"
+        android:layout_alignBottom="@id/viewPager"
+        android:layout_centerHorizontal="true"
+        android:visibility="gone"/>
+
     <TextView
         android:id="@+id/moduleNotFound"
         style="@style/TextStyle.Primary"
@@ -36,10 +46,10 @@
         android:layout_height="match_parent"
         android:layout_above="@+id/markDoneWrapper"
         android:gravity="center"
-        android:visibility="gone"
-        android:textColor="@color/secondaryText"
         android:text="@string/moduleItemNotFound"
-        tools:visibility="visible"/>
+        android:textColor="@color/secondaryText"
+        android:visibility="gone"
+        tools:visibility="visible" />
 
     <View
         android:layout_width="match_parent"
@@ -54,7 +64,8 @@
         android:layout_above="@+id/bottomBarModule"
         android:background="@color/white"
         android:clickable="true"
-        android:visibility="visible">
+        android:visibility="gone"
+        tools:visibility="visible">
 
         <LinearLayout
             android:id="@+id/markDoneButton"
@@ -98,14 +109,15 @@
         android:layout_alignParentBottom="true"
         android:background="@color/white"
         android:clickable="true"
+        android:visibility="gone"
         tools:visibility="visible">
 
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
-            android:layout_toEndOf="@+id/prev_item"
             android:layout_toStartOf="@+id/next_item"
+            android:layout_toEndOf="@+id/prev_item"
             android:gravity="center"
             tools:ignore="UseCompoundDrawables">
 
@@ -142,7 +154,7 @@
             android:layout_alignParentStart="true"
             android:layout_centerVertical="true"
             android:background="@drawable/ic_chevron_left"
-            android:contentDescription="@string/previous"/>
+            android:contentDescription="@string/previous" />
 
         <Button
             android:id="@+id/next_item"
@@ -151,7 +163,7 @@
             android:layout_alignParentEnd="true"
             android:layout_centerVertical="true"
             android:background="@drawable/ic_chevron_right"
-            android:contentDescription="@string/next"/>
+            android:contentDescription="@string/next" />
 
     </RelativeLayout>
 

--- a/apps/student/src/main/res/layout/fragment_assignment_details.xml
+++ b/apps/student/src/main/res/layout/fragment_assignment_details.xml
@@ -45,6 +45,7 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
+            android:background="@color/white"
             app:layout_constraintTop_toBottomOf="@id/toolbar"
             app:layout_constraintBottom_toTopOf="@+id/submitButton">
 

--- a/apps/student/src/test/java/com/instructure/student/test/util/RouterUtilsTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/util/RouterUtilsTest.kt
@@ -288,7 +288,7 @@ class RouterUtilsTest : TestCase() {
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/discussion_topics/1234")
         assertNotNull(route)
         assertEquals(DiscussionListFragment::class.java, route!!.primaryClass)
-        assertEquals(DiscussionDetailsFragment::class.java, route.secondaryClass)
+        assertEquals(CourseModuleProgressionFragment::class.java, route.secondaryClass)
 
         val expectedParams = HashMap<String, String>()
         expectedParams[RouterParams.COURSE_ID] = "836357"
@@ -306,7 +306,7 @@ class RouterUtilsTest : TestCase() {
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/pages/hello")
         assertNotNull(route)
         assertEquals(PageListFragment::class.java, route!!.primaryClass)
-        assertEquals(PageDetailsFragment::class.java, route.secondaryClass)
+        assertEquals(CourseModuleProgressionFragment::class.java, route.secondaryClass)
 
         val expectedParams = HashMap<String, String>()
         expectedParams[RouterParams.COURSE_ID] = "836357"
@@ -340,7 +340,7 @@ class RouterUtilsTest : TestCase() {
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/quizzes/12345")
         assertNotNull(route)
         assertEquals(QuizListFragment::class.java, route!!.primaryClass)
-        assertEquals(BasicQuizViewFragment::class.java, route.secondaryClass)
+        assertEquals(CourseModuleProgressionFragment::class.java, route.secondaryClass)
 
         val expectedParams = HashMap<String, String>()
         expectedParams[RouterParams.COURSE_ID] = "836357"
@@ -368,7 +368,7 @@ class RouterUtilsTest : TestCase() {
         route = callGetInternalRoute("https://mobiledev.instructure.com/courses/836357/assignments/213445213445213445213445213445213445213445213445213445213445213445213445")
         assertNotNull(route)
         assertEquals(AssignmentListFragment::class.java, route!!.primaryClass)
-        assertEquals(AssignmentDetailsFragment::class.java, route.secondaryClass)
+        assertEquals(CourseModuleProgressionFragment::class.java, route.secondaryClass)
 
         val expectedParams = HashMap<String, String>()
         expectedParams[RouterParams.COURSE_ID] = "836357"
@@ -471,7 +471,7 @@ class RouterUtilsTest : TestCase() {
         val queryParams = HashMap<String, String>()
 
 
-        val url = RouteMatcher.generateUrl(canvasContext.type, QuizListFragment::class.java, BasicQuizViewFragment::class.java, replacementParams, queryParams)
+        val url = RouteMatcher.generateUrl(canvasContext.type, QuizListFragment::class.java, CourseModuleProgressionFragment::class.java, replacementParams, queryParams)
         assertEquals("https://mobiledev.instructure.com/courses/123/quizzes/456", url)
     }
 
@@ -485,7 +485,7 @@ class RouterUtilsTest : TestCase() {
 
         val queryParams = HashMap<String, String>()
 
-        val url = RouteMatcher.generateUrl(canvasContext.type, QuizListFragment::class.java, BasicQuizViewFragment::class.java, replacementParams, queryParams)
+        val url = RouteMatcher.generateUrl(canvasContext.type, QuizListFragment::class.java, CourseModuleProgressionFragment::class.java, replacementParams, queryParams)
         assertEquals("https://mobiledev.instructure.com/groups/123/quizzes/456", url)
     }
 }

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/endpoints/CourseEndpoints.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/endpoints/CourseEndpoints.kt
@@ -65,6 +65,7 @@ object CourseEndpoint : Endpoint(
         Segment("files") to CourseFilesEndpoint,
         Segment("discussion_topics") to CourseDiscussionTopicListEndpoint,
         Segment("modules") to CourseModuleListEndpoint,
+        Segment("module_item_sequence") to CourseModuleItemSequenceEndpoint,
         Segment("quizzes") to CourseQuizListEndpoint,
         Segment("all_quizzes") to CourseQuizListEndpoint,
         Segment("users") to CourseUsersEndpoint,
@@ -903,5 +904,13 @@ object CourseSingleUserEndpoint : Endpoint(
             }
         }
 
+    }
+)
+
+object CourseModuleItemSequenceEndpoint : Endpoint(
+    response = {
+        GET {
+            request.successResponse(ModuleItemSequence())
+        }
     }
 )

--- a/libs/interactions/src/main/java/com/instructure/interactions/router/BaseRouteMatcher.kt
+++ b/libs/interactions/src/main/java/com/instructure/interactions/router/BaseRouteMatcher.kt
@@ -44,7 +44,7 @@ open class BaseRouteMatcher {
 
         return routes.find { it.apply(urlValidator.url) }?.takeUnless {
             RouteContext.INTERNAL == it.routeContext || RouteContext.DO_NOT_ROUTE == it.routeContext
-        }
+        }?.copy()
     }
 
     /**

--- a/libs/interactions/src/main/java/com/instructure/interactions/router/Route.kt
+++ b/libs/interactions/src/main/java/com/instructure/interactions/router/Route.kt
@@ -62,7 +62,9 @@ data class Route(
         /* The URL of the path before the params have been replaced. */
         var routePath: String? = null,
         /* A tab id see the Tabs api for a definition. Not required for most routes. */
-        var tabId: String? = null
+        var tabId: String? = null,
+        /* If true removes the previous screen from the backstack when routing to this route. */
+        var removePreviousScreen: Boolean = false
 ) : Parcelable {
 
     //All constructors should eventually set the [Route.routePath]
@@ -93,6 +95,11 @@ data class Route(
 
     constructor(routePath: String?, routeContext: RouteContext) : this(routePath) {
         this.routeContext = routeContext
+    }
+
+    constructor(routePath: String?, routeContext: RouteContext, secondaryClass: Class<out Fragment>?) : this(routePath) {
+        this.routeContext = routeContext
+        this.secondaryClass = secondaryClass
     }
 
     constructor(routePath: String?, primaryClass: Class<out Fragment>?) : this(routePath) {


### PR DESCRIPTION
Test plan: I added a test user in the JIRA ticket. Each type of module item there has 3 links, 1 that has module_item_id and 1 that doesn't. These two should work the same, navigation buttons should be visible. The 3rd link is a content that is not included in the course modules. This link should open the same page, but redirect to the standalone screen after that.

Opening module items from the modules list should also be smoke tested.

refs: MBL-9773
affects: Student
release note: Module items opened from links now show module navigation buttons.