### PR TITLE
[MBL-14665] [Teacher] - Fix seeding user with email

### DIFF
--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/StudentContextPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/StudentContextPage.kt
@@ -17,13 +17,11 @@
 
 package com.instructure.teacher.ui.pages
 
-import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import com.instructure.dataseeding.model.CanvasUserApiModel
 import com.instructure.dataseeding.model.CourseApiModel
 import com.instructure.espresso.WaitForViewWithId
 import com.instructure.espresso.assertDisplayed
 import com.instructure.espresso.assertHasText
-import com.instructure.espresso.click
 import com.instructure.espresso.page.*
 import com.instructure.teacher.R
 
@@ -40,9 +38,8 @@ class StudentContextPage : BasePage(R.id.studentContextPage) {
     fun assertDisplaysStudentInfo(student: CanvasUserApiModel) {
         waitForView(withParent(R.id.toolbar) + withText(student.shortName)).assertDisplayed()
         studentName.assertHasText(student.shortName)
-        // MBL-14665: Seeding an email address for a user apparently no longer works.
-        // We'll need to fix that before we can un-comment this code.
-        //studentEmail.assertHasText(student.loginId)
+        studentEmail.assertHasText(student.loginId)
+        onView(withId(R.id.gradeItems)).assertDisplayed()
     }
 
     fun assertDisplaysCourseInfo(course: CourseApiModel) {


### PR DESCRIPTION
Fix assertion for seeding user with e-mail.

refs: MBL-15466
affects: Teacher
release note: none