### PR TITLE
[MBL-15938][Student] Display calendar events without course even tough some courses are deselected

### DIFF
--- a/libs/flutter_student_embed/lib/l10n/app_localizations.dart
+++ b/libs/flutter_student_embed/lib/l10n/app_localizations.dart
@@ -230,8 +230,8 @@ class AppLocalizations {
         desc: 'Message displayed when calendar events could not be loaded for the current student',
       );
 
-  String get calendarTapToFavoriteDesc => Intl.message('Tap to favorite the courses you want to see on the Calendar.',
-      desc: 'Description text on calendar filter screen.');
+  String get calendarSelectFavoriteCalendars => Intl.message('Select elements to display on the calendar.',
+      desc: 'Select calendars description');
 
   String get gotoTodayButtonLabel =>
       Intl.message('Go to today', desc: 'Accessibility label used for the today button in the planner');

--- a/libs/flutter_student_embed/lib/network/utils/dio_config.dart
+++ b/libs/flutter_student_embed/lib/network/utils/dio_config.dart
@@ -14,7 +14,6 @@
 
 import 'dart:io';
 
-import 'package:dio/adapter.dart';
 import 'package:dio/dio.dart';
 import 'package:dio_http_cache/dio_http_cache.dart';
 import 'package:flutter/widgets.dart';
@@ -103,24 +102,7 @@ class DioConfig {
       error: debug,
     ));
 
-    // if (DebugFlags.isDebug) {
-      _configureDebugProxy(dio);
-    // }
-
     return dio;
-  }
-
-  // To use proxy add the following run args to run configuration: --dart-define=PROXY={your proxy io}:{proxy port}
-  void _configureDebugProxy(Dio dio) {
-    // const proxy = String.fromEnvironment('PROXY', defaultValue: null);
-    // if (proxy == null) return;
-
-    (dio.httpClientAdapter as DefaultHttpClientAdapter).onHttpClientCreate =
-        (client) {
-      client.findProxy = (uri) => "PROXY 192.168.1.58:8888;";
-      client.badCertificateCallback =
-          (X509Certificate cert, String host, int port) => true;
-    };
   }
 
   Interceptor _cacheInterceptor() {

--- a/libs/flutter_student_embed/lib/network/utils/dio_config.dart
+++ b/libs/flutter_student_embed/lib/network/utils/dio_config.dart
@@ -14,6 +14,7 @@
 
 import 'dart:io';
 
+import 'package:dio/adapter.dart';
 import 'package:dio/dio.dart';
 import 'package:dio_http_cache/dio_http_cache.dart';
 import 'package:flutter/widgets.dart';
@@ -102,7 +103,24 @@ class DioConfig {
       error: debug,
     ));
 
+    // if (DebugFlags.isDebug) {
+      _configureDebugProxy(dio);
+    // }
+
     return dio;
