### PR TITLE
[MBL-15930][Teacher] Crash in SlidingPanel in Speed Grader.

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/view/SubmissionContentView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/view/SubmissionContentView.kt
@@ -268,7 +268,9 @@ class SubmissionContentView(
                 else -> SlidingUpPanelLayout.PanelState.ANCHORED
             }
 
-            slidingUpPanelLayout?.panelState = newState
+            if (newState != SlidingUpPanelLayout.PanelState.DRAGGING) {
+                slidingUpPanelLayout?.panelState = newState
+            }
 
             // Have to post here as we wait for contentRoot height to settle
             contentRoot.post {


### PR DESCRIPTION
Test plan: It's not easy to reproduce this issue, but the crash is pretty self-explanatory, so instead of trying to reproduce it I would suggest to smoke test the Speed Grader and the Comment Library if everything works as intended.

refs: MBL-15930
affects: Teacher
release note: Fixed a crash in Speed Grader