### PR TITLE
[MBL-16274][Student] Inconsistent reordering of announcement list after view

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/DiscussionListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/DiscussionListFragment.kt
@@ -335,6 +335,7 @@ open class DiscussionListFragment : ParentFragment(), Bookmarkable {
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN, sticky = true)
     fun onDiscussionTopicCountChange(event: DiscussionTopicHeaderEvent) {
+        if (isAnnouncement) return
         event.get {
             // Gets written over on phones - added also to {@link #onRefreshFinished()}
             when {
@@ -345,7 +346,7 @@ open class DiscussionListFragment : ParentFragment(), Bookmarkable {
                     recyclerAdapter.addOrUpdateItem(DiscussionListRecyclerAdapter.CLOSED_FOR_COMMENTS, it)
                 }
                 else -> {
-                    if (!isAnnouncement) recyclerAdapter.addOrUpdateItem(DiscussionListRecyclerAdapter.UNPINNED, it)
+                    recyclerAdapter.addOrUpdateItem(DiscussionListRecyclerAdapter.UNPINNED, it)
                 }
             }
         }


### PR DESCRIPTION
refs: MBL-16274
affects: Student
release note: None

test plan: in the ticket

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Approve from product or not needed
