### PR TITLE
[Student][MBL-16034] Add Assignment/Page/Announcement/Discussion/ETC name to the screen reader label for checkboxes in the K5 Schedule

### DIFF
--- a/libs/pandautils/src/main/res/layout/item_schedule_planner_item.xml
+++ b/libs/pandautils/src/main/res/layout/item_schedule_planner_item.xml
@@ -68,7 +68,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 android:importantForAccessibility="yes"
-                android:contentDescription="@{itemViewModel.completed ? @string/a11y_mark_as_done : @string/a11y_mark_as_not_done}"/>
+                android:contentDescription="@{itemViewModel.completed ? @string/a11y_markAsNotDoneWithName(itemViewModel.data.title) : @string/a11y_markAsDoneWithName(itemViewModel.data.title)}"/>
 
             <ImageView
                 android:id="@+id/icon"

--- a/libs/pandautils/src/main/res/values-ar/strings.xml
+++ b/libs/pandautils/src/main/res/values-ar/strings.xml
@@ -505,8 +505,6 @@
     <string name="a11y_page">صفحة</string>
     <string name="a11y_marked_as_done">تم وضع علامة "تم"</string>
     <string name="a11y_not_marked_as_done">لم يتم وضع علامة "تم"</string>
-    <string name="a11y_mark_as_done">وضع علامة "تم"</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">عذرًا! حدث خطأ أثناء تحميل تفاصيل المساق.</string>
     <string name="a11y_schedule_marked_as_not_done">لم يتم وضع علامة تم على %s</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-b+da+instk12/strings.xml
+++ b/libs/pandautils/src/main/res/values-b+da+instk12/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Side</string>
     <string name="a11y_marked_as_done">Markeret som færdig</string>
     <string name="a11y_not_marked_as_done">Ikke markeret som færdig</string>
-    <string name="a11y_mark_as_done">Marker som færdig</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Åh nej! Der opstod en fejl ved forsøg på at indlæse fagdetaljer.</string>
     <string name="a11y_schedule_marked_as_not_done">%s markeret som ikke færdig</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-b+en+AU+unimelb/strings.xml
+++ b/libs/pandautils/src/main/res/values-b+en+AU+unimelb/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Page</string>
     <string name="a11y_marked_as_done">Marked as done</string>
     <string name="a11y_not_marked_as_done">Not marked as done</string>
-    <string name="a11y_mark_as_done">Mark as done</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Uh oh! An error occurred while loading the subject details.</string>
     <string name="a11y_schedule_marked_as_not_done">%s marked as not done</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-b+en+GB+instukhe/strings.xml
+++ b/libs/pandautils/src/main/res/values-b+en+GB+instukhe/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Page</string>
     <string name="a11y_marked_as_done">Marked as done</string>
     <string name="a11y_not_marked_as_done">Not marked as done</string>
-    <string name="a11y_mark_as_done">Mark as done</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Uh oh! An error occurred while loading the module details.</string>
     <string name="a11y_schedule_marked_as_not_done">%s marked as not done</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-b+nb+instk12/strings.xml
+++ b/libs/pandautils/src/main/res/values-b+nb+instk12/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Side</string>
     <string name="a11y_marked_as_done">Merket som ferdig</string>
     <string name="a11y_not_marked_as_done">Er ikke merket som ferdig</string>
-    <string name="a11y_mark_as_done">Merk som ferdig</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Oi sann! Det oppsto en feil ved lasting av fagdetaljer.</string>
 
     <string name="a11y_schedule_marked_as_not_done">%s merket som ikke ferdig</string>

--- a/libs/pandautils/src/main/res/values-b+sv+instk12/strings.xml
+++ b/libs/pandautils/src/main/res/values-b+sv+instk12/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Sida</string>
     <string name="a11y_marked_as_done">Markera som färdig</string>
     <string name="a11y_not_marked_as_done">Inte markerad som färdig</string>
-    <string name="a11y_mark_as_done">Markera som färdig</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Oj då! Ett fel uppstod vid inläsning av kursinformationen:</string>
     <string name="a11y_schedule_marked_as_not_done">%s har markerats som ej färdig</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-b+zh+Hans/strings.xml
+++ b/libs/pandautils/src/main/res/values-b+zh+Hans/strings.xml
@@ -475,8 +475,6 @@
     <string name="a11y_page">页面</string>
     <string name="a11y_marked_as_done">标记为完成</string>
     <string name="a11y_not_marked_as_done">未标记为完成</string>
