### PR TITLE
[MBL-16312][Teacher][Student] - Rename 'Rate on the App Store' menu

### DIFF
--- a/apps/teacher/src/main/res/layout/fragment_settings.xml
+++ b/apps/teacher/src/main/res/layout/fragment_settings.xml
@@ -124,7 +124,7 @@
                 android:minHeight="?android:listPreferredItemHeight"
                 android:paddingEnd="16dp"
                 android:paddingStart="16dp"
-                android:text="@string/rateOnTheAppStore"
+                android:text="@string/rateOnThePlayStore"
                 android:textColor="@color/textDarkest"
                 android:textSize="16sp"/>
 

--- a/apps/teacher/src/main/res/values-ar/strings.xml
+++ b/apps/teacher/src/main/res/values-ar/strings.xml
@@ -763,6 +763,7 @@
     <string name="changeUser">تغيير المستخدم</string>
     <string name="general">عام</string>
     <string name="sendFeedback">إرسال تعليقات</string>
+    <string name="privacyPolicy">سياسة الخصوصية</string>
     <string name="EULA">اتفاقية ترخيص المستخدم</string>
     <string name="termsOfUse">شروط الاستخدام</string>
     <string name="searchGuides">البحث في Canvas Guides</string>

--- a/apps/teacher/src/main/res/values-ar/strings.xml
+++ b/apps/teacher/src/main/res/values-ar/strings.xml
@@ -763,8 +763,6 @@
     <string name="changeUser">تغيير المستخدم</string>
     <string name="general">عام</string>
     <string name="sendFeedback">إرسال تعليقات</string>
-    <string name="rateOnTheAppStore">التقييم على App Store</string>
-    <string name="privacyPolicy">سياسة الخصوصية</string>
     <string name="EULA">اتفاقية ترخيص المستخدم</string>
     <string name="termsOfUse">شروط الاستخدام</string>
     <string name="searchGuides">البحث في Canvas Guides</string>

--- a/apps/teacher/src/main/res/values-b+da+instk12/strings.xml
+++ b/apps/teacher/src/main/res/values-b+da+instk12/strings.xml
@@ -717,7 +717,6 @@
     <string name="changeUser">Skift bruger</string>
     <string name="general">Generelt</string>
     <string name="sendFeedback">Send feedback</string>
-    <string name="rateOnTheAppStore">Vurder i App Store</string>
     <string name="privacyPolicy">Datapolitik</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Betingelser for brug</string>

--- a/apps/teacher/src/main/res/values-b+en+AU+unimelb/strings.xml
+++ b/apps/teacher/src/main/res/values-b+en+AU+unimelb/strings.xml
@@ -715,7 +715,6 @@
     <string name="changeUser">Change User</string>
     <string name="general">General</string>
     <string name="sendFeedback">Send Feedback</string>
-    <string name="rateOnTheAppStore">Rate on the App Store</string>
     <string name="privacyPolicy">Privacy Policy</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Terms of Use</string>

--- a/apps/teacher/src/main/res/values-b+en+GB+instukhe/strings.xml
+++ b/apps/teacher/src/main/res/values-b+en+GB+instukhe/strings.xml
@@ -715,7 +715,6 @@
     <string name="changeUser">Change user</string>
     <string name="general">General</string>
     <string name="sendFeedback">Send feedback</string>
-    <string name="rateOnTheAppStore">Rate on the App Store</string>
     <string name="privacyPolicy">Privacy Policy</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Terms of Use</string>

--- a/apps/teacher/src/main/res/values-b+nb+instk12/strings.xml
+++ b/apps/teacher/src/main/res/values-b+nb+instk12/strings.xml
@@ -718,7 +718,6 @@
     <string name="changeUser">Endre bruker</string>
     <string name="general">Generelt</string>
     <string name="sendFeedback">Send tilbakemelding</string>
-    <string name="rateOnTheAppStore">Vurder på App Store</string>
     <string name="privacyPolicy">Retningslinjer for personvern</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">brukervilkår</string>

