### PR TITLE
[MBL-15990] [Student][Teacher] - Implement Dark mode tests in both apps

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/SettingsE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/SettingsE2ETest.kt
@@ -26,7 +26,6 @@ import com.instructure.panda_annotations.FeatureCategory
 import com.instructure.panda_annotations.Priority
 import com.instructure.panda_annotations.TestCategory
 import com.instructure.panda_annotations.TestMetaData
-import com.instructure.pandautils.utils.AppTheme
 import com.instructure.student.R
 import com.instructure.student.ui.utils.StudentTest
 import com.instructure.student.ui.utils.seedData
@@ -127,8 +126,8 @@ class SettingsE2ETest : StudentTest() {
         Log.d(STEP_TAG,"Navigate to Settings Page and open App Theme Settings.")
         settingsPage.openAppThemeSettings()
 
-        Log.d(STEP_TAG,"Select ${AppTheme.DARK} App Theme and assert that the App Theme Title and Status has the proper text color (which is used in Dark mode).")
-        settingsPage.selectAppTheme(AppTheme.DARK)
+        Log.d(STEP_TAG,"Select Dark App Theme and assert that the App Theme Title and Status has the proper text color (which is used in Dark mode).")
+        settingsPage.selectAppTheme("Dark")
         settingsPage.assertAppThemeTitleTextColor("#FFFFFFFF") //Currently, this color is used in the Dark mode for the AppTheme Title text.
         settingsPage.assertAppThemeStatusTextColor("#FFC7CDD1") //Currently, this color is used in the Dark mode for the AppTheme Status text.
 
@@ -141,13 +140,13 @@ class SettingsE2ETest : StudentTest() {
         courseBrowserPage.assertTabLabelTextColor("Discussions","#FFFFFFFF")
         courseBrowserPage.assertTabLabelTextColor("Grades","#FFFFFFFF")
 
-        Log.d(STEP_TAG,"Navigate to Settins Page and open App Theme Settings again.")
+        Log.d(STEP_TAG,"Navigate to Settings Page and open App Theme Settings again.")
         Espresso.pressBack()
         dashboardPage.launchSettingsPage()
         settingsPage.openAppThemeSettings()
 
-        Log.d(STEP_TAG,"Select ${AppTheme.LIGHT} App Theme and assert that the App Theme Title and Status has the proper text color (which is used in Light mode).")
-        settingsPage.selectAppTheme(AppTheme.LIGHT)
+        Log.d(STEP_TAG,"Select Light App Theme and assert that the App Theme Title and Status has the proper text color (which is used in Light mode).")
+        settingsPage.selectAppTheme("Light")
         settingsPage.assertAppThemeTitleTextColor("#FF2D3B45") //Currently, this color is used in the Light mode for the AppTheme Title texts.
         settingsPage.assertAppThemeStatusTextColor("#FF556572") //Currently, this color is used in the Light mode for the AppTheme Status text.
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/SettingsE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/SettingsE2ETest.kt
@@ -52,10 +52,10 @@ class SettingsE2ETest : StudentTest() {
 
         Log.d(PREPARATION_TAG, "Seeding data.")
         val data = seedData(students = 1, teachers = 1, courses = 1)
-        val teacher = data.teachersList[0]
+        val student = data.studentsList[0]
 
-        Log.d(STEP_TAG, "Login with user: ${teacher.name}, login id: ${teacher.loginId} , password: ${teacher.password}")
-        tokenLogin(teacher)
+        Log.d(STEP_TAG, "Login with user: ${student.name}, login id: ${student.loginId} , password: ${student.password}")
+        tokenLogin(student)
         dashboardPage.waitForRender()
 
         Log.d(STEP_TAG, "Navigate to User Settings Page.")
@@ -113,11 +113,11 @@ class SettingsE2ETest : StudentTest() {
     fun testDarkModeE2E() {
         Log.d(PREPARATION_TAG, "Seeding data.")
         val data = seedData(students = 1, teachers = 1, courses = 1)
-        val teacher = data.teachersList[0]
+        val student = data.studentsList[0]
         val course = data.coursesList[0]
 
-        Log.d(STEP_TAG, "Login with user: ${teacher.name}, login id: ${teacher.loginId} , password: ${teacher.password}")
-        tokenLogin(teacher)
+        Log.d(STEP_TAG, "Login with user: ${student.name}, login id: ${student.loginId} , password: ${student.password}")
+        tokenLogin(student)
         dashboardPage.waitForRender()
 
         Log.d(STEP_TAG, "Navigate to User Settings Page.")
@@ -138,7 +138,7 @@ class SettingsE2ETest : StudentTest() {
 
         Log.d(STEP_TAG,"Select ${course.name} course and assert on the Course Browser Page that the tabs has the proper text color (which is used in Dark mode).")
         dashboardPage.selectCourse(course)
-        courseBrowserPage.assertTabLabelTextColor("Announcements","#FFFFFFFF")
+        courseBrowserPage.assertTabLabelTextColor("Discussions","#FFFFFFFF")
         courseBrowserPage.assertTabLabelTextColor("Grades","#FFFFFFFF")
 
         Log.d(STEP_TAG,"Navigate to Settins Page and open App Theme Settings again.")

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/SettingsE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/SettingsE2ETest.kt
@@ -26,6 +26,7 @@ import com.instructure.panda_annotations.FeatureCategory
 import com.instructure.panda_annotations.Priority
 import com.instructure.panda_annotations.TestCategory
 import com.instructure.panda_annotations.TestMetaData
+import com.instructure.pandautils.utils.AppTheme
 import com.instructure.student.R
 import com.instructure.student.ui.utils.StudentTest
 import com.instructure.student.ui.utils.seedData
@@ -62,7 +63,7 @@ class SettingsE2ETest : StudentTest() {
         settingsPage.assertPageObjects()
 
         Log.d(STEP_TAG, "Open Profile Settings Page.")
-        settingsPage.launchProfileSettings()
+        settingsPage.openProfileSettings()
         profileSettingsPage.assertPageObjects()
 
         val newUserName = "John Doe"
@@ -78,7 +79,7 @@ class SettingsE2ETest : StudentTest() {
         Log.d(STEP_TAG, "Navigate to Settings Page again and open Panda Avatar Creator.")
         dashboardPage.launchSettingsPage()
         settingsPage.assertPageObjects()
-        settingsPage.launchProfileSettings()
+        settingsPage.openProfileSettings()
         profileSettingsPage.assertPageObjects()
         profileSettingsPage.launchPandaAvatarCreator()
 
@@ -108,6 +109,55 @@ class SettingsE2ETest : StudentTest() {
 
     @E2E
     @Test
+    @TestMetaData(Priority.IMPORTANT, FeatureCategory.SETTINGS, TestCategory.E2E)
+    fun testDarkModeE2E() {
+        Log.d(PREPARATION_TAG, "Seeding data.")
+        val data = seedData(students = 1, teachers = 1, courses = 1)
+        val teacher = data.teachersList[0]
+        val course = data.coursesList[0]
+
+        Log.d(STEP_TAG, "Login with user: ${teacher.name}, login id: ${teacher.loginId} , password: ${teacher.password}")
+        tokenLogin(teacher)
+        dashboardPage.waitForRender()
+
+        Log.d(STEP_TAG, "Navigate to User Settings Page.")
+        dashboardPage.launchSettingsPage()
+        settingsPage.assertPageObjects()
+
+        Log.d(STEP_TAG,"Navigate to Settings Page and open App Theme Settings.")
+        settingsPage.openAppThemeSettings()
+
+        Log.d(STEP_TAG,"Select ${AppTheme.DARK} App Theme and assert that the App Theme Title and Status has the proper text color (which is used in Dark mode).")
+        settingsPage.selectAppTheme(AppTheme.DARK)
+        settingsPage.assertAppThemeTitleTextColor("#FFFFFFFF") //Currently, this color is used in the Dark mode for the AppTheme Title text.
+        settingsPage.assertAppThemeStatusTextColor("#FFC7CDD1") //Currently, this color is used in the Dark mode for the AppTheme Status text.
+
+        Log.d(STEP_TAG,"Navigate back to Dashboard. Assert that the 'Courses' label has the proper text color (which is used in Dark mode).")
+        Espresso.pressBack()
+        dashboardPage.assertCourseLabelTextColor("#FFFFFFFF")
+
+        Log.d(STEP_TAG,"Select ${course.name} course and assert on the Course Browser Page that the tabs has the proper text color (which is used in Dark mode).")
+        dashboardPage.selectCourse(course)
+        courseBrowserPage.assertTabLabelTextColor("Announcements","#FFFFFFFF")
+        courseBrowserPage.assertTabLabelTextColor("Grades","#FFFFFFFF")
+
+        Log.d(STEP_TAG,"Navigate to Settins Page and open App Theme Settings again.")
+        Espresso.pressBack()
+        dashboardPage.launchSettingsPage()
+        settingsPage.openAppThemeSettings()
+
+        Log.d(STEP_TAG,"Select ${AppTheme.LIGHT} App Theme and assert that the App Theme Title and Status has the proper text color (which is used in Light mode).")
+        settingsPage.selectAppTheme(AppTheme.LIGHT)
+        settingsPage.assertAppThemeTitleTextColor("#FF2D3B45") //Currently, this color is used in the Light mode for the AppTheme Title texts.
+        settingsPage.assertAppThemeStatusTextColor("#FF556572") //Currently, this color is used in the Light mode for the AppTheme Status text.
+
+        Log.d(STEP_TAG,"Navigate back to Dashboard. Assert that the 'Courses' label has the proper text color (which is used in Light mode).")
+        Espresso.pressBack()
+        dashboardPage.assertCourseLabelTextColor("#FF2D3B45")
+    }
+
+    @E2E
+    @Test
     @TestMetaData(Priority.MANDATORY, FeatureCategory.SETTINGS, TestCategory.E2E)
     fun testLegalPageE2E() {
 
@@ -124,7 +174,7 @@ class SettingsE2ETest : StudentTest() {
         settingsPage.assertPageObjects()
 
         Log.d(STEP_TAG, "Click on 'Legal' link to open Legal Page. Assert that Legal Page has opened.")
-        settingsPage.launchLegalPage()
+        settingsPage.openLegalPage()
         legalPage.assertPageObjects()
     }
 
@@ -146,7 +196,7 @@ class SettingsE2ETest : StudentTest() {
         settingsPage.assertPageObjects()
 
         Log.d(STEP_TAG, "Click on 'About' link to open About Page. Assert that About Page has opened.")
-        settingsPage.launchAboutPage()
+        settingsPage.openAboutPage()
         aboutPage.assertPageObjects()
 
         Log.d(STEP_TAG,"Check that domain is equal to: ${student.domain} (student's domain).")
@@ -182,7 +232,7 @@ class SettingsE2ETest : StudentTest() {
         RemoteConfigParam.values().forEach {param -> initialValues.put(param.rc_name, RemoteConfigUtils.getString(param))}
 
         Log.d(STEP_TAG, "Navigate to Remote Config Settings Page.")
-        settingsPage.launchRemoteConfigParams()
+        settingsPage.openRemoteConfigParams()
 
         RemoteConfigParam.values().forEach { param ->
 
@@ -202,7 +252,7 @@ class SettingsE2ETest : StudentTest() {
         Espresso.pressBack()
 
         Log.d(STEP_TAG, "Navigate to Remote Config Settings Page.")
-        settingsPage.launchRemoteConfigParams()
+        settingsPage.openRemoteConfigParams()
 
         Log.d(STEP_TAG, "Assert that all fields have maintained their initial value.")
         RemoteConfigParam.values().forEach { param ->

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/ProfileSettingsInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/ProfileSettingsInteractionTest.kt
@@ -43,7 +43,7 @@ class ProfileSettingsInteractionTest : StudentTest() {
         tokenLogin(data.domain, token, student)
 
         dashboardPage.launchSettingsPage()
-        settingsPage.launchProfileSettings()
+        settingsPage.openProfileSettings()
         profileSettingsPage.changeUserNameTo(newUserName)
 
         Espresso.pressBack() // to settings page
@@ -62,7 +62,7 @@ class ProfileSettingsInteractionTest : StudentTest() {
         tokenLogin(data.domain, token, student)
 
         dashboardPage.launchSettingsPage()
-        settingsPage.launchProfileSettings()
+        settingsPage.openProfileSettings()
         profileSettingsPage.assertSettingsDisabled() // No permissions granted
     }
 
@@ -86,7 +86,7 @@ class ProfileSettingsInteractionTest : StudentTest() {
 
         // Navigate to avatar creation page
         dashboardPage.launchSettingsPage()
-        settingsPage.launchProfileSettings()
+        settingsPage.openProfileSettings()
         profileSettingsPage.launchPandaAvatarCreator()
 
         // Select head

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/SettingsInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/SettingsInteractionTest.kt
@@ -58,7 +58,7 @@ class SettingsInteractionTest : StudentTest() {
         setUpAndSignIn()
 
         dashboardPage.launchSettingsPage()
-        settingsPage.launchLegalPage()
+        settingsPage.openLegalPage()
 
         Intents.init()
         try {
@@ -79,7 +79,7 @@ class SettingsInteractionTest : StudentTest() {
         setUpAndSignIn()
 
         dashboardPage.launchSettingsPage()
-        settingsPage.launchLegalPage()
+        settingsPage.openLegalPage()
         legalPage.openTermsOfUse()
         legalPage.assertTermsOfUseDisplayed()
     }
@@ -91,7 +91,7 @@ class SettingsInteractionTest : StudentTest() {
         setUpAndSignIn()
 
         dashboardPage.launchSettingsPage()
-        settingsPage.launchLegalPage()
+        settingsPage.openLegalPage()
         legalPage.openPrivacyPolicy()
         canvasWebViewPage.acceptCookiePolicyIfNecessary()
         canvasWebViewPage.checkWebViewURL("https://www.instructure.com/canvas/privacy")
@@ -107,7 +107,7 @@ class SettingsInteractionTest : StudentTest() {
 
         ApiPrefs.canGeneratePairingCode = true
         dashboardPage.launchSettingsPage()
-        settingsPage.launchPairObserverPage()
+        settingsPage.openPairObserverPage()
 
         pairObserverPage.hasCode("1")
         pairObserverPage.refresh()

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/CourseBrowserPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/CourseBrowserPage.kt
@@ -23,22 +23,15 @@ import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
-import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast
-import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.espresso.matcher.ViewMatchers.*
 import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.canvas.espresso.withCustomConstraints
 import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.models.Group
 import com.instructure.canvasapi2.models.Tab
 import com.instructure.dataseeding.model.CourseApiModel
-import com.instructure.espresso.WaitForViewWithId
-import com.instructure.espresso.assertHasText
-import com.instructure.espresso.click
+import com.instructure.espresso.*
 import com.instructure.espresso.page.BasePage
-import com.instructure.espresso.swipeUp
 import com.instructure.pandautils.views.SwipeRefreshLayoutAppBar
 import com.instructure.student.R
 import org.hamcrest.Matcher
@@ -134,6 +127,10 @@ class CourseBrowserPage : BasePage(R.id.courseBrowserPage) {
 
     fun assertTabDisplayed(tab: Tab) {
         assertTabDisplayed(tab.label!!)
+    }
+
+    fun assertTabLabelTextColor(tabTitle: String, expectedColor: String) {
+        onView(withText(tabTitle)).check(TextViewColorAssertion(expectedColor))
     }
 
     fun assertTabDisplayed(tabTitle: String) {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DashboardPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DashboardPage.kt
@@ -28,11 +28,7 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast
-import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
-import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.espresso.matcher.ViewMatchers.*
 import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.canvas.espresso.waitForMatcherWithSleeps
 import com.instructure.canvas.espresso.withCustomConstraints
@@ -43,24 +39,8 @@ import com.instructure.canvasapi2.models.User
 import com.instructure.dataseeding.model.CanvasUserApiModel
 import com.instructure.dataseeding.model.CourseApiModel
 import com.instructure.dataseeding.model.GroupApiModel
-import com.instructure.espresso.OnViewWithContentDescription
-import com.instructure.espresso.OnViewWithId
-import com.instructure.espresso.WaitForViewWithId
-import com.instructure.espresso.assertDisplayed
-import com.instructure.espresso.assertNotDisplayed
-import com.instructure.espresso.click
-import com.instructure.espresso.page.BasePage
-import com.instructure.espresso.page.onView
-import com.instructure.espresso.page.onViewWithId
-import com.instructure.espresso.page.onViewWithText
-import com.instructure.espresso.page.plus
-import com.instructure.espresso.page.withAncestor
-import com.instructure.espresso.page.withId
-import com.instructure.espresso.page.withParent
-import com.instructure.espresso.page.withText
-import com.instructure.espresso.scrollTo
-import com.instructure.espresso.swipeDown
-import com.instructure.espresso.waitForCheck
+import com.instructure.espresso.*
+import com.instructure.espresso.page.*
 import com.instructure.student.R
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
@@ -138,6 +118,10 @@ class DashboardPage : BasePage(R.id.dashboardPage) {
         // slow FTL devices.  So let's pause for a bit until we see the canvas logo.
         waitForMatcherWithSleeps(ViewMatchers.withId(R.id.canvasLogo), 20000).check(matches(isDisplayed()))
 
+    }
+
+    fun assertCourseLabelTextColor(expectedTextColor: String) {
+        onView(withId(R.id.courseLabel)).check(TextViewColorAssertion(expectedTextColor))
     }
 
     fun pressChangeUser() {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SettingsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SettingsPage.kt
@@ -21,7 +21,6 @@ import com.instructure.espresso.TextViewColorAssertion
 import com.instructure.espresso.click
 import com.instructure.espresso.page.*
 import com.instructure.espresso.scrollTo
-import com.instructure.pandautils.utils.AppTheme
 import com.instructure.student.R
 
 class SettingsPage : BasePage(R.id.settingsFragment) {
@@ -62,13 +61,9 @@ class SettingsPage : BasePage(R.id.settingsFragment) {
         appThemeTitle.scrollTo().click()
     }
 
-    fun selectAppTheme(appTheme: AppTheme)
+    fun selectAppTheme(appTheme: String)
     {
-        when (appTheme) {
-            AppTheme.LIGHT -> onView(withText(R.string.appThemeLight) + withParent(R.id.select_dialog_listview)).click()
-            AppTheme.DARK -> onView(withText(R.string.appThemeDark) + withParent(R.id.select_dialog_listview)).click()
-            AppTheme.SYSTEM -> onView(withText(R.string.appThemeSystem) + withParent(R.id.select_dialog_listview)).click()
-        }
+            onView(withText(appTheme) + withParent(R.id.select_dialog_listview)).click()
     }
 
     fun assertAppThemeTitleTextColor(expectedTextColor: String) {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SettingsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SettingsPage.kt
@@ -17,10 +17,11 @@
 package com.instructure.student.ui.pages
 
 import com.instructure.espresso.OnViewWithId
-import com.instructure.espresso.assertHasContentDescription
+import com.instructure.espresso.TextViewColorAssertion
 import com.instructure.espresso.click
-import com.instructure.espresso.page.BasePage
+import com.instructure.espresso.page.*
 import com.instructure.espresso.scrollTo
+import com.instructure.pandautils.utils.AppTheme
 import com.instructure.student.R
 
 class SettingsPage : BasePage(R.id.settingsFragment) {
@@ -28,29 +29,53 @@ class SettingsPage : BasePage(R.id.settingsFragment) {
     private val profileSettingLabel by OnViewWithId(R.id.profileSettings)
     private val accountPreferencesLabel by OnViewWithId(R.id.accountPreferences)
     private val pushNotificationsLabel by OnViewWithId(R.id.pushNotifications)
+
     // The pairObserverLabel may not be present if the corresponding remote-config flag is disabled.
-    private val pairObserverLabel by OnViewWithId(R.id.pairObserver,autoAssert=false)
+    private val pairObserverLabel by OnViewWithId(R.id.pairObserver, autoAssert = false)
     private val aboutLabel by OnViewWithId(R.id.about)
     private val legalLabel by OnViewWithId(R.id.legal)
     private val remoteConfigLabel by OnViewWithId(R.id.remoteConfigParams)
+    private val appThemeTitle by OnViewWithId(R.id.appThemeTitle)
+    private val appThemeStatus by OnViewWithId(R.id.appThemeStatus)
 
-    fun launchAboutPage() {
+    fun openAboutPage() {
         aboutLabel.click()
     }
 
-    fun launchLegalPage() {
+    fun openLegalPage() {
         legalLabel.scrollTo().click()
     }
 
-    fun launchRemoteConfigParams() {
+    fun openRemoteConfigParams() {
         remoteConfigLabel.scrollTo().click()
     }
 
-    fun launchPairObserverPage() {
+    fun openPairObserverPage() {
         pairObserverLabel.scrollTo().click()
     }
 
-    fun launchProfileSettings() {
+    fun openProfileSettings() {
         profileSettingLabel.scrollTo().click()
+    }
+
+    fun openAppThemeSettings() {
+        appThemeTitle.scrollTo().click()
+    }
+
+    fun selectAppTheme(appTheme: AppTheme)
+    {
+        when (appTheme) {
+            AppTheme.LIGHT -> onView(withText(R.string.appThemeLight) + withParent(R.id.select_dialog_listview)).click()
+            AppTheme.DARK -> onView(withText(R.string.appThemeDark) + withParent(R.id.select_dialog_listview)).click()
+            AppTheme.SYSTEM -> onView(withText(R.string.appThemeSystem) + withParent(R.id.select_dialog_listview)).click()
+        }
+    }
+
+    fun assertAppThemeTitleTextColor(expectedTextColor: String) {
+        appThemeTitle.check(TextViewColorAssertion(expectedTextColor))
+    }
+
+    fun assertAppThemeStatusTextColor(expectedTextColor: String) {
+        appThemeStatus.check(TextViewColorAssertion(expectedTextColor))
     }
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/SettingsE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/SettingsE2ETest.kt
@@ -27,7 +27,6 @@ import com.instructure.panda_annotations.FeatureCategory
 import com.instructure.panda_annotations.Priority
 import com.instructure.panda_annotations.TestCategory
 import com.instructure.panda_annotations.TestMetaData
-import com.instructure.pandautils.utils.AppTheme
 import com.instructure.teacher.ui.utils.TeacherTest
 import com.instructure.teacher.ui.utils.seedData
 import com.instructure.teacher.ui.utils.tokenLogin
@@ -118,8 +117,8 @@ class SettingsE2ETest : TeacherTest() {
         Log.d(STEP_TAG,"Navigate to Settings Page and open App Theme Settings.")
         settingsPage.openAppThemeSettings()
 
-        Log.d(STEP_TAG,"Select ${AppTheme.DARK} App Theme and assert that the App Theme Title and Status has the proper text color (which is used in Dark mode).")
-        settingsPage.selectAppTheme(AppTheme.DARK)
+        Log.d(STEP_TAG,"Select Dark App Theme and assert that the App Theme Title and Status has the proper text color (which is used in Dark mode).")
+        settingsPage.selectAppTheme("Dark")
         settingsPage.assertAppThemeTitleTextColor("#FFFFFFFF") //Currently, this color is used in the Dark mode for the AppTheme Title text.
         settingsPage.assertAppThemeStatusTextColor("#FFC7CDD1") //Currently, this color is used in the Dark mode for the AppTheme Status text.
 
@@ -137,8 +136,8 @@ class SettingsE2ETest : TeacherTest() {
         dashboardPage.openUserSettingsPage()
         settingsPage.openAppThemeSettings()
 
-        Log.d(STEP_TAG,"Select ${AppTheme.LIGHT} App Theme and assert that the App Theme Title and Status has the proper text color (which is used in Light mode).")
-        settingsPage.selectAppTheme(AppTheme.LIGHT)
+        Log.d(STEP_TAG,"Select Light App Theme and assert that the App Theme Title and Status has the proper text color (which is used in Light mode).")
+        settingsPage.selectAppTheme("Light")
         settingsPage.assertAppThemeTitleTextColor("#FF2D3B45") //Currently, this color is used in the Light mode for the AppTheme Title texts.
         settingsPage.assertAppThemeStatusTextColor("#FF556572") //Currently, this color is used in the Light mode for the AppTheme Status text.
 

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/SettingsE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/SettingsE2ETest.kt
@@ -18,12 +18,7 @@ package com.instructure.teacher.ui.e2e
 
 import android.util.Log
 import androidx.test.espresso.Espresso
-import com.instructure.teacher.R
-import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.NoMatchingViewException
-import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.withId
 import com.instructure.canvas.espresso.E2E
 import com.instructure.canvasapi2.utils.RemoteConfigParam
 import com.instructure.canvasapi2.utils.RemoteConfigUtils
@@ -32,6 +27,7 @@ import com.instructure.panda_annotations.FeatureCategory
 import com.instructure.panda_annotations.Priority
 import com.instructure.panda_annotations.TestCategory
 import com.instructure.panda_annotations.TestMetaData
+import com.instructure.pandautils.utils.AppTheme
 import com.instructure.teacher.ui.utils.TeacherTest
 import com.instructure.teacher.ui.utils.seedData
 import com.instructure.teacher.ui.utils.tokenLogin
@@ -100,6 +96,55 @@ class SettingsE2ETest : TeacherTest() {
         Log.d(STEP_TAG,"Assert that the username value remained $newUserName.")
         profileSettingsPage.assertUserNameIs(newUserName)
 
+    }
+
+    @E2E
+    @Test
+    @TestMetaData(Priority.IMPORTANT, FeatureCategory.SETTINGS, TestCategory.E2E)
+    fun testDarkModeE2E() {
+        Log.d(PREPARATION_TAG, "Seeding data.")
+        val data = seedData(students = 1, teachers = 1, courses = 1)
+        val teacher = data.teachersList[0]
+        val course = data.coursesList[0]
+
+        Log.d(STEP_TAG, "Login with user: ${teacher.name}, login id: ${teacher.loginId} , password: ${teacher.password}")
+        tokenLogin(teacher)
+        dashboardPage.waitForRender()
+
+        Log.d(STEP_TAG, "Navigate to User Settings Page.")
+        dashboardPage.openUserSettingsPage()
+        settingsPage.assertPageObjects()
+
+        Log.d(STEP_TAG,"Navigate to Settings Page and open App Theme Settings.")
+        settingsPage.openAppThemeSettings()
+
+        Log.d(STEP_TAG,"Select ${AppTheme.DARK} App Theme and assert that the App Theme Title and Status has the proper text color (which is used in Dark mode).")
+        settingsPage.selectAppTheme(AppTheme.DARK)
+        settingsPage.assertAppThemeTitleTextColor("#FFFFFFFF") //Currently, this color is used in the Dark mode for the AppTheme Title text.
+        settingsPage.assertAppThemeStatusTextColor("#FFC7CDD1") //Currently, this color is used in the Dark mode for the AppTheme Status text.
+
+        Log.d(STEP_TAG,"Navigate back to Dashboard. Assert that the 'Courses' label has the proper text color (which is used in Dark mode).")
+        Espresso.pressBack()
+        dashboardPage.assertCourseLabelTextColor("#FFFFFFFF")
+
+        Log.d(STEP_TAG,"Select ${course.name} course and assert on the Course Browser Page that the tabs has the proper text color (which is used in Dark mode).")
+        dashboardPage.openCourse(course.name)
+        courseBrowserPage.assertTabLabelTextColor("Announcements","#FFFFFFFF")
+        courseBrowserPage.assertTabLabelTextColor("Assignments","#FFFFFFFF")
+
+        Log.d(STEP_TAG,"Navigate to Settins Page and open App Theme Settings again.")
+        Espresso.pressBack()
+        dashboardPage.openUserSettingsPage()
+        settingsPage.openAppThemeSettings()
+
+        Log.d(STEP_TAG,"Select ${AppTheme.LIGHT} App Theme and assert that the App Theme Title and Status has the proper text color (which is used in Light mode).")
+        settingsPage.selectAppTheme(AppTheme.LIGHT)
+        settingsPage.assertAppThemeTitleTextColor("#FF2D3B45") //Currently, this color is used in the Light mode for the AppTheme Title texts.
+        settingsPage.assertAppThemeStatusTextColor("#FF556572") //Currently, this color is used in the Light mode for the AppTheme Status text.
+
+        Log.d(STEP_TAG,"Navigate back to Dashboard. Assert that the 'Courses' label has the proper text color (which is used in Light mode).")
+        Espresso.pressBack()
+        dashboardPage.assertCourseLabelTextColor("#FF2D3B45")
     }
 
     @E2E

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/CourseBrowserPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/CourseBrowserPage.kt
@@ -16,7 +16,6 @@
  */
 package com.instructure.teacher.ui.pages
 
-import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.PerformException
@@ -24,7 +23,6 @@ import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
-import androidx.test.espresso.matcher.BoundedMatcher
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast
 import com.instructure.canvas.espresso.withCustomConstraints
@@ -32,8 +30,6 @@ import com.instructure.espresso.*
 import com.instructure.espresso.page.*
 import com.instructure.teacher.R
 import com.instructure.teacher.holders.CourseBrowserViewHolder
-import org.hamcrest.Description
-import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
 
 class CourseBrowserPage : BasePage() {
@@ -126,5 +122,9 @@ class CourseBrowserPage : BasePage() {
 
     fun assertCourseTitle(courseTitle: String) {
         onView(withId(R.id.courseBrowserTitle) + withText(courseTitle)).assertDisplayed()
+    }
+
+    fun assertTabLabelTextColor(tabTitle: String, expectedColor: String) {
+        onView(ViewMatchers.withText(tabTitle)).check(TextViewColorAssertion(expectedColor))
     }
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/DashboardPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/DashboardPage.kt
@@ -104,4 +104,8 @@ class DashboardPage : BasePage() {
         onView(hamburgerButtonMatcher).click()
         onViewWithId(R.id.navigationDrawerItem_files).click()
     }
+
+    fun assertCourseLabelTextColor(expectedTextColor: String) {
+        onView(withId(R.id.courseLabel)).check(TextViewColorAssertion(expectedTextColor))
+    }
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/SettingsPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/SettingsPage.kt
@@ -20,9 +20,11 @@ import androidx.test.espresso.Espresso
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers
 import com.instructure.espresso.OnViewWithId
+import com.instructure.espresso.TextViewColorAssertion
 import com.instructure.espresso.click
-import com.instructure.espresso.page.BasePage
+import com.instructure.espresso.page.*
 import com.instructure.espresso.scrollTo
+import com.instructure.pandautils.utils.AppTheme
 import com.instructure.teacher.R
 
 class SettingsPage : BasePage(R.id.settingsPage) {
@@ -33,6 +35,8 @@ class SettingsPage : BasePage(R.id.settingsPage) {
     private val legalLabel by OnViewWithId(R.id.legalButton)
     private val featureFlagLabel by OnViewWithId(R.id.featureFlagButton)
     private val remoteConfigLabel by OnViewWithId(R.id.remoteConfigButton)
+    private val appThemeTitle by OnViewWithId(R.id.appThemeTitle)
+    private val appThemeStatus by OnViewWithId(R.id.appThemeStatus)
 
     fun openProfileSettingsPage() {
         profileSettingLabel.scrollTo().click()
@@ -63,5 +67,26 @@ class SettingsPage : BasePage(R.id.settingsPage) {
             Espresso.onView(ViewMatchers.withId(R.id.star + i))
                 .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
         }
+    }
+
+    fun openAppThemeSettings() {
+        appThemeTitle.scrollTo().click()
+    }
+
+    fun selectAppTheme(appTheme: AppTheme)
+    {
+        when (appTheme) {
+            AppTheme.LIGHT -> onView(withText(R.string.appThemeLight) + withParent(R.id.select_dialog_listview)).click()
+            AppTheme.DARK -> onView(withText(R.string.appThemeDark) + withParent(R.id.select_dialog_listview)).click()
+            AppTheme.SYSTEM -> onView(withText(R.string.appThemeSystem) + withParent(R.id.select_dialog_listview)).click()
+        }
+    }
+
+    fun assertAppThemeTitleTextColor(expectedTextColor: String) {
+        appThemeTitle.check(TextViewColorAssertion(expectedTextColor))
+    }
+
+    fun assertAppThemeStatusTextColor(expectedTextColor: String) {
+        appThemeStatus.check(TextViewColorAssertion(expectedTextColor))
     }
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/SettingsPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/SettingsPage.kt
@@ -24,7 +24,6 @@ import com.instructure.espresso.TextViewColorAssertion
 import com.instructure.espresso.click
 import com.instructure.espresso.page.*
 import com.instructure.espresso.scrollTo
-import com.instructure.pandautils.utils.AppTheme
 import com.instructure.teacher.R
 
 class SettingsPage : BasePage(R.id.settingsPage) {
@@ -73,13 +72,9 @@ class SettingsPage : BasePage(R.id.settingsPage) {
         appThemeTitle.scrollTo().click()
     }
 
-    fun selectAppTheme(appTheme: AppTheme)
+    fun selectAppTheme(appTheme: String)
     {
-        when (appTheme) {
-            AppTheme.LIGHT -> onView(withText(R.string.appThemeLight) + withParent(R.id.select_dialog_listview)).click()
-            AppTheme.DARK -> onView(withText(R.string.appThemeDark) + withParent(R.id.select_dialog_listview)).click()
-            AppTheme.SYSTEM -> onView(withText(R.string.appThemeSystem) + withParent(R.id.select_dialog_listview)).click()
-        }
+            onView(withText(appTheme) + withParent(R.id.select_dialog_listview)).click()
     }
 
     fun assertAppThemeTitleTextColor(expectedTextColor: String) {

--- a/automation/espresso/src/main/kotlin/com/instructure/espresso/CustomViewAssertions.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/espresso/CustomViewAssertions.kt
@@ -16,14 +16,16 @@
  */
 package com.instructure.espresso
 
+import android.graphics.Color
+import android.view.View
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.ViewAssertion
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.viewpager.widget.ViewPager
-import androidx.recyclerview.widget.RecyclerView
-import android.view.View
 import org.hamcrest.Matchers
-import java.lang.ClassCastException
+import org.junit.Assert.assertEquals
 
 class RecyclerViewItemCountAssertion(private val expectedCount: Int) : ViewAssertion {
     override fun check(view: View, noViewFoundException: NoMatchingViewException?) {
@@ -49,5 +51,14 @@ class ViewPagerItemCountAssertion(private val expectedCount: Int) : ViewAssertio
         val count = (view as? ViewPager)?.adapter?.count
                 ?: throw ClassCastException("View of type ${view.javaClass.simpleName} must be a ViewPager")
         ViewMatchers.assertThat(count, Matchers.`is`(expectedCount))
+    }
+}
+
+class TextViewColorAssertion(private val colorHexCode: String) : ViewAssertion {
+    override fun check(view: View, noViewFoundException: NoMatchingViewException?) {
+        noViewFoundException?.let { throw it }
+        val item = (view as? TextView)
+            ?: throw ClassCastException("View of type ${view.javaClass.simpleName} must be a TextView")
+        assertEquals(item.currentTextColor, Color.parseColor(colorHexCode))
     }
 }


### PR DESCRIPTION
Implement Teacher Dark Mode settings test case.
Extend some pages in Teacher app with color asserting methods.
Extend Teacher SettingsPage with AppTheme related elements and methods.
Rename 'launch'-leading method name conventions to 'open'.
+Some refactor

Implement Student Dark Mode settings test case.
Extend some pages with color asserting methods.
Extend SettingsPage with AppTheme related elements and methods.
Rename 'launch'-leading method name conventions to 'open'.
+Some little refactor.

refs: MBL-15990
affects: Student, Teacher
release note: none