### PR TITLE
[MBL-16249][Student][Teacher] Multiple file selection on FileUpload

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadDialogFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadDialogFragment.kt
@@ -82,15 +82,15 @@ class FileUploadDialogFragment : DialogFragment() {
         }
     }
 
-    private val galleryPickerContract = registerForActivityResult(ActivityResultContracts.GetContent()) {
+    private val filePickerContract = registerForActivityResult(ActivityResultContracts.GetContent()) {
         it?.let {
             viewModel.addFile(it)
         }
     }
 
-    private val filePickerContract = registerForActivityResult(ActivityResultContracts.GetContent()) {
+    private val multipleFilePickerContract = registerForActivityResult(ActivityResultContracts.GetMultipleContents()) {
         it?.let {
-            viewModel.addFile(it)
+            viewModel.addFiles(it)
         }
     }
 
@@ -199,8 +199,10 @@ class FileUploadDialogFragment : DialogFragment() {
     private fun handleAction(action: FileUploadAction) {
         when (action) {
             is FileUploadAction.TakePhoto -> takePicture()
-            is FileUploadAction.PickPhoto -> pickFromGallery()
+            is FileUploadAction.PickImage -> pickFromGallery()
             is FileUploadAction.PickFile -> pickFromFiles()
+            is FileUploadAction.PickMultipleFile -> pickMultipleFile()
+            is FileUploadAction.PickMultipleImage -> pickMultipleImage()
             is FileUploadAction.ShowToast -> Toast.makeText(requireContext(), action.toast, Toast.LENGTH_SHORT).show()
             is FileUploadAction.UploadStarted -> dismiss()
         }
@@ -219,11 +221,19 @@ class FileUploadDialogFragment : DialogFragment() {
     }
 
     private fun pickFromGallery() {
-        galleryPickerContract.launch("image/*")
+        filePickerContract.launch("image/*")
     }
 
     private fun pickFromFiles() {
         filePickerContract.launch("*/*")
+    }
+
+    private fun pickMultipleFile() {
+        multipleFilePickerContract.launch("*/*")
+    }
+
+    private fun pickMultipleImage() {
+        multipleFilePickerContract.launch("image/*")
     }
 
     companion object {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadDialogViewData.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadDialogViewData.kt
@@ -38,8 +38,10 @@ data class FileUploadData(
 
 sealed class FileUploadAction {
     object TakePhoto : FileUploadAction()
-    object PickPhoto : FileUploadAction()
+    object PickImage : FileUploadAction()
     object PickFile : FileUploadAction()
+    object PickMultipleImage : FileUploadAction()
+    object PickMultipleFile : FileUploadAction()
     object UploadStarted : FileUploadAction()
     data class ShowToast(val toast: String) : FileUploadAction()
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadDialogViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadDialogViewModel.kt
@@ -32,8 +32,8 @@ import com.instructure.pandautils.R
 import com.instructure.pandautils.features.file.upload.itemviewmodels.FileItemViewModel
 import com.instructure.pandautils.features.file.upload.worker.FileUploadBundleCreator
 import com.instructure.pandautils.features.file.upload.worker.FileUploadWorker
-import com.instructure.pandautils.utils.humanReadableByteCount
 import com.instructure.pandautils.mvvm.Event
+import com.instructure.pandautils.utils.humanReadableByteCount
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.util.*
 import javax.inject.Inject
@@ -109,15 +109,37 @@ class FileUploadDialogViewModel @Inject constructor(
     }
 
     fun onCameraClicked() {
+        if (isOneFileOnly && filesToUpload.isNotEmpty()) {
+            _events.postValue(Event(FileUploadAction.ShowToast(resources.getString(R.string.oneFileOnly))))
+            return
+        }
         _events.postValue(Event(FileUploadAction.TakePhoto))
     }
 
     fun onGalleryClicked() {
-        _events.postValue(Event(FileUploadAction.PickPhoto))
+        if (isOneFileOnly && filesToUpload.isNotEmpty()) {
+            _events.postValue(Event(FileUploadAction.ShowToast(resources.getString(R.string.oneFileOnly))))
+            return
+        }
+
+        if (isOneFileOnly) {
+            _events.postValue(Event(FileUploadAction.PickImage))
+        } else {
+            _events.postValue(Event(FileUploadAction.PickMultipleImage))
+        }
     }
 
     fun onFilesClicked() {
-        _events.postValue(Event(FileUploadAction.PickFile))
+        if (isOneFileOnly && filesToUpload.isNotEmpty()) {
+            _events.postValue(Event(FileUploadAction.ShowToast(resources.getString(R.string.oneFileOnly))))
+            return
+        }
+
+        if (isOneFileOnly) {
+            _events.postValue(Event(FileUploadAction.PickFile))
+        } else {
+            _events.postValue(Event(FileUploadAction.PickMultipleFile))
+        }
     }
 
     fun addFile(fileUri: Uri) {
@@ -133,6 +155,12 @@ class FileUploadDialogViewModel @Inject constructor(
                         ?: resources.getString(R.string.errorOccurred))))
             }
         } ?: _events.postValue(Event(FileUploadAction.ShowToast(resources.getString(R.string.errorOccurred))))
+    }
+
+    fun addFiles(fileUris: List<Uri>) {
+        fileUris.forEach {
+            addFile(it)
+        }
     }
 
     private fun updateItems() {

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/file/upload/FileUploadViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/file/upload/FileUploadViewModelTest.kt
@@ -83,7 +83,7 @@ class FileUploadViewModelTest {
 
         viewModel.onGalleryClicked()
 
-        assertEquals(FileUploadAction.PickPhoto, viewModel.events.value?.getContentIfNotHandled())
+        assertEquals(FileUploadAction.PickMultipleImage, viewModel.events.value?.getContentIfNotHandled())
     }
 
     @Test
@@ -93,7 +93,7 @@ class FileUploadViewModelTest {
 
         viewModel.onFilesClicked()
 
-        assertEquals(FileUploadAction.PickFile, viewModel.events.value?.getContentIfNotHandled())
+        assertEquals(FileUploadAction.PickMultipleFile, viewModel.events.value?.getContentIfNotHandled())
     }
 
     @Test
@@ -192,10 +192,99 @@ class FileUploadViewModelTest {
         assert(viewModel.events.value?.getContentIfNotHandled() is FileUploadAction.UploadStarted)
     }
 
+    @Test
+    fun `Only single image can be picked as discussion attachment`() {
+        val viewModel = createViewModel()
+        val course = createCourse(1L, "Course 1")
+        viewModel.setData(null, arrayListOf(), FileUploadType.DISCUSSION, course, -1L, -1L, -1, -1L)
+
+        viewModel.onGalleryClicked()
+
+        assertEquals(FileUploadAction.PickImage, viewModel.events.value?.getContentIfNotHandled())
+    }
+
+    @Test
+    fun `Only single file can be picked as discussion attachment`() {
+        val viewModel = createViewModel()
+        val course = createCourse(1L, "Course 1")
+        viewModel.setData(null, arrayListOf(), FileUploadType.DISCUSSION, course, -1L, -1L, -1, -1L)
+
+        viewModel.onFilesClicked()
+
+        assertEquals(FileUploadAction.PickFile, viewModel.events.value?.getContentIfNotHandled())
+    }
+
+    @Test
+    fun `Only single image can be picked as quiz attachment`() {
+        val viewModel = createViewModel()
+        val course = createCourse(1L, "Course 1")
+        viewModel.setData(null, arrayListOf(), FileUploadType.QUIZ, course, -1L, -1L, -1, -1L)
+
+        viewModel.onGalleryClicked()
+
+        assertEquals(FileUploadAction.PickImage, viewModel.events.value?.getContentIfNotHandled())
+    }
+
+    @Test
+    fun `Only single file can be picked as quiz attachment`() {
+        val viewModel = createViewModel()
+        val course = createCourse(1L, "Course 1")
+        viewModel.setData(null, arrayListOf(), FileUploadType.QUIZ, course, -1L, -1L, -1, -1L)
+
+        viewModel.onFilesClicked()
+
+        assertEquals(FileUploadAction.PickFile, viewModel.events.value?.getContentIfNotHandled())
+    }
+
+    @Test
+    fun `Error when trying to add more files to quiz attachments`() {
+        val uri: Uri = mockk(relaxed = true)
+        val viewModel = createViewModel()
+        val course = createCourse(1L, "Course 1")
+        val assignment = createAssignment(1L, "Assignment 1", 1L, listOf("pdf"))
+        val submitObject = createSubmitObject("test.pdf")
+
+        every { fileUploadUtilsHelper.getFileSubmitObjectFromInputStream(any(), any(), any()) } returns submitObject
+
+        viewModel.setData(assignment, arrayListOf(uri), FileUploadType.QUIZ, course, -1L, -1L, -1, -1L)
+
+        viewModel.onFilesClicked()
+        assertEquals(FileUploadAction.ShowToast("This submission only accepts one file upload"), viewModel.events.value?.getContentIfNotHandled())
+
+        viewModel.onCameraClicked()
+        assertEquals(FileUploadAction.ShowToast("This submission only accepts one file upload"), viewModel.events.value?.getContentIfNotHandled())
+
+        viewModel.onGalleryClicked()
+        assertEquals(FileUploadAction.ShowToast("This submission only accepts one file upload"), viewModel.events.value?.getContentIfNotHandled())
+    }
+
+    @Test
+    fun `Error when trying to add more files to discussion attachments`() {
+        val uri: Uri = mockk(relaxed = true)
+        val viewModel = createViewModel()
+        val course = createCourse(1L, "Course 1")
+        val assignment = createAssignment(1L, "Assignment 1", 1L, listOf("pdf"))
+        val submitObject = createSubmitObject("test.pdf")
+
+        every { fileUploadUtilsHelper.getFileSubmitObjectFromInputStream(any(), any(), any()) } returns submitObject
+
+        viewModel.setData(assignment, arrayListOf(uri), FileUploadType.DISCUSSION, course, -1L, -1L, -1, -1L)
+
+        viewModel.onFilesClicked()
+        assertEquals(FileUploadAction.ShowToast("This submission only accepts one file upload"), viewModel.events.value?.getContentIfNotHandled())
+
+        viewModel.onCameraClicked()
+        assertEquals(FileUploadAction.ShowToast("This submission only accepts one file upload"), viewModel.events.value?.getContentIfNotHandled())
+
+        viewModel.onGalleryClicked()
+        assertEquals(FileUploadAction.ShowToast("This submission only accepts one file upload"), viewModel.events.value?.getContentIfNotHandled())
+    }
+
     private fun setupStrings() {
         every { resources.getString(R.string.extensionNotAllowed) } returns "The selected file type is not allowed."
         every { resources.getString(R.string.noFilesUploaded) } returns "You haven't selected any files."
         every { resources.getString(R.string.fileUploadNotSupported) } returns "You can't upload files to the selected assignment."
+        every { resources.getString(R.string.oneFileOnly) } returns "This submission only accepts one file upload"
     }
 
     private fun createCourse(id: Long, name: String): Course {


### PR DESCRIPTION
refs: MBL-16249
affects: Student, Teacher
release note: Added the option to select multiple files from the file browser for uploading.

test plan: Test all the screens where the file upload dialog is available.
- User files in both apps
- Discussion reply in both apps
- Create discussion in both apps
- Messages in both apps
- Create/Edit announcement in the Teacher app
