### PR TITLE
[MBL-16098][Teacher] Attendance tool is shown as LTI tool in course navigation in some cases

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/CourseBrowserFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/CourseBrowserFragment.kt
@@ -94,7 +94,7 @@ class CourseBrowserFragment : BaseSyncFragment<
             Tab.STUDENT_VIEW,
             Tab.SYLLABUS_ID -> true
             else -> {
-                if (attendanceId != 0L && tab.tabId.endsWith(attendanceId.toString())) {
+                if (attendanceId != 0L && tab.tabId.endsWith("_$attendanceId")) {
                     TeacherPrefs.attendanceExternalToolId = tab.tabId
                 }
                 tab.type == Tab.TYPE_EXTERNAL


### PR DESCRIPTION
Test plan: in the ticket

refs: MBL-16098
affects: Teacher
release note: Fixed an issue when the attendance tool was displayed as an LTI tool in course navigation.