### PR TITLE
[MBL-16108][Teacher] FileList folder delete refresh

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/EditFileFolderFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/EditFileFolderFragment.kt
@@ -118,7 +118,7 @@ class EditFileFolderFragment : BasePresenterFragment<
     override fun onRefreshStarted() = Unit
 
     override fun folderDeleted(deletedFileFolder: FileFolder) {
-        FileFolderDeletedEvent(deletedFileFolder).post()
+        FileFolderDeletedEvent(deletedFileFolder).postSticky()
         requireActivity().onBackPressed()
     }
 


### PR DESCRIPTION
refs: MBL-16108
affects: Teacher
release note: Fixed a bug where deleted folders would still be accessible until manual refresh.

test plan: Delete a folder on the Files screen > The folder should no longer be visible.