### PR TITLE
[MBL-16117] [Teacher] - Remove unnecessary % sign from customize grade dialog

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/SpeedGraderGradeFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/SpeedGraderGradeFragment.kt
@@ -218,7 +218,7 @@ class SpeedGraderGradeFragment : BasePresenterFragment<SpeedGraderGradePresenter
         var grade: String? = ""
         if (presenter.submission != null) {
             var gradeInput = presenter.submission?.grade
-            if(gradeInput!!.last().toString() == "%") {
+            if(gradeInput?.isNullOrEmpty() == false && gradeInput.last().toString() == "%") {
                 gradeInput = gradeInput.dropLast(1)
             }
             grade = gradeInput

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/SpeedGraderGradeFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/SpeedGraderGradeFragment.kt
@@ -218,10 +218,13 @@ class SpeedGraderGradeFragment : BasePresenterFragment<SpeedGraderGradePresenter
         var grade: String? = ""
         if (presenter.submission != null) {
             var gradeInput = presenter.submission?.grade
-            if(gradeInput?.isNullOrEmpty() == false && gradeInput.last().toString() == "%") {
-                gradeInput = gradeInput.dropLast(1)
-            }
-            grade = gradeInput
+            if(gradeInput?.last()?.toString() == "%") {
+                if(!gradeInput?.isNullOrEmpty()) {
+                    gradeInput = gradeInput.dropLast(1)
+                    grade = gradeInput
+                } else grade = "0"
+            } else grade = gradeInput
+
         }
 
         val dialog = CustomizeGradeDialog.getInstance(requireActivity().supportFragmentManager,

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/SpeedGraderGradeFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/SpeedGraderGradeFragment.kt
@@ -217,7 +217,11 @@ class SpeedGraderGradeFragment : BasePresenterFragment<SpeedGraderGradePresenter
         val pointsPossible: String = NumberHelper.formatDecimal(presenter.assignment.pointsPossible, 2, true)
         var grade: String? = ""
         if (presenter.submission != null) {
-            grade = presenter.submission?.grade
+            var gradeInput = presenter.submission?.grade
+            if(gradeInput!!.last().toString() == "%") {
+                gradeInput = gradeInput.dropLast(1)
+            }
+            grade = gradeInput
         }
 
         val dialog = CustomizeGradeDialog.getInstance(requireActivity().supportFragmentManager,

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/SpeedGraderGradeFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/SpeedGraderGradeFragment.kt
@@ -218,13 +218,10 @@ class SpeedGraderGradeFragment : BasePresenterFragment<SpeedGraderGradePresenter
         var grade: String? = ""
         if (presenter.submission != null) {
             var gradeInput = presenter.submission?.grade
-            if(gradeInput?.last()?.toString() == "%") {
-                if(!gradeInput?.isNullOrEmpty()) {
-                    gradeInput = gradeInput.dropLast(1)
-                    grade = gradeInput
-                } else grade = "0"
-            } else grade = gradeInput
-
+            if(!gradeInput.isNullOrEmpty() && gradeInput.last().toString() == "%") {
+                gradeInput = gradeInput.dropLast(1)
+            }
+            grade = gradeInput
         }
 
         val dialog = CustomizeGradeDialog.getInstance(requireActivity().supportFragmentManager,


### PR DESCRIPTION
Fix unnecessary % sign in customize grade dialog when the grade type is percentage.

refs: MBL-16117
affects: Teacher
release note: none