### PR TITLE
[MBL-16375][Student][Teacher] Video colors are inverted when embedded in discussion replies with dark mode enabled

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/WebViewExtensions.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/WebViewExtensions.kt
@@ -118,7 +118,7 @@ fun WebView.addDarkThemeToHtmlDocument() {
                         html {
                             filter: invert(100%) hue-rotate(180deg);
                         }
-                        img:not(.ignore-color-scheme), video:not(.ignore-color-scheme), .ignore-color-scheme {
+                        img:not(.ignore-color-scheme), video:not(.ignore-color-scheme), iframe:not(.ignore-color-scheme), .ignore-color-scheme {
                             filter: invert(100%) hue-rotate(180deg) !important;
                         }
                     }


### PR DESCRIPTION
refs: MBL-16375
affects: Student, Teacher
release note: none

Test plan: In the ticket

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Approve from product or not needed