-    <string name="a11y_mark_as_done">标记为完成</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">嗳哟！加载课程详情时遇到错误。</string>
     <string name="a11y_schedule_marked_as_not_done">%s 已标记为未完成</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-b+zh+Hant/strings.xml
+++ b/libs/pandautils/src/main/res/values-b+zh+Hant/strings.xml
@@ -475,8 +475,6 @@
     <string name="a11y_page">頁面</string>
     <string name="a11y_marked_as_done">標記為已完成</string>
     <string name="a11y_not_marked_as_done">未被標記為已完成</string>
-    <string name="a11y_mark_as_done">標記為已完成</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">噢！載入課程詳細資料時發生錯誤。</string>
     <string name="a11y_schedule_marked_as_not_done">%s 標記為未完成</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-ca/strings.xml
+++ b/libs/pandautils/src/main/res/values-ca/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Pàgina</string>
     <string name="a11y_marked_as_done">Marcada com a feta</string>
     <string name="a11y_not_marked_as_done">No marcada com a feta</string>
-    <string name="a11y_mark_as_done">Marca com a feta</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Oh! S\'ha produït un error en carregar els detalls de l\'assignatura.</string>
 
     <string name="a11y_schedule_marked_as_not_done">%s s’ha marcat com a no fet</string>

--- a/libs/pandautils/src/main/res/values-cy/strings.xml
+++ b/libs/pandautils/src/main/res/values-cy/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Tudalen</string>
     <string name="a11y_marked_as_done">Wedi ei farcio ei fod wedi’i wneud</string>
     <string name="a11y_not_marked_as_done">Heb ei farcio ei fod wedi’i wneud</string>
-    <string name="a11y_mark_as_done">Marcio eu bod wedi’u gwneud</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">O na! Gwall wrth lwytho manylion y cwrs.</string>
     <string name="a11y_schedule_marked_as_not_done">%s wedi’i farcio fel heb ei gwblhau</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-da/strings.xml
+++ b/libs/pandautils/src/main/res/values-da/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Side</string>
     <string name="a11y_marked_as_done">Markeret som færdig</string>
     <string name="a11y_not_marked_as_done">Ikke markeret som færdig</string>
-    <string name="a11y_mark_as_done">Marker som færdig</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Åh ååh! Der opstod en fejl ved forsøg på at indlæse fagdetaljer.</string>
     <string name="a11y_schedule_marked_as_not_done">%s markeret som ikke færdig</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-de/strings.xml
+++ b/libs/pandautils/src/main/res/values-de/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Seite</string>
     <string name="a11y_marked_as_done">Als fertig markiert</string>
     <string name="a11y_not_marked_as_done">Nicht als fertig markiert</string>
-    <string name="a11y_mark_as_done">Als fertig markieren</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Oh je! Fehler beim Laden der Kursdetails</string>
     <string name="a11y_schedule_marked_as_not_done">%s als nicht erledigt markiert</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-en-rAU/strings.xml
+++ b/libs/pandautils/src/main/res/values-en-rAU/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Page</string>
     <string name="a11y_marked_as_done">Marked as done</string>
     <string name="a11y_not_marked_as_done">Not marked as done</string>
-    <string name="a11y_mark_as_done">Mark as done</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Uh oh! An error occurred while loading the course details.</string>
     <string name="a11y_schedule_marked_as_not_done">%s marked as not done</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-en-rCA/strings.xml
+++ b/libs/pandautils/src/main/res/values-en-rCA/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Page</string>
     <string name="a11y_marked_as_done">Marked as done</string>
     <string name="a11y_not_marked_as_done">Not marked as done</string>
-    <string name="a11y_mark_as_done">Mark as done</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Uh oh! An error occurred while loading the course details.</string>
     <string name="a11y_schedule_marked_as_not_done">%s marked as not done</string>
 

--- a/libs/pandautils/src/main/res/values-en-rCY/strings.xml
+++ b/libs/pandautils/src/main/res/values-en-rCY/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Page</string>
     <string name="a11y_marked_as_done">Marked as done</string>
     <string name="a11y_not_marked_as_done">Not marked as done</string>
-    <string name="a11y_mark_as_done">Mark as done</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Uh oh! An error occurred while loading the module details.</string>
     <string name="a11y_schedule_marked_as_not_done">%s marked as not done</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-en-rGB/strings.xml
+++ b/libs/pandautils/src/main/res/values-en-rGB/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Page</string>
     <string name="a11y_marked_as_done">Marked as done</string>
     <string name="a11y_not_marked_as_done">Not marked as done</string>
