### PR TITLE
[MBL-16252][Student][Teacher] Revert dark mode popup

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentActivityTestRule.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentActivityTestRule.kt
@@ -23,6 +23,7 @@ import com.instructure.student.util.StudentPrefs
 import com.instructure.espresso.InstructureActivityTestRule
 import com.instructure.loginapi.login.util.PreviousUsersUtils
 import com.instructure.pandautils.utils.PandaAppResetter
+import com.instructure.pandautils.utils.ThemePrefs
 
 class StudentActivityTestRule<T : Activity>(activityClass: Class<T>) : InstructureActivityTestRule<T>(activityClass) {
 
@@ -31,6 +32,9 @@ class StudentActivityTestRule<T : Activity>(activityClass: Class<T>) : Instructu
         StudentPrefs.clearPrefs()
         CacheControlFlags.clearPrefs()
         PreviousUsersUtils.clear(context)
+
+        // We need to set this true so the theme selector won't stop our tests.
+        ThemePrefs.themeSelectionShown = true
     }
 
 }

--- a/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
@@ -67,7 +67,7 @@ import com.instructure.loginapi.login.dialog.MasqueradingDialog
 import com.instructure.loginapi.login.tasks.LogoutTask
 import com.instructure.pandautils.features.help.HelpDialogFragment
 import com.instructure.pandautils.features.notification.preferences.PushNotificationPreferencesFragment
-
+import com.instructure.pandautils.features.themeselector.ThemeSelectorBottomSheet
 import com.instructure.pandautils.models.PushNotification
 import com.instructure.pandautils.receivers.PushExternalReceiver
 import com.instructure.pandautils.typeface.TypefaceBehavior
@@ -261,6 +261,12 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
 
         val savedBottomScreens = savedInstanceState?.getStringArrayList(BOTTOM_SCREENS_BUNDLE_KEY)
         restoreBottomNavState(savedBottomScreens)
