### PR TITLE
[Teacher][MBL-16033] Editing video file name does not get applied until navigating back to Files page

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/events/BusEvents.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/events/BusEvents.kt
@@ -197,9 +197,6 @@ class UploadMediaCommentUpdateEvent(updatedComments: MutableMap<String, MutableL
 
 class SubmissionCommentsUpdated(skipId: String? = null) : RationedBusEvent<Boolean>(true, skipId)
 
-class FileFolderDeletedEvent(val deletedFileFolder: FileFolder, skipId: String? = null) : RationedBusEvent<FileFolder>(deletedFileFolder, skipId)
-class FileFolderUpdatedEvent(val updatedFileFolder: FileFolder, skipId: String? = null) : RationedBusEvent<FileFolder>(updatedFileFolder, skipId)
-
 class SectionsUpdatedEvent
 
 class SubmissionFilterChangedEvent(val filterIndex: Int = -1, val canvasContext: ArrayList<CanvasContext>? = null)

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ModuleListEventBusSource.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ModuleListEventBusSource.kt
@@ -17,7 +17,15 @@
 package com.instructure.teacher.features.modules.list
 
 import com.instructure.canvasapi2.models.ModuleItem
-import com.instructure.teacher.events.*
+import com.instructure.pandautils.utils.FileFolderDeletedEvent
+import com.instructure.pandautils.utils.FileFolderUpdatedEvent
+import com.instructure.teacher.events.AssignmentDeletedEvent
+import com.instructure.teacher.events.AssignmentUpdatedEvent
+import com.instructure.teacher.events.DiscussionTopicHeaderDeletedEvent
+import com.instructure.teacher.events.DiscussionUpdatedEvent
+import com.instructure.teacher.events.PageDeletedEvent
+import com.instructure.teacher.events.PageUpdatedEvent
+import com.instructure.teacher.events.QuizUpdatedEvent
 import com.instructure.teacher.mobius.common.EventBusSource
 import org.greenrobot.eventbus.Subscribe
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/EditFileFolderFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/EditFileFolderFragment.kt
@@ -42,8 +42,8 @@ import com.instructure.pandautils.utils.*
 import com.instructure.teacher.R
 import com.instructure.teacher.adapters.LongNameArrayAdapter
 import com.instructure.teacher.dialog.ConfirmDeleteFileFolderDialog
-import com.instructure.teacher.events.FileFolderDeletedEvent
-import com.instructure.teacher.events.FileFolderUpdatedEvent
+import com.instructure.pandautils.utils.FileFolderDeletedEvent
+import com.instructure.pandautils.utils.FileFolderUpdatedEvent
 import com.instructure.teacher.events.post
 import com.instructure.teacher.factory.EditFilePresenterFactory
 import com.instructure.teacher.presenters.EditFileFolderPresenter
@@ -125,7 +125,7 @@ class EditFileFolderFragment : BasePresenterFragment<
     }
 
     override fun fileFolderUpdated(updatedFileFolder: FileFolder) {
-        FileFolderUpdatedEvent(updatedFileFolder).post()
+        FileFolderUpdatedEvent(updatedFileFolder).postSticky()
         requireActivity().onBackPressed()
     }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/FileListFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/FileListFragment.kt
@@ -41,8 +41,8 @@ import com.instructure.teacher.R
 import com.instructure.teacher.adapters.FileListAdapter
 import com.instructure.teacher.dialog.CreateFolderDialog
 import com.instructure.teacher.dialog.NoInternetConnectionDialog
-import com.instructure.teacher.events.FileFolderDeletedEvent
-import com.instructure.teacher.events.FileFolderUpdatedEvent
+import com.instructure.pandautils.utils.FileFolderDeletedEvent
+import com.instructure.pandautils.utils.FileFolderUpdatedEvent
 import com.instructure.teacher.factory.FileListPresenterFactory
 import com.instructure.teacher.features.files.search.FileSearchFragment
 import com.instructure.teacher.holders.FileFolderViewHolder

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/ViewHtmlFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/ViewHtmlFragment.kt
@@ -33,8 +33,8 @@ import com.instructure.pandautils.models.EditableFile
 import com.instructure.pandautils.utils.*
 import com.instructure.pandautils.utils.Utils.copyToClipboard
 import com.instructure.teacher.R
-import com.instructure.teacher.events.FileFolderDeletedEvent
-import com.instructure.teacher.events.FileFolderUpdatedEvent
+import com.instructure.pandautils.utils.FileFolderDeletedEvent
+import com.instructure.pandautils.utils.FileFolderUpdatedEvent
 import com.instructure.teacher.router.RouteMatcher
 import com.instructure.teacher.utils.setupMenu
 import kotlinx.android.synthetic.main.fragment_internal_webview.*

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/ViewImageFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/ViewImageFragment.kt
@@ -38,8 +38,8 @@ import com.instructure.pandautils.models.EditableFile
 import com.instructure.pandautils.utils.*
 import com.instructure.pandautils.utils.Utils.copyToClipboard
 import com.instructure.teacher.R
-import com.instructure.teacher.events.FileFolderDeletedEvent
-import com.instructure.teacher.events.FileFolderUpdatedEvent
+import com.instructure.pandautils.utils.FileFolderDeletedEvent
+import com.instructure.pandautils.utils.FileFolderUpdatedEvent
 import com.instructure.teacher.router.RouteMatcher
 import com.instructure.teacher.utils.setupBackButton
 import com.instructure.teacher.utils.setupMenu

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/ViewPdfFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/ViewPdfFragment.kt
@@ -24,8 +24,8 @@ import android.view.View
 import android.view.ViewGroup
 import com.instructure.pandautils.utils.*
 import com.instructure.teacher.R
-import com.instructure.teacher.events.FileFolderDeletedEvent
-import com.instructure.teacher.events.FileFolderUpdatedEvent
+import com.instructure.pandautils.utils.FileFolderDeletedEvent
+import com.instructure.pandautils.utils.FileFolderUpdatedEvent
 import com.instructure.teacher.factory.ViewPdfFragmentPresenterFactory
 import com.instructure.teacher.presenters.ViewPdfFragmentPresenter
 import com.instructure.interactions.router.Route

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/ViewUnsupportedFileFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/ViewUnsupportedFileFragment.kt
@@ -36,8 +36,8 @@ import com.instructure.pandautils.models.EditableFile
 import com.instructure.pandautils.utils.*
 import com.instructure.pandautils.utils.Utils.copyToClipboard
 import com.instructure.teacher.R
-import com.instructure.teacher.events.FileFolderDeletedEvent
-import com.instructure.teacher.events.FileFolderUpdatedEvent
+import com.instructure.pandautils.utils.FileFolderDeletedEvent
+import com.instructure.pandautils.utils.FileFolderUpdatedEvent
 import com.instructure.teacher.router.RouteMatcher
 import com.instructure.teacher.utils.setupBackButton
 import com.instructure.teacher.utils.setupMenu


### PR DESCRIPTION
Test plan: In the ticket

refs: MBL-16033
affects: Teacher
release note: Fixed a bug where a video file's new name was not shown after editing.