-    <string name="a11y_mark_as_done">Mark as done</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Uh oh! An error occurred while loading the course details.</string>
     <string name="a11y_schedule_marked_as_not_done">%s marked as not done</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-es-rES/strings.xml
+++ b/libs/pandautils/src/main/res/values-es-rES/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Página</string>
     <string name="a11y_marked_as_done">Marcado como hecho</string>
     <string name="a11y_not_marked_as_done">Marcado como no hecho</string>
-    <string name="a11y_mark_as_done">Marcar como hecho</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">¡Ay, no! Ha habido un error al cargar los detalles de la asignatura.</string>
 
     <string name="a11y_schedule_marked_as_not_done">%s marcado como no hecho</string>

--- a/libs/pandautils/src/main/res/values-es/strings.xml
+++ b/libs/pandautils/src/main/res/values-es/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Página</string>
     <string name="a11y_marked_as_done">Marcado como realizado</string>
     <string name="a11y_not_marked_as_done">No marcado como realizado</string>
-    <string name="a11y_mark_as_done">Marcar como realizado</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">¡Ay, no! Ocurrió un error al cargar los detalles del curso.</string>
     <string name="a11y_schedule_marked_as_not_done">%s marcado como no realizado</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-fi/strings.xml
+++ b/libs/pandautils/src/main/res/values-fi/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Sivu</string>
     <string name="a11y_marked_as_done">Merkitty tehdyksi</string>
     <string name="a11y_not_marked_as_done">Ei ole merkitty valmiiksi</string>
-    <string name="a11y_mark_as_done">Merkitse valmiiksi</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Voi ei! Kurssin tietoja ladattaessa ilmeni virhe.</string>
     <string name="a11y_schedule_marked_as_not_done">%s merkitty ei valmiiksi</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-fr-rCA/strings.xml
+++ b/libs/pandautils/src/main/res/values-fr-rCA/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Page</string>
     <string name="a11y_marked_as_done">Marquer comme terminé</string>
     <string name="a11y_not_marked_as_done">Non marqué comme terminé</string>
-    <string name="a11y_mark_as_done">Marquer comme terminé</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Oh oh! Une erreur s’est produite lors du chargement des détails du cours.</string>
     <string name="a11y_schedule_marked_as_not_done">%s marqué comme non terminé</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-fr/strings.xml
+++ b/libs/pandautils/src/main/res/values-fr/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Page</string>
     <string name="a11y_marked_as_done">Marqué comme terminé</string>
     <string name="a11y_not_marked_as_done">Pas marqué comme terminé</string>
-    <string name="a11y_mark_as_done">Marquer comme terminé</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Oups ! Une erreur est survenue pendant le chargement des détails du cours.</string>
     <string name="a11y_schedule_marked_as_not_done">%s est marqué comme non terminé</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-ht/strings.xml
+++ b/libs/pandautils/src/main/res/values-ht/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Paj</string>
     <string name="a11y_marked_as_done">Make tankou li fini</string>
     <string name="a11y_not_marked_as_done">Pa make tankou li fini</string>
-    <string name="a11y_mark_as_done">Make tankou li fini</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Uh oh! Gen yon erè ki fèt pandan chajman detay kou yo.</string>
     <string name="a11y_schedule_marked_as_not_done">%s make ke li poko fini</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-is/strings.xml
+++ b/libs/pandautils/src/main/res/values-is/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Síða</string>
     <string name="a11y_marked_as_done">Merkt sem lokið</string>
     <string name="a11y_not_marked_as_done">Ekki merkt sem lokið</string>
-    <string name="a11y_mark_as_done">Merkja sem lokið</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Æi! Villa átti sér stað við að hlaða inn námskeiðsupplýsingum.</string>
     <string name="a11y_schedule_marked_as_not_done">%s merkt sem ólokið</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-it/strings.xml
+++ b/libs/pandautils/src/main/res/values-it/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Pagina</string>
     <string name="a11y_marked_as_done">Contrassegnato come fatto</string>
     <string name="a11y_not_marked_as_done">Non contrassegnato come fatto</string>
-    <string name="a11y_mark_as_done">Contrassegna come fatto</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Spiacenti. Si è verificato un errore durante il caricamento dei dettagli del corso.</string>
     <string name="a11y_schedule_marked_as_not_done">%s contrassegnato come non fatto</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-ja/strings.xml