--- a/apps/teacher/src/main/res/values-b+sv+instk12/strings.xml
+++ b/apps/teacher/src/main/res/values-b+sv+instk12/strings.xml
@@ -717,7 +717,6 @@
     <string name="changeUser">Ändra användare</string>
     <string name="general">Allmänt</string>
     <string name="sendFeedback">Skicka feedback</string>
-    <string name="rateOnTheAppStore">Bedöm på App Store</string>
     <string name="privacyPolicy">Integritetspolicy</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Användningsvillkor</string>

--- a/apps/teacher/src/main/res/values-b+zh+HK/strings.xml
+++ b/apps/teacher/src/main/res/values-b+zh+HK/strings.xml
@@ -703,7 +703,6 @@
     <string name="changeUser">變更使用者</string>
     <string name="general">一般</string>
     <string name="sendFeedback">發送回饋</string>
-    <string name="rateOnTheAppStore">前往 App Store 評分</string>
     <string name="privacyPolicy">《隱私政策》</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">《使用條款》</string>

--- a/apps/teacher/src/main/res/values-b+zh+Hans/strings.xml
+++ b/apps/teacher/src/main/res/values-b+zh+Hans/strings.xml
@@ -703,7 +703,6 @@
     <string name="changeUser">更改用户</string>
     <string name="general">一般</string>
     <string name="sendFeedback">发送反馈</string>
-    <string name="rateOnTheAppStore">给应用商店评分</string>
     <string name="privacyPolicy">隐私政策</string>
     <string name="EULA">最终用户许可协议</string>
     <string name="termsOfUse">使用条款</string>

--- a/apps/teacher/src/main/res/values-b+zh+Hant/strings.xml
+++ b/apps/teacher/src/main/res/values-b+zh+Hant/strings.xml
@@ -703,7 +703,6 @@
     <string name="changeUser">變更使用者</string>
     <string name="general">一般</string>
     <string name="sendFeedback">發送回饋</string>
-    <string name="rateOnTheAppStore">前往 App Store 評分</string>
     <string name="privacyPolicy">《隱私政策》</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">《使用條款》</string>

--- a/apps/teacher/src/main/res/values-ca/strings.xml
+++ b/apps/teacher/src/main/res/values-ca/strings.xml
@@ -718,7 +718,6 @@
     <string name="changeUser">Canvia l\'usuari</string>
     <string name="general">General</string>
     <string name="sendFeedback">Envia els comentaris</string>
-    <string name="rateOnTheAppStore">Puntuació a App Store</string>
     <string name="privacyPolicy">Política de privacitat</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Condicions d\'ús</string>

--- a/apps/teacher/src/main/res/values-cy/strings.xml
+++ b/apps/teacher/src/main/res/values-cy/strings.xml
@@ -715,7 +715,6 @@
     <string name="changeUser">Newid Defnyddiwr</string>
     <string name="general">Cyffredinol</string>
     <string name="sendFeedback">Anfon Adborth</string>
-    <string name="rateOnTheAppStore">Sgorio’r App Store</string>
     <string name="privacyPolicy">Polisi Preifatrwydd</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Telerau Defnyddio</string>

--- a/apps/teacher/src/main/res/values-da/strings.xml
+++ b/apps/teacher/src/main/res/values-da/strings.xml
@@ -715,7 +715,6 @@
     <string name="changeUser">Skift bruger</string>
     <string name="general">Generelt</string>
     <string name="sendFeedback">Send feedback</string>
-    <string name="rateOnTheAppStore">Vurder i App Store</string>
     <string name="privacyPolicy">Datapolitik</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Betingelser for brug</string>

--- a/apps/teacher/src/main/res/values-de/strings.xml
+++ b/apps/teacher/src/main/res/values-de/strings.xml
@@ -715,7 +715,6 @@
     <string name="changeUser">Benutzer wechseln</string>
     <string name="general">Allgemein</string>
     <string name="sendFeedback">Feedback senden</string>
-    <string name="rateOnTheAppStore">Im App Store bewerten</string>
     <string name="privacyPolicy">Datenschutzrichtlinien</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Nutzungsbedingungen</string>

