### PR TITLE
[MBL-16369][Teacher] - Searching people only shows shortname

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/presenters/PeopleListPresenter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/presenters/PeopleListPresenter.kt
@@ -186,7 +186,7 @@ class PeopleListPresenter(private val mCanvasContext: CanvasContext?) : SyncPres
         return User(
                 avatarUrl = recipient.avatarURL,
                 id = recipient.idAsLong,
-                name = recipient.name ?: "",
+                name = recipient.fullName ?: recipient.name ?: "",
                 pronouns = recipient.pronouns,
                 sortableName = recipient.name,
                 enrollments = enrollments

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Recipient.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Recipient.kt
@@ -19,7 +19,6 @@ package com.instructure.canvasapi2.models
 
 import com.google.gson.annotations.SerializedName
 import kotlinx.android.parcel.Parcelize
-import java.util.HashMap
 
 @Parcelize
 data class Recipient(
@@ -27,6 +26,8 @@ data class Recipient(
         val stringId: String? = null,
         val name: String? = null,
         val pronouns: String? = null,
+        @SerializedName("full_name")
+        val fullName: String? = null,
         @SerializedName("user_count")
         val userCount: Int = 0,
         @SerializedName("item_count")


### PR DESCRIPTION
Fix searching on people list page only showed shortname (in automation context).

refs: MBL-16369
affects: Teacher
release note: none

test plan: in the ticket.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>
<img width="336" alt="image" src="https://user-images.githubusercontent.com/92309696/200572936-9794bed1-66f2-43b9-9e8d-c1e5d9724934.png">
<td>
<img width="335" alt="image" src="https://user-images.githubusercontent.com/92309696/200570085-dbbcdd2a-e657-4156-8502-a251650a2f69.png">
</td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Approve from product or not needed