+++ b/libs/pandautils/src/main/res/values-ja/strings.xml
@@ -475,8 +475,6 @@
     <string name="a11y_page">ページ</string>
     <string name="a11y_marked_as_done">完了としてマークする</string>
     <string name="a11y_not_marked_as_done">完了とマークされていない</string>
-    <string name="a11y_mark_as_done">完了にする</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">エラーです！コース詳細の読み込み中にエラーが発生しました：</string>
     <string name="a11y_schedule_marked_as_not_done">%s完了とマークされていない</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-mi/strings.xml
+++ b/libs/pandautils/src/main/res/values-mi/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Whārangi</string>
     <string name="a11y_marked_as_done">Tohua kua oti</string>
     <string name="a11y_not_marked_as_done">Kaore i tohua kua oti</string>
-    <string name="a11y_mark_as_done">Tohu kua oti</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Aue! He hapa i puta i te wā e uta ana i ngā taipitopito akoranga</string>
     <string name="a11y_schedule_marked_as_not_done">%s kua tohua hei karekau i oti</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-nb/strings.xml
+++ b/libs/pandautils/src/main/res/values-nb/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Side</string>
     <string name="a11y_marked_as_done">Merket som ferdig</string>
     <string name="a11y_not_marked_as_done">Er ikke merket som ferdig</string>
-    <string name="a11y_mark_as_done">Merk som ferdig</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Oi sann! Det oppsto en feil ved lasting av emnedetaljer.</string>
 
     <string name="a11y_schedule_marked_as_not_done">%s merket som ikke ferdig</string>

--- a/libs/pandautils/src/main/res/values-nl/strings.xml
+++ b/libs/pandautils/src/main/res/values-nl/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Pagina</string>
     <string name="a11y_marked_as_done">Gemarkeerd als klaar</string>
     <string name="a11y_not_marked_as_done">Niet gemarkeerd als klaar</string>
-    <string name="a11y_mark_as_done">Markeren als klaar</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Let op! Er is een fout opgetreden tijdens het laden van de cursusdetails.</string>
     <string name="a11y_schedule_marked_as_not_done">%s niet gemarkeerd als klaar</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-pl/strings.xml
+++ b/libs/pandautils/src/main/res/values-pl/strings.xml
@@ -495,8 +495,6 @@
     <string name="a11y_page">Strona</string>
     <string name="a11y_marked_as_done">Oznaczono jako gotowe</string>
     <string name="a11y_not_marked_as_done">Nie oznaczono jako gotowe</string>
-    <string name="a11y_mark_as_done">Oznacz jako gotowe</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">O, nie! Podczas wczytywania szczegółów kursu wystąpił błąd.</string>
     <string name="a11y_schedule_marked_as_not_done">%s oznaczono jako niegotowe</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-pt-rBR/strings.xml
+++ b/libs/pandautils/src/main/res/values-pt-rBR/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Página</string>
     <string name="a11y_marked_as_done">Marcado como concluído</string>
     <string name="a11y_not_marked_as_done">Não marcado como concluído</string>
-    <string name="a11y_mark_as_done">Marcar como concluído</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Que difícil... Ocorreu um erro ao carregar os detalhes do curso.</string>
     <string name="a11y_schedule_marked_as_not_done">%s marcado como não pronto</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-pt-rPT/strings.xml
+++ b/libs/pandautils/src/main/res/values-pt-rPT/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Página</string>
     <string name="a11y_marked_as_done">Marcado como terminado</string>
     <string name="a11y_not_marked_as_done">Não marcado como terminado</string>
-    <string name="a11y_mark_as_done">Marcar como terminado</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Ah não! Ocorreu um erro ao carregar os detalhes da disciplina.</string>
     <string name="a11y_schedule_marked_as_not_done">%s marcado como não feito</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-ru/strings.xml
+++ b/libs/pandautils/src/main/res/values-ru/strings.xml
@@ -495,8 +495,6 @@
     <string name="a11y_page">Страница</string>
     <string name="a11y_marked_as_done">Отмечено как выполненное</string>
     <string name="a11y_not_marked_as_done">Не отмечено как выполненное</string>
-    <string name="a11y_mark_as_done">Отметить как выполненное</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Ой-ой! Произошла ошибка при загрузке информации о курсе.</string>
     <string name="a11y_schedule_marked_as_not_done">%s отмечено как невыполненное</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-sl/strings.xml
+++ b/libs/pandautils/src/main/res/values-sl/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Stran</string>
     <string name="a11y_marked_as_done">Označi kot dokončano</string>
     <string name="a11y_not_marked_as_done">Ni označeno kot dokončano</string>
