### PR TITLE
[MBL-16066][Student][Teacher] Attempting to use the "Act as User" feature twice logs the active user out

### DIFF
--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/MasqueradeHelper.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/MasqueradeHelper.kt
@@ -64,7 +64,7 @@ object MasqueradeHelper {
         masqueradingUserId: Long,
         masqueradingDomain: String?,
         startingClass: Class<out ACTIVITY>,
-        masqueradeToken: String = "",
+        masqueradeToken: String = ApiPrefs.accessToken,
         masqueradeClientId: String = ApiPrefs.clientId,
         masqueradeClientSecret: String = ApiPrefs.clientSecret,
         courseId: Long? = null,


### PR DESCRIPTION
Test plan: In the ticket. Smoke test also other masquerading cases (qr code, student view)

refs: MBL-16066
affects: Teacher, Student
release note: None