### PR TITLE
[MBL-15913][Student][Teacher] Discussion Redesign, anonymous replies don't load

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/DiscussionDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/DiscussionDetailsFragment.kt
@@ -617,7 +617,7 @@ class DiscussionDetailsFragment : ParentFragment(), Bookmarkable {
 
     private fun showAnonymousDiscussionView() {
         anonymousDiscussionsNotSupported.setVisible()
-        openInBrowser.setVisible()
+        openInBrowser.setVisible(discussionTopicHeader.htmlUrl?.isNotEmpty() == true)
         replyToDiscussionTopic.setGone()
         swipeRefreshLayout.isEnabled = false
         openInBrowser.onClick {

--- a/apps/student/src/main/java/com/instructure/student/fragment/DiscussionDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/DiscussionDetailsFragment.kt
@@ -571,7 +571,8 @@ class DiscussionDetailsFragment : ParentFragment(), Bookmarkable {
             loadDiscussionTopicHeaderViews(discussionTopicHeader)
             addAccessibilityButton()
 
-            if (forceRefresh || discussionTopic == null) {
+            // We only want to request the full discussion if it is not anonymous. Anonymous discussions are not supported by the API
+            if (forceRefresh || discussionTopic == null && discussionTopicHeader.anonymousState == null) {
                 // forceRefresh is true, fetch the discussion topic
                 discussionTopic = getDiscussionTopic()
 
@@ -583,6 +584,10 @@ class DiscussionDetailsFragment : ParentFragment(), Bookmarkable {
                 discussionProgressBar.setGone()
                 discussionTopicRepliesTitle.setGone()
                 swipeRefreshLayout.isRefreshing = false
+
+                if (discussionTopicHeader.anonymousState != null) {
+                    showAnonymousDiscussionView()
+                }
             } else {
                 val html = inBackground {
                     DiscussionUtils.createDiscussionTopicHtml(
@@ -607,6 +612,18 @@ class DiscussionDetailsFragment : ParentFragment(), Bookmarkable {
             }
         } catch {
             Logger.e("Error loading discussion topic " + it.message)
+        }
+    }
+
+    private fun showAnonymousDiscussionView() {
+        anonymousDiscussionsNotSupported.setVisible()
+        openInBrowser.setVisible()
+        replyToDiscussionTopic.setGone()
+        swipeRefreshLayout.isEnabled = false
+        openInBrowser.onClick {
+            discussionTopicHeader.htmlUrl?.let { url ->
+                InternalWebviewFragment.loadInternalWebView(activity, InternalWebviewFragment.makeRoute(canvasContext, url, true, true))
+            }
         }
     }
 

--- a/apps/student/src/main/res/layout/fragment_discussions_details.xml
+++ b/apps/student/src/main/res/layout/fragment_discussions_details.xml
@@ -345,6 +345,30 @@
                         android:background="@color/lightGray" />
 
                     <TextView
+                        android:id="@+id/anonymousDiscussionsNotSupported"
+                        style="@style/TextFont.Regular"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:visibility="gone"
+                        android:layout_marginTop="16dp"
+                        android:paddingStart="16dp"
+                        android:paddingEnd="16dp"
+                        android:text="@string/anonymousDiscussionNotSupported" />
+
+                    <TextView
+                        android:id="@+id/openInBrowser"
+                        style="@style/TextFont.Regular"
+                        android:foreground="?attr/selectableItemBackground"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:padding="16dp"
+                        android:textColor="@color/defaultActionColor"
+                        android:visibility="gone"
+                        android:text="@string/openInBrowser" />
+
+                    <TextView
                         android:id="@+id/discussionTopicRepliesTitle"
                         style="@style/TextFont.Medium"
                         android:layout_width="wrap_content"

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/DiscussionsDetailsFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/DiscussionsDetailsFragment.kt
@@ -707,7 +707,7 @@ class DiscussionsDetailsFragment : BasePresenterFragment<
 
     override fun showAnonymousDiscussionView() {
         anonymousDiscussionsNotSupported.setVisible()
-        openInBrowser.setVisible()
+        openInBrowser.setVisible(mDiscussionTopicHeader.htmlUrl?.isNotEmpty() == true)
         replyToDiscussionTopic.setGone()
         swipeRefreshLayout.isEnabled = false
         openInBrowser.onClick {

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/DiscussionsDetailsFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/DiscussionsDetailsFragment.kt
@@ -16,13 +16,11 @@
 package com.instructure.teacher.fragments
 
 import android.annotation.SuppressLint
-import android.content.Context
 import android.graphics.Color
 import android.graphics.Rect
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
-import android.view.accessibility.AccessibilityManager
 import android.webkit.CookieManager
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
@@ -49,6 +47,7 @@ import com.instructure.pandautils.utils.*
 import com.instructure.pandautils.views.CanvasWebView
 import com.instructure.teacher.BuildConfig
 import com.instructure.teacher.R
+import com.instructure.teacher.activities.InternalWebViewActivity
 import com.instructure.teacher.adapters.StudentContextFragment
 import com.instructure.teacher.dialog.NoInternetConnectionDialog
 import com.instructure.teacher.events.*
@@ -68,13 +67,6 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import java.net.URLDecoder
 import java.util.*
-import kotlin.collections.ArrayList
-import kotlin.collections.List
-import kotlin.collections.forEach
-import kotlin.collections.isNotEmpty
-import kotlin.collections.joinToString
-import kotlin.collections.map
-import kotlin.collections.singleOrNull
 
 @ScreenView(SCREEN_VIEW_DISCUSSION_DETAILS)
 class DiscussionsDetailsFragment : BasePresenterFragment<
@@ -713,12 +705,24 @@ class DiscussionsDetailsFragment : BasePresenterFragment<
         discussionRepliesWebView.post { discussionRepliesWebView.loadUrl("javascript:markAsUnread('$markedAsUnreadId')") }
     }
 
+    override fun showAnonymousDiscussionView() {
+        anonymousDiscussionsNotSupported.setVisible()
+        openInBrowser.setVisible()
+        replyToDiscussionTopic.setGone()
+        swipeRefreshLayout.isEnabled = false
+        openInBrowser.onClick {
+            mDiscussionTopicHeader.htmlUrl?.let { url ->
+                requireContext().startActivity(InternalWebViewActivity.createIntent(requireContext(), url, "", true))
+            }
+        }
+    }
+
     /**
      * Checks to see if the webview element is within the viewable bounds of the scrollview.
      */
     private fun isElementInViewPortWithinScrollView(elementHeight: Int, topOffset: Int): Boolean {
         if (discussionsScrollView == null) return false
-        val scrollBounds = Rect().apply{ discussionsScrollView.getDrawingRect(this) }
+        val scrollBounds = Rect().apply { discussionsScrollView.getDrawingRect(this) }
 
         val discussionRepliesHeight = discussionRepliesWebView.height
         val discussionScrollViewContentHeight = discussionsScrollViewContentWrapper.height

--- a/apps/teacher/src/main/java/com/instructure/teacher/presenters/DiscussionsDetailsPresenter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/presenters/DiscussionsDetailsPresenter.kt
@@ -48,7 +48,12 @@ class DiscussionsDetailsPresenter(
 
     override fun loadData(forceNetwork: Boolean) {
         viewCallback?.onRefreshStarted()
-        DiscussionManager.getFullDiscussionTopic(canvasContext, discussionTopicHeader.id, forceNetwork, mDiscussionTopicCallback)
+        if (discussionTopicHeader.anonymousState == null) {
+            DiscussionManager.getFullDiscussionTopic(canvasContext, discussionTopicHeader.id, forceNetwork, mDiscussionTopicCallback)
+        } else {
+            viewCallback?.onRefreshFinished()
+            viewCallback?.showAnonymousDiscussionView()
+        }
     }
 
     override fun refresh(forceNetwork: Boolean) {

--- a/apps/teacher/src/main/java/com/instructure/teacher/viewinterface/DiscussionsDetailsView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/viewinterface/DiscussionsDetailsView.kt
@@ -31,4 +31,5 @@ interface DiscussionsDetailsView : FragmentViewInterface {
     fun updateDiscussionsMarkedAsUnreadCompleted(markedAsUnreadId: Long)
     fun updateDiscussionAsDeleted(discussionEntry: DiscussionEntry)
     fun updateDiscussionEntry(discussionEntry: DiscussionEntry)
+    fun showAnonymousDiscussionView()
 }

--- a/apps/teacher/src/main/res/layout/fragment_discussions_details.xml
+++ b/apps/teacher/src/main/res/layout/fragment_discussions_details.xml
@@ -440,6 +440,30 @@
                     android:layout_height="0.5dp"
                     android:background="@color/divider"/>
 
+                <TextView
+                    android:id="@+id/anonymousDiscussionsNotSupported"
+                    style="@style/TextFont.Regular"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:visibility="gone"
+                    android:layout_marginTop="16dp"
+                    android:paddingStart="16dp"
+                    android:paddingEnd="16dp"
+                    android:text="@string/anonymousDiscussionNotSupported" />
+
+                <TextView
+                    android:id="@+id/openInBrowser"
+                    style="@style/TextFont.Regular"
+                    android:foreground="?attr/selectableItemBackground"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:padding="16dp"
+                    android:textColor="@color/defaultActionColor"
+                    android:visibility="gone"
+                    android:text="@string/openInBrowser" />
+
                 <LinearLayout
                     android:id="@+id/discussionRepliesHeaderWrapper"
                     android:layout_width="match_parent"

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/DiscussionTopicHeader.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/DiscussionTopicHeader.kt
@@ -112,7 +112,10 @@ data class DiscussionTopicHeader(
         var userCanSeePosts: Boolean = true,
         @SerializedName("specific_sections")
         var specificSections: String? = null, // For when we're submitting the sections
-        var sections: List<Section>? = null // Comes back from the server
+        var sections: List<Section>? = null, // Comes back from the server
+
+        @SerializedName("anonymous_state")
+        var anonymousState: String? = null
 ) : CanvasModel<DiscussionTopicHeader>() {
     override val comparisonDate: Date?
         get() = if (lastReplyDate != null)

--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -1255,4 +1255,7 @@
     <string name="filter_name_monochrome">Monochrome</string>
     <string name="filter_name_original">Original</string>
     <string name="noCompatibleAppInstalled">Your device does not have any applications installed that can open this link.</string>
+
+    <string name="anonymousDiscussionNotSupported">Anonymous discussions are currently not supported on mobile. Open in browser to view discussion.</string>
+    <string name="discussionOpenInBrowser">Open in browser</string>
 </resources>


### PR DESCRIPTION
Test plan: 
- Create an anonymous discussion with the discussions redesign (one is included in the ticket)
- Open the anonymous discussion
- You should see a text that the discussion is not supported on mobile and a link to open the discussion in a WebView.
- Verify that the discussion opens
- Also smoke test regular discussions

refs: MBL-15913
affects: Teacher, Student
release note: Added a button to open anonymous discussions in browser.