### PR TITLE
[MBL-16130][Student] Banner image on K5 Course details

### DIFF
--- a/apps/student/src/main/res/layout-sw720dp/fragment_elementary_course.xml
+++ b/apps/student/src/main/res/layout-sw720dp/fragment_elementary_course.xml
@@ -103,8 +103,7 @@
                         android:background="@{ColorUtils.parseColor(course.courseColor)}"
                         android:importantForAccessibility="no"
                         android:scaleType="centerCrop"
-                        app:imageUrl="@{course.imageUrl}"
-                        app:overlayColor="@{ColorUtils.parseColor(course.courseColor)}"
+                        app:imageUrl="@{course.bannerImageUrl != null ? course.bannerImageUrl : course.imageUrl}"
                         tools:background="@color/backgroundWarning" />
 
                     <TextView

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CourseAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CourseAPI.kt
@@ -38,7 +38,7 @@ object CourseAPI {
         @get:GET("dashboard/dashboard_cards")
         val dashboardCourses: Call<List<DashboardCard>>
 
-        @get:GET("courses?include[]=term&include[]=total_scores&include[]=license&include[]=is_public&include[]=needs_grading_count&include[]=permissions&include[]=favorites&include[]=current_grading_period_scores&include[]=course_image&include[]=sections&state[]=completed&state[]=available")
+        @get:GET("courses?include[]=term&include[]=total_scores&include[]=license&include[]=is_public&include[]=needs_grading_count&include[]=permissions&include[]=favorites&include[]=current_grading_period_scores&include[]=course_image&include[]=banner_image&include[]=sections&state[]=completed&state[]=available")
         val firstPageCourses: Call<List<Course>>
 
         @get:GET("courses?include[]=term&include[]=total_scores&include[]=license&include[]=is_public&include[]=needs_grading_count&include[]=permissions&include[]=favorites&include[]=current_grading_period_scores&include[]=course_image&include[]=sections&state[]=current_and_concluded")

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Course.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Course.kt
@@ -60,6 +60,8 @@ data class Course(
         val accessRestrictedByDate: Boolean = false,
         @SerializedName("image_download_url")
         val imageUrl: String? = null,
+        @SerializedName("banner_image_download_url")
+        val bannerImageUrl: String? = null,
         @SerializedName("has_weighted_grading_periods")
         val isWeightedGradingPeriods: Boolean = false,
         @SerializedName("has_grading_periods")

--- a/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/pact/canvas/apis/CoursesApiPactTests.kt
+++ b/libs/canvas-api-2/src/test/java/com/instructure/canvasapi2/pact/canvas/apis/CoursesApiPactTests.kt
@@ -102,7 +102,7 @@ class CoursesApiPactTests : ApiPactTestBase() {
     //region Test grabbing all courses
     //
 
-    val allCoursesQuery = "include[]=term&include[]=total_scores&include[]=license&include[]=is_public&include[]=needs_grading_count&include[]=permissions&include[]=favorites&include[]=current_grading_period_scores&include[]=course_image&include[]=sections&state[]=completed&state[]=available"
+    val allCoursesQuery = "include[]=term&include[]=total_scores&include[]=license&include[]=is_public&include[]=needs_grading_count&include[]=permissions&include[]=favorites&include[]=current_grading_period_scores&include[]=course_image&include[]=banner_image&include[]=sections&state[]=completed&state[]=available"
     val allCoursesPath = "/api/v1/courses"
     val allCoursesFieldInfo = listOf(
             // Evidently, permissions info is *not* returned from this call, even though include[]=permissions is specified


### PR DESCRIPTION
refs: MBL-16130
affects: Student
release note: Added banner image to the Elementary Course Details screen.

test plan: 
Only the tablet layout is affected.
If the banner image has been set in the course settings it should show on the elementary course details screen.
If the banner image is not set, the course image is used instead.
If the course image and the banner image are not set the course color is used.