### PR TITLE
[MBL-16228][Student] On Paper and No Submission assignments with a past due date display missing label

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/AssignmentDetailsRenderTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/renderTests/AssignmentDetailsRenderTest.kt
@@ -76,7 +76,8 @@ class AssignmentDetailsRenderTest : StudentRenderTest() {
     fun displaysTitleDataNotSubmitted() {
         val assignment = Assignment(
             name = "Test Assignment",
-            pointsPossible = 35.0
+            pointsPossible = 35.0,
+            submissionTypesRaw = listOf("online_text_entry")
         )
         val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
         loadPageWithModel(model)

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsPresenterTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/AssignmentDetailsPresenterTest.kt
@@ -266,7 +266,7 @@ class AssignmentDetailsPresenterTest : Assert() {
 
     @Test
     fun `Uses correct label text for submitted status when submission is null`() {
-        val assignment = baseAssignment.copy(submission = null, dueAt = null)
+        val assignment = baseAssignment.copy(submission = null, dueAt = null, submissionTypesRaw = listOf("online_text_entry"))
         val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
         val state = AssignmentDetailsPresenter.present(model, context) as AssignmentDetailsViewState.Loaded
         assertEquals("Not Submitted", state.submittedStateLabel)
@@ -275,7 +275,7 @@ class AssignmentDetailsPresenterTest : Assert() {
     @Test
     fun `Uses correct label text for submitted status when submission is not submitted`() {
         val submission = baseSubmission.copy(attempt = 0, workflowState = "unsubmitted", submittedAt = null)
-        val assignment = baseAssignment.copy(submission = submission)
+        val assignment = baseAssignment.copy(submission = submission, submissionTypesRaw = listOf("online_text_entry"))
         val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
         val state = AssignmentDetailsPresenter.present(model, context) as AssignmentDetailsViewState.Loaded
         assertEquals("Not Submitted", state.submittedStateLabel)
@@ -284,7 +284,7 @@ class AssignmentDetailsPresenterTest : Assert() {
     @Test
     fun `Uses correct label text for submitted status when submission is graded but not submitted`() {
         val submission = baseSubmission.copy(attempt = 0, submittedAt = null, grade = "8", postedAt = Date(), workflowState = "graded")
-        val assignment = baseAssignment.copy(submission = submission)
+        val assignment = baseAssignment.copy(submission = submission, submissionTypesRaw = listOf("online_text_entry"))
         val model = baseModel.copy(assignmentResult = DataResult.Success(assignment))
         val state = AssignmentDetailsPresenter.present(model, context) as AssignmentDetailsViewState.Loaded
         assertEquals("Not Submitted", state.submittedStateLabel)
@@ -300,21 +300,21 @@ class AssignmentDetailsPresenterTest : Assert() {
 
     @Test
     fun `uses correct icon for not-submitted status`() {
-        val model = baseModel.copy(assignmentResult = DataResult.Success(baseAssignment))
+        val model = baseModel.copy(assignmentResult = DataResult.Success(baseAssignment.copy(submissionTypesRaw = listOf("online_text_entry"))))
         val state = AssignmentDetailsPresenter.present(model, context) as AssignmentDetailsViewState.Loaded
         assertEquals(R.drawable.ic_no, state.submittedStateIcon)
     }
 
     @Test
     fun `Uses correct text for non-submitted status`() {
-        val model = baseModel.copy(assignmentResult = DataResult.Success(baseAssignment))
+        val model = baseModel.copy(assignmentResult = DataResult.Success(baseAssignment.copy(submissionTypesRaw = listOf("online_text_entry"))))
         val state = AssignmentDetailsPresenter.present(model, context) as AssignmentDetailsViewState.Loaded
         assertEquals("Not Submitted", state.submittedStateLabel)
     }
 
     @Test
     fun `Uses gray color for non-submitted status`() {
-        val model = baseModel.copy(assignmentResult = DataResult.Success(baseAssignment))
+        val model = baseModel.copy(assignmentResult = DataResult.Success(baseAssignment.copy(submissionTypesRaw = listOf("online_text_entry"))))
         val state = AssignmentDetailsPresenter.present(model, context) as AssignmentDetailsViewState.Loaded
         assertEquals(0xFF556572.toInt(), state.submittedStateColor)
     }
@@ -1140,7 +1140,7 @@ class AssignmentDetailsPresenterTest : Assert() {
 
     @Test
     fun `Dont show submission and rubric when assignment is not graded and does not have submission`() {
-        val model = baseModel.copy(assignmentResult = DataResult.Success(baseAssignment.copy(gradingType = Assignment.NOT_GRADED_TYPE)))
+        val model = baseModel.copy(assignmentResult = DataResult.Success(baseAssignment.copy(submissionTypesRaw = listOf("online_text_entry"), gradingType = Assignment.NOT_GRADED_TYPE)))
         val state = AssignmentDetailsPresenter.present(model, context) as AssignmentDetailsViewState.Loaded
         assertFalse(state.showSubmissionsAndRubric)
     }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Assignment.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Assignment.kt
@@ -123,7 +123,13 @@ data class Assignment(
      * an empty submission with a null value for "submittedAt". For very old assignments, canvas might not
      * return a submission at all.
      */
-    val isSubmitted: Boolean get() = submission?.submittedAt != null
+    val isSubmitted: Boolean get() {
+        return if (turnInType == TurnInType.NONE || turnInType == TurnInType.ON_PAPER) {
+            !(submission?.missing ?: false)
+        } else {
+            submission?.submittedAt != null
+        }
+    }
 
     val isAllowedToSubmit: Boolean
         get() {


### PR DESCRIPTION
Test plan:
- In the ticket
- Also verify that the assignments will show up as missing if the teacher explicitly marks it in the gradebook (you need to create new assignments for this in your sandbox).

refs: MBL-16228
affects: Student
release note: Fixed a bug where on paper and no submission assignments would show as missing in grades.

--- edit or delete this section ---
## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72397075/190406746-4c122220-b29a-4a04-9893-2e8304f6583d.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/72397075/190405849-850a5464-4240-4fb1-b9ce-66015d8b2415.png" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Approve from product or not needed
