### PR TITLE
[MBL-16111][Student] K5 Schedule only shows the first 10 planner items per week

### DIFF
--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/PlannerManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/PlannerManager.kt
@@ -38,7 +38,7 @@ class PlannerManager(private val plannerApi: PlannerAPI) {
             endDate: String? = null
     ) {
         val adapter = RestBuilder(callback)
-        val params = RestParams(isForceReadFromNetwork = forceNetwork)
+        val params = RestParams(isForceReadFromNetwork = forceNetwork, usePerPageQueryParam = true)
 
         plannerApi.getPlannerItems(adapter, callback, params, startDate, endDate)
     }


### PR DESCRIPTION
Test plan: In the ticket.

refs: MBL-16111
affects: Student
release note: Fixed a bug in elementary schedule view where maximum of 10 items were displayed per week.