### PR TITLE
[MBL-16237][Parent] Excused does not appear in the app

### DIFF
--- a/apps/flutter_parent/lib/screens/courses/details/course_grades_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_grades_screen.dart
@@ -371,7 +371,10 @@ class _AssignmentRow extends StatelessWidget {
     final localizations = L10n(context);
 
     final submission = assignment.submission(studentId);
-    if (submission?.grade != null) {
+    if (submission?.excused ?? false) {
+      text = localizations.gradeFormatScoreOutOfPointsPossible(localizations.excused, points);
+      semantics = localizations.contentDescriptionScoreOutOfPointsPossible('', points);
+    } else if (submission?.grade != null) {
       text = localizations.gradeFormatScoreOutOfPointsPossible(submission.grade, points);
       semantics = localizations.contentDescriptionScoreOutOfPointsPossible(submission.grade, points);
     } else {


### PR DESCRIPTION
refs: MBL-16237
affects: Parent
release note: Fixed a bug where Excused label was missing.

Test plan: In the ticket.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/109959688/191279275-291fd83e-b817-4762-b671-fafbc9d523cb.png" height=500></td>
<td><img src="https://user-images.githubusercontent.com/109959688/191279077-6a746d07-5ead-44c5-9a32-860f52a801f6.png" height=500></td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Approve from product or not needed
