### PR TITLE
[MBL-16086][Student][Teacher] Set only the correct WebViews to force dark mode

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/features/dashboard/notifications/StudentDashboardRouter.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/dashboard/notifications/StudentDashboardRouter.kt
@@ -31,7 +31,8 @@ class StudentDashboardRouter(private val activity: FragmentActivity) : Dashboard
                 subject,
                 false,
                 message,
-                allowUnsupportedRouting = false)
+                allowUnsupportedRouting = false
+            )
         )
     }
 }

--- a/apps/student/src/main/java/com/instructure/student/features/dashboard/notifications/StudentDashboardRouter.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/dashboard/notifications/StudentDashboardRouter.kt
@@ -31,9 +31,7 @@ class StudentDashboardRouter(private val activity: FragmentActivity) : Dashboard
                 subject,
                 false,
                 message,
-                allowUnsupportedRouting = false,
-                forceDark = true
-            )
+                allowUnsupportedRouting = false)
         )
     }
 }

--- a/apps/student/src/main/java/com/instructure/student/features/dashboard/notifications/StudentDashboardRouter.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/dashboard/notifications/StudentDashboardRouter.kt
@@ -31,7 +31,8 @@ class StudentDashboardRouter(private val activity: FragmentActivity) : Dashboard
                 subject,
                 false,
                 message,
-                allowUnsupportedRouting = false
+                allowUnsupportedRouting = false,
+                forceDark = true
             )
         )
     }

--- a/apps/student/src/main/java/com/instructure/student/features/elementary/course/ElementaryCoursePagerAdapter.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/elementary/course/ElementaryCoursePagerAdapter.kt
@@ -25,6 +25,7 @@ import android.widget.ProgressBar
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager.widget.PagerAdapter
 import com.instructure.canvasapi2.utils.ApiPrefs
+import com.instructure.pandautils.utils.setDarkModeSupport
 import com.instructure.pandautils.utils.setGone
 import com.instructure.pandautils.utils.setVisible
 import com.instructure.pandautils.views.CanvasWebView
