### PR TITLE
[MBL-15936][Student] Canvas for Elementary theme is applied to courses which don't have it enabled.

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/GradesInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/GradesInteractionTest.kt
@@ -139,11 +139,15 @@ class GradesInteractionTest : StudentTest() {
         withGradingPeriods: Boolean = false,
         homeroomCourseCount: Int = 0): MockCanvas {
 
-        return MockCanvas.init(
+        val data =  MockCanvas.init(
             studentCount = 1,
             courseCount = courseCount,
             withGradingPeriods = withGradingPeriods,
             homeroomCourseCount = homeroomCourseCount)
+
+        data.elementarySubjectPages = true
+
+        return data
     }
 
     private fun goToGradesTab(data: MockCanvas) {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/HomeroomInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/HomeroomInteractionTest.kt
@@ -297,6 +297,8 @@ class HomeroomInteractionTest : StudentTest() {
             accountNotificationCount = announcementCount,
             homeroomCourseCount = homeroomCourseCount)
 
+        data.elementarySubjectPages = true
+
         return data
     }
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/ScheduleInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/ScheduleInteractionTest.kt
@@ -289,11 +289,15 @@ class ScheduleInteractionTest : StudentTest() {
         withGradingPeriods: Boolean = false,
         homeroomCourseCount: Int = 0): MockCanvas {
 
-        return MockCanvas.init(
+        val data = MockCanvas.init(
             studentCount = 1,
             courseCount = courseCount,
             withGradingPeriods = withGradingPeriods,
             homeroomCourseCount = homeroomCourseCount)
+
+        data.elementarySubjectPages = true
+
+        return data
     }
 
     private fun goToScheduleTab(data: MockCanvas) {

--- a/apps/student/src/main/java/com/instructure/student/features/elementary/course/ElementaryCourseViewData.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/elementary/course/ElementaryCourseViewData.kt
@@ -17,6 +17,7 @@
 package com.instructure.student.features.elementary.course
 
 import android.graphics.drawable.Drawable
+import com.instructure.canvasapi2.models.CanvasContext
 
 data class ElementaryCourseViewData(
     val tabs: List<ElementaryCourseTab>
@@ -28,3 +29,9 @@ data class ElementaryCourseTab(
     val text: String?,
     val url: String
 )
+
+sealed class ElementaryCourseAction {
+    object RedirectToCourseBrowserPage : ElementaryCourseAction()
+    object RedirectToGrades : ElementaryCourseAction()
+    object RedirectToModules : ElementaryCourseAction()
+}

--- a/apps/student/src/main/res/layout-sw720dp/fragment_elementary_course.xml
+++ b/apps/student/src/main/res/layout-sw720dp/fragment_elementary_course.xml
@@ -35,7 +35,8 @@
     <FrameLayout
         android:id="@+id/elementaryCoursePage"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:background="@color/white">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"

--- a/apps/student/src/main/res/layout/fragment_elementary_course.xml
+++ b/apps/student/src/main/res/layout/fragment_elementary_course.xml
@@ -35,7 +35,8 @@
     <FrameLayout
         android:id="@+id/elementaryCoursePage"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:background="@color/white">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/MockCanvas.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/MockCanvas.kt
@@ -256,6 +256,9 @@ class MockCanvas {
                 .distinctBy { it.userId }
                 .map { users[it.userId]!! }
 
+    /** Sets whether dashboard_cards returns true or false for isK5Subject field. */
+    var elementarySubjectPages: Boolean = false
+
     /** Returns the current auth token for the specified user. Returns null if no such token exists. */
     fun tokenFor(user: User): String? {
         tokens.forEach { (token, userId) ->

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/endpoints/MiscEndpoints.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/endpoints/MiscEndpoints.kt
@@ -17,6 +17,7 @@
 package com.instructure.canvas.espresso.mockCanvas.endpoints
 
 import com.instructure.canvas.espresso.mockCanvas.Endpoint
+import com.instructure.canvas.espresso.mockCanvas.MockCanvas
 import com.instructure.canvas.espresso.mockCanvas.utils.successPaginatedResponse
 import com.instructure.canvasapi2.apis.EnrollmentAPI
 import com.instructure.canvasapi2.models.DashboardCard
@@ -35,7 +36,7 @@ object DashboardCardsEndpoint : Endpoint(response = {
         // Only show favorite courses. To match web behavior, if there are no favorites then we show all active courses.
         val favoriteCourses = data.courses.values.filter { it.isFavorite }.ifEmpty { currentCourses }
 
-        val cards = favoriteCourses.map { DashboardCard(it.id) }
+        val cards = favoriteCourses.map { DashboardCard(it.id, data.elementarySubjectPages) }
         request.successPaginatedResponse(cards)
     }
 })

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/DashboardCard.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/DashboardCard.kt
@@ -20,5 +20,6 @@ import kotlinx.android.parcel.Parcelize
 
 @Parcelize
 data class DashboardCard(
-    override val id: Long = 0
+    override val id: Long = 0,
+    val isK5Subject: Boolean = false
 ) : CanvasModel<DashboardCard>()


### PR DESCRIPTION
Test plan: Description in the ticket. There are also more cases where this bug could happen. It can also happen when opening a non K5 course grades from the K5 grades page. In that case we should redirect to the standard grades page.

refs: MBL-15936
affects: Student
release note: Fixed a bug where elementary subject page would open instead of course page.