--- a/apps/teacher/src/main/res/values-en-rAU/strings.xml
+++ b/apps/teacher/src/main/res/values-en-rAU/strings.xml
@@ -715,7 +715,6 @@
     <string name="changeUser">Change User</string>
     <string name="general">General</string>
     <string name="sendFeedback">Send Feedback</string>
-    <string name="rateOnTheAppStore">Rate on the App Store</string>
     <string name="privacyPolicy">Privacy Policy</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Terms of Use</string>

--- a/apps/teacher/src/main/res/values-en-rCA/strings.xml
+++ b/apps/teacher/src/main/res/values-en-rCA/strings.xml
@@ -718,7 +718,6 @@
     <string name="changeUser">Change User</string>
     <string name="general">General</string>
     <string name="sendFeedback">Send Feedback</string>
-    <string name="rateOnTheAppStore">Rate on the App Store</string>
     <string name="privacyPolicy">Privacy Policy</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Terms of Use</string>

--- a/apps/teacher/src/main/res/values-en-rCY/strings.xml
+++ b/apps/teacher/src/main/res/values-en-rCY/strings.xml
@@ -715,7 +715,6 @@
     <string name="changeUser">Change user</string>
     <string name="general">General</string>
     <string name="sendFeedback">Send feedback</string>
-    <string name="rateOnTheAppStore">Rate on the App Store</string>
     <string name="privacyPolicy">Privacy Policy</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Terms of Use</string>

--- a/apps/teacher/src/main/res/values-en-rGB/strings.xml
+++ b/apps/teacher/src/main/res/values-en-rGB/strings.xml
@@ -715,7 +715,6 @@
     <string name="changeUser">Change user</string>
     <string name="general">General</string>
     <string name="sendFeedback">Send feedback</string>
-    <string name="rateOnTheAppStore">Rate on the App Store</string>
     <string name="privacyPolicy">Privacy Policy</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Terms of Use</string>

--- a/apps/teacher/src/main/res/values-es-rES/strings.xml
+++ b/apps/teacher/src/main/res/values-es-rES/strings.xml
@@ -718,7 +718,6 @@
     <string name="changeUser">Cambiar usuario</string>
     <string name="general">General</string>
     <string name="sendFeedback">Enviar comentarios</string>
-    <string name="rateOnTheAppStore">Califica en la App Store</string>
     <string name="privacyPolicy">Política de privacidad</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Términos de uso</string>

--- a/apps/teacher/src/main/res/values-es/strings.xml
+++ b/apps/teacher/src/main/res/values-es/strings.xml
@@ -716,7 +716,6 @@
     <string name="changeUser">Cambiar usuario</string>
     <string name="general">General</string>
     <string name="sendFeedback">Enviar los comentarios</string>
-    <string name="rateOnTheAppStore">Califique en App Store</string>
     <string name="privacyPolicy">Política de privacidad</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Términos de uso</string>

--- a/apps/teacher/src/main/res/values-fi/strings.xml
+++ b/apps/teacher/src/main/res/values-fi/strings.xml
@@ -715,7 +715,6 @@
     <string name="changeUser">Change User (Vaihda käyttäjää)</string>
     <string name="general">Yleinen</string>
     <string name="sendFeedback">Lähetä palautetta</string>
-    <string name="rateOnTheAppStore">Arvostele App Storessa</string>
     <string name="privacyPolicy">Tietosuojakäytäntö</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Käyttöehdot</string>

--- a/apps/teacher/src/main/res/values-fr-rCA/strings.xml
+++ b/apps/teacher/src/main/res/values-fr-rCA/strings.xml
@@ -715,7 +715,6 @@
     <string name="changeUser">Changer d\'utilisateur</string>
     <string name="general">Général</string>
     <string name="sendFeedback">Envoyer un avis</string>
-    <string name="rateOnTheAppStore">Noter sur l\'App Store</string>
     <string name="privacyPolicy">Politique de confidentialité</string>
     <string name="EULA">CLUF</string>
     <string name="termsOfUse">Conditions d\'utilisation</string>

