### PR TITLE
[MBL-16227][Parent] - Rename build apk names to contains the appname

### DIFF
--- a/apps/flutter_parent/android/app/build.gradle
+++ b/apps/flutter_parent/android/app/build.gradle
@@ -78,6 +78,19 @@ android {
             shrinkResources false // Must be false, otherwise resources we need are erroneously stripped out
             proguardFiles 'proguard-rules.pro'
         }
+        applicationVariants.all{
+            variant ->
+                variant.outputs.each{
+                    output->
+                        project.ext { appName = 'parent' }
+                        def dateTimeStamp = new Date().format('yyyy-MM-dd-HH-mm-ss')
+                        def newName = output.outputFile.name
+                        newName = newName.replace("app-", "$project.ext.appName-")
+                        newName = newName.replace("-debug", "-dev-debug-" + dateTimeStamp)
+                        newName = newName.replace("-release", "-prod-release")
+                        output.outputFileName  = newName
+                }
+        }
     }
 }
 


### PR DESCRIPTION
add variant section

define an apk build name which contains the word 'parent' instead of using a default build name (app-debug.apk or app-release.apk)

add timestamp to debug builds to be more accurate

refs: MBL-16227
affects: Parent
release note:

test plan: