### PR TITLE
[MBL-15729][Student] - Remove stub from show privacyPolicy test 

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/SettingsInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/SettingsInteractionTest.kt
@@ -87,7 +87,6 @@ class SettingsInteractionTest : StudentTest() {
 
     // Should display the privacy policy in a WebView
     @Test
-    @Stub  //need to consider how to fix this, it is breaking sometimes on low res mode
     @TestMetaData(Priority.P0, FeatureCategory.SETTINGS, TestCategory.INTERACTION, false)
     fun testLegal_showPrivacyPolicy() {
         setUpAndSignIn()


### PR DESCRIPTION
It works locally so the Stub annotation has been removed. I have tested it on bitrise as well, it has passed. (We will see it running again under this PR check)

refs: MBL-15729
affects: Student
release note: none