--- a/apps/teacher/src/main/res/values-fr/strings.xml
+++ b/apps/teacher/src/main/res/values-fr/strings.xml
@@ -715,7 +715,6 @@
     <string name="changeUser">Changer d\'utilisateur</string>
     <string name="general">Général</string>
     <string name="sendFeedback">Envoyer un avis</string>
-    <string name="rateOnTheAppStore">Évaluez sur l’App Store</string>
     <string name="privacyPolicy">Politique de confidentialité</string>
     <string name="EULA">CGU</string>
     <string name="termsOfUse">Conditions d\'utilisation</string>

--- a/apps/teacher/src/main/res/values-ht/strings.xml
+++ b/apps/teacher/src/main/res/values-ht/strings.xml
@@ -715,7 +715,6 @@
     <string name="changeUser">Chanje Itilizatè</string>
     <string name="general">Jeneral</string>
     <string name="sendFeedback">Voye Kòmantè</string>
-    <string name="rateOnTheAppStore">Evalye nan App Store</string>
     <string name="privacyPolicy">Politik Konfidansyalite</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Kondisyon Itilizasyon</string>

--- a/apps/teacher/src/main/res/values-is/strings.xml
+++ b/apps/teacher/src/main/res/values-is/strings.xml
@@ -716,7 +716,6 @@
     <string name="changeUser">Breyta notanda</string>
     <string name="general">Almennt</string>
     <string name="sendFeedback">Senda endurgjöf</string>
-    <string name="rateOnTheAppStore">Gefa einkunn á App Store</string>
     <string name="privacyPolicy">Persónuverndarstefna</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Notandaskilmálar</string>

--- a/apps/teacher/src/main/res/values-it/strings.xml
+++ b/apps/teacher/src/main/res/values-it/strings.xml
@@ -716,7 +716,6 @@
     <string name="changeUser">Cambia utente</string>
     <string name="general">Generale</string>
     <string name="sendFeedback">Invia feedback</string>
-    <string name="rateOnTheAppStore">Valuta su App Store</string>
     <string name="privacyPolicy">Informativa sulla privacy</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Termini di utilizzo</string>

--- a/apps/teacher/src/main/res/values-ja/strings.xml
+++ b/apps/teacher/src/main/res/values-ja/strings.xml
@@ -703,7 +703,6 @@
     <string name="changeUser">ユーザーを変更する</string>
     <string name="general">一般</string>
     <string name="sendFeedback">フィードバックを送る</string>
-    <string name="rateOnTheAppStore">App Storeでレート</string>
     <string name="privacyPolicy">プライバシーポリシー</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">利用規約</string>

--- a/apps/teacher/src/main/res/values-mi/strings.xml
+++ b/apps/teacher/src/main/res/values-mi/strings.xml
@@ -715,7 +715,6 @@
     <string name="changeUser">Huri Kaiwhakamahi</string>
     <string name="general">Whānui</string>
     <string name="sendFeedback">Tuku Urupare</string>
-    <string name="rateOnTheAppStore">Auau i runga i te Taupānga Toa</string>
     <string name="privacyPolicy">Kaupapahere Tūmataiti</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Ngā ritenga whakamahi</string>

--- a/apps/teacher/src/main/res/values-nb/strings.xml
+++ b/apps/teacher/src/main/res/values-nb/strings.xml
@@ -718,7 +718,6 @@
     <string name="changeUser">Endre bruker</string>
     <string name="general">Generelt</string>
     <string name="sendFeedback">Send tilbakemelding</string>
-    <string name="rateOnTheAppStore">Vurder på App Store</string>
     <string name="privacyPolicy">Retningslinjer for personvern</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">brukervilkår</string>

--- a/apps/teacher/src/main/res/values-nl/strings.xml
+++ b/apps/teacher/src/main/res/values-nl/strings.xml
@@ -715,7 +715,6 @@
     <string name="changeUser">Gebruiker wijzigen</string>
     <string name="general">Algemeen</string>
     <string name="sendFeedback">Feedback versturen</string>