@@ -64,6 +65,7 @@ class ElementaryCoursePagerAdapter(
         val baseContext = (webView.context as ContextWrapper).baseContext
         val activity = (baseContext as? FragmentActivity)
         activity?.let { webView.addVideoClient(it) }
+        webView.setDarkModeSupport()
         webView.setZoomSettings(false)
         webView.canvasWebViewClientCallback = object : CanvasWebView.CanvasWebViewClientCallback {
             override fun openMediaFromWebView(mime: String, url: String, filename: String) {

--- a/apps/student/src/main/java/com/instructure/student/fragment/BasicQuizViewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/BasicQuizViewFragment.kt
@@ -40,6 +40,7 @@ import com.instructure.pandautils.views.CanvasWebView
 import com.instructure.student.R
 import com.instructure.student.router.RouteMatcher
 import com.instructure.student.util.LockInfoHTMLHelper
+import kotlinx.android.synthetic.main.fragment_webview.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
@@ -84,6 +85,7 @@ class BasicQuizViewFragment : InternalWebviewFragment() {
 
         // Make sure we are prepared to handle file uploads for quizzes that allow them
         setupFilePicker()
+        canvasWebView?.setDarkModeSupport()
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {

--- a/apps/student/src/main/java/com/instructure/student/fragment/DiscussionDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/DiscussionDetailsFragment.kt
@@ -17,7 +17,6 @@
 package com.instructure.student.fragment
 
 import android.annotation.SuppressLint
-import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -362,7 +361,7 @@ class DiscussionDetailsFragment : ParentFragment(), Bookmarkable {
     //region WebView And Javascript
 
     @SuppressLint("SetJavaScriptEnabled")
-    private fun setupWebView(webView: CanvasWebView) {
+    private fun setupWebView(webView: CanvasWebView, addDarkTheme: Boolean = false) {
         WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG)
         webView.setBackgroundColor(requireContext().getColor(R.color.backgroundLightest))
         webView.settings.javaScriptEnabled = true
@@ -383,8 +382,20 @@ class DiscussionDetailsFragment : ParentFragment(), Bookmarkable {
                 openMedia(canvasContext, url, filename)
             }
 
-            override fun onPageStartedCallback(webView: WebView, url: String) {}
-            override fun onPageFinishedCallback(webView: WebView, url: String) {}
+            override fun onPageStartedCallback(webView: WebView, url: String) {
+                // This executes a JavaScript to add the dark theme.
+                // It won't work exactl when the page starts to load, because the html document is not yet created,
+                // so we add a little delay to make sure the script can modify the document.
+                if (addDarkTheme) {
+                    webView.postDelayed({ webView.addDarkThemeToHtmlDocument() }, 50)
+                }
+            }
+            override fun onPageFinishedCallback(webView: WebView, url: String) {
+                // This is just a fallback if in some cases the document wouldn't be loaded after the delay
+                if (addDarkTheme) {
+                    webView.addDarkThemeToHtmlDocument()
+                }
+            }
         }
 
         webView.addVideoClient(requireActivity())
@@ -398,7 +409,7 @@ class DiscussionDetailsFragment : ParentFragment(), Bookmarkable {
 
     @SuppressLint("SetJavaScriptEnabled")
     private fun setupRepliesWebView() {
-        setupWebView(discussionRepliesWebView)
+        setupWebView(discussionRepliesWebView, addDarkTheme = true)
         discussionRepliesWebView.addJavascriptInterface(JSDiscussionInterface(), "accessor")
     }
 

--- a/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
@@ -65,6 +65,7 @@ open class InternalWebviewFragment : ParentFragment() {
     var allowRoutingTheSameUrlInternally: Boolean by BooleanArg(default = true, key = ALLOW_ROUTING_THE_SAME_URL_INTERNALLY)
     var allowRoutingToLogin: Boolean by BooleanArg(default = true, key = ALLOW_ROUTING_TO_LOGIN)
     var allowEmbedRouting: Boolean by BooleanArg(default = true, key = ALLOW_EMBED_ROUTING)
+    var forceDark: Boolean by BooleanArg(key = FORCE_DARK)
 
     var hideToolbar: Boolean by BooleanArg(key = Const.HIDDEN_TOOLBAR)
 
@@ -103,6 +104,7 @@ open class InternalWebviewFragment : ParentFragment() {
             originalUserAgentString = canvasWebView.settings.userAgentString
             canvasWebView.settings.userAgentString = ApiPrefs.userAgent
             canvasWebView.setInitialScale(100)
+            canvasWebView.setDarkModeSupport(webThemeDarkeningOnly = !forceDark)
             webViewLoading?.setVisible(true)
 
             canvasWebView.canvasWebChromeClientCallback = object : CanvasWebView.CanvasWebChromeClientCallback {
@@ -387,6 +389,7 @@ open class InternalWebviewFragment : ParentFragment() {
         const val ALLOW_ROUTING_THE_SAME_URL_INTERNALLY = "allowRoutingTheSameUrlInternally"
         const val ALLOW_ROUTING_TO_LOGIN = "allowRoutingToLogin"
         const val ALLOW_EMBED_ROUTING = "allowEmbedRouting"
+        const val FORCE_DARK = "forceDark"
 
         fun newInstance(route: Route): InternalWebviewFragment {
             return InternalWebviewFragment().withArgs(route.argsWithContext)
@@ -397,7 +400,7 @@ open class InternalWebviewFragment : ParentFragment() {
      * Otherwise the canvasContext won't be saved and will cause issues with the dropdown navigation
      * -dw
      */
-        fun makeRoute(url: String, title: String, authenticate: Boolean, html: String, allowUnsupportedRouting: Boolean = true): Route =
+        fun makeRoute(url: String, title: String, authenticate: Boolean, html: String, allowUnsupportedRouting: Boolean = true, forceDark: Boolean = false): Route =
                 Route(InternalWebviewFragment::class.java, CanvasContext.emptyUserContext(),
                         CanvasContext.emptyUserContext().makeBundle().apply {
                             putString(Const.INTERNAL_URL, url)
@@ -405,6 +408,7 @@ open class InternalWebviewFragment : ParentFragment() {
                             putBoolean(Const.AUTHENTICATE, authenticate)
                             putString(Const.HTML, html)
                             putBoolean(Const.ALLOW_UNSUPPORTED_ROUTING, allowUnsupportedRouting)
+                            putBoolean(FORCE_DARK, forceDark)
                         })
 
         fun makeRoute(canvasContext: CanvasContext, url: String?, title: String?, authenticate: Boolean, html: String): Route =

--- a/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
@@ -65,7 +65,6 @@ open class InternalWebviewFragment : ParentFragment() {
     var allowRoutingTheSameUrlInternally: Boolean by BooleanArg(default = true, key = ALLOW_ROUTING_THE_SAME_URL_INTERNALLY)
     var allowRoutingToLogin: Boolean by BooleanArg(default = true, key = ALLOW_ROUTING_TO_LOGIN)
     var allowEmbedRouting: Boolean by BooleanArg(default = true, key = ALLOW_EMBED_ROUTING)
-    var forceDark: Boolean by BooleanArg(key = FORCE_DARK)
 
     var hideToolbar: Boolean by BooleanArg(key = Const.HIDDEN_TOOLBAR)
 
@@ -104,7 +103,7 @@ open class InternalWebviewFragment : ParentFragment() {
             originalUserAgentString = canvasWebView.settings.userAgentString
             canvasWebView.settings.userAgentString = ApiPrefs.userAgent
             canvasWebView.setInitialScale(100)
-            canvasWebView.setDarkModeSupport(webThemeDarkeningOnly = !forceDark)
+            canvasWebView.setDarkModeSupport(webThemeDarkeningOnly = true)
             webViewLoading?.setVisible(true)
 
             canvasWebView.canvasWebChromeClientCallback = object : CanvasWebView.CanvasWebChromeClientCallback {
@@ -325,13 +324,6 @@ open class InternalWebviewFragment : ParentFragment() {
         }
     }
 
-    // BaseURL is set as Referer. Referer needed for some vimeo videos to play
-    fun loadHtml(html: String) {
-        canvasWebView?.loadDataWithBaseURL(ApiPrefs.fullDomain,
-                FileUtils.getAssetsFile(requireContext(), "html_wrapper.html").replace("{\$CONTENT$}", html, ignoreCase = false),
-                "text/html", "UTF-8", null)
-    }
-
     fun loadHtml(data: String, mimeType: String, encoding: String, historyUrl: String?) {
         // BaseURL is set as Referer. Referer needed for some vimeo videos to play
         canvasWebView?.loadDataWithBaseURL(CanvasWebView.getReferrer(), data, mimeType, encoding, historyUrl)
@@ -339,7 +331,7 @@ open class InternalWebviewFragment : ParentFragment() {
 
     fun loadUrl(targetUrl: String?) {
         if (!html.isNullOrBlank()) {
-            loadHtml(html!!)
+            canvasWebView?.loadHtml(html!!, title ?: "")
             return
         }
 
@@ -400,7 +392,7 @@ open class InternalWebviewFragment : ParentFragment() {
      * Otherwise the canvasContext won't be saved and will cause issues with the dropdown navigation
      * -dw
      */
-        fun makeRoute(url: String, title: String, authenticate: Boolean, html: String, allowUnsupportedRouting: Boolean = true, forceDark: Boolean = false): Route =
+        fun makeRoute(url: String, title: String, authenticate: Boolean, html: String, allowUnsupportedRouting: Boolean = true): Route =
                 Route(InternalWebviewFragment::class.java, CanvasContext.emptyUserContext(),
                         CanvasContext.emptyUserContext().makeBundle().apply {
                             putString(Const.INTERNAL_URL, url)
@@ -408,7 +400,6 @@ open class InternalWebviewFragment : ParentFragment() {
                             putBoolean(Const.AUTHENTICATE, authenticate)
                             putString(Const.HTML, html)
                             putBoolean(Const.ALLOW_UNSUPPORTED_ROUTING, allowUnsupportedRouting)
-                            putBoolean(FORCE_DARK, forceDark)
                         })
 
         fun makeRoute(canvasContext: CanvasContext, url: String?, title: String?, authenticate: Boolean, html: String): Route =

--- a/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
@@ -381,7 +381,6 @@ open class InternalWebviewFragment : ParentFragment() {
         const val ALLOW_ROUTING_THE_SAME_URL_INTERNALLY = "allowRoutingTheSameUrlInternally"
         const val ALLOW_ROUTING_TO_LOGIN = "allowRoutingToLogin"
         const val ALLOW_EMBED_ROUTING = "allowEmbedRouting"
-        const val FORCE_DARK = "forceDark"
 
         fun newInstance(route: Route): InternalWebviewFragment {
             return InternalWebviewFragment().withArgs(route.argsWithContext)

--- a/apps/student/src/main/java/com/instructure/student/fragment/PageDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/PageDetailsFragment.kt
@@ -106,6 +106,7 @@ class PageDetailsFragment : InternalWebviewFragment(), Bookmarkable {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        getCanvasWebView()?.setDarkModeSupport()
         getCanvasWebView()?.canvasEmbeddedWebViewCallback = object : CanvasWebView.CanvasEmbeddedWebViewCallback {
             override fun shouldLaunchInternalWebViewFragment(url: String): Boolean = true
             override fun launchInternalWebViewFragment(url: String) = InternalWebviewFragment.loadInternalWebView(activity, InternalWebviewFragment.makeRoute(canvasContext, url, isLTITool))

--- a/apps/student/src/main/java/com/instructure/student/fragment/PageDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/PageDetailsFragment.kt
@@ -106,7 +106,6 @@ class PageDetailsFragment : InternalWebviewFragment(), Bookmarkable {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        getCanvasWebView()?.setDarkModeSupport()
         getCanvasWebView()?.canvasEmbeddedWebViewCallback = object : CanvasWebView.CanvasEmbeddedWebViewCallback {
             override fun shouldLaunchInternalWebViewFragment(url: String): Boolean = true
             override fun launchInternalWebViewFragment(url: String) = InternalWebviewFragment.loadInternalWebView(activity, InternalWebviewFragment.makeRoute(canvasContext, url, isLTITool))

--- a/apps/student/src/main/java/com/instructure/student/fragment/StudioWebViewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/StudioWebViewFragment.kt
@@ -50,6 +50,7 @@ class StudioWebViewFragment : InternalWebviewFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        getCanvasWebView()?.setDarkModeSupport()
         getCanvasWebView()?.addJavascriptInterface(JSInterface(), "HtmlViewer")
 
         getCanvasWebView()?.canvasWebViewClientCallback = object : CanvasWebView.CanvasWebViewClientCallback {

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/DiscussionSubmissionViewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/DiscussionSubmissionViewFragment.kt
@@ -29,6 +29,7 @@ import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.canvasapi2.utils.weave.StatusCallbackError
 import com.instructure.canvasapi2.utils.weave.awaitApi
 import com.instructure.pandautils.utils.StringArg
+import com.instructure.pandautils.utils.setDarkModeSupport
 import com.instructure.pandautils.utils.setGone
 import com.instructure.pandautils.utils.setVisible
 import com.instructure.pandautils.views.CanvasWebView
@@ -57,6 +58,7 @@ class DiscussionSubmissionViewFragment : Fragment() {
     override fun onStart() {
         super.onStart()
         progressBar.announceForAccessibility(getString(R.string.loading))
+        discussionSubmissionWebView.setDarkModeSupport()
         discussionSubmissionWebView.webChromeClient = object : WebChromeClient() {
             override fun onProgressChanged(view: WebView?, newProgress: Int) {
                 super.onProgressChanged(view, newProgress)

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/QuizSubmissionViewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/QuizSubmissionViewFragment.kt
@@ -22,6 +22,7 @@ import android.webkit.WebView
 import com.instructure.pandautils.analytics.SCREEN_VIEW_QUIZ_SUBMISSION_VIEW
 import com.instructure.pandautils.analytics.ScreenView
 import com.instructure.pandautils.utils.Const
+import com.instructure.pandautils.utils.setDarkModeSupport
 import com.instructure.pandautils.utils.setGone
 import com.instructure.pandautils.utils.setInvisible
 import com.instructure.pandautils.utils.setVisible
@@ -33,7 +34,7 @@ import kotlinx.android.synthetic.main.fragment_webview.*
 class QuizSubmissionViewFragment : InternalWebviewFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         getCanvasLoading()?.setVisible() // Set visible so we can test it
-
+        canvasWebView?.setDarkModeSupport()
         canvasWebView.setInitialScale(100)
         canvasWebView.setInvisible() // Set invisible so we can test it
         canvasWebView.webChromeClient = object : WebChromeClient() {

--- a/apps/student/src/main/res/layout/fragment_syllabus_webview.xml
+++ b/apps/student/src/main/res/layout/fragment_syllabus_webview.xml
@@ -22,6 +22,6 @@
     <com.instructure.pandautils.views.CanvasWebView
         android:id="@+id/syllabusWebView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="wrap_content" />
 
 </FrameLayout>

--- a/apps/student/src/main/res/layout/fragment_webview.xml
+++ b/apps/student/src/main/res/layout/fragment_webview.xml
@@ -41,7 +41,8 @@
         android:layout_height="match_parent"
         android:layout_below="@+id/toolbar"
         android:clipToPadding="false"
-        android:scrollbarStyle="outsideOverlay" />
+        android:scrollbarStyle="outsideOverlay"
+        android:background="@color/backgroundLightest" />
 
     <ProgressBar
         android:id="@+id/webViewLoading"

--- a/apps/teacher/src/main/java/com/instructure/teacher/activities/FeedbackActivity.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/activities/FeedbackActivity.kt
@@ -42,7 +42,7 @@ class FeedbackActivity : AppCompatActivity() {
         webView.setWebChromeClient(WebChromeClient())
         webView.settings.javaScriptEnabled = true
         webView.settings.setSupportZoom(false)
-        webView.setDarkModeSupport()
+        webView.setDarkModeSupport(webThemeDarkeningOnly = true)
         webView.loadUrl(buildUrl())
     }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/dialog/CriterionLongDescriptionDialog.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/dialog/CriterionLongDescriptionDialog.kt
@@ -92,7 +92,7 @@ class CriterionLongDescriptionDialog : DialogFragment() {
             setBackgroundResource(android.R.color.transparent)
 
             // Load description
-            webView.loadHtml(mLongDescription, mDescription)
+            webView.loadHtml(mLongDescription, mDescription, R.color.backgroundLightestElevated)
         }
 
         return AlertDialog.Builder(requireContext())

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/DiscussionsDetailsFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/DiscussionsDetailsFragment.kt
@@ -461,7 +461,7 @@ class DiscussionsDetailsFragment : BasePresenterFragment<
         discussionRepliesWebView.onResume()
 
         setupWebView(discussionTopicHeaderWebView, false)
-        setupWebView(discussionRepliesWebView, true)
+        setupWebView(discussionRepliesWebView, true, addDarkTheme = true)
     }
 
     private fun setupToolbar() {
@@ -499,7 +499,7 @@ class DiscussionsDetailsFragment : BasePresenterFragment<
     }
 
     @SuppressLint("SetJavaScriptEnabled")
-    private fun setupWebView(webView: CanvasWebView, addJSSupport: Boolean) {
+    private fun setupWebView(webView: CanvasWebView, addJSSupport: Boolean, addDarkTheme: Boolean = false) {
         WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG)
         webView.setBackgroundColor(requireContext().getColor(R.color.backgroundLightest))
         webView.settings.javaScriptEnabled = true
@@ -523,8 +523,20 @@ class DiscussionsDetailsFragment : BasePresenterFragment<
                 showToast(R.string.downloadingFile)
                 RouteMatcher.openMedia(activity, url)
             }
-            override fun onPageStartedCallback(webView: WebView, url: String) {}
-            override fun onPageFinishedCallback(webView: WebView, url: String) {}
+            override fun onPageStartedCallback(webView: WebView, url: String) {
+                // This executes a JavaScript to add the dark theme.
+                // It won't work exactl when the page starts to load, because the html document is not yet created,
+                // so we add a little delay to make sure the script can modify the document.
+                if (addDarkTheme) {
+                    webView.postDelayed({ webView.addDarkThemeToHtmlDocument() }, 50)
+                }
+            }
+            override fun onPageFinishedCallback(webView: WebView, url: String) {
+                // This is just a fallback if in some cases the document wouldn't be loaded after the delay
+                if (addDarkTheme) {
+                    webView.addDarkThemeToHtmlDocument()
+                }
+            }
         }
 
         webView.addVideoClient(requireActivity())

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/InternalWebViewFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/InternalWebViewFragment.kt
@@ -119,6 +119,7 @@ open class InternalWebViewFragment : BaseFragment() {
 
         setupToolbar(courseColor)
 
+        canvasWebView.setDarkModeSupport(webThemeDarkeningOnly = true)
         canvasWebView.settings.loadWithOverviewMode = true
         canvasWebView.settings.displayZoomControls = false
         canvasWebView.settings.setSupportZoom(true)

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/QuizPreviewWebviewFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/QuizPreviewWebviewFragment.kt
@@ -24,6 +24,7 @@ import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.pandautils.analytics.SCREEN_VIEW_QUIZ_PREVIEW
 import com.instructure.pandautils.analytics.ScreenView
 import com.instructure.pandautils.utils.ViewStyler
+import com.instructure.pandautils.utils.setDarkModeSupport
 import com.instructure.pandautils.utils.setGone
 import com.instructure.pandautils.utils.setVisible
 import com.instructure.pandautils.views.CanvasWebView
@@ -56,6 +57,7 @@ class QuizPreviewWebviewFragment : InternalWebViewFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         setShouldLoadUrl(false)
         super.onActivityCreated(savedInstanceState)
+        canvasWebView?.setDarkModeSupport()
 
         canvasWebView.canvasWebViewClientCallback = object : CanvasWebView.CanvasWebViewClientCallback {
             override fun openMediaFromWebView(mime: String, url: String, filename: String) =

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/SimpleWebViewFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/SimpleWebViewFragment.kt
@@ -17,6 +17,7 @@
 package com.instructure.teacher.fragments
 
 import android.os.Bundle
+import com.instructure.pandautils.utils.setDarkModeSupport
 import com.instructure.pandautils.utils.setGone
 import kotlinx.android.synthetic.main.fragment_internal_webview.*
 import kotlinx.coroutines.Job
@@ -39,6 +40,7 @@ class SimpleWebViewFragment : InternalWebViewFragment() {
         setShouldRouteInternally(false)
         canvasWebView.setInitialScale(100)
         super.onActivityCreated(savedInstanceState)
+        canvasWebView?.setDarkModeSupport()
 
         loadUrl(url)
         toolbar?.setGone()

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/SpeedGraderQuizWebViewFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/SpeedGraderQuizWebViewFragment.kt
@@ -30,6 +30,7 @@ import com.instructure.interactions.router.RouteContext.FILE
 import com.instructure.pandautils.analytics.SCREEN_VIEW_SPEED_GRADER_QUIZ_WEB_VIEW
 import com.instructure.pandautils.analytics.ScreenView
 import com.instructure.pandautils.utils.LongArg
+import com.instructure.pandautils.utils.setDarkModeSupport
 import com.instructure.pandautils.utils.setInvisible
 import com.instructure.pandautils.utils.setVisible
 import com.instructure.pandautils.utils.toast
@@ -64,6 +65,7 @@ class SpeedGraderQuizWebViewFragment : InternalWebViewFragment() {
         setShouldLoadUrl(false)
         canvasWebView.setInitialScale(100)
         super.onActivityCreated(savedInstanceState)
+        canvasWebView?.setDarkModeSupport()
 
         val originalCallback = canvasWebView.canvasWebViewClientCallback!!
         canvasWebView.canvasWebViewClientCallback = object : CanvasWebView.CanvasWebViewClientCallback by originalCallback {

--- a/apps/teacher/src/main/res/layout/fragment_calendar_event.xml
+++ b/apps/teacher/src/main/res/layout/fragment_calendar_event.xml
@@ -114,11 +114,12 @@
     <com.instructure.pandautils.views.CanvasWebView
         android:id="@+id/calendarEventWebView"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
         android:layout_marginTop="20dp"
         android:padding="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/locationSubtitle"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintVertical_bias="0.0" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/teacher/src/main/res/layout/fragment_page_details.xml
+++ b/apps/teacher/src/main/res/layout/fragment_page_details.xml
@@ -35,7 +35,7 @@
     <com.instructure.pandautils.views.CanvasWebView
         android:id="@+id/canvasWebView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:scrollbarStyle="outsideOverlay"
         android:layout_below="@id/toolbar"
         android:layout_marginTop="8dp"

--- a/apps/teacher/src/main/res/layout/fragment_syllabus_webview.xml
+++ b/apps/teacher/src/main/res/layout/fragment_syllabus_webview.xml
@@ -22,6 +22,6 @@
     <com.instructure.pandautils.views.CanvasWebView
         android:id="@+id/syllabusWebView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="wrap_content" />
 
 </FrameLayout>

--- a/libs/login-api-2/src/main/java/com/instructure/loginapi/login/activities/BaseLoginSignInActivity.kt
+++ b/libs/login-api-2/src/main/java/com/instructure/loginapi/login/activities/BaseLoginSignInActivity.kt
@@ -132,7 +132,7 @@ abstract class BaseLoginSignInActivity : AppCompatActivity(), OnAuthenticationSe
         webView.settings.setAppCacheEnabled(false)
         webView.settings.domStorageEnabled = true
         webView.settings.userAgentString = Utils.generateUserAgent(this, userAgent())
-        webView.setDarkModeSupport()
+        webView.setDarkModeSupport(webThemeDarkeningOnly = true)
         webView.webViewClient = mWebViewClient
         if (0 != applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) {
             WebView.setWebContentsDebuggingEnabled(true)

--- a/libs/pandautils/src/main/assets/html_wrapper.html
+++ b/libs/pandautils/src/main/assets/html_wrapper.html
@@ -29,6 +29,11 @@
             padding: 0;
         }
 
+        html {
+            background-color: {$BACKGROUND$};
+            color: {$COLOR$};
+        }
+
         img {
             max-width: 100% !important;
             height: auto;
@@ -66,6 +71,11 @@
 
         a {
             word-wrap: break-word;
+            color: {$LINK_COLOR$}
+        }
+
+        a:visited {
+            color: {$VISITED_LINK_COLOR$}
         }
 
     </style>

--- a/libs/pandautils/src/main/assets/html_wrapper_k5.html
+++ b/libs/pandautils/src/main/assets/html_wrapper_k5.html
@@ -35,6 +35,11 @@
             padding: 0;
         }
 
+        html {
+            background-color: {$BACKGROUND$};
+            color: {$COLOR$};
+        }
+
         img {
             max-width: 100% !important;
             height: auto;
@@ -72,6 +77,11 @@
 
         a {
             word-wrap: break-word;
+            color: {$LINK_COLOR$}
+        }
+
+        a:visited {
+            color: {$VISITED_LINK_COLOR$}
         }
 
     </style>

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/WebViewExtensions.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/WebViewExtensions.kt
@@ -168,3 +168,23 @@ fun WebView.setDarkModeSupport(webThemeDarkeningOnly: Boolean = false) {
         }
     }
 }
+
+fun WebView.addDarkThemeToHtmlDocument() {
+    val css = """
+                    @media (prefers-color-scheme: dark) {
+                        html {
+                            filter: invert(100%) hue-rotate(180deg);
+                        }
+                        img:not(.ignore-color-scheme), video:not(.ignore-color-scheme), .ignore-color-scheme {
+                            filter: invert(100%) hue-rotate(180deg) !important;
+                        }
+                    }
+                    """
+    val cssString = css.split("\n").joinToString(" ")
+    val js = """
+                    var element = document.createElement('style');
+                    element.innerHTML = '$cssString)';
+                    document.head.appendChild(element);
+                """
+    evaluateJavascript(js, {})
+}

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/WebViewExtensions.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/WebViewExtensions.kt
@@ -153,12 +153,16 @@ class JsExternalToolInterface(val callback: (ltiUrl: String) -> Unit) {
     }
 }
 
-fun WebView.setDarkModeSupport() {
+fun WebView.setDarkModeSupport(webThemeDarkeningOnly: Boolean = false) {
     if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
         val nightModeFlags: Int = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
         if (nightModeFlags == Configuration.UI_MODE_NIGHT_YES) {
             WebSettingsCompat.setForceDark(settings, WebSettingsCompat.FORCE_DARK_ON)
-            WebSettingsCompat.setForceDarkStrategy(settings, WebSettingsCompat.DARK_STRATEGY_PREFER_WEB_THEME_OVER_USER_AGENT_DARKENING)
+            if (webThemeDarkeningOnly) {
+                WebSettingsCompat.setForceDarkStrategy(settings, WebSettingsCompat.DARK_STRATEGY_WEB_THEME_DARKENING_ONLY)
+            } else {
+                WebSettingsCompat.setForceDarkStrategy(settings, WebSettingsCompat.DARK_STRATEGY_PREFER_WEB_THEME_OVER_USER_AGENT_DARKENING)
+            }
         } else {
             WebSettingsCompat.setForceDark(settings, WebSettingsCompat.FORCE_DARK_OFF)
         }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/views/CanvasWebView.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/views/CanvasWebView.kt
@@ -165,9 +165,6 @@ class CanvasWebView @JvmOverloads constructor(
             }
         }
         CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
-
-        // The default settings for all CanvasWebView instances that we force dark mode, because most of the time that should be the expected behavior.
-        // If we want to override this behavior in a CanvasWebView we need to call this function with `true` parameter.
     }
 
     @SuppressLint("SetJavaScriptEnabled")

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/views/CanvasWebView.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/views/CanvasWebView.kt
@@ -47,6 +47,7 @@ import android.view.MotionEvent
 import android.webkit.*
 import android.widget.TextView
 import android.widget.Toast
+import androidx.annotation.ColorRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.FileProvider
@@ -167,7 +168,6 @@ class CanvasWebView @JvmOverloads constructor(
 
         // The default settings for all CanvasWebView instances that we force dark mode, because most of the time that should be the expected behavior.
         // If we want to override this behavior in a CanvasWebView we need to call this function with `true` parameter.
-        setDarkModeSupport()
     }
 
     @SuppressLint("SetJavaScriptEnabled")
@@ -485,8 +485,8 @@ class CanvasWebView @JvmOverloads constructor(
      * @param title
      * @return
      */
-    fun loadHtml(html: String, title: String?): String {
-        val result = formatHtml(html, title)
+    fun loadHtml(html: String, title: String?, backgroundColorRes: Int = R.color.backgroundLightest): String {
+        val result = formatHtml(html, title, backgroundColorRes)
         loadDataWithBaseURL(getReferrer(true), result, "text/html", encoding, getHtmlAsUrl(result))
         return result
     }
@@ -494,7 +494,7 @@ class CanvasWebView @JvmOverloads constructor(
     /**
      * Helper function that makes html content somewhat suitable for mobile
      */
-    fun formatHtml(html: String, title: String? = ""): String {
+    fun formatHtml(html: String, title: String? = "", @ColorRes backgroundColorRes: Int = R.color.backgroundLightest): String {
         var formatted = applyWorkAroundForDoubleSlashesAsUrlSource(html)
         formatted = addProtocolToLinks(formatted)
         formatted = checkForMathTags(formatted)
@@ -503,6 +503,14 @@ class CanvasWebView @JvmOverloads constructor(
         return htmlWrapper
             .replace("{\$CONTENT$}", formatted)
             .replace("{\$TITLE$}", title ?: "")
+            .replace("{\$BACKGROUND$}", colorResToHexString(backgroundColorRes))
+            .replace("{\$COLOR$}", colorResToHexString(R.color.textDarkest))
+            .replace("{\$LINK_COLOR$}", colorResToHexString(R.color.textInfo))
+            .replace("{\$VISITED_LINK_COLOR\$}", colorResToHexString(R.color.textAlert))
+    }
+
+    private fun colorResToHexString(@ColorRes colorRes: Int): String {
+        return "#" + Integer.toHexString(context.getColor(colorRes)).substring(2)
     }
 
     /**

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/views/CanvasWebView.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/views/CanvasWebView.kt
@@ -164,6 +164,9 @@ class CanvasWebView @JvmOverloads constructor(
             }
         }
         CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
+
+        // The default settings for all CanvasWebView instances that we force dark mode, because most of the time that should be the expected behavior.
+        // If we want to override this behavior in a CanvasWebView we need to call this function with `true` parameter.
         setDarkModeSupport()
     }
 


### PR DESCRIPTION
Test plan:

Check all the WebViews in the app in dark/light mode and verify that all the content looks good.

These are the screens that should be checked:

- Login
- Discussion details
- Announcement details
- K5 homeroom/important links/subject pages
- Calendar event
- Assignment details
- Quiz details
- Quiz submission
- Discussion submission
- Rubric description
- Syllabus
- Text submission details
- Page details
- Global announcements
- External links
- Url submissions

refs: MBL-16086
affects: Teacher, Student
release note: none