### PR TITLE
[MBL-16257][Student][Teacher] Calendar events for specific sections show for everyone in the app on the Syllabus

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/syllabus/SyllabusPresenter.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/syllabus/SyllabusPresenter.kt
@@ -29,7 +29,7 @@ import com.instructure.student.mobius.syllabus.ui.EventsViewState
 import com.instructure.student.mobius.syllabus.ui.ScheduleItemViewState
 import com.instructure.student.mobius.syllabus.ui.SyllabusViewState
 import com.instructure.student.util.toDueAtString
-import java.util.Date
+import java.util.*
 
 object SyllabusPresenter : Presenter<SyllabusModel, SyllabusViewState> {
     override fun present(model: SyllabusModel, context: Context): SyllabusViewState {
@@ -56,7 +56,7 @@ object SyllabusPresenter : Presenter<SyllabusModel, SyllabusViewState> {
             eventsResult.isFail -> EventsViewState.Error
             eventsResult.dataOrNull.isNullOrEmpty() -> EventsViewState.Empty
             else -> {
-                EventsViewState.Loaded(eventsResult.dataOrThrow.map {
+                EventsViewState.Loaded(eventsResult.dataOrThrow.filter { it.isHidden.not() }.map {
                     ScheduleItemViewState(
                         it.itemId,
                         it.title ?: "",

--- a/apps/student/src/test/java/com/instructure/student/test/syllabus/SyllabusPresenterTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/syllabus/SyllabusPresenterTest.kt
@@ -39,8 +39,7 @@ import org.threeten.bp.DateTimeUtils
 import org.threeten.bp.OffsetDateTime
 import org.threeten.bp.ZoneId
 import org.threeten.bp.format.DateTimeFormatter
-import java.util.Calendar
-import java.util.Date
+import java.util.*
 
 @RunWith(AndroidJUnit4::class)
 class SyllabusPresenterTest : Assert() {
@@ -79,6 +78,14 @@ class SyllabusPresenterTest : Assert() {
             assignment = Assignment(id = 125L, submissionTypesRaw = listOf("discussion_topic")),
             startAt = null,
             itemType = ScheduleItem.Type.TYPE_ASSIGNMENT
+        ),
+        ScheduleItem(
+            itemId = "4",
+            title = "discussion",
+            assignment = Assignment(id = 126L, submissionTypesRaw = listOf("discussion_topic")),
+            startAt = null,
+            itemType = ScheduleItem.Type.TYPE_ASSIGNMENT,
+            isHidden = true
         )
     )
     private lateinit var baseEventsViewState: List<ScheduleItemViewState>

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusPresenter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusPresenter.kt
@@ -67,7 +67,7 @@ class SyllabusPresenter : Presenter<SyllabusModel, SyllabusViewState> {
     }
 
     private fun createLoadedEvents(eventsResult: DataResult<List<ScheduleItem>>, context: Context, color: Int): EventsViewState.Loaded {
-        return EventsViewState.Loaded(eventsResult.dataOrThrow.map {
+        return EventsViewState.Loaded(eventsResult.dataOrThrow.filter { it.isHidden.not() }.map {
             ScheduleItemViewState(
                     it.itemId,
                     it.title ?: "",

--- a/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/SyllabusPresenterTest.kt
+++ b/apps/teacher/src/test/java/com/instructure/teacher/features/syllabus/SyllabusPresenterTest.kt
@@ -79,6 +79,14 @@ class SyllabusPresenterTest {
                     assignment = Assignment(id = 125L, submissionTypesRaw = listOf("discussion_topic")),
                     startAt = null,
                     itemType = ScheduleItem.Type.TYPE_ASSIGNMENT
+            ),
+            ScheduleItem(
+                    itemId = "4",
+                    title = "discussion",
+                    assignment = Assignment(id = 126L, submissionTypesRaw = listOf("discussion_topic")),
+                    startAt = null,
+                    itemType = ScheduleItem.Type.TYPE_ASSIGNMENT,
+                    isHidden = true
             )
     )
 


### PR DESCRIPTION
refs: MBL-16257
affects: Student
release note: Fixed a bug where events for specific sections show for everyone.

Test plan: In the ticket.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/109959688/191468834-2f12714a-0bc1-4021-9e8d-d1da9e7e803b.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/109959688/191468730-1406c1a5-aaec-4588-bd86-3e4d44ded7d2.png" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Approve from product or not needed