-    <string name="a11y_mark_as_done">Označi kot dokončano</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Ojoj! Pri nalaganju podrobnosti o predmetu je prišlo do napake.</string>
     <string name="a11y_schedule_marked_as_not_done">%s označeno kot nedokončano</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-sv/strings.xml
+++ b/libs/pandautils/src/main/res/values-sv/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Sida</string>
     <string name="a11y_marked_as_done">Markera som färdig</string>
     <string name="a11y_not_marked_as_done">Inte markerad som färdig</string>
-    <string name="a11y_mark_as_done">Markera som färdig</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Oj då! Ett fel uppstod vid inläsning av kursinformationen:</string>
     <string name="a11y_schedule_marked_as_not_done">%s har markerats som ej färdig</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-th/strings.xml
+++ b/libs/pandautils/src/main/res/values-th/strings.xml
@@ -482,8 +482,6 @@
     <string name="a11y_page">หน้าเพจ</string>
     <string name="a11y_marked_as_done">กำกับว่าเสร็จสิ้นแล้ว</string>
     <string name="a11y_not_marked_as_done">ไม่ได้กำกับว่าเสร็จสิ้นแล้ว</string>
-    <string name="a11y_mark_as_done">กำกับว่าเสร็จสิ้นแล้ว</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">โอ๊ะ โอ! เกิดข้อผิดพลาดขณะโหลดรายละเอียดบทเรียน</string>
     <string name="a11y_schedule_marked_as_not_done">%s กำลังไว้ว่าไม่เสร็จสิ้น</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-vi/strings.xml
+++ b/libs/pandautils/src/main/res/values-vi/strings.xml
@@ -481,8 +481,6 @@
     <string name="a11y_page">Trang</string>
     <string name="a11y_marked_as_done">Được đánh dấu là đã xong</string>
     <string name="a11y_not_marked_as_done">Không được đánh dấu là đã xong</string>
-    <string name="a11y_mark_as_done">Đánh dấu là đã xong</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Rất tiếc! Đã xảy ra lỗi khi tải thông tin chi tiết khóa học.</string>
 
     <string name="a11y_schedule_marked_as_not_done">%s không được đánh dấu là đã xong</string>

--- a/libs/pandautils/src/main/res/values-zh-rHK/strings.xml
+++ b/libs/pandautils/src/main/res/values-zh-rHK/strings.xml
@@ -475,8 +475,6 @@
     <string name="a11y_page">頁面</string>
     <string name="a11y_marked_as_done">標記為已完成</string>
     <string name="a11y_not_marked_as_done">未被標記為已完成</string>
-    <string name="a11y_mark_as_done">標記為已完成</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">噢！載入課程詳細資料時發生錯誤。</string>
     <string name="a11y_schedule_marked_as_not_done">%s 標記為未完成</string>
 </resources>

--- a/libs/pandautils/src/main/res/values-zh/strings.xml
+++ b/libs/pandautils/src/main/res/values-zh/strings.xml
@@ -475,8 +475,6 @@
     <string name="a11y_page">页面</string>
     <string name="a11y_marked_as_done">标记为完成</string>
     <string name="a11y_not_marked_as_done">未标记为完成</string>
-    <string name="a11y_mark_as_done">标记为完成</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">嗳哟！加载课程详情时遇到错误。</string>
     <string name="a11y_schedule_marked_as_not_done">%s 已标记为未完成</string>
 </resources>

--- a/libs/pandautils/src/main/res/values/strings.xml
+++ b/libs/pandautils/src/main/res/values/strings.xml
@@ -481,9 +481,9 @@
     <string name="a11y_page">Page</string>
     <string name="a11y_marked_as_done">Marked as done</string>
     <string name="a11y_not_marked_as_done">Not marked as done</string>
-    <string name="a11y_mark_as_done">Mark as done</string>
-    <string name="a11y_mark_as_not_done">mark_as_not_done</string>
     <string name="error_loading_course_details">Uh oh! An error occurred while loading the course details.</string>
     <string name="a11y_schedule_marked_as_not_done">%s marked as not done</string>
+    <string name="a11y_markAsDoneWithName">%s Mark as done</string>
+    <string name="a11y_markAsNotDoneWithName">%s Mark as not done</string>
 
 </resources>


### PR DESCRIPTION
Test plan: In the ticket

refs: MBL-16034
affects: Student
release note: Accessibility improvement on K5 Schedule