### PR TITLE
[MBL-16357][Student] Camera Permissions Prompt doesn't show when attempting to share a file to Student App

### DIFF
--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -1324,4 +1324,5 @@
     <string name="filterAssignmentGraded">Graded</string>
     <string name="filterAssignmentUpcoming">Upcoming</string>
     <string name="createdByStudentView">Created by Student View</string>
+    <string name="cameraPermissionPermanentlyDenied">Camera permission was permanently denied. Go to app settings to allow it.</string>
 </resources>

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadDialogFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadDialogFragment.kt
@@ -70,7 +70,11 @@ class FileUploadDialogFragment : DialogFragment() {
     private var dialogCallback: ((Int) -> Unit)? = null
 
     private val cameraPermissionContract = registerForActivityResult(ActivityResultContracts.RequestPermission()) { isPermissionGranted ->
-        if (isPermissionGranted) takePicture()
+        if (isPermissionGranted) {
+            takePicture()
+        } else if (!requireActivity().shouldShowRequestPermissionRationale(Manifest.permission.CAMERA)) {
+            toast(R.string.cameraPermissionPermanentlyDenied, Toast.LENGTH_LONG)
+        }
     }
 
     private val takePictureContract = registerForActivityResult(ActivityResultContracts.TakePicture()) { imageSaved ->


### PR DESCRIPTION
refs: MBL-16357
affects: Student
release note: none

test plan: In the ticket. See my comment on the ticket for repro steps.

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Approve from product or not needed
