### PR TITLE
[MBL-15859] [Student] [Teacher] -  Introduce new test related annotations

### DIFF
--- a/apps/student/flank.yml
+++ b/apps/student/flank.yml
@@ -12,7 +12,7 @@ gcloud:
   record-video: true
   timeout: 60m
   test-targets:
-  - notAnnotation com.instructure.canvas.espresso.E2E, com.instructure.canvas.espresso.Stub
+  - notAnnotation com.instructure.canvas.espresso.E2E, com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.Flaky, com.instructure.canvas.espresso.KnownBug
   device:
   - model: NexusLowRes
     version: 26

--- a/apps/student/flank_e2e.yml
+++ b/apps/student/flank_e2e.yml
@@ -13,7 +13,7 @@ gcloud:
   timeout: 60m
   test-targets:
   - annotation com.instructure.canvas.espresso.E2E
-  - notAnnotation com.instructure.canvas.espresso.Stub
+  - notAnnotation com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.Flaky, com.instructure.canvas.espresso.KnownBug
   device:
   - model: NexusLowRes
     version: 26

--- a/apps/student/flank_e2e_flaky.yml
+++ b/apps/student/flank_e2e_flaky.yml
@@ -1,0 +1,25 @@
+gcloud:
+  project: delta-essence-114723
+# Use the next two lines to run locally
+#  app: ./build/outputs/apk/qa/debug/student-qa-debug.apk
+#  test: ./build/outputs/apk/androidTest/qa/debug/student-qa-debug-androidTest.apk
+  app: ./apps/student/build/outputs/apk/qa/debug/student-qa-debug.apk
+  test: ./apps/student/build/outputs/apk/androidTest/qa/debug/student-qa-debug-androidTest.apk
+  results-bucket: android-student
+  auto-google-login: true
+  use-orchestrator: true
+  performance-metrics: false
+  record-video: true
+  timeout: 60m
+  test-targets:
+  - annotation com.instructure.canvas.espresso.FlakyE2E
+  device:
+  - model: NexusLowRes
+    version: 26
+    locale: en_US
+    orientation: portrait
+
+flank:
+  testShards: 1
+  testRuns: 1
+

--- a/apps/student/flank_e2e_knownbug.yml
+++ b/apps/student/flank_e2e_knownbug.yml
@@ -1,0 +1,25 @@
+gcloud:
+  project: delta-essence-114723
+# Use the next two lines to run locally
+#  app: ./build/outputs/apk/qa/debug/student-qa-debug.apk
+#  test: ./build/outputs/apk/androidTest/qa/debug/student-qa-debug-androidTest.apk
+  app: ./apps/student/build/outputs/apk/qa/debug/student-qa-debug.apk
+  test: ./apps/student/build/outputs/apk/androidTest/qa/debug/student-qa-debug-androidTest.apk
+  results-bucket: android-student
+  auto-google-login: true
+  use-orchestrator: true
+  performance-metrics: false
+  record-video: true
+  timeout: 60m
+  test-targets:
+  - annotation com.instructure.canvas.espresso.KnownBug
+  device:
+  - model: NexusLowRes
+    version: 26
+    locale: en_US
+    orientation: portrait
+
+flank:
+  testShards: 1
+  testRuns: 1
+

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/k5/HomeroomE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/k5/HomeroomE2ETest.kt
@@ -18,6 +18,7 @@ package com.instructure.student.ui.e2e.k5
 
 import androidx.test.espresso.Espresso
 import com.instructure.canvas.espresso.E2E
+import com.instructure.canvas.espresso.FlakyE2E
 import com.instructure.canvasapi2.utils.toApiString
 import com.instructure.dataseeding.api.AssignmentsApi
 import com.instructure.dataseeding.model.GradingType
@@ -48,6 +49,7 @@ class HomeroomE2ETest : StudentTest() {
     }
 
     @E2E
