### PR TITLE
[MBL-16002][Student] Fixed section filtering on Edit Dashboard

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/features/dashboard/edit/EditDashboardViewModel.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/dashboard/edit/EditDashboardViewModel.kt
@@ -336,7 +336,7 @@ class EditDashboardViewModel @Inject constructor(private val courseManager: Cour
     }
 
     private fun getPastCourses(courses: List<Course>): List<EditDashboardCourseItemViewModel> {
-        val pastCourses = courses.filter { it.isPastEnrolment() }
+        val pastCourses = courses.filter { it.isPastEnrolment() && !it.isCurrentEnrolment() && !it.isFutureEnrolment() }
         return pastCourses.map {
             EditDashboardCourseItemViewModel(
                     id = it.id,
@@ -351,7 +351,7 @@ class EditDashboardViewModel @Inject constructor(private val courseManager: Cour
     }
 
     private fun getFutureCourses(courses: List<Course>): List<EditDashboardCourseItemViewModel> {
-        val futureCourses = courses.filter { it.isFutureEnrolment() }
+        val futureCourses = courses.filter { it.isFutureEnrolment() && !it.isCurrentEnrolment() }
         favoriteCourseMap.putAll(futureCourses.filter { it.isFavorite }.associateBy { it.id })
         return futureCourses.map {
             EditDashboardCourseItemViewModel(

--- a/apps/student/src/test/java/com/instructure/student/features/dashboard/edit/EditDashboardViewModelTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/features/dashboard/edit/EditDashboardViewModelTest.kt
@@ -844,6 +844,137 @@ class EditDashboardViewModelTest {
         assertEquals("Future section past term course", futureCourseItemViewModel.name)
     }
 
+    @Test
+    fun `Course with past and current section only shows up in the current`() {
+        val courses = listOf(
+                createCourse(
+                        id = 1L,
+                        name = "Course with past and current enrollment",
+                        isFavorite = false,
+                        term = createTerm(
+                                startAt = OffsetDateTime.now().withYear(OffsetDateTime.now().year - 1).toApiString(),
+                                endAt = OffsetDateTime.now().withYear(OffsetDateTime.now().year + 1).toApiString()),
+                        sections = listOf(
+                                createSection(endAt = OffsetDateTime.now().withYear(OffsetDateTime.now().year - 1).toApiString()),
+                                createSection(startAt = OffsetDateTime.now().withYear(OffsetDateTime.now().year - 1).toApiString(),
+                                        endAt = OffsetDateTime.now().withYear(OffsetDateTime.now().year + 1).toApiString())
+                        ),
+                        restrictEnrolmentsToCourseDate = false
+                )
+        )
+
+        every { courseManager.getCoursesWithConcludedAsync(any()) } returns mockk {
+            coEvery { await() } returns DataResult.Success(courses)
+        }
+
+        every { groupManager.getAllGroupsAsync(any()) } returns mockk {
+            coEvery { await() } returns DataResult.Success(emptyList())
+        }
+
+        viewModel = EditDashboardViewModel(courseManager, groupManager)
+        viewModel.data.observe(lifecycleOwner, Observer {})
+
+        val data = viewModel.data.value?.items ?: emptyList()
+
+        assertEquals(4, data.size)
+
+        assert(data[2] is EditDashboardEnrollmentItemViewModel)
+        val currentHeader = data[2] as EditDashboardEnrollmentItemViewModel
+        assertEquals(R.string.current_enrollments, currentHeader.title)
+
+        assert(data[3] is EditDashboardCourseItemViewModel)
+        val currentCourseItemViewModel = data[3] as EditDashboardCourseItemViewModel
+        assertEquals("Course with past and current enrollment", currentCourseItemViewModel.name)
+    }
+
+    @Test
+    fun `Course with past and current section only shows up as current`() {
+        val courses = listOf(
+                createCourse(
+                        id = 1L,
+                        name = "Course with current and future enrollment",
+                        isFavorite = false,
+                        term = createTerm(
+                                startAt = OffsetDateTime.now().withYear(OffsetDateTime.now().year - 1).toApiString(),
+                                endAt = OffsetDateTime.now().withYear(OffsetDateTime.now().year + 1).toApiString()),
+                        sections = listOf(
+                                createSection(startAt = OffsetDateTime.now().withYear(OffsetDateTime.now().year - 1).toApiString(),
+                                        endAt = OffsetDateTime.now().withYear(OffsetDateTime.now().year + 1).toApiString()),
+                                createSection(startAt = OffsetDateTime.now().withYear(OffsetDateTime.now().year + 1).toApiString(),
+                                        endAt = OffsetDateTime.now().withYear(OffsetDateTime.now().year + 2).toApiString())
+                        ),
+                        restrictEnrolmentsToCourseDate = false
+                )
+        )
+
+        every { courseManager.getCoursesWithConcludedAsync(any()) } returns mockk {
+            coEvery { await() } returns DataResult.Success(courses)
+        }
+
+        every { groupManager.getAllGroupsAsync(any()) } returns mockk {
+            coEvery { await() } returns DataResult.Success(emptyList())
+        }
+
+        viewModel = EditDashboardViewModel(courseManager, groupManager)
+        viewModel.data.observe(lifecycleOwner, Observer {})
+
+        val data = viewModel.data.value?.items ?: emptyList()
+
+        assertEquals(4, data.size)
+
+        assert(data[2] is EditDashboardEnrollmentItemViewModel)
+        val currentHeader = data[2] as EditDashboardEnrollmentItemViewModel
+        assertEquals(R.string.current_enrollments, currentHeader.title)
+
+        assert(data[3] is EditDashboardCourseItemViewModel)
+        val currentCourseItemViewModel = data[3] as EditDashboardCourseItemViewModel
+        assertEquals("Course with current and future enrollment", currentCourseItemViewModel.name)
+    }
+
+    @Test
+    fun `Course with past and future section only shows up as future`() {
+        val courses = listOf(
+                createCourse(
+                        id = 1L,
+                        name = "Course with past and future enrollment",
+                        isFavorite = false,
+                        term = createTerm(
+                                startAt = OffsetDateTime.now().withYear(OffsetDateTime.now().year - 1).toApiString(),
+                                endAt = OffsetDateTime.now().withYear(OffsetDateTime.now().year + 1).toApiString()),
+                        sections = listOf(
+                                createSection(startAt = OffsetDateTime.now().withYear(OffsetDateTime.now().year - 2).toApiString(),
+                                        endAt = OffsetDateTime.now().withYear(OffsetDateTime.now().year - 1).toApiString()),
+                                createSection(startAt = OffsetDateTime.now().withYear(OffsetDateTime.now().year + 1).toApiString(),
+                                        endAt = OffsetDateTime.now().withYear(OffsetDateTime.now().year + 2).toApiString())
+                        ),
+                        restrictEnrolmentsToCourseDate = false
+                )
+        )
+
+        every { courseManager.getCoursesWithConcludedAsync(any()) } returns mockk {
+            coEvery { await() } returns DataResult.Success(courses)
+        }
+
+        every { groupManager.getAllGroupsAsync(any()) } returns mockk {
+            coEvery { await() } returns DataResult.Success(emptyList())
+        }
+
+        viewModel = EditDashboardViewModel(courseManager, groupManager)
+        viewModel.data.observe(lifecycleOwner, Observer {})
+
+        val data = viewModel.data.value?.items ?: emptyList()
+
+        assertEquals(4, data.size)
+
+        assert(data[2] is EditDashboardEnrollmentItemViewModel)
+        val currentHeader = data[2] as EditDashboardEnrollmentItemViewModel
+        assertEquals(R.string.future_enrollments, currentHeader.title)
+
+        assert(data[3] is EditDashboardCourseItemViewModel)
+        val currentCourseItemViewModel = data[3] as EditDashboardCourseItemViewModel
+        assertEquals("Course with past and future enrollment", currentCourseItemViewModel.name)
+    }
+
     private fun createCourse(
             id: Long,
             name: String,

--- a/apps/student/src/test/java/com/instructure/student/features/dashboard/edit/EditDashboardViewModelTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/features/dashboard/edit/EditDashboardViewModelTest.kt
@@ -888,7 +888,7 @@ class EditDashboardViewModelTest {
     }
 
     @Test
-    fun `Course with past and current section only shows up as current`() {
+    fun `Course with current and future section only shows up as current`() {
         val courses = listOf(
                 createCourse(
                         id = 1L,


### PR DESCRIPTION
refs: MBL-16002
affects: Student
release note: Fixed a bug where course on the edit dashboard screen would show up multiple times.

test plan: See ticket.