+  }
+
+  // To use proxy add the following run args to run configuration: --dart-define=PROXY={your proxy io}:{proxy port}
+  void _configureDebugProxy(Dio dio) {
+    // const proxy = String.fromEnvironment('PROXY', defaultValue: null);
+    // if (proxy == null) return;
+
+    (dio.httpClientAdapter as DefaultHttpClientAdapter).onHttpClientCreate =
+        (client) {
+      client.findProxy = (uri) => "PROXY 192.168.1.58:8888;";
+      client.badCertificateCallback =
+          (X509Certificate cert, String host, int port) => true;
+    };
   }
 
   Interceptor _cacheInterceptor() {

--- a/libs/flutter_student_embed/lib/screens/calendar/calendar_widget/calendar_filter_screen/calendar_filter_list_screen.dart
+++ b/libs/flutter_student_embed/lib/screens/calendar/calendar_widget/calendar_filter_screen/calendar_filter_list_screen.dart
@@ -88,6 +88,7 @@ class CalendarFilterListScreenState extends State<CalendarFilterListScreen> {
           } else if (snapshot.hasData) {
             _courses = snapshot.data;
             courseLength = _courses.length;
+            if (ApiPrefs.getUser() != null) courseLength++;
             if (selectedContextIds.isEmpty && selectAllIfEmpty) {
               // We only want to do this the first time we load, otherwise if the user ever deselects all the
               // contexts, then they will all automatically be put into the selected list

--- a/libs/flutter_student_embed/lib/screens/calendar/calendar_widget/calendar_filter_screen/calendar_filter_list_screen.dart
+++ b/libs/flutter_student_embed/lib/screens/calendar/calendar_widget/calendar_filter_screen/calendar_filter_list_screen.dart
@@ -15,6 +15,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_student_embed/l10n/app_localizations.dart';
 import 'package:flutter_student_embed/models/course.dart';
+import 'package:flutter_student_embed/network/utils/api_prefs.dart';
 import 'package:flutter_student_embed/utils/common_widgets/appbar_dynamic_style.dart';
 import 'package:flutter_student_embed/utils/common_widgets/empty_panda_widget.dart';
 import 'package:flutter_student_embed/utils/common_widgets/error_panda_widget.dart';
@@ -66,7 +67,7 @@ class CalendarFilterListScreenState extends State<CalendarFilterListScreen> {
             SizedBox(height: 16.0),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
-              child: Text(L10n(context).calendarTapToFavoriteDesc, style: Theme.of(context).textTheme.bodyText2),
+              child: Text(L10n(context).calendarSelectFavoriteCalendars, style: Theme.of(context).textTheme.bodyText2),
             ),
             SizedBox(height: 24.0),
             Expanded(child: _body())
@@ -94,6 +95,9 @@ class CalendarFilterListScreenState extends State<CalendarFilterListScreen> {
 
               // List will be empty when all courses are selected (on first load)
               selectedContextIds.addAll(_courses.map((c) => 'course_${c.id}').toList());
+              if (ApiPrefs.getUser() != null) {
+                selectedContextIds.add('user_${ApiPrefs.getUser().id}');
+              }
               selectAllIfEmpty = false;
             }
             _body = (_courses == null || _courses.isEmpty)
@@ -102,7 +106,7 @@ class CalendarFilterListScreenState extends State<CalendarFilterListScreen> {
                     title: L10n(context).noCoursesTitle,
                     subtitle: L10n(context).noCoursesMessage,
                   )
-                : _courseList(_courses);
+                : _calendarList(_courses);
           } else {
             selectedContextIds.addAll(widget._selectedCourses);
             if (selectedContextIds.isNotEmpty) {
@@ -126,9 +130,20 @@ class CalendarFilterListScreenState extends State<CalendarFilterListScreen> {
         });
   }
 
-  ListView _courseList(List<Course> courses) {
+  ListView _calendarList(List<Course> courses) {
+    final user = ApiPrefs.getUser();
     List<Widget> _listItems = [
-      _listHeader(L10n(context).coursesLabel),
+      if (user != null) LabeledCheckbox(
+          label: user.name,
+          padding: const EdgeInsets.only(left: 2.0, right: 16.0),
+          value: selectedContextIds.contains('user_${user.id}'),
+          onChanged: (bool newValue) {
+            setState(() {
+              newValue
+                  ? selectedContextIds.add('user_${user.id}')
+                  : selectedContextIds.remove('user_${user.id}');
+            });
+          }),
       ...courses.map((c) => MergeSemantics(
             child: LabeledCheckbox(
                 label: c.name,
@@ -150,14 +165,6 @@ class CalendarFilterListScreenState extends State<CalendarFilterListScreen> {
           return _listItems[index];
         });
   }
-
-  Widget _listHeader(String title) => Padding(
-        padding: const EdgeInsets.only(left: 16.0),
-        child: Text(
-          title,
-          style: Theme.of(context).textTheme.overline,
-        ),
-      );
 }
 
 // Custom checkbox to better control the padding at the start

--- a/libs/flutter_student_embed/test/screens/calendar/calendar_screen_test.dart
+++ b/libs/flutter_student_embed/test/screens/calendar/calendar_screen_test.dart
@@ -282,6 +282,7 @@ void main() {
     // Tap on unselected context items
     await tester.tap(find.text('Course2'));
     await tester.tap(find.text('Course3'));
+    await tester.tap(find.text(ApiPrefs.getUser().name));
     await tester.pumpAndSettle();
 
     // Tap on the back button

--- a/libs/flutter_student_embed/test/screens/calendar/calendar_widget/calendar_filter_list_screen_test.dart
+++ b/libs/flutter_student_embed/test/screens/calendar/calendar_widget/calendar_filter_list_screen_test.dart
@@ -17,6 +17,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_student_embed/l10n/app_localizations.dart';
 import 'package:flutter_student_embed/models/course.dart';
+import 'package:flutter_student_embed/network/utils/api_prefs.dart';
 import 'package:flutter_student_embed/screens/calendar/calendar_widget/calendar_filter_screen/calendar_filter_list_interactor.dart';
 import 'package:flutter_student_embed/screens/calendar/calendar_widget/calendar_filter_screen/calendar_filter_list_screen.dart';
 import 'package:flutter_student_embed/utils/common_widgets/empty_panda_widget.dart';
@@ -118,10 +119,10 @@ void main() {
       await tester.pump();
       await tester.pump();
 
-      expect(find.text(AppLocalizations().calendarTapToFavoriteDesc), findsOneWidget);
+      expect(find.text(AppLocalizations().calendarSelectFavoriteCalendars), findsOneWidget);
     });
 
-    testWidgetsWithAccessibilityChecks('shows course list with header item', (tester) async {
+    testWidgetsWithAccessibilityChecks('shows course list', (tester) async {
       var interactor = MockCalendarFilterListInteractor();
       when(interactor.getCoursesForUser(isRefresh: anyNamed('isRefresh')))
           .thenAnswer((_) => Future.value(_mockCourses()));
@@ -134,7 +135,6 @@ void main() {
       await tester.pump();
       await tester.pump();
 
-      expect(find.text(AppLocalizations().coursesLabel), findsOneWidget);
       expect(find.byType(LabeledCheckbox), findsNWidgets(3));
     });
 


### PR DESCRIPTION
refs: MBL-15938
affects: Student
release note: Added filtering option for user calendar.

Test plan: In the ticket

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72397075/198229039-776af3e8-2f54-44e6-b6ab-a23ad48c75ab.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/72397075/198229410-49bae582-2901-43c8-803e-d5515019091a.png" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Approve from product or not needed