+
+        if (!ThemePrefs.themeSelectionShown) {
+            val themeSelector = ThemeSelectorBottomSheet()
+            themeSelector.show(supportFragmentManager, ThemeSelectorBottomSheet::javaClass.name)
+            ThemePrefs.themeSelectionShown = true
+        }
     }
 
     private fun restoreBottomNavState(savedBottomScreens: List<String>?) {

--- a/apps/student/src/main/res/values/themes_canvastheme.xml
+++ b/apps/student/src/main/res/values/themes_canvastheme.xml
@@ -32,6 +32,7 @@
         <item name="windowActionModeOverlay">true</item>
         <item name="android:alertDialogTheme">@style/CanvasDialogTheme_Default</item>
         <item name="alertDialogTheme">@style/CanvasDialogTheme_Default</item>
+        <item name="bottomSheetDialogTheme">@style/AppBottomSheetDialogTheme</item>
         <item name="pspdf__propertyInspectorStyle">@style/PropertyInspector</item>
         <item name="pspdf__contextualToolbarStyle">@style/ContextualToolbarStyle</item>
         <item name="pspdf__annotationCreationToolbarIconsStyle">@style/AnnotationCreationToolbarIconsStyle</item>

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/utils/TeacherActivityTestRule.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/utils/TeacherActivityTestRule.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import com.instructure.espresso.InstructureActivityTestRule
 import com.instructure.loginapi.login.util.PreviousUsersUtils
 import com.instructure.pandautils.utils.PandaAppResetter
+import com.instructure.pandautils.utils.ThemePrefs
 import com.instructure.teacher.utils.TeacherPrefs
 
 class TeacherActivityTestRule<T: Activity>(activityClass: Class<T>) : InstructureActivityTestRule<T>(activityClass) {
@@ -29,6 +30,9 @@ class TeacherActivityTestRule<T: Activity>(activityClass: Class<T>) : Instructur
         PandaAppResetter.reset(context)
         TeacherPrefs.safeClearPrefs()
         PreviousUsersUtils.clear(context)
+
+        // We need to set this true so the theme selector won't stop our tests.
+        ThemePrefs.themeSelectionShown = true
     }
 
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/activities/InitActivity.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/activities/InitActivity.kt
@@ -55,6 +55,7 @@ import com.instructure.loginapi.login.tasks.LogoutTask
 import com.instructure.pandautils.activities.BasePresenterActivity
 import com.instructure.pandautils.dialogs.RatingDialog
 import com.instructure.pandautils.features.help.HelpDialogFragment
+import com.instructure.pandautils.features.themeselector.ThemeSelectorBottomSheet
 import com.instructure.pandautils.models.PushNotification
 import com.instructure.pandautils.receivers.PushExternalReceiver
 import com.instructure.pandautils.typeface.TypefaceBehavior
@@ -162,6 +163,12 @@ class InitActivity : BasePresenterActivity<InitActivityPresenter, InitActivityVi
         RatingDialog.showRatingDialog(this, com.instructure.pandautils.utils.AppType.TEACHER)
 
         updateManager.checkForInAppUpdate(this)
+
+        if (!ThemePrefs.themeSelectionShown) {
+            val themeSelector = ThemeSelectorBottomSheet()
+            themeSelector.show(supportFragmentManager, ThemeSelectorBottomSheet::javaClass.name)
+            ThemePrefs.themeSelectionShown = true
+        }
     }
 
     override fun onNewIntent(intent: Intent?) {

--- a/apps/teacher/src/main/res/values/styles.xml
+++ b/apps/teacher/src/main/res/values/styles.xml
@@ -23,6 +23,7 @@
         <item name="colorAccent">@color/textDark</item>
         <item name="android:alertDialogTheme">@style/CanvasDialogTheme_Default</item>
         <item name="alertDialogTheme">@style/CanvasDialogTheme_Default</item>
+        <item name="bottomSheetDialogTheme">@style/AppBottomSheetDialogTheme</item>
 
         <item name="android:windowBackground">@color/backgroundLightest</item>
         <item name="android:actionOverflowButtonStyle">@style/Widget.ActionButton.Overflow</item>

--- a/libs/pandares/src/main/res/drawable/bg_bottom_sheet.xml
+++ b/libs/pandares/src/main/res/drawable/bg_bottom_sheet.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (C)  - present Instructure, Inc.
+  ~
+  ~     This program is free software: you can redistribute it and/or modify
+  ~     it under the terms of the GNU General Public License as published by
+  ~     the Free Software Foundation, version 3 of the License.
+  ~
+  ~     This program is distributed in the hope that it will be useful,
+  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~     GNU General Public License for more details.
+  ~
+  ~     You should have received a copy of the GNU General Public License
+  ~     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  ~
+  -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/backgroundLightest" />
+    <corners
+        android:topRightRadius="8dp"
+        android:topLeftRadius="8dp" />
+
+</shape>

--- a/libs/pandares/src/main/res/drawable/ic_dark_light_theme.xml
+++ b/libs/pandares/src/main/res/drawable/ic_dark_light_theme.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,2C6.4771,2 2,6.4771 2,12C2,17.5228 6.4771,22 12,22C17.5228,22 22,17.5228 22,12C22,6.4771 17.5228,2 12,2ZM12.5556,4.2418V19.7582C16.5918,19.4734 19.7778,16.1088 19.7778,12C19.7778,7.8913 16.5918,4.5266 12.5556,4.2418Z"
+      android:fillColor="#2D3B45"
+      android:fillType="evenOdd"/>
+</vector>

--- a/libs/pandares/src/main/res/values-ar/strings.xml
+++ b/libs/pandares/src/main/res/values-ar/strings.xml
@@ -1317,5 +1317,12 @@
     <string name="appThemeLight">فاتح</string>
     <string name="appThemeDark">داكن</string>
     <string name="appThemeSystem">مثل الجهاز</string>
+    <string name="themeSelectorTitle">Canvas متاح الآن في النسق الداكن</string>
+    <string name="themeSelectorDescription">اختر نسق التطبيق</string>
+    <string name="themeSelectorLightTheme">النسق الفاتح</string>
+    <string name="themeSelectorDarkTheme">النسق الداكن</string>
+    <string name="themeSelectorDeviceTheme">مثل نسق الجهاز</string>
+    <string name="themeSelectorSave">حفظ</string>
+    <string name="themeSelectorChangeLater">يمكنك تغييرها لاحقًا في إعدادات التطبيق</string>
     <string name="grabAnnotationTool">تحديد</string>
 </resources>

--- a/libs/pandares/src/main/res/values-b+da+instk12/strings.xml
+++ b/libs/pandares/src/main/res/values-b+da+instk12/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Lys</string>
     <string name="appThemeDark">Mørk</string>
     <string name="appThemeSystem">Samme som enhed</string>
+    <string name="themeSelectorTitle">Canvas er nu tilgængelig i mørkt tema</string>
+    <string name="themeSelectorDescription">Vælg app-tema</string>
+    <string name="themeSelectorLightTheme">Lyst tema</string>
+    <string name="themeSelectorDarkTheme">Mørkt tema</string>
+    <string name="themeSelectorDeviceTheme">Samme tema som på enhed</string>
+    <string name="themeSelectorSave">Gem</string>
+    <string name="themeSelectorChangeLater">Du kan ændre det senere i app-indstillinger</string>
     <string name="grabAnnotationTool">Tag fat</string>
 </resources>

--- a/libs/pandares/src/main/res/values-b+en+AU+unimelb/strings.xml
+++ b/libs/pandares/src/main/res/values-b+en+AU+unimelb/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Light</string>
     <string name="appThemeDark">Dark</string>
     <string name="appThemeSystem">Same as device</string>
+    <string name="themeSelectorTitle">Canvas is now available in dark theme</string>
+    <string name="themeSelectorDescription">Choose app theme</string>
+    <string name="themeSelectorLightTheme">Light theme</string>
+    <string name="themeSelectorDarkTheme">Dark theme</string>
+    <string name="themeSelectorDeviceTheme">Same as device theme</string>
+    <string name="themeSelectorSave">Save</string>
+    <string name="themeSelectorChangeLater">You can change it later in app settings</string>
     <string name="grabAnnotationTool">Grab</string>
 </resources>

--- a/libs/pandares/src/main/res/values-b+en+GB+instukhe/strings.xml
+++ b/libs/pandares/src/main/res/values-b+en+GB+instukhe/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Light</string>
     <string name="appThemeDark">Dark</string>
     <string name="appThemeSystem">Same as device</string>
+    <string name="themeSelectorTitle">Canvas is now available in dark theme</string>
+    <string name="themeSelectorDescription">Choose app theme</string>
+    <string name="themeSelectorLightTheme">Light theme</string>
+    <string name="themeSelectorDarkTheme">Dark theme</string>
+    <string name="themeSelectorDeviceTheme">Same as device theme</string>
+    <string name="themeSelectorSave">Save</string>
+    <string name="themeSelectorChangeLater">You can change it later in app settings</string>
     <string name="grabAnnotationTool">Grab</string>
 </resources>

--- a/libs/pandares/src/main/res/values-b+nb+instk12/strings.xml
+++ b/libs/pandares/src/main/res/values-b+nb+instk12/strings.xml
@@ -1263,5 +1263,12 @@
     <string name="appThemeLight">Lys</string>
     <string name="appThemeDark">Mørk</string>
     <string name="appThemeSystem">Samme som enhet</string>
+    <string name="themeSelectorTitle">Canvas er nå tilgjengelig med mørkt tema</string>
+    <string name="themeSelectorDescription">Velg app-tema</string>
+    <string name="themeSelectorLightTheme">Lyst tema</string>
+    <string name="themeSelectorDarkTheme">Mørkt tema</string>
+    <string name="themeSelectorDeviceTheme">Samme som enhetstema</string>
+    <string name="themeSelectorSave">Lagre</string>
+    <string name="themeSelectorChangeLater">Du kan endre det senere i appinnstillinger</string>
     <string name="grabAnnotationTool">Grip</string>
 </resources>

--- a/libs/pandares/src/main/res/values-b+sv+instk12/strings.xml
+++ b/libs/pandares/src/main/res/values-b+sv+instk12/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Ljus</string>
     <string name="appThemeDark">Mörk</string>
     <string name="appThemeSystem">Samma som enhet</string>
+    <string name="themeSelectorTitle">Canvas finns inte tillgängligt med ett mörkt tema</string>
+    <string name="themeSelectorDescription">Välj apptema</string>
+    <string name="themeSelectorLightTheme">Ljust tema</string>
+    <string name="themeSelectorDarkTheme">Mörkt tema</string>
+    <string name="themeSelectorDeviceTheme">Samma tema som enheten</string>
+    <string name="themeSelectorSave">Spara</string>
+    <string name="themeSelectorChangeLater">Du kan ändra det sedan i appinställningarna</string>
     <string name="grabAnnotationTool">Ta tag i</string>
 </resources>

--- a/libs/pandares/src/main/res/values-b+zh+Hans/strings.xml
+++ b/libs/pandares/src/main/res/values-b+zh+Hans/strings.xml
@@ -1248,5 +1248,12 @@
     <string name="appThemeLight">浅色的、轻的</string>
     <string name="appThemeDark">深色的、黑的</string>
     <string name="appThemeSystem">与设备相同</string>
+    <string name="themeSelectorTitle">Canvas 已推出深色主题</string>
+    <string name="themeSelectorDescription">选择应用程序主题</string>
+    <string name="themeSelectorLightTheme">浅色主题</string>
+    <string name="themeSelectorDarkTheme">深色主题</string>
+    <string name="themeSelectorDeviceTheme">与设备主题相同</string>
+    <string name="themeSelectorSave">保存</string>
+    <string name="themeSelectorChangeLater">您可以后在应用设置中更改</string>
     <string name="grabAnnotationTool">抓取图像</string>
 </resources>

--- a/libs/pandares/src/main/res/values-b+zh+Hant/strings.xml
+++ b/libs/pandares/src/main/res/values-b+zh+Hant/strings.xml
@@ -1248,5 +1248,12 @@
     <string name="appThemeLight">亮色</string>
     <string name="appThemeDark">暗色</string>
     <string name="appThemeSystem">和裝置相同</string>
+    <string name="themeSelectorTitle">Canvas 現在可在暗色主題中使用</string>
+    <string name="themeSelectorDescription">選擇應用程式主題</string>
+    <string name="themeSelectorLightTheme">淡色主題</string>
+    <string name="themeSelectorDarkTheme">暗色主題</string>
+    <string name="themeSelectorDeviceTheme">和裝置主題相同</string>
+    <string name="themeSelectorSave">儲存</string>
+    <string name="themeSelectorChangeLater">您可以稍後在應用桯式設定中變更</string>
     <string name="grabAnnotationTool">擷取</string>
 </resources>

--- a/libs/pandares/src/main/res/values-ca/strings.xml
+++ b/libs/pandares/src/main/res/values-ca/strings.xml
@@ -1263,5 +1263,12 @@
     <string name="appThemeLight">Clar</string>
     <string name="appThemeDark">Fosc</string>
     <string name="appThemeSystem">El mateix que el dispositiu</string>
+    <string name="themeSelectorTitle">Ara, el Canvas està disponible en tema fosc</string>
+    <string name="themeSelectorDescription">Trieu el tema de l’aplicació</string>
+    <string name="themeSelectorLightTheme">Tema clar</string>
+    <string name="themeSelectorDarkTheme">Tema fosc</string>
+    <string name="themeSelectorDeviceTheme">El mateix tema que el del dispositiu</string>
+    <string name="themeSelectorSave">Desa</string>
+    <string name="themeSelectorChangeLater">Podeu canviar-lo més endavant a la configuració de l’aplicació</string>
     <string name="grabAnnotationTool">Agafa</string>
 </resources>

--- a/libs/pandares/src/main/res/values-cy/strings.xml
+++ b/libs/pandares/src/main/res/values-cy/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Golau</string>
     <string name="appThemeDark">Tywyll</string>
     <string name="appThemeSystem">Yn un fath a’r ddyfais</string>
+    <string name="themeSelectorTitle">Mae Canvas bellach ar gael mewn thema dywyll</string>
+    <string name="themeSelectorDescription">Dewis thema ap</string>
+    <string name="themeSelectorLightTheme">Thema golau</string>
+    <string name="themeSelectorDarkTheme">Thema dywyll</string>
+    <string name="themeSelectorDeviceTheme">Yr un fath a thema’r ddyfais</string>
+    <string name="themeSelectorSave">Cadw</string>
+    <string name="themeSelectorChangeLater">Gallwch chi ei newid yn nes ymlaen yng ngosodiadau’r ap</string>
     <string name="grabAnnotationTool">Gafael</string>
 </resources>

--- a/libs/pandares/src/main/res/values-da/strings.xml
+++ b/libs/pandares/src/main/res/values-da/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Lys</string>
     <string name="appThemeDark">Mørk</string>
     <string name="appThemeSystem">Samme som enhed</string>
+    <string name="themeSelectorTitle">Canvas er nu tilgængelig i mørkt tema</string>
+    <string name="themeSelectorDescription">Vælg app-tema</string>
+    <string name="themeSelectorLightTheme">Lyst tema</string>
+    <string name="themeSelectorDarkTheme">Mørkt tema</string>
+    <string name="themeSelectorDeviceTheme">Samme tema som på enhed</string>
+    <string name="themeSelectorSave">Gem</string>
+    <string name="themeSelectorChangeLater">Du kan ændre det senere i app-indstillinger</string>
     <string name="grabAnnotationTool">Tag fat</string>
 </resources>

--- a/libs/pandares/src/main/res/values-de/strings.xml
+++ b/libs/pandares/src/main/res/values-de/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Hell</string>
     <string name="appThemeDark">Dunkel</string>
     <string name="appThemeSystem">Wie Gerät</string>
+    <string name="themeSelectorTitle">Canvas ist jetzt in dunklem Design verfügbar</string>
+    <string name="themeSelectorDescription">App-Design auswählen</string>
+    <string name="themeSelectorLightTheme">Helles Design</string>
+    <string name="themeSelectorDarkTheme">Dunkles Design</string>
+    <string name="themeSelectorDeviceTheme">Entspricht dem Gerätedesign</string>
+    <string name="themeSelectorSave">Speichern</string>
+    <string name="themeSelectorChangeLater">Sie können es später in den App-Einstellungen ändern.</string>
     <string name="grabAnnotationTool">Greifen</string>
 </resources>

--- a/libs/pandares/src/main/res/values-en-rAU/strings.xml
+++ b/libs/pandares/src/main/res/values-en-rAU/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Light</string>
     <string name="appThemeDark">Dark</string>
     <string name="appThemeSystem">Same as device</string>
+    <string name="themeSelectorTitle">Canvas is now available in dark theme</string>
+    <string name="themeSelectorDescription">Choose app theme</string>
+    <string name="themeSelectorLightTheme">Light theme</string>
+    <string name="themeSelectorDarkTheme">Dark theme</string>
+    <string name="themeSelectorDeviceTheme">Same as device theme</string>
+    <string name="themeSelectorSave">Save</string>
+    <string name="themeSelectorChangeLater">You can change it later in app settings</string>
     <string name="grabAnnotationTool">Grab</string>
 </resources>

--- a/libs/pandares/src/main/res/values-en-rCA/strings.xml
+++ b/libs/pandares/src/main/res/values-en-rCA/strings.xml
@@ -1268,6 +1268,13 @@
     <string name="appThemeDark">Dark</string>
     <string name="appThemeSystem">Same as device</string>
 
+    <string name="themeSelectorTitle">Canvas is now available in dark theme</string>
+    <string name="themeSelectorDescription">Choose app theme</string>
+    <string name="themeSelectorLightTheme">Light theme</string>
+    <string name="themeSelectorDarkTheme">Dark theme</string>
+    <string name="themeSelectorDeviceTheme">Same as device theme</string>
+    <string name="themeSelectorSave">Save</string>
+    <string name="themeSelectorChangeLater">You can change it later in app settings</string>
 
     <string name="grabAnnotationTool">Grab</string>
 

--- a/libs/pandares/src/main/res/values-en-rCY/strings.xml
+++ b/libs/pandares/src/main/res/values-en-rCY/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Light</string>
     <string name="appThemeDark">Dark</string>
     <string name="appThemeSystem">Same as device</string>
+    <string name="themeSelectorTitle">Canvas is now available in dark theme</string>
+    <string name="themeSelectorDescription">Choose app theme</string>
+    <string name="themeSelectorLightTheme">Light theme</string>
+    <string name="themeSelectorDarkTheme">Dark theme</string>
+    <string name="themeSelectorDeviceTheme">Same as device theme</string>
+    <string name="themeSelectorSave">Save</string>
+    <string name="themeSelectorChangeLater">You can change it later in app settings</string>
     <string name="grabAnnotationTool">Grab</string>
 </resources>

--- a/libs/pandares/src/main/res/values-en-rGB/strings.xml
+++ b/libs/pandares/src/main/res/values-en-rGB/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Light</string>
     <string name="appThemeDark">Dark</string>
     <string name="appThemeSystem">Same as device</string>
+    <string name="themeSelectorTitle">Canvas is now available in dark theme</string>
+    <string name="themeSelectorDescription">Choose app theme</string>
+    <string name="themeSelectorLightTheme">Light theme</string>
+    <string name="themeSelectorDarkTheme">Dark theme</string>
+    <string name="themeSelectorDeviceTheme">Same as device theme</string>
+    <string name="themeSelectorSave">Save</string>
+    <string name="themeSelectorChangeLater">You can change it later in app settings</string>
     <string name="grabAnnotationTool">Grab</string>
 </resources>

--- a/libs/pandares/src/main/res/values-es-rES/strings.xml
+++ b/libs/pandares/src/main/res/values-es-rES/strings.xml
@@ -1264,5 +1264,12 @@
     <string name="appThemeLight">Iluminado</string>
     <string name="appThemeDark">Oscuro</string>
     <string name="appThemeSystem">Coincidir con el dispositivo</string>
+    <string name="themeSelectorTitle">Canvas está ahora disponible en tema oscuro</string>
+    <string name="themeSelectorDescription">Elegir el tema de la aplicación</string>
+    <string name="themeSelectorLightTheme">Tema claro</string>
+    <string name="themeSelectorDarkTheme">Tema oscuro</string>
+    <string name="themeSelectorDeviceTheme">Coincidir con el tema del dispositivo</string>
+    <string name="themeSelectorSave">Guardar</string>
+    <string name="themeSelectorChangeLater">Se puede cambiar después en los ajustes de la aplicación</string>
     <string name="grabAnnotationTool">Captar</string>
 </resources>

--- a/libs/pandares/src/main/res/values-es/strings.xml
+++ b/libs/pandares/src/main/res/values-es/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Claro</string>
     <string name="appThemeDark">Oscuro</string>
     <string name="appThemeSystem">Igual que el dispositivo</string>
+    <string name="themeSelectorTitle">Canvas está ahora disponible en tema oscuro</string>
+    <string name="themeSelectorDescription">Elegir el tema de la aplicación</string>
+    <string name="themeSelectorLightTheme">Tema claro</string>
+    <string name="themeSelectorDarkTheme">Tema oscuro</string>
+    <string name="themeSelectorDeviceTheme">Igual que el tema del dispositivo</string>
+    <string name="themeSelectorSave">Guardar</string>
+    <string name="themeSelectorChangeLater">Puede cambiarlo más tarde en las configuraciones de la aplicación</string>
     <string name="grabAnnotationTool">Capturar</string>
 </resources>

--- a/libs/pandares/src/main/res/values-fi/strings.xml
+++ b/libs/pandares/src/main/res/values-fi/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Valo</string>
     <string name="appThemeDark">Tumma</string>
     <string name="appThemeSystem">Sama kuin laite</string>
+    <string name="themeSelectorTitle">Canvas on nyt saatavilla tummana teema</string>
+    <string name="themeSelectorDescription">Valitse sovelluksen teema</string>
+    <string name="themeSelectorLightTheme">Vaalea teema</string>
+    <string name="themeSelectorDarkTheme">Tumma teema</string>
+    <string name="themeSelectorDeviceTheme">Sama kuin laitteen teema</string>
+    <string name="themeSelectorSave">Tallenna</string>
+    <string name="themeSelectorChangeLater">Voit vaihtaa sen myöhemmin sovellusasetuksissa</string>
     <string name="grabAnnotationTool">Nappaa</string>
 </resources>

--- a/libs/pandares/src/main/res/values-fr-rCA/strings.xml
+++ b/libs/pandares/src/main/res/values-fr-rCA/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Clair</string>
     <string name="appThemeDark">Foncé</string>
     <string name="appThemeSystem">Identique au dispositif</string>
+    <string name="themeSelectorTitle">Canvas est désormais disponible en thème sombre</string>
+    <string name="themeSelectorDescription">Choisissez le thème de l’application</string>
+    <string name="themeSelectorLightTheme">Thème clair</string>
+    <string name="themeSelectorDarkTheme">Thème sombre</string>
+    <string name="themeSelectorDeviceTheme">Identique au thème du dispositif</string>
+    <string name="themeSelectorSave">Enregistrer</string>
+    <string name="themeSelectorChangeLater">Vous pouvez le changer plus tard dans les paramètres de l’application</string>
     <string name="grabAnnotationTool">Attraper</string>
 </resources>

--- a/libs/pandares/src/main/res/values-fr/strings.xml
+++ b/libs/pandares/src/main/res/values-fr/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Clair</string>
     <string name="appThemeDark">Foncé</string>
     <string name="appThemeSystem">Identique à l’appareil</string>
+    <string name="themeSelectorTitle">Canvas est désormais disponible en thème sombre</string>
+    <string name="themeSelectorDescription">Sélectionnez le thème de l’application</string>
+    <string name="themeSelectorLightTheme">Thème clair</string>
+    <string name="themeSelectorDarkTheme">Thème sombre</string>
+    <string name="themeSelectorDeviceTheme">Identique au thème de l’appareil</string>
+    <string name="themeSelectorSave">Enregistrer</string>
+    <string name="themeSelectorChangeLater">Vous pourrez modifier le thème ultérieurement dans les paramètres de l’application</string>
     <string name="grabAnnotationTool">Attraper</string>
 </resources>

--- a/libs/pandares/src/main/res/values-ht/strings.xml
+++ b/libs/pandares/src/main/res/values-ht/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Limyè</string>
     <string name="appThemeDark">Nwa</string>
     <string name="appThemeSystem">Menm ak aparèy la</string>
+    <string name="themeSelectorTitle">Canvas disponib kounye a an mòd sonm</string>
+    <string name="themeSelectorDescription">Chwazi app pou chanje mòd la</string>
+    <string name="themeSelectorLightTheme">Mòd klere</string>
+    <string name="themeSelectorDarkTheme">Mòd sonm</string>
+    <string name="themeSelectorDeviceTheme">Menm ak mòd aparèy la</string>
+    <string name="themeSelectorSave">Anrejistre</string>
+    <string name="themeSelectorChangeLater">Ou ka chanje l apre nan paramèt app la.</string>
     <string name="grabAnnotationTool">Sezi</string>
 </resources>

--- a/libs/pandares/src/main/res/values-is/strings.xml
+++ b/libs/pandares/src/main/res/values-is/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Ljóst</string>
     <string name="appThemeDark">Dökkt</string>
     <string name="appThemeSystem">Sama og tæki</string>
+    <string name="themeSelectorTitle">Canvas er nú í boði með dökku þema</string>
+    <string name="themeSelectorDescription">Veldu þema smáforrits</string>
+    <string name="themeSelectorLightTheme">Ljóst þema</string>
+    <string name="themeSelectorDarkTheme">Dökkt þema</string>
+    <string name="themeSelectorDeviceTheme">Sama og þema tækis</string>
+    <string name="themeSelectorSave">Vista</string>
+    <string name="themeSelectorChangeLater">Þú getur breytt því síðar í stillingum smáforrits</string>
     <string name="grabAnnotationTool">Grípa</string>
 </resources>

--- a/libs/pandares/src/main/res/values-it/strings.xml
+++ b/libs/pandares/src/main/res/values-it/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Chiaro</string>
     <string name="appThemeDark">Scuro</string>
     <string name="appThemeSystem">Come il dispositivo</string>
+    <string name="themeSelectorTitle">Canvas è ora disponibile in tema scuso</string>
+    <string name="themeSelectorDescription">Scegli tema app</string>
+    <string name="themeSelectorLightTheme">Tema chiaro</string>
+    <string name="themeSelectorDarkTheme">Tema scuro</string>
+    <string name="themeSelectorDeviceTheme">Come il tema dispositivo</string>
+    <string name="themeSelectorSave">Salva</string>
+    <string name="themeSelectorChangeLater">Puoi modificarlo successivamente nelle impostazioni dell’app</string>
     <string name="grabAnnotationTool">Afferra</string>
 </resources>

--- a/libs/pandares/src/main/res/values-ja/strings.xml
+++ b/libs/pandares/src/main/res/values-ja/strings.xml
@@ -1248,5 +1248,12 @@
     <string name="appThemeLight">明るい</string>
     <string name="appThemeDark">暗い</string>
     <string name="appThemeSystem">デバイスと同じ</string>
+    <string name="themeSelectorTitle">Canvasがダークテーマで利用可能に</string>
+    <string name="themeSelectorDescription">アプリのテーマを選ぶ</string>
+    <string name="themeSelectorLightTheme">ライトテーマ</string>
+    <string name="themeSelectorDarkTheme">ダークテーマ</string>
+    <string name="themeSelectorDeviceTheme">デバイスのテーマと同じ</string>
+    <string name="themeSelectorSave">保存</string>
+    <string name="themeSelectorChangeLater">後でアプリの設定から変更可能</string>
     <string name="grabAnnotationTool">捕捉</string>
 </resources>

--- a/libs/pandares/src/main/res/values-mi/strings.xml
+++ b/libs/pandares/src/main/res/values-mi/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Marama</string>
     <string name="appThemeDark">Pōuri</string>
     <string name="appThemeSystem">Rite tonu ka rite ki pūrere</string>
+    <string name="themeSelectorTitle">Canvas ko inaianei e wātea ana i te pouri kaupapa</string>
+    <string name="themeSelectorDescription">Whiriwhiria taupānga kaupapa</string>
+    <string name="themeSelectorLightTheme">Maama kaupapa</string>
+    <string name="themeSelectorDarkTheme">Pouriuri kaupapa</string>
+    <string name="themeSelectorDeviceTheme">Rite tonu ka rite ki pūrere kaupapa</string>
+    <string name="themeSelectorSave">Tiaki</string>
+    <string name="themeSelectorChangeLater">Ka taea e koe te whakarereke i muri mai i te taupānga tautuhinga</string>
     <string name="grabAnnotationTool">Kōrapurapu</string>
 </resources>

--- a/libs/pandares/src/main/res/values-nb/strings.xml
+++ b/libs/pandares/src/main/res/values-nb/strings.xml
@@ -1263,5 +1263,12 @@
     <string name="appThemeLight">Lys</string>
     <string name="appThemeDark">Mørk</string>
     <string name="appThemeSystem">Samme som enhet</string>
+    <string name="themeSelectorTitle">Canvas er nå tilgjengelig med mørkt tema</string>
+    <string name="themeSelectorDescription">Velg app-tema</string>
+    <string name="themeSelectorLightTheme">Lyst tema</string>
+    <string name="themeSelectorDarkTheme">Mørkt tema</string>
+    <string name="themeSelectorDeviceTheme">Samme som enhetstema</string>
+    <string name="themeSelectorSave">Lagre</string>
+    <string name="themeSelectorChangeLater">Du kan endre det senere i appinnstillinger</string>
     <string name="grabAnnotationTool">Grip</string>
 </resources>

--- a/libs/pandares/src/main/res/values-nl/strings.xml
+++ b/libs/pandares/src/main/res/values-nl/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Licht</string>
     <string name="appThemeDark">Donker</string>
     <string name="appThemeSystem">Hetzelfde als apparaat</string>
+    <string name="themeSelectorTitle">Canvas is niet beschikbaar in donker thema</string>
+    <string name="themeSelectorDescription">Kies app-thema</string>
+    <string name="themeSelectorLightTheme">Licht thema</string>
+    <string name="themeSelectorDarkTheme">Donker thema</string>
+    <string name="themeSelectorDeviceTheme">Hetzelfde als apparaatthema</string>
+    <string name="themeSelectorSave">Opslaan</string>
+    <string name="themeSelectorChangeLater">Je kunt dit later wijzigen in de app-instellingen.</string>
     <string name="grabAnnotationTool">Pakken</string>
 </resources>

--- a/libs/pandares/src/main/res/values-pl/strings.xml
+++ b/libs/pandares/src/main/res/values-pl/strings.xml
@@ -1290,5 +1290,12 @@
     <string name="appThemeLight">Jasny</string>
     <string name="appThemeDark">Ciemny</string>
     <string name="appThemeSystem">Taki sam jak urządzenia</string>
+    <string name="themeSelectorTitle">Dla Canvas jest teraz dostępny ciemny motyw</string>
+    <string name="themeSelectorDescription">Wybierz motyw aplikacji</string>
+    <string name="themeSelectorLightTheme">Jasny motyw</string>
+    <string name="themeSelectorDarkTheme">Ciemny motyw</string>
+    <string name="themeSelectorDeviceTheme">Taki sam jak motyw urządzenia</string>
+    <string name="themeSelectorSave">Zapisz</string>
+    <string name="themeSelectorChangeLater">Można zmienić go później w Ustawieniach aplikacji</string>
     <string name="grabAnnotationTool">Chwyć</string>
 </resources>

--- a/libs/pandares/src/main/res/values-pt-rBR/strings.xml
+++ b/libs/pandares/src/main/res/values-pt-rBR/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Claro</string>
     <string name="appThemeDark">Escuro</string>
     <string name="appThemeSystem">Igual ao dispositivo</string>
+    <string name="themeSelectorTitle">O Canvas agora está disponível no tema escuro</string>
+    <string name="themeSelectorDescription">Escolha o tema do aplicativo</string>
+    <string name="themeSelectorLightTheme">Tema claro</string>
+    <string name="themeSelectorDarkTheme">Tema escuro</string>
+    <string name="themeSelectorDeviceTheme">Igual ao tema do dispositivo</string>
+    <string name="themeSelectorSave">Salvar</string>
+    <string name="themeSelectorChangeLater">Você pode alterá-lo mais tarde nas configurações do aplicativo</string>
     <string name="grabAnnotationTool">Pegar</string>
 </resources>

--- a/libs/pandares/src/main/res/values-pt-rPT/strings.xml
+++ b/libs/pandares/src/main/res/values-pt-rPT/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Claro</string>
     <string name="appThemeDark">Escuro</string>
     <string name="appThemeSystem">O mesmo que dispositivo</string>
+    <string name="themeSelectorTitle">O ecrã está agora disponível em tema escuro</string>
+    <string name="themeSelectorDescription">Escolha o tema da aplicação</string>
+    <string name="themeSelectorLightTheme">Tema claro</string>
+    <string name="themeSelectorDarkTheme">Tema escuro</string>
+    <string name="themeSelectorDeviceTheme">O mesmo tema do dispositivo</string>
+    <string name="themeSelectorSave">Guardar</string>
+    <string name="themeSelectorChangeLater">Pode alterá-lo mais tarde nas definições da aplicação</string>
     <string name="grabAnnotationTool">Agarrar</string>
 </resources>

--- a/libs/pandares/src/main/res/values-ru/strings.xml
+++ b/libs/pandares/src/main/res/values-ru/strings.xml
@@ -1290,5 +1290,12 @@
     <string name="appThemeLight">Светлая</string>
     <string name="appThemeDark">Темная</string>
     <string name="appThemeSystem">Аналогично устройству</string>
+    <string name="themeSelectorTitle">Canvas теперь доступно в темной теме</string>
+    <string name="themeSelectorDescription">Выбрать тему приложения</string>
+    <string name="themeSelectorLightTheme">Светлая тема</string>
+    <string name="themeSelectorDarkTheme">Темная тема</string>
+    <string name="themeSelectorDeviceTheme">Аналогично теме устройства</string>
+    <string name="themeSelectorSave">Сохранить</string>
+    <string name="themeSelectorChangeLater">Вы можете изменить этот параметр позднее в настройках приложения</string>
     <string name="grabAnnotationTool">Захват</string>
 </resources>

--- a/libs/pandares/src/main/res/values-sl/strings.xml
+++ b/libs/pandares/src/main/res/values-sl/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Svetlo</string>
     <string name="appThemeDark">Temno</string>
     <string name="appThemeSystem">Enako kot naprava</string>
+    <string name="themeSelectorTitle">Sistem Canvas je zdaj na voljo v temni preobleki</string>
+    <string name="themeSelectorDescription">Izberite preobleko aplikacije</string>
+    <string name="themeSelectorLightTheme">Svetla preobleka</string>
+    <string name="themeSelectorDarkTheme">Temna preobleka</string>
+    <string name="themeSelectorDeviceTheme">Enako kot preobleka na napravi</string>
+    <string name="themeSelectorSave">Shrani</string>
+    <string name="themeSelectorChangeLater">To lahko pozneje spremenite v nastavitvah aplikacije</string>
     <string name="grabAnnotationTool">Zgrabi</string>
 </resources>

--- a/libs/pandares/src/main/res/values-sv/strings.xml
+++ b/libs/pandares/src/main/res/values-sv/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">Ljus</string>
     <string name="appThemeDark">Mörk</string>
     <string name="appThemeSystem">Samma som enhet</string>
+    <string name="themeSelectorTitle">Canvas finns inte tillgängligt med ett mörkt tema</string>
+    <string name="themeSelectorDescription">Välj apptema</string>
+    <string name="themeSelectorLightTheme">Ljust tema</string>
+    <string name="themeSelectorDarkTheme">Mörkt tema</string>
+    <string name="themeSelectorDeviceTheme">Samma tema som enheten</string>
+    <string name="themeSelectorSave">Spara</string>
+    <string name="themeSelectorChangeLater">Du kan ändra det sedan i appinställningarna</string>
     <string name="grabAnnotationTool">Ta tag i</string>
 </resources>

--- a/libs/pandares/src/main/res/values-th/strings.xml
+++ b/libs/pandares/src/main/res/values-th/strings.xml
@@ -1262,5 +1262,12 @@
     <string name="appThemeLight">สว่าง</string>
     <string name="appThemeDark">มืด</string>
     <string name="appThemeSystem">เหมือนกันกับอุปกรณ์</string>
+    <string name="themeSelectorTitle">Canvas พร้อมใช้งานในธีมมืดแล้ว</string>
+    <string name="themeSelectorDescription">เลือกธีมของแอพ</string>
+    <string name="themeSelectorLightTheme">ธีมสว่าง</string>
+    <string name="themeSelectorDarkTheme">ธีมมืด</string>
+    <string name="themeSelectorDeviceTheme">ธีมเหมือนกับอุปกรณ์</string>
+    <string name="themeSelectorSave">บันทึก</string>
+    <string name="themeSelectorChangeLater">คุณสามารถแก้ไขได้ในภายหลังจากค่าปรับตั้งแอพ</string>
     <string name="grabAnnotationTool">คว้าไว้</string>
 </resources>

--- a/libs/pandares/src/main/res/values-vi/strings.xml
+++ b/libs/pandares/src/main/res/values-vi/strings.xml
@@ -1263,5 +1263,12 @@
     <string name="appThemeLight">Sáng</string>
     <string name="appThemeDark">Tối</string>
     <string name="appThemeSystem">Tương tự như thiết bị</string>
+    <string name="themeSelectorTitle">Canvas hiện nay đã có sẵn ở chủ đề tối</string>
+    <string name="themeSelectorDescription">Lựa chọn chủ đề ứng dụng</string>
+    <string name="themeSelectorLightTheme">Chủ đề sáng</string>
+    <string name="themeSelectorDarkTheme">Chủ đề tối</string>
+    <string name="themeSelectorDeviceTheme">Tương tự như chủ đề thiết bị</string>
+    <string name="themeSelectorSave">Lưu</string>
+    <string name="themeSelectorChangeLater">Bạn có thể thay đổi sau trong cài đặt ứng dụng</string>
     <string name="grabAnnotationTool">Nắm lấy</string>
 </resources>

--- a/libs/pandares/src/main/res/values-zh-rHK/strings.xml
+++ b/libs/pandares/src/main/res/values-zh-rHK/strings.xml
@@ -1248,5 +1248,12 @@
     <string name="appThemeLight">亮色</string>
     <string name="appThemeDark">暗色</string>
     <string name="appThemeSystem">和裝置相同</string>
+    <string name="themeSelectorTitle">Canvas 現在可在暗色主題中使用</string>
+    <string name="themeSelectorDescription">選擇應用程式主題</string>
+    <string name="themeSelectorLightTheme">淡色主題</string>
+    <string name="themeSelectorDarkTheme">暗色主題</string>
+    <string name="themeSelectorDeviceTheme">和裝置主題相同</string>
+    <string name="themeSelectorSave">儲存</string>
+    <string name="themeSelectorChangeLater">您可以稍後在應用桯式設定中變更</string>
     <string name="grabAnnotationTool">擷取</string>
 </resources>

--- a/libs/pandares/src/main/res/values-zh/strings.xml
+++ b/libs/pandares/src/main/res/values-zh/strings.xml
@@ -1248,5 +1248,12 @@
     <string name="appThemeLight">浅色的、轻的</string>
     <string name="appThemeDark">深色的、黑的</string>
     <string name="appThemeSystem">与设备相同</string>
+    <string name="themeSelectorTitle">Canvas 已推出深色主题</string>
+    <string name="themeSelectorDescription">选择应用程序主题</string>
+    <string name="themeSelectorLightTheme">浅色主题</string>
+    <string name="themeSelectorDarkTheme">深色主题</string>
+    <string name="themeSelectorDeviceTheme">与设备主题相同</string>
+    <string name="themeSelectorSave">保存</string>
+    <string name="themeSelectorChangeLater">您可以后在应用设置中更改</string>
     <string name="grabAnnotationTool">抓取图像</string>
 </resources>

--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -1267,6 +1267,14 @@
     <string name="appThemeDark">Dark</string>
     <string name="appThemeSystem">Same as device</string>
 
+    <string name="themeSelectorTitle">Canvas is now available in dark theme</string>
+    <string name="themeSelectorDescription">Choose app theme</string>
+    <string name="themeSelectorLightTheme">Light theme</string>
+    <string name="themeSelectorDarkTheme">Dark theme</string>
+    <string name="themeSelectorDeviceTheme">Same as device theme</string>
+    <string name="themeSelectorSave">Save</string>
+    <string name="themeSelectorChangeLater">You can change it later in app settings</string>
+
     <string name="grabAnnotationTool">Grab</string>
     <string name="fileUpload">File Upload</string>
 

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/themeselector/ThemeSelectorBottomSheet.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/themeselector/ThemeSelectorBottomSheet.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.pandautils.features.themeselector
+
+import android.content.DialogInterface
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.widget.CompoundButtonCompat
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.instructure.pandautils.R
+import com.instructure.pandautils.utils.AppTheme
+import com.instructure.pandautils.utils.ThemePrefs
+import com.instructure.pandautils.utils.ViewStyler
+import com.instructure.pandautils.utils.onClick
+import kotlinx.android.synthetic.main.bottom_sheet_theme_selector.*
+
+class ThemeSelectorBottomSheet : BottomSheetDialogFragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? = inflater.inflate(R.layout.bottom_sheet_theme_selector, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val radioButtonColor = ViewStyler.makeColorStateListForRadioGroup(requireContext().getColor(R.color.textDarkest), requireContext().getColor(R.color.textInfo))
+        CompoundButtonCompat.setButtonTintList(buttonLightTheme, radioButtonColor)
+        CompoundButtonCompat.setButtonTintList(buttonDarkTheme, radioButtonColor)
+        CompoundButtonCompat.setButtonTintList(buttonDeviceTheme, radioButtonColor)
+
+        saveButton.onClick {
+            val appTheme = when {
+                buttonLightTheme.isChecked -> AppTheme.LIGHT
+                buttonDarkTheme.isChecked -> AppTheme.DARK
+                else -> AppTheme.SYSTEM
+            }
+            setAppTheme(appTheme)
+        }
+    }
+
+    private fun setAppTheme(appTheme: AppTheme) {
+        AppCompatDelegate.setDefaultNightMode(appTheme.nightModeType)
+        ThemePrefs.appTheme = appTheme.ordinal
+        dismiss()
+    }
+
+}

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/ThemePrefs.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/ThemePrefs.kt
@@ -54,7 +54,9 @@ object ThemePrefs : PrefManager("CanvasTheme") {
 
     var appTheme by IntPref(defaultValue = 0)
 
-    override fun keepBaseProps() = listOf(::appTheme)
+    var themeSelectionShown by BooleanPref()
+
+    override fun keepBaseProps() = listOf(::appTheme, ::themeSelectionShown)
 
     override fun onClearPrefs() {
     }

--- a/libs/pandautils/src/main/res/layout/bottom_sheet_theme_selector.xml
+++ b/libs/pandautils/src/main/res/layout/bottom_sheet_theme_selector.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (C)  - present Instructure, Inc.
+  ~
+  ~     This program is free software: you can redistribute it and/or modify
+  ~     it under the terms of the GNU General Public License as published by
+  ~     the Free Software Foundation, version 3 of the License.
+  ~
+  ~     This program is distributed in the hope that it will be useful,
+  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~     GNU General Public License for more details.
+  ~
+  ~     You should have received a copy of the GNU General Public License
+  ~     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  ~
+  -->
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/bg_bottom_sheet"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <ImageView
+        android:id="@+id/darkLightIcon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_dark_light_theme"
+        android:layout_marginTop="32dp"
+        app:tint="@color/textDarkest"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:tint="@color/textDarkest" />
+
+    <TextView
+        android:id="@+id/titleText"
+        style="@style/TextStyle.Primary"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="64dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="64dp"
+        android:text="@string/themeSelectorTitle"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/darkLightIcon" />
+
+    <TextView
+        android:id="@+id/descriptionText"
+        style="@style/TextStyle.Primary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginEnd="16dp"
+        android:text="@string/themeSelectorDescription"
+        android:textSize="16sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/titleText" />
+
+    <TextView
+        android:id="@+id/changeLateText"
+        style="@style/TextStyle.Primary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:text="@string/themeSelectorChangeLater"
+        android:textSize="14sp"
+        android:textColor="@color/textDark"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/descriptionText" />
+
+    <RadioGroup
+        android:id="@+id/themeSelectionGroup"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_marginTop="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        app:layout_constraintTop_toBottomOf="@id/changeLateText"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <androidx.appcompat.widget.AppCompatRadioButton
+            android:id="@+id/buttonLightTheme"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="16sp"
+            android:textColor="@color/textDarkest"
+            android:text="@string/themeSelectorLightTheme"
+            android:buttonTint="@color/textInfo"
+            android:checked="true"
+            android:minHeight="?android:listPreferredItemHeightSmall"/>
+
+        <androidx.appcompat.widget.AppCompatRadioButton
+            android:id="@+id/buttonDarkTheme"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="16sp"
+            android:textColor="@color/textDarkest"
+            android:text="@string/themeSelectorDarkTheme"
+            android:buttonTint="@color/textInfo"
+            android:minHeight="?android:listPreferredItemHeightSmall"/>
+
+        <androidx.appcompat.widget.AppCompatRadioButton
+            android:id="@+id/buttonDeviceTheme"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="16sp"
+            android:textColor="@color/textDarkest"
+            android:text="@string/themeSelectorDeviceTheme"
+            android:buttonTint="@color/textInfo"
+            android:minHeight="?android:listPreferredItemHeightSmall"/>
+
+    </RadioGroup>
+
+    <Button
+        android:id="@+id/saveButton"
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="32dp"
+        android:background="@drawable/bg_button_rounded_transparent"
+        android:text="@string/themeSelectorSave"
+        android:textColor="@color/textInfo"
+        android:textSize="16sp"
+        app:layout_constraintTop_toBottomOf="@id/themeSelectionGroup"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintVertical_bias="0.0"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/libs/pandautils/src/main/res/values/themes_canvasthemes.xml
+++ b/libs/pandautils/src/main/res/values/themes_canvasthemes.xml
@@ -76,4 +76,11 @@
         <item name="android:colorAccent">@color/textInfo</item>
     </style>
 
+    <style name="AppBottomSheetDialogTheme" parent="Theme.Design.Light.BottomSheetDialog">
+        <item name="bottomSheetStyle">@style/AppModalStyle</item>
+    </style>
+
+    <style name="AppModalStyle" parent="Widget.Design.BottomSheet.Modal">
+        <item name="android:background">@drawable/bg_bottom_sheet</item>
+    </style>
 </resources>


### PR DESCRIPTION
Test plan: Check if dark mode popup is present on first start.

refs: MBL-16252
affects: Student, Teacher
release note: none

--- edit or delete this section ---
## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="" maxHeight=500></td>
<td><img src="" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Approve from product or not needed
