### PR TITLE
[MBL-16116][Student][Teacher] Change default theme colors

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/ThemePrefs.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/ThemePrefs.kt
@@ -31,20 +31,22 @@ object ThemePrefs : PrefManager("CanvasTheme") {
     const val DARK_MULTIPLIER = 0.85f
     const val ALPHA_VALUE = 0x32
 
-    var brandColor by ColorPref(R.color.backgroundDarkest)
+    var brandColor by ColorPref(R.color.textInfo)
 
-    var primaryColor by ColorPref(R.color.textDarkest)
+    // Used for Toolbar background color
+    var primaryColor by ColorPref(R.color.licorice)
 
     val darkPrimaryColor: Int
         get() = darker(primaryColor, DARK_MULTIPLIER)
 
-    var primaryTextColor by ColorPref(R.color.textLightest)
+    // Used for text color in Toolbars
+    var primaryTextColor by ColorPref(R.color.white)
 
     var accentColor by ColorPref(R.color.textInfo)
 
     var buttonColor by ColorPref(R.color.backgroundInfo)
 
-    var buttonTextColor by ColorPref(R.color.textLightest)
+    var buttonTextColor by ColorPref(R.color.white)
 
     var logoUrl by StringPref()
 


### PR DESCRIPTION
Test plan: 
- Clear the app data. 
- Intercept the brand variables endpoint in Charles and make it fail.
- Now you should see the default colors instead of the colors from the server.

refs: MBL-16116
affects: Student, Teacher
release note: none