+    @FlakyE2E("Need to investigate why is it breaking when asserting todo text. Timezone shouldn't be a problem anymore since we run these tests at 8 PM.")
     @Test
     @TestMetaData(Priority.P0, FeatureCategory.K5_DASHBOARD, TestCategory.E2E)
     fun homeroomE2ETest() {

--- a/apps/teacher/flank.yml
+++ b/apps/teacher/flank.yml
@@ -9,7 +9,7 @@ gcloud:
   record-video: true
   timeout: 60m
   test-targets:
-  - notAnnotation com.instructure.canvas.espresso.E2E, com.instructure.canvas.espresso.Stub
+  - notAnnotation com.instructure.canvas.espresso.E2E, com.instructure.canvas.espresso.Stub,  com.instructure.canvas.espresso.Flaky, com.instructure.canvas.espresso.KnownBug
   device:
   - model: NexusLowRes
     version: 26

--- a/apps/teacher/flank_e2e.yml
+++ b/apps/teacher/flank_e2e.yml
@@ -13,7 +13,7 @@ gcloud:
   timeout: 60m
   test-targets:
   - annotation com.instructure.canvas.espresso.E2E
-  - notAnnotation com.instructure.canvas.espresso.Stub
+  - notAnnotation com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.Flaky, com.instructure.canvas.espresso.KnownBug
   device:
   - model: NexusLowRes
     version: 26

--- a/apps/teacher/flank_e2e_flaky.yml
+++ b/apps/teacher/flank_e2e_flaky.yml
@@ -1,0 +1,25 @@
+gcloud:
+  project: delta-essence-114723
+  # Use the next two lines to run locally
+  #  app: ./build/outputs/apk/qa/debug/teacher-qa-debug.apk
+  #  test: ./build/outputs/apk/androidTest/qa/debug/teacher-qa-debug-androidTest.apk
+  app: ./apps/teacher/build/outputs/apk/qa/debug/teacher-qa-debug.apk
+  test: ./apps/teacher/build/outputs/apk/androidTest/qa/debug/teacher-qa-debug-androidTest.apk
+  results-bucket: android-student
+  auto-google-login: true
+  use-orchestrator: true
+  performance-metrics: false
+  record-video: true
+  timeout: 60m
+  test-targets:
+  - annotation com.instructure.canvas.espresso.FlakyE2E
+  device:
+  - model: NexusLowRes
+    version: 26
+    locale: en_US
+    orientation: portrait
+
+flank:
+  testShards: 1
+  testRuns: 1
+

--- a/apps/teacher/flank_e2e_knownbug.yml
+++ b/apps/teacher/flank_e2e_knownbug.yml
@@ -1,0 +1,25 @@
+gcloud:
+  project: delta-essence-114723
+  # Use the next two lines to run locally
+  #  app: ./build/outputs/apk/qa/debug/teacher-qa-debug.apk
+  #  test: ./build/outputs/apk/androidTest/qa/debug/teacher-qa-debug-androidTest.apk
+  app: ./apps/teacher/build/outputs/apk/qa/debug/teacher-qa-debug.apk
+  test: ./apps/teacher/build/outputs/apk/androidTest/qa/debug/teacher-qa-debug-androidTest.apk
+  results-bucket: android-student
+  auto-google-login: true
+  use-orchestrator: true
+  performance-metrics: false
+  record-video: true
+  timeout: 60m
+  test-targets:
+  - annotation com.instructure.canvas.espresso.KnownBug
+  device:
+  - model: NexusLowRes
+    version: 26
+    locale: en_US
+    orientation: portrait
+
+flank:
+  testShards: 1
+  testRuns: 1
+

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/FlakyE2EAnnotation.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/FlakyE2EAnnotation.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2021 - present Instructure, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.instructure.canvas.espresso
+
+// When applied to a test method, denotes that the test is stubbed out and not yet implemented only for landscape tests.
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class FlakyE2E(val explanation: String = "")

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/KnownBug.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/KnownBug.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2021 - present Instructure, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.instructure.canvas.espresso
+
+// When applied to a test method, denotes that the test is stubbed out and not yet implemented only for landscape tests.
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class KnownBug(val bugLink: String = "", val explanation: String = "")


### PR DESCRIPTION
Introduce FlakyE2E and KnownBug annotations in both apps (Teacher, Student) to separate these breaking tests from nightly. (They'll also run but separately).


refs: MBL-15859
affects: Student, Teacher
release note: none