### PR TITLE
[MBL-16398][Teacher] Delete description on different screens does not refresh automatically

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/AssignmentDetailsFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/AssignmentDetailsFragment.kt
@@ -243,14 +243,9 @@ class AssignmentDetailsFragment : BasePresenterFragment<
 
     @Suppress("UsePropertyAccessSyntax")
     private fun configureDescription(assignment: Assignment): Unit = with(assignment) {
-        // Show "No description" layout if there is no description
-        if (assignment.description.isNullOrBlank()) {
-            noDescriptionTextView.setVisible()
-            return
-        }
+        noDescriptionTextView.setVisible(assignment.description.isNullOrBlank())
 
         // Show progress bar while loading description
-        noDescriptionTextView.setGone()
         descriptionProgressBar.announceForAccessibility(getString(R.string.loading))
         descriptionProgressBar.setVisible()
         descriptionWebViewWrapper.webView.setWebChromeClient(object : WebChromeClient() {

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/QuizDetailsFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/QuizDetailsFragment.kt
@@ -322,11 +322,7 @@ class QuizDetailsFragment : BasePresenterFragment<
     }
 
     private fun setupDescription(quiz: Quiz) {
-        // Show "No description" layout if there is no description
-        if (quiz.description.isNullOrBlank()) {
-            noInstructionsTextView.setVisible()
-            return
-        }
+        noInstructionsTextView.setVisible(quiz.description.isNullOrBlank())
 
         // Show progress bar while loading description
         instructionsProgressBar.announceForAccessibility(getString(R.string.loading))


### PR DESCRIPTION
Test plan: In the ticket.

refs: MBL-16398
affects: Teacher
release note: none

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Approve from product or not needed
