### PR TITLE
[Teacher][MBL-16091] Page Error when previewing NQ assessments via Quizzes

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/QuizListFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/QuizListFragment.kt
@@ -113,8 +113,12 @@ class QuizListFragment : BaseExpandableSyncFragment<
 
     override fun createAdapter(): QuizListAdapter {
         return QuizListAdapter(requireContext(), presenter, mCourseColor) { quiz ->
-            val args = QuizDetailsFragment.makeBundle(quiz)
-            RouteMatcher.route(requireContext(), Route(null, QuizDetailsFragment::class.java, mCanvasContext, args))
+            if (RouteMatcher.canRouteInternally(requireActivity(), quiz.htmlUrl, ApiPrefs.domain, false)) {
+                RouteMatcher.routeUrl(requireActivity(), quiz.htmlUrl!!, ApiPrefs.domain)
+            } else {
+                val args = QuizDetailsFragment.makeBundle(quiz)
+                RouteMatcher.route(requireContext(), Route(null, QuizDetailsFragment::class.java, mCanvasContext, args))
+            }
         }
     }
 


### PR DESCRIPTION
Test plan: Verify that the new quizzes route to the assignment details screen instead of the quiz details screen.

refs: MBL-16091
affects: Teacher
release note: Fixed a bug where teachers couldn't preview quizzes created with the new quizzes tool.