### PR TITLE
[MBL-15753][Parent] Add back the userId param when the api is fixed

### DIFF
--- a/apps/flutter_parent/lib/network/api/enrollments_api.dart
+++ b/apps/flutter_parent/lib/network/api/enrollments_api.dart
@@ -41,7 +41,7 @@ class EnrollmentsApi {
     final dio = canvasDio(forceRefresh: forceRefresh);
     final params = {
       'state[]': ['active', 'completed'], // current_and_concluded state not supported for observers
-      //'user_id': studentId, <-- add this back when the api is fixed
+      'user_id': studentId,
       if (gradingPeriodId?.isNotEmpty == true)
         'grading_period_id': gradingPeriodId,
     };

--- a/apps/flutter_parent/lib/screens/courses/details/course_details_model.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_details_model.dart
@@ -98,8 +98,6 @@ class CourseDetailsModel extends BaseModel {
     final enrollmentsFuture = _interactor()
         .loadEnrollmentsForGradingPeriod(courseId, student.id, _nextGradingPeriod?.id, forceRefresh: forceRefresh)
         ?.then((enrollments) {
-      enrollments = enrollments
-          .where((element) => element.userId == student.id).toList();
       return enrollments.length > 0 ? enrollments.first : null;
     })?.catchError((_) => null); // Some 'legacy' parents can't read grades for students, so catch and return null
 

--- a/apps/flutter_parent/test/screens/courses/course_details_model_test.dart
+++ b/apps/flutter_parent/test/screens/courses/course_details_model_test.dart
@@ -150,8 +150,7 @@ void main() {
       // Initial setup
       final termEnrollment = Enrollment((b) => b
         ..id = '10'
-        ..enrollmentState = 'active'
-        ..userId = _studentId);
+        ..enrollmentState = 'active');
       final gradingPeriods = [
         GradingPeriod((b) => b
           ..id = '123'

--- a/apps/flutter_parent/test/screens/courses/course_grades_screen_test.dart
+++ b/apps/flutter_parent/test/screens/courses/course_grades_screen_test.dart
@@ -326,8 +326,7 @@ void main() {
       ];
       final enrollment = Enrollment((b) => b
         ..enrollmentState = 'active'
-        ..grades = _mockGrade(currentScore: 1.2345)
-        ..userId = _studentId);
+        ..grades = _mockGrade(currentScore: 1.2345));
 
       final model = CourseDetailsModel(_student, _courseId);
       model.course = _mockCourse();
@@ -351,8 +350,7 @@ void main() {
       ];
       final enrollment = Enrollment((b) => b
         ..enrollmentState = 'active'
-        ..grades = _mockGrade(currentGrade: grade)
-        ..userId = _studentId);
+        ..grades = _mockGrade(currentGrade: grade));
       final model = CourseDetailsModel(_student, _courseId);
       model.course = _mockCourse();
       when(interactor.loadAssignmentGroups(_courseId, _studentId, null)).thenAnswer((_) async => groups);


### PR DESCRIPTION
refs: MBL-15753
affects: Parent
release note: none

Test plan: in the ticket