### PR TITLE
[MBL-16110][Student] Modifying course nickname triggers an unnecessary reorder on Dashboard

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/DashboardFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/DashboardFragment.kt
@@ -134,7 +134,7 @@ class DashboardFragment : ParentFragment() {
                             course.name = response.nickname!!
                             course.originalName = response.name
                         }
-                        recyclerAdapter?.addOrUpdateItem(DashboardRecyclerAdapter.ItemType.COURSE_HEADER, course)
+                        recyclerAdapter?.notifyDataSetChanged()
                     } catch {
                         toast(R.string.courseNicknameError)
                     }


### PR DESCRIPTION
Test plan: In the ticket

refs: MBL-16110
affects: Student
release note: none