-    <string name="rateOnTheAppStore">Beoordelen in de App Store</string>
     <string name="privacyPolicy">Privacy-beleid</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Gebruiksvoorwaarden</string>

--- a/apps/teacher/src/main/res/values-pl/strings.xml
+++ b/apps/teacher/src/main/res/values-pl/strings.xml
@@ -739,7 +739,6 @@
     <string name="changeUser">Zmień użytkownika</string>
     <string name="general">Ogólne</string>
     <string name="sendFeedback">Wyślij informację zwrotną</string>
-    <string name="rateOnTheAppStore">Pobierz w sklepie App Store</string>
     <string name="privacyPolicy">Polityka prywatności</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Warunki korzystania</string>

--- a/apps/teacher/src/main/res/values-pt-rBR/strings.xml
+++ b/apps/teacher/src/main/res/values-pt-rBR/strings.xml
@@ -716,7 +716,6 @@
     <string name="changeUser">Trocar Usuário</string>
     <string name="general">Geral</string>
     <string name="sendFeedback">Enviar Comentários</string>
-    <string name="rateOnTheAppStore">Avaliar na App Store</string>
     <string name="privacyPolicy">Política de privacidade</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Termos de Uso</string>

--- a/apps/teacher/src/main/res/values-pt-rPT/strings.xml
+++ b/apps/teacher/src/main/res/values-pt-rPT/strings.xml
@@ -413,7 +413,7 @@
     </string-array>
 
   <string name="not_a_teacher">Não é professor?</string>
-    <string name="not_a_teacher_tap_to_visit_play_store">Um dos nossos outros aplicativos pode ser um ajuste melhor. Toque em um para visitar a Play Store.</string>
+    <string name="not_a_teacher_tap_to_visit_play_store">Um dos nossos outros aplicativos pode ser um ajuste melhor. Toque em um para visitar a App Store.</string>
     <string name="sg_tab_grade">Nota</string>
     <string name="sg_tab_comments">Comentários</string>
     <string name="sg_tab_files">Ficheiros</string>

--- a/apps/teacher/src/main/res/values-pt-rPT/strings.xml
+++ b/apps/teacher/src/main/res/values-pt-rPT/strings.xml
@@ -413,7 +413,7 @@
     </string-array>
 
   <string name="not_a_teacher">Não é professor?</string>
-    <string name="not_a_teacher_tap_to_visit_play_store">Um dos nossos outros aplicativos pode ser um ajuste melhor. Toque em um para visitar a App Store.</string>
+    <string name="not_a_teacher_tap_to_visit_play_store">Um dos nossos outros aplicativos pode ser um ajuste melhor. Toque em um para visitar a Play Store.</string>
     <string name="sg_tab_grade">Nota</string>
     <string name="sg_tab_comments">Comentários</string>
     <string name="sg_tab_files">Ficheiros</string>
@@ -715,7 +715,6 @@
     <string name="changeUser">Mudar utilizador</string>
     <string name="general">Geral</string>
     <string name="sendFeedback">Enviar Comentários</string>
-    <string name="rateOnTheAppStore">Taxa na App Store</string>
     <string name="privacyPolicy">Política de Privacidade</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Termos de uso</string>

--- a/apps/teacher/src/main/res/values-ru/strings.xml
+++ b/apps/teacher/src/main/res/values-ru/strings.xml
@@ -739,7 +739,6 @@
     <string name="changeUser">Сменить пользователя</string>
     <string name="general">Общее</string>
     <string name="sendFeedback">Отправить отзыв</string>
-    <string name="rateOnTheAppStore">Оценить в App Store</string>
     <string name="privacyPolicy">Политика конфиденциальности</string>
     <string name="EULA">Лицензионный договор</string>
     <string name="termsOfUse">Условия использования</string>

