### PR TITLE
[MBL-16236][Student] Multiple file sharing support

### DIFF
--- a/apps/student/src/main/AndroidManifest.xml
+++ b/apps/student/src/main/AndroidManifest.xml
@@ -214,6 +214,7 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.SEND"/>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
                 <category android:name="android.intent.category.DEFAULT"/>
 
                 <data android:mimeType="audio/*"/>

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadDialogFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadDialogFragment.kt
@@ -34,7 +34,7 @@ import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
-import androidx.work.*
+import androidx.work.WorkInfo
 import com.instructure.canvasapi2.models.*
 import com.instructure.canvasapi2.models.postmodels.FileSubmitObject
 import com.instructure.canvasapi2.utils.ApiPrefs
@@ -43,7 +43,6 @@ import com.instructure.pandautils.databinding.FragmentFileUploadDialogBinding
 import com.instructure.pandautils.utils.*
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.File
-import kotlin.collections.ArrayList
 
 @AndroidEntryPoint
 class FileUploadDialogFragment : DialogFragment() {
@@ -56,7 +55,7 @@ class FileUploadDialogFragment : DialogFragment() {
     private var canvasContext: CanvasContext by ParcelableArg(ApiPrefs.user)
     private var position: Int by IntArg()
 
-    private var fileSubmitUris: ArrayList<Uri> = arrayListOf()
+    private var fileSubmitUris: ArrayList<Uri>? = arrayListOf()
     private var cameraImageUri: Uri? = null
 
     private var assignment: Assignment? by NullableParcelableArg()
@@ -236,7 +235,7 @@ class FileUploadDialogFragment : DialogFragment() {
             return FileUploadDialogFragment().apply {
                 arguments = args
 
-                fileSubmitUris = args.getParcelableArrayList<Uri>(Const.URIS) as ArrayList<Uri>
+                fileSubmitUris = args.getParcelableArrayList(Const.URIS)
                 uploadType = args.getSerializable(Const.UPLOAD_TYPE) as FileUploadType
                 parentFolderId = args.getLong(Const.PARENT_FOLDER_ID, INVALID_ID)
                 quizQuestionId = args.getLong(Const.QUIZ_ANSWER_ID, INVALID_ID)

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadDialogFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadDialogFragment.kt
@@ -56,7 +56,7 @@ class FileUploadDialogFragment : DialogFragment() {
     private var canvasContext: CanvasContext by ParcelableArg(ApiPrefs.user)
     private var position: Int by IntArg()
 
-    private var fileSubmitUri: Uri? = null
+    private var fileSubmitUris: ArrayList<Uri> = arrayListOf()
     private var cameraImageUri: Uri? = null
 
     private var assignment: Assignment? by NullableParcelableArg()
@@ -173,7 +173,7 @@ class FileUploadDialogFragment : DialogFragment() {
             }
         })
 
-        viewModel.setData(assignment, fileSubmitUri, uploadType, canvasContext, parentFolderId, quizQuestionId,
+        viewModel.setData(assignment, fileSubmitUris, uploadType, canvasContext, parentFolderId, quizQuestionId,
                 position, quizId, dialogCallback, attachmentCallback, workerCallback)
     }
 
@@ -236,7 +236,7 @@ class FileUploadDialogFragment : DialogFragment() {
             return FileUploadDialogFragment().apply {
                 arguments = args
 
-                fileSubmitUri = args.getParcelable(Const.URI)
+                fileSubmitUris = args.getParcelableArrayList<Uri>(Const.URIS) as ArrayList<Uri>
                 uploadType = args.getSerializable(Const.UPLOAD_TYPE) as FileUploadType
                 parentFolderId = args.getLong(Const.PARENT_FOLDER_ID, INVALID_ID)
                 quizQuestionId = args.getLong(Const.QUIZ_ANSWER_ID, INVALID_ID)
@@ -249,28 +249,28 @@ class FileUploadDialogFragment : DialogFragment() {
             }
         }
 
-        fun createBundle(submitURI: Uri?, type: FileUploadType, parentFolderId: Long?): Bundle {
+        fun createBundle(submitURIs: ArrayList<Uri>, type: FileUploadType, parentFolderId: Long?): Bundle {
             val bundle = Bundle()
-            if (submitURI != null) bundle.putParcelable(Const.URI, submitURI)
+            if (submitURIs.isNotEmpty()) bundle.putParcelableArrayList(Const.URIS, submitURIs)
             if (parentFolderId != null) bundle.putLong(Const.PARENT_FOLDER_ID, parentFolderId)
             bundle.putSerializable(Const.UPLOAD_TYPE, type)
             return bundle
         }
 
         fun createMessageAttachmentsBundle(defaultFileList: ArrayList<FileSubmitObject>): Bundle {
-            val bundle = createBundle(null, FileUploadType.MESSAGE, null)
+            val bundle = createBundle(arrayListOf(), FileUploadType.MESSAGE, null)
             bundle.putParcelableArrayList(Const.FILES, defaultFileList)
             return bundle
         }
 
         fun createDiscussionsBundle(defaultFileList: ArrayList<FileSubmitObject>): Bundle {
-            val bundle = createBundle(null, FileUploadType.DISCUSSION, null)
+            val bundle = createBundle(arrayListOf(), FileUploadType.DISCUSSION, null)
             bundle.putParcelableArrayList(Const.FILES, defaultFileList)
             return bundle
         }
 
-        fun createFilesBundle(submitURI: Uri?, parentFolderId: Long?): Bundle {
-            return createBundle(submitURI, FileUploadType.USER, parentFolderId)
+        fun createFilesBundle(submitUris: ArrayList<Uri>, parentFolderId: Long?): Bundle {
+            return createBundle(submitUris, FileUploadType.USER, parentFolderId)
         }
 
         fun createContextBundle(submitURI: Uri?, context: CanvasContext, parentFolderId: Long?): Bundle {
@@ -282,32 +282,41 @@ class FileUploadDialogFragment : DialogFragment() {
         }
 
         private fun createCourseBundle(submitURI: Uri?, course: Course, parentFolderId: Long?): Bundle {
-            val bundle = createBundle(submitURI, FileUploadType.COURSE, parentFolderId)
+            val submitUris = submitURI?.let {
+                arrayListOf(it)
+            } ?: arrayListOf()
+            val bundle = createBundle(submitUris, FileUploadType.COURSE, parentFolderId)
             bundle.putParcelable(Const.CANVAS_CONTEXT, course)
             return bundle
         }
 
         private fun createGroupBundle(submitURI: Uri?, group: Group, parentFolderId: Long?): Bundle {
-            val bundle = createBundle(submitURI, FileUploadType.GROUP, parentFolderId)
+            val submitUris = submitURI?.let {
+                arrayListOf(it)
+            } ?: arrayListOf()
+            val bundle = createBundle(submitUris, FileUploadType.GROUP, parentFolderId)
             bundle.putParcelable(Const.CANVAS_CONTEXT, group)
             return bundle
         }
 
         private fun createUserBundle(submitURI: Uri?, user: User, parentFolderId: Long?): Bundle {
-            val bundle = createBundle(submitURI, FileUploadType.USER, parentFolderId)
+            val submitUris = submitURI?.let {
+                arrayListOf(it)
+            } ?: arrayListOf()
+            val bundle = createBundle(submitUris, FileUploadType.USER, parentFolderId)
             bundle.putParcelable(Const.CANVAS_CONTEXT, user)
             return bundle
         }
 
-        fun createAssignmentBundle(submitURI: Uri?, course: Course, assignment: Assignment): Bundle {
-            val bundle = createBundle(submitURI, FileUploadType.ASSIGNMENT, null)
+        fun createAssignmentBundle(submitURIs: ArrayList<Uri>, course: Course, assignment: Assignment): Bundle {
+            val bundle = createBundle(submitURIs, FileUploadType.ASSIGNMENT, null)
             bundle.putParcelable(Const.CANVAS_CONTEXT, course)
             bundle.putParcelable(Const.ASSIGNMENT, assignment)
             return bundle
         }
 
         fun createQuizFileBundle(quizQuestionId: Long, courseId: Long, quizId: Long, position: Int): Bundle {
-            val bundle = createBundle(null, FileUploadType.QUIZ, null)
+            val bundle = createBundle(arrayListOf(), FileUploadType.QUIZ, null)
             bundle.putLong(Const.QUIZ_ANSWER_ID, quizQuestionId)
             bundle.putLong(Const.QUIZ, quizId)
             bundle.putLong(Const.COURSE_ID, courseId)
@@ -316,7 +325,7 @@ class FileUploadDialogFragment : DialogFragment() {
         }
 
         fun createSubmissionCommentBundle(course: Course, assignment: Assignment, defaultFileList: java.util.ArrayList<FileSubmitObject>): Bundle {
-            val bundle = createBundle(null, FileUploadType.SUBMISSION_COMMENT, null)
+            val bundle = createBundle(arrayListOf(), FileUploadType.SUBMISSION_COMMENT, null)
             bundle.putParcelable(Const.CANVAS_CONTEXT, course)
             bundle.putParcelable(Const.ASSIGNMENT, assignment)
             bundle.putParcelableArrayList(Const.FILES, defaultFileList)
@@ -324,7 +333,7 @@ class FileUploadDialogFragment : DialogFragment() {
         }
 
         fun createAttachmentsBundle(defaultFileList: ArrayList<FileSubmitObject> = ArrayList()): Bundle {
-            val bundle = createBundle(null, FileUploadType.MESSAGE, null)
+            val bundle = createBundle(arrayListOf(), FileUploadType.MESSAGE, null)
             bundle.putParcelableArrayList(Const.FILES, defaultFileList)
             return bundle
         }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadDialogViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadDialogViewModel.kt
@@ -72,7 +72,7 @@ class FileUploadDialogViewModel @Inject constructor(
 
     fun setData(
             assignment: Assignment?,
-            files: ArrayList<Uri>,
+            files: ArrayList<Uri>?,
             uploadType: FileUploadType,
             canvasContext: CanvasContext,
             parentFolderId: Long,
@@ -84,7 +84,7 @@ class FileUploadDialogViewModel @Inject constructor(
             workerCallback: ((LiveData<WorkInfo>) -> Unit)? = null
     ) {
         this.assignment = assignment
-        files.forEach { uri ->
+        files?.forEach { uri ->
             val submitObject = getUriContents(uri)
             submitObject?.let { fso ->
                 this.filesToUpload.add(FileUploadData(uri, fso))

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadDialogViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadDialogViewModel.kt
@@ -72,7 +72,7 @@ class FileUploadDialogViewModel @Inject constructor(
 
     fun setData(
             assignment: Assignment?,
-            file: Uri?,
+            files: ArrayList<Uri>,
             uploadType: FileUploadType,
             canvasContext: CanvasContext,
             parentFolderId: Long,
@@ -84,10 +84,10 @@ class FileUploadDialogViewModel @Inject constructor(
             workerCallback: ((LiveData<WorkInfo>) -> Unit)? = null
     ) {
         this.assignment = assignment
-        file?.let { uri ->
+        files.forEach { uri ->
             val submitObject = getUriContents(uri)
-            submitObject?.let {
-                this.filesToUpload = mutableListOf(FileUploadData(uri, it))
+            submitObject?.let { fso ->
+                this.filesToUpload.add(FileUploadData(uri, fso))
             }
         }
         this.uploadType = uploadType

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/shareextension/ShareExtensionActivity.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/shareextension/ShareExtensionActivity.kt
@@ -92,11 +92,11 @@ abstract class ShareExtensionActivity : AppCompatActivity() {
     private fun handleAction(action: ShareExtensionAction) {
         when (action) {
             is ShareExtensionAction.ShowAssignmentUploadDialog -> {
-                val bundle = FileUploadDialogFragment.createAssignmentBundle(action.fileUri, action.course as Course, action.assignment)
+                val bundle = FileUploadDialogFragment.createAssignmentBundle(action.fileUris, action.course as Course, action.assignment)
                 showUploadDialog(bundle, action.dialogCallback)
             }
             is ShareExtensionAction.ShowMyFilesUploadDialog -> {
-                val bundle = FileUploadDialogFragment.createFilesBundle(action.fileUri, null)
+                val bundle = FileUploadDialogFragment.createFilesBundle(action.fileUris, null)
                 showUploadDialog(bundle, action.dialogCallback)
             }
             is ShareExtensionAction.ShowToast -> {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/shareextension/ShareExtensionViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/shareextension/ShareExtensionViewModel.kt
@@ -38,7 +38,7 @@ class ShareExtensionViewModel @Inject constructor(
         private val resources: Resources
 ) : ViewModel() {
 
-    var uri: Uri? = null
+    var uri: ArrayList<Uri>? = arrayListOf()
     var uploadType = FileUploadType.USER
 
     val events: LiveData<Event<ShareExtensionAction>>
@@ -53,8 +53,8 @@ class ShareExtensionViewModel @Inject constructor(
         val action = intent.action
         val type = intent.type
 
-        uri = if (Intent.ACTION_SEND == action && type != null) {
-            intent.getParcelableExtra(Intent.EXTRA_STREAM)
+        uri = if (Intent.ACTION_SEND_MULTIPLE == action && type != null) {
+            intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM) as ArrayList<Uri>
         } else {
             _events.postValue(Event(ShareExtensionAction.ShowToast(resources.getString(R.string.uploadingFromSourceFailed))))
             null
@@ -109,8 +109,8 @@ class ShareExtensionViewModel @Inject constructor(
 }
 
 sealed class ShareExtensionAction {
-    data class ShowAssignmentUploadDialog(val course: CanvasContext, val assignment: Assignment, val fileUri: Uri, val uploadType: FileUploadType, val dialogCallback: (Int) -> Unit) : ShareExtensionAction()
-    data class ShowMyFilesUploadDialog(val fileUri: Uri, val dialogCallback: (Int) -> Unit) : ShareExtensionAction()
+    data class ShowAssignmentUploadDialog(val course: CanvasContext, val assignment: Assignment, val fileUris: ArrayList<Uri>, val uploadType: FileUploadType, val dialogCallback: (Int) -> Unit) : ShareExtensionAction()
+    data class ShowMyFilesUploadDialog(val fileUris: ArrayList<Uri>, val dialogCallback: (Int) -> Unit) : ShareExtensionAction()
     object ShowProgressDialog : ShareExtensionAction()
     object ShowSuccessDialog : ShareExtensionAction()
     object Finish : ShareExtensionAction()

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/Const.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/Const.kt
@@ -87,6 +87,7 @@ object Const {
     const val UNREAD = "unread"
     const val UPLOAD_TYPE = "uploadType"
     const val URI = "uri"
+    const val URIS = "uris"
     const val URL = "url"
     const val USER = "user"
     const val USER_ID = "userId"

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/file/upload/FileUploadViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/file/upload/FileUploadViewModelTest.kt
@@ -101,7 +101,7 @@ class FileUploadViewModelTest {
         val viewModel = createViewModel()
         val course = createCourse(1L, "Course 1")
         val assignment = createAssignment(1L, "Assignment 1", 1L, listOf("pdf", "mp4", "docx"))
-        viewModel.setData(assignment, null, FileUploadType.ASSIGNMENT, course, -1L, -1L, -1, -1L)
+        viewModel.setData(assignment, arrayListOf(), FileUploadType.ASSIGNMENT, course, -1L, -1L, -1, -1L)
 
         viewModel.data.observe(lifecycleOwner) {}
 
@@ -114,7 +114,7 @@ class FileUploadViewModelTest {
         val viewModel = createViewModel()
         val course = createCourse(1L, "Course 1")
         val assignment = createAssignment(1L, "Assignment 1", 1L, listOf("pdf"))
-        viewModel.setData(assignment, null, FileUploadType.ASSIGNMENT, course, -1L, -1L, -1, -1L)
+        viewModel.setData(assignment, arrayListOf(), FileUploadType.ASSIGNMENT, course, -1L, -1L, -1, -1L)
 
         every { fileUploadUtilsHelper.getFileSubmitObjectFromInputStream(any(), any(), any()) } returns createSubmitObject("test.pdf")
 
@@ -132,7 +132,7 @@ class FileUploadViewModelTest {
         val viewModel = createViewModel()
         val course = createCourse(1L, "Course 1")
         val assignment = createAssignment(1L, "Assignment 1", 1L, listOf("pdf"))
-        viewModel.setData(assignment, null, FileUploadType.ASSIGNMENT, course, -1L, -1L, -1, -1L)
+        viewModel.setData(assignment, arrayListOf(), FileUploadType.ASSIGNMENT, course, -1L, -1L, -1, -1L)
 
         every { fileUploadUtilsHelper.getFileSubmitObjectFromInputStream(any(), any(), any()) } returns createSubmitObject("test.doc")
 
@@ -150,7 +150,7 @@ class FileUploadViewModelTest {
         val viewModel = createViewModel()
         val course = createCourse(1L, "Course 1")
         val assignment = createAssignment(1L, "Assignment 1", 1L)
-        viewModel.setData(assignment, null, FileUploadType.ASSIGNMENT, course, -1L, -1L, -1, -1L)
+        viewModel.setData(assignment, arrayListOf(), FileUploadType.ASSIGNMENT, course, -1L, -1L, -1, -1L)
 
         viewModel.uploadFiles()
 
@@ -163,7 +163,7 @@ class FileUploadViewModelTest {
         val viewModel = createViewModel()
         val course = createCourse(1L, "Course 1")
         val assignment = createAssignment(1L, "Assignment 1", 1L, submissionTypes = listOf("online_text_entry"))
-        viewModel.setData(assignment, null, FileUploadType.ASSIGNMENT, course, -1L, -1L, -1, -1L)
+        viewModel.setData(assignment, arrayListOf(), FileUploadType.ASSIGNMENT, course, -1L, -1L, -1, -1L)
 
         viewModel.addFile(uri)
         viewModel.uploadFiles()
@@ -181,7 +181,7 @@ class FileUploadViewModelTest {
 
         every { fileUploadUtilsHelper.getFileSubmitObjectFromInputStream(any(), any(), any()) } returns submitObject
 
-        viewModel.setData(assignment, null, FileUploadType.ASSIGNMENT, course, -1L, -1L, -1, -1L)
+        viewModel.setData(assignment, arrayListOf(), FileUploadType.ASSIGNMENT, course, -1L, -1L, -1, -1L)
 
         viewModel.data.observe(lifecycleOwner) {}
         viewModel.events.observe(lifecycleOwner) {}


### PR DESCRIPTION
refs: MBL-16236
affects: Student
release note: Added support for sharing multiple files to the app.

test plan: Select multiple files in the device file explorer. Canvas should be visible in the share sheet. All the files should be visible in the file upload dialog.

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Approve from product or not needed
