### PR TITLE
[MBL-16006][Teacher] Crash fix when editing media files

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/activities/ViewMediaActivity.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/activities/ViewMediaActivity.kt
@@ -33,7 +33,7 @@ class ViewMediaActivity : BaseViewMediaActivity() {
     override fun allowCopyingUrl() = true
     override fun handleEditing(editableFile: EditableFile) {
         val args = EditFileFolderFragment.makeBundle(editableFile.file, editableFile.usageRights, editableFile.licenses, editableFile.canvasContext!!.id)
-        RouteMatcher.route(applicationContext, Route(EditFileFolderFragment::class.java, editableFile.canvasContext, args))
+        RouteMatcher.route(this, Route(EditFileFolderFragment::class.java, editableFile.canvasContext, args))
     }
 
     companion object {


### PR DESCRIPTION
refs: MBL-16006
affects: Teacher
release note: Fixed a crash when trying to edit media files.

test plan: See ticket.