--- a/apps/teacher/src/main/res/values-sl/strings.xml
+++ b/apps/teacher/src/main/res/values-sl/strings.xml
@@ -715,7 +715,6 @@
     <string name="changeUser">Spremeni uporabnika</string>
     <string name="general">Splošno</string>
     <string name="sendFeedback">Pošlji povratne informacije</string>
-    <string name="rateOnTheAppStore">Oceni v trgovini App Store</string>
     <string name="privacyPolicy">Pravilnik o zasebnosti</string>
     <string name="EULA">Licenčni pogoji za končnega uporabnika</string>
     <string name="termsOfUse">Pogoji uporabe</string>

--- a/apps/teacher/src/main/res/values-sv/strings.xml
+++ b/apps/teacher/src/main/res/values-sv/strings.xml
@@ -716,7 +716,6 @@
     <string name="changeUser">Ändra användare</string>
     <string name="general">Allmänt</string>
     <string name="sendFeedback">Skicka feedback</string>
-    <string name="rateOnTheAppStore">Bedöm på App Store</string>
     <string name="privacyPolicy">Integritetspolicy</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Användningsvillkor</string>

--- a/apps/teacher/src/main/res/values-th/strings.xml
+++ b/apps/teacher/src/main/res/values-th/strings.xml
@@ -717,7 +717,6 @@
     <string name="changeUser">เปลี่ยนผู้ใช้</string>
     <string name="general">ทั่วไป</string>
     <string name="sendFeedback">ส่งความเห็น</string>
-    <string name="rateOnTheAppStore">ให้คะแนนใน App Store</string>
     <string name="privacyPolicy">นโยบายความเป็นส่วนตัว</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">เงื่อนไขการใช้งาน</string>

--- a/apps/teacher/src/main/res/values-vi/strings.xml
+++ b/apps/teacher/src/main/res/values-vi/strings.xml
@@ -718,7 +718,6 @@
     <string name="changeUser">Thay Đổi Người Dùng</string>
     <string name="general">Chung</string>
     <string name="sendFeedback">Gửi Ý Kiến Phản Hồi</string>
-    <string name="rateOnTheAppStore">Đánh giá trên App Store</string>
     <string name="privacyPolicy">Chính Sách Quyền Riêng Tư</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Điều Khoản Sử Dụng</string>

--- a/apps/teacher/src/main/res/values-zh/strings.xml
+++ b/apps/teacher/src/main/res/values-zh/strings.xml
@@ -703,7 +703,6 @@
     <string name="changeUser">更改用户</string>
     <string name="general">一般</string>
     <string name="sendFeedback">发送反馈</string>
-    <string name="rateOnTheAppStore">给应用商店评分</string>
     <string name="privacyPolicy">隐私政策</string>
     <string name="EULA">最终用户许可协议</string>
     <string name="termsOfUse">使用条款</string>

--- a/apps/teacher/src/main/res/values/strings.xml
+++ b/apps/teacher/src/main/res/values/strings.xml
@@ -718,7 +718,6 @@
     <string name="changeUser">Change User</string>
     <string name="general">General</string>
     <string name="sendFeedback">Send Feedback</string>
-    <string name="rateOnTheAppStore">Rate on the App Store</string>
     <string name="privacyPolicy">Privacy Policy</string>
     <string name="EULA">EULA</string>
     <string name="termsOfUse">Terms of Use</string>

--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -1042,7 +1042,7 @@
     <string name="currentGrade">Current grade</string>
     <string name="opensInCanvasStudent">Opens in Canvas Student</string>
     <string name="tab_student_view">Student View</string>
-
+    <string name="rateOnThePlayStore">Rate on the Play Store</string>
 
     <!-- Panda Avatar Content Descriptions -->
 


### PR DESCRIPTION
Rename 'Rate on the App Store' menu in Teacher app settings page to  'Rate on the Play Store'.

Remove the rateOnTheAppStore resource from the teacher strings.xml. Pick up a new, rateOnThePlayStore resource within the pandares strings.xml (because we store every string in the pandares).

refs: MBL-16312
affects: Teacher, Student
release note: none

## Checklist

- [x] A11y checked
