### PR TITLE
[MBL-16115][Student] Students cannot comment student annotations

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/AnnotationComments/AnnotationCommentListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/AnnotationComments/AnnotationCommentListFragment.kt
@@ -58,6 +58,7 @@ class AnnotationCommentListFragment : ParentFragment() {
     private var docSession by ParcelableArg<DocSession>()
     private var apiValues by ParcelableArg<ApiValues>()
     private var headAnnotationId by StringArg()
+    private var canComment by BooleanArg(true, CAN_COMMENT)
 
     private var recyclerAdapter: AnnotationCommentListRecyclerAdapter? = null
 
@@ -132,7 +133,7 @@ class AnnotationCommentListFragment : ParentFragment() {
 
     private fun setupCommentInput() {
         // We want users with read permission to still be able to create and respond to comments.
-        if(docSession.annotationMetadata?.canRead() == false) {
+        if(docSession.annotationMetadata?.canRead() == false || !canComment) {
             commentInputContainer.setVisible(false)
         } else {
             sendCommentButton.imageTintList = ViewStyler.generateColorStateList(
@@ -233,11 +234,12 @@ class AnnotationCommentListFragment : ParentFragment() {
         private const val DOC_SESSION = "docSession"
         private const val API_VALUES = "apiValues"
         private const val HEAD_ANNOTATION_ID = "headAnnotationId"
+        private const val CAN_COMMENT = "canComment"
 
         fun newInstance(bundle: Bundle) = AnnotationCommentListFragment().apply { arguments = bundle }
 
-        fun makeRoute(annotations: ArrayList<CanvaDocAnnotation>, headAnnotationId: String, docSession: DocSession, apiValues: ApiValues, assigneeId: Long): Route {
-            val args = makeBundle(annotations, headAnnotationId, docSession, apiValues, assigneeId)
+        fun makeRoute(annotations: ArrayList<CanvaDocAnnotation>, headAnnotationId: String, docSession: DocSession, apiValues: ApiValues, assigneeId: Long, canComment: Boolean): Route {
+            val args = makeBundle(annotations, headAnnotationId, docSession, apiValues, assigneeId, canComment)
 
             return Route(null, AnnotationCommentListFragment::class.java, null, args)
         }
@@ -255,13 +257,14 @@ class AnnotationCommentListFragment : ParentFragment() {
             return AnnotationCommentListFragment().withArgs(route.arguments)
         }
 
-        fun makeBundle(annotations: ArrayList<CanvaDocAnnotation>, headAnnotationId: String, docSession: DocSession, apiValues: ApiValues, assigneeId: Long): Bundle {
+        fun makeBundle(annotations: ArrayList<CanvaDocAnnotation>, headAnnotationId: String, docSession: DocSession, apiValues: ApiValues, assigneeId: Long, canComment: Boolean): Bundle {
             val args = Bundle()
             args.putParcelableArrayList(ANNOTATIONS, annotations)
             args.putLong(ASSIGNEE_ID, assigneeId)
             args.putParcelable(DOC_SESSION, docSession)
             args.putParcelable(API_VALUES, apiValues)
             args.putString(HEAD_ANNOTATION_ID, headAnnotationId)
+            args.putBoolean(CAN_COMMENT, canComment)
             return args
         }
     }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/annnotation/AnnotationSubmissionUploadFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/annnotation/AnnotationSubmissionUploadFragment.kt
@@ -57,7 +57,7 @@ class AnnotationSubmissionUploadFragment : Fragment() {
 
         viewModel.pdfUrl.observe(viewLifecycleOwner, {
             binding.annotationSubmissionViewContainer.addView(
-                PdfStudentSubmissionView(requireActivity(), it, true)
+                PdfStudentSubmissionView(requireActivity(), it, studentAnnotationSubmit = true)
             )
         })
 

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/AnnotationSubmissionViewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/AnnotationSubmissionViewFragment.kt
@@ -48,7 +48,7 @@ class AnnotationSubmissionViewFragment : Fragment() {
         viewModel.loadAnnotatedPdfUrl(submissionId, submissionAttempt.toString())
 
         viewModel.pdfUrl.observe(viewLifecycleOwner, {
-            binding.annotationSubmissionViewContainer.addView(PdfStudentSubmissionView(requireActivity(), it))
+            binding.annotationSubmissionViewContainer.addView(PdfStudentSubmissionView(requireActivity(), it, studentAnnotationView = true))
         })
 
         return binding.root

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/PdfStudentSubmissionView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/PdfStudentSubmissionView.kt
@@ -61,8 +61,9 @@ import java.util.ArrayList
 class PdfStudentSubmissionView(
         context: Context,
         private val pdfUrl: String,
-        private val studentAnnotation: Boolean = false
-) : PdfSubmissionView(context), AnnotationManager.OnAnnotationCreationModeChangeListener, AnnotationManager.OnAnnotationEditingModeChangeListener {
+        private val studentAnnotationSubmit: Boolean = false,
+        private val studentAnnotationView: Boolean = false
+) : PdfSubmissionView(context, studentAnnotationView), AnnotationManager.OnAnnotationCreationModeChangeListener, AnnotationManager.OnAnnotationEditingModeChangeListener {
 
     private var initJob: Job? = null
     private var deleteJob: Job? = null
@@ -85,7 +86,7 @@ class PdfStudentSubmissionView(
     override fun setIsCurrentlyAnnotating(boolean: Boolean) {}
 
     override fun showAnnotationComments(commentList: ArrayList<CanvaDocAnnotation>, headAnnotationId: String, docSession: DocSession, apiValues: ApiValues) {
-        if (isAttachedToWindow) RouteMatcher.route(context, AnnotationCommentListFragment.makeRoute(commentList, headAnnotationId, docSession, apiValues, ApiPrefs.user!!.id))
+        if (isAttachedToWindow) RouteMatcher.route(context, AnnotationCommentListFragment.makeRoute(commentList, headAnnotationId, docSession, apiValues, ApiPrefs.user!!.id, !studentAnnotationView))
     }
 
     override fun showFileError() {
@@ -99,7 +100,7 @@ class PdfStudentSubmissionView(
 
     override fun configureCommentView(commentsButton: ImageView) {
         // If we are making annotations position the comments button as we would position in the teacher.
-        if (studentAnnotation) {
+        if (studentAnnotationSubmit) {
             super.configureCommentView(commentsButton)
             return
         }
@@ -151,7 +152,7 @@ class PdfStudentSubmissionView(
     override fun attachDocListener() {
         // We need to add this flag, because we want to show the toolbar in the student annotation, but hide when
         // we open an already submitted file submission with a teacher's annotations.
-        if (!studentAnnotation) {
+        if (!studentAnnotationSubmit) {
             // Modify the session data permissions to make sure students can't annotate already submitted assignments
             if (docSession.annotationMetadata?.canWrite() == true) {
                 docSession.annotationMetadata?.permissions = "read"

--- a/libs/annotations/src/main/java/com/instructure/annotations/PdfSubmissionView.kt
+++ b/libs/annotations/src/main/java/com/instructure/annotations/PdfSubmissionView.kt
@@ -84,7 +84,7 @@ import java.io.File
 import java.util.*
 
 @SuppressLint("ViewConstructor")
-abstract class PdfSubmissionView(context: Context) : FrameLayout(context), AnnotationManager.OnAnnotationCreationModeChangeListener, AnnotationManager.OnAnnotationEditingModeChangeListener {
+abstract class PdfSubmissionView(context: Context, private val studentAnnotationView: Boolean = false) : FrameLayout(context), AnnotationManager.OnAnnotationCreationModeChangeListener, AnnotationManager.OnAnnotationEditingModeChangeListener {
 
     protected lateinit var docSession: DocSession
     protected lateinit var apiValues: ApiValues
@@ -596,7 +596,7 @@ abstract class PdfSubmissionView(context: Context) : FrameLayout(context), Annot
                     setIsCurrentlyAnnotating(true)
                 }
 
-                if (annotation.type != AnnotationType.FREETEXT && annotation.name.isValid()) {
+                if (annotation.type != AnnotationType.FREETEXT && annotation.name.isValid() && (!studentAnnotationView || hasComments(annotation))) {
                     // if the annotation is an existing annotation (has an ID) and is NOT freetext
                     // we want to display the button to view/make comments
                     commentsButton.setVisible()
@@ -604,6 +604,13 @@ abstract class PdfSubmissionView(context: Context) : FrameLayout(context), Annot
             }
             return true
         }
+    }
+
+    private fun hasComments(annotation: Annotation): Boolean {
+        val currentAnnotation = annotation.convertPDFAnnotationToCanvaDoc(docSession.documentId)
+        return currentAnnotation != null
+            && commentRepliesHashMap[currentAnnotation.annotationId] != null
+            && commentRepliesHashMap[currentAnnotation.annotationId]?.isNotEmpty() == true
     }
 
     val mAnnotationDeselectedListener = AnnotationManager.OnAnnotationDeselectedListener { _, _ ->


### PR DESCRIPTION
Test plan: 
- Specification and expected behavior is in the ticket.
- Smoke test also the following scenarios:
  - Students can comment on teacher's annotations on PDF submissions
  - Teachers commenting annotations on both student annotation and PDF submission types.

refs: MBL-16115
affects: Student
release note: none