### PR TITLE
[MBL-15985][Student][Teacher] Dark mode for WebViews

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/url/ui/UrlSubmissionUploadView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/url/ui/UrlSubmissionUploadView.kt
@@ -69,6 +69,7 @@ class UrlSubmissionUploadView(inflater: LayoutInflater, parent: ViewGroup) : Mob
     override fun applyTheme() {}
 
     fun showPreviewUrl(url: String) {
+        urlPreviewWebView?.setVisible()
         urlPreviewWebView.loadUrl(url)
     }
 
@@ -84,6 +85,6 @@ class UrlSubmissionUploadView(inflater: LayoutInflater, parent: ViewGroup) : Mob
 
     companion object {
         private const val DELAY = 400L
-        private const val URL_MINIMUM_LENGTH = 0
+        private const val URL_MINIMUM_LENGTH = 3
     }
 }

--- a/apps/student/src/main/res/layout/fragment_submission_rubric_description.xml
+++ b/apps/student/src/main/res/layout/fragment_submission_rubric_description.xml
@@ -28,11 +28,6 @@
         tools:navigationIcon="@drawable/ic_back_arrow"
         tools:title="Rubric Criterion Title"/>
 
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="0.5dp"
-        android:background="@color/backgroundMedium"/>
-
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/apps/student/src/main/res/layout/fragment_url_submission_upload.xml
+++ b/apps/student/src/main/res/layout/fragment_url_submission_upload.xml
@@ -82,6 +82,8 @@
             android:id="@+id/urlPreviewWebView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:background="@color/backgroundLightest"
+            android:visibility="gone"
             tools:background="#EEE"
             tools:scaleType="center"
             tools:src="@tools:sample/backgrounds/scenic" />

--- a/apps/student/src/main/res/values/styles.xml
+++ b/apps/student/src/main/res/values/styles.xml
@@ -45,6 +45,8 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="windowActionModeOverlay">true</item>
+        <item name="android:alertDialogTheme">@style/CanvasDialogTheme_Default</item>
+        <item name="alertDialogTheme">@style/CanvasDialogTheme_Default</item>
         <item name="pspdf__annotationCreationToolbarIconsStyle">@style/PSPDFAnnotationCreationToolbarIconsStyle</item>
         <item name="pspdf__actionBarIconsStyle">@style/PSPDFKitActionBarIconsStyle</item>
     </style>

--- a/apps/teacher/src/main/java/com/instructure/teacher/activities/FeedbackActivity.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/activities/FeedbackActivity.kt
@@ -13,6 +13,7 @@ import com.instructure.pandautils.analytics.SCREEN_VIEW_FEEDBACK
 import com.instructure.pandautils.analytics.ScreenView
 import com.instructure.pandautils.utils.ThemePrefs
 import com.instructure.pandautils.utils.ViewStyler
+import com.instructure.pandautils.utils.setDarkModeSupport
 import com.instructure.teacher.R
 import com.instructure.teacher.utils.setupBackButton
 import kotlinx.android.synthetic.main.activity_feedback.*
@@ -41,6 +42,7 @@ class FeedbackActivity : AppCompatActivity() {
         webView.setWebChromeClient(WebChromeClient())
         webView.settings.javaScriptEnabled = true
         webView.settings.setSupportZoom(false)
+        webView.setDarkModeSupport()
         webView.loadUrl(buildUrl())
     }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/AttendanceListFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/AttendanceListFragment.kt
