### PR TITLE
[MBL-15766][Student][Teacher] The keyboard is not hiding when changing the tab

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/ui/SubmissionDetailsView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/ui/SubmissionDetailsView.kt
@@ -76,6 +76,7 @@ class SubmissionDetailsView(
             if (slidingUpPanelLayout?.panelState == SlidingUpPanelLayout.PanelState.COLLAPSED) {
                 slidingUpPanelLayout?.panelState = SlidingUpPanelLayout.PanelState.ANCHORED
             }
+            drawerViewPager.hideKeyboard()
             logTabSelected(tab?.position)
         }
     }

--- a/apps/teacher/src/main/java/com/instructure/teacher/activities/SpeedGraderActivity.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/activities/SpeedGraderActivity.kt
@@ -241,6 +241,7 @@ class SpeedGraderActivity : BasePresenterActivity<SpeedGraderPresenter, SpeedGra
     @Suppress("unused")
     @Subscribe
     fun onTabSelected(event: TabSelectedEvent) {
+        submissionContentPager.hideKeyboard()
         adapter.initialTabIdx = event.selectedTabIdx
     }
 


### PR DESCRIPTION
refs: MBL-15766
affects: Student, Teacher
release note: none

test plan: in the ticket

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/109959688/190413255-00de0f0c-be91-462f-bc85-07ae89ad436b.jpg" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/109959688/190413284-205c64da-16b3-41bf-b53c-7ef107ff4ba6.jpg" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Approve from product or not needed
