### PR TITLE
[MBL-16097][Student][Teacher] Viewing rotated images for a submission crashes the app

### DIFF
--- a/libs/annotations/src/main/java/com/instructure/annotations/PdfSubmissionView.kt
+++ b/libs/annotations/src/main/java/com/instructure/annotations/PdfSubmissionView.kt
@@ -461,14 +461,15 @@ abstract class PdfSubmissionView(context: Context) : FrameLayout(context), Annot
     }
 
     private fun handlePageRotation(pdfDocument: PdfDocument, rotationMap: HashMap<String, Int>) {
+        // Removing the listener prevents an infinite loop with onDocumentLoaded, which is triggered
+        // by the calls to setRotationOffset()
+        pdfFragment?.removeDocumentListener(documentListener)
+
         rotationMap.forEach { pageRotation ->
             pageRotation.key.toIntOrNull()?.let { pageIndex ->
                 pdfDocument.setRotationOffset(calculateRotationOffset(pdfDocument.getPageRotation(pageIndex), pageRotation.value), pageIndex)
             }
         }
-        // Removing the listener prevents an infinite loop with onDocumentLoaded, which is triggered
-        // by the calls to setRotationOffset()
-        pdfFragment?.removeDocumentListener(documentListener)
     }
 
     @Suppress("EXPERIMENTAL_FEATURE_WARNING")


### PR DESCRIPTION
Test plan: In the ticket

refs: MBL-16097
affects: Student, Teacher
release note: Fixed a crash when opening rotated image submissions.