### PR TITLE
[MBL-16173][Teacher] Grading and grading state gets confused after grading via To Do section

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/presenters/SpeedGraderGradePresenter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/presenters/SpeedGraderGradePresenter.kt
@@ -16,6 +16,7 @@
  */
 package com.instructure.teacher.presenters
 
+import com.instructure.canvasapi2.CanvasRestAdapter
 import com.instructure.canvasapi2.managers.SubmissionManager
 import com.instructure.canvasapi2.models.*
 import com.instructure.canvasapi2.utils.weave.awaitApi
@@ -95,6 +96,8 @@ class SpeedGraderGradePresenter(var submission: Submission?, val assignment: Ass
         viewCallback?.updateGradeText()
         AssignmentGradedEvent(assignment.id).post() //post bus event
         SubmissionUpdatedEvent(newSubmission).post()
+        CanvasRestAdapter.clearCacheUrls("courses/${course.id}/assignment_groups")
+        CanvasRestAdapter.clearCacheUrls("courses/${course.id}/assignments/${assignment.id}")
     }
 
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/presenters/ToDoPresenter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/presenters/ToDoPresenter.kt
@@ -68,7 +68,9 @@ class ToDoPresenter : SyncPresenter<ToDo, ToDoView>(ToDo::class.java) {
                             // Set the context info for each to do
                             ToDo.setContextInfo(it, courses, groups)
                         }
+
                     data.addOrUpdate(toDos)
+                    data.removeDistinctItems(toDos)
 
                     // We want the count of the assignments that need grading. If there are more than 100 we will just show 99+
                     val todoCount = toDos.sumOf { it.needsGradingCount }

--- a/apps/teacher/src/main/java/com/instructure/teacher/view/edit_rubric/RubricEditView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/view/edit_rubric/RubricEditView.kt
@@ -24,6 +24,7 @@ import android.util.AttributeSet
 import android.view.View
 import android.view.accessibility.AccessibilityEvent
 import android.widget.FrameLayout
+import com.instructure.canvasapi2.CanvasRestAdapter
 import com.instructure.canvasapi2.managers.SubmissionManager
 import com.instructure.canvasapi2.models.*
 import com.instructure.canvasapi2.utils.NumberHelper
@@ -171,6 +172,8 @@ class RubricEditView @JvmOverloads constructor(
                 // Post update event
                 AssignmentGradedEvent(mAssignment.id).post()
                 SubmissionUpdatedEvent(updatedSubmission).post()
+                CanvasRestAdapter.clearCacheUrls("courses/${mAssignment.courseId}/assignment_groups")
+                CanvasRestAdapter.clearCacheUrls("courses/${mAssignment.courseId}/assignments/${mAssignment.id}")
 
                 // Show success toast
                 this@RubricEditView.toast(R.string.success_saving_rubric_assessment)

--- a/libs/recyclerview/src/main/java/com/instructure/pandarecycler/util/UpdatableSortedList.kt
+++ b/libs/recyclerview/src/main/java/com/instructure/pandarecycler/util/UpdatableSortedList.kt
@@ -54,6 +54,18 @@ class UpdatableSortedList<MODEL>(
         endBatchedUpdates()
     }
 
+    fun removeDistinctItems(items: List<MODEL>) {
+        val ids = items.map { getItemId(it) }.toSet()
+        beginBatchedUpdates()
+        for (i in size() - 1 downTo 0) {
+            val item = get(i)
+            if (!ids.contains(getItemId(item))) {
+                removeItemAt(i)
+            }
+        }
+        endBatchedUpdates()
+    }
+
     companion object {
         var NOT_IN_LIST = -2
         var ITEM_UPDATED = -3


### PR DESCRIPTION
Test plan:
- Repro steps in the ticket, but one thing is not mentioned there. To reproduce the issue first you need to open that assignment details screen from the assignments list to have it cached. Than follow the steps in the ticket.
- I also fixed the issue that the todo item is not disappearing when all the assignments were graded for that item.

refs: MBL-16173
affects: Teacher
release note: none