@@ -93,6 +93,7 @@ class AttendanceListFragment : BaseSyncFragment<
     }
 
     private fun setupViews() {
+        webView?.setDarkModeSupport()
         toolbar.setupMenu(R.menu.menu_attendance) { menuItem ->
             when(menuItem.itemId) {
                 R.id.menuFilterSections -> { /* Do Nothing */ }

--- a/apps/teacher/src/main/res/values/styles.xml
+++ b/apps/teacher/src/main/res/values/styles.xml
@@ -21,6 +21,8 @@
         <item name="colorPrimary">@color/textDark</item>
         <item name="colorPrimaryDark">@color/textDarkest</item>
         <item name="colorAccent">@color/textDark</item>
+        <item name="android:alertDialogTheme">@style/CanvasDialogTheme_Default</item>
+        <item name="alertDialogTheme">@style/CanvasDialogTheme_Default</item>
 
         <item name="android:windowBackground">@color/backgroundLightest</item>
         <item name="android:actionOverflowButtonStyle">@style/Widget.ActionButton.Overflow</item>
@@ -31,6 +33,8 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="windowActionModeOverlay">true</item>
+        <item name="android:alertDialogTheme">@style/CanvasDialogTheme_Default</item>
+        <item name="alertDialogTheme">@style/CanvasDialogTheme_Default</item>
 
         <item name="pspdf__contextualToolbarStyle">@style/ContextualToolbarStyle</item>
         <item name="pspdf__annotationCreationToolbarIconsStyle">@style/AnnotationCreationToolbarIconsStyle</item>
@@ -108,6 +112,8 @@
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowAnimationStyle">@android:style/Animation</item>
         <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:alertDialogTheme">@style/CanvasDialogTheme_Default</item>
+        <item name="alertDialogTheme">@style/CanvasDialogTheme_Default</item>
     </style>
 
     <style name="RoundedContextDialog" parent="Theme.AppCompat.DayNight.Dialog.Alert">

--- a/buildSrc/src/main/java/GlobalDependencies.kt
+++ b/buildSrc/src/main/java/GlobalDependencies.kt
@@ -74,6 +74,7 @@ object Libs {
     const val ANDROIDX_CORE_TESTING = "androidx.arch.core:core-testing:2.1.0"
     const val ANDROIDX_WORK_MANAGER = "androidx.work:work-runtime:${Versions.WORK_MANAGER}"
     const val ANDROIDX_WORK_MANAGER_KTX = "androidx.work:work-runtime-ktx:${Versions.WORK_MANAGER}"
+    const val ANDROIDX_WEBKIT = "androidx.webkit:webkit:1.4.0"
 
     /* Firebase */
     const val FIREBASE_BOM = "com.google.firebase:firebase-bom:29.3.0"

--- a/libs/login-api-2/src/main/java/com/instructure/loginapi/login/activities/BaseLoginSignInActivity.kt
+++ b/libs/login-api-2/src/main/java/com/instructure/loginapi/login/activities/BaseLoginSignInActivity.kt
@@ -132,6 +132,7 @@ abstract class BaseLoginSignInActivity : AppCompatActivity(), OnAuthenticationSe
         webView.settings.setAppCacheEnabled(false)
         webView.settings.domStorageEnabled = true
         webView.settings.userAgentString = Utils.generateUserAgent(this, userAgent())
+        webView.setDarkModeSupport()
         webView.webViewClient = mWebViewClient
         if (0 != applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) {
             WebView.setWebContentsDebuggingEnabled(true)

--- a/libs/pandautils/build.gradle
+++ b/libs/pandautils/build.gradle
@@ -145,6 +145,7 @@ dependencies {
     implementation Libs.ANDROIDX_SWIPE_REFRESH_LAYOUT
     implementation Libs.ANDROIDX_CONSTRAINT_LAYOUT
     implementation Libs.PLAY_CORE_KTX
+    implementation Libs.ANDROIDX_WEBKIT
 
     /* Work Manager */
     implementation Libs.ANDROIDX_WORK_MANAGER

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/discussions/DiscussionUtils.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/discussions/DiscussionUtils.kt
@@ -469,7 +469,7 @@ object DiscussionUtils {
             val avatarBitmap = ProfileUtils.getInitialsAvatarBitMap(
                     context, discussionEntry.author!!.displayName!!,
                     Color.TRANSPARENT,
-                    ContextCompat.getColor(context, R.color.textDarkest),
+                    ContextCompat.getColor(context, R.color.licorice),
                     ContextCompat.getColor(context, R.color.borderMedium))
             val outputStream = ByteArrayOutputStream()
             avatarBitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/WebViewExtensions.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/WebViewExtensions.kt
@@ -16,8 +16,11 @@
 package com.instructure.pandautils.utils
 
 import android.content.Context
+import android.content.res.Configuration
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
+import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebViewFeature
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.instructure.canvasapi2.managers.OAuthManager
 import com.instructure.canvasapi2.models.AuthenticatedSession
@@ -147,5 +150,17 @@ class JsExternalToolInterface(val callback: (ltiUrl: String) -> Unit) {
     @JavascriptInterface
     fun onLtiToolButtonPressed(ltiUrl: String) {
         callback(ltiUrl)
+    }
+}
+
+fun WebView.setDarkModeSupport() {
+    if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
+        val nightModeFlags: Int = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        if (nightModeFlags == Configuration.UI_MODE_NIGHT_YES) {
+            WebSettingsCompat.setForceDark(settings, WebSettingsCompat.FORCE_DARK_ON)
+            WebSettingsCompat.setForceDarkStrategy(settings, WebSettingsCompat.DARK_STRATEGY_PREFER_WEB_THEME_OVER_USER_AGENT_DARKENING)
+        } else {
+            WebSettingsCompat.setForceDark(settings, WebSettingsCompat.FORCE_DARK_OFF)
+        }
     }
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/views/CanvasWebView.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/views/CanvasWebView.kt
@@ -164,6 +164,7 @@ class CanvasWebView @JvmOverloads constructor(
             }
         }
         CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
+        setDarkModeSupport()
     }
 
     @SuppressLint("SetJavaScriptEnabled")

--- a/libs/pandautils/src/main/res/values/themes_canvasthemes.xml
+++ b/libs/pandautils/src/main/res/values/themes_canvasthemes.xml
@@ -63,10 +63,12 @@
         <item name="colorPrimary">@color/textDarkest</item>
         <item name="colorPrimaryDark">@color/textDarkest</item>
         <item name="colorAccent">@color/textDarkest</item>
+        <item name="background">@color/backgroundLightestElevated</item>
         <item name="android:colorPrimary">@color/textDarkest</item>
         <item name="android:colorPrimaryDark">@color/textDarkest</item>
         <item name="android:colorAccent">@color/textDarkest</item>
         <item name="android:windowNoTitle">true</item>
+        <item name="android:background">@color/backgroundLightestElevated</item>
     </style>
 
     <style name="AccentDialogTheme" parent="CanvasDialogTheme_Default">


### PR DESCRIPTION
Test notes:
- In this PR I set up forced dark mode for all the WebViews and all the web content we have in the app (only exception is url preview in the url submission view). Later we might revert some of them, but this will be discussed with the team.

These are the screens that should be checked:
- Login
- Discussion details
- Announcement details
- K5 homeroom/important links/subject pages
- Calendar event
- Assignment details
- Quiz details
- Quiz submission
- Rubric description
- Syllabus
- Text submission details
- Page details

refs: MBL-15985
affects: Teacher, Student
release note: none