### PR TITLE
[MBL-16425][Teacher] Edit syllabus not working after change to detailed permission

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusEffectHandler.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusEffectHandler.kt
@@ -72,7 +72,7 @@ class SyllabusEffectHandler : EffectHandler<SyllabusView, SyllabusEvent, Syllabu
                 }
             }
 
-            val permissionsDeferred = CourseManager.getPermissionsAsync(course.dataOrThrow.id, listOf(CanvasContextPermission.MANAGE_CONTENT))
+            val permissionsDeferred = CourseManager.getPermissionsAsync(course.dataOrThrow.id, listOf(CanvasContextPermission.MANAGE_CONTENT, CanvasContextPermission.MANAGE_COURSE_CONTENT_EDIT))
             val permissionsResult = permissionsDeferred.await()
 
             consumer.accept(SyllabusEvent.DataLoaded(course, summaryResult, permissionsResult, summaryAllowed))

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusPresenter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/SyllabusPresenter.kt
@@ -48,7 +48,7 @@ class SyllabusPresenter : Presenter<SyllabusModel, SyllabusViewState> {
         val course = model.course?.dataOrNull
         val events = mapEventsResultToViewState(course?.textAndIconColor ?: 0, model.events, context)
         val body = model.syllabus?.description?.takeIf { it.isValid() }
-        val canEdit = model.permissions?.dataOrNull?.canManageContent == true
+        val canEdit = model.permissions?.dataOrNull?.canManageContent == true || model.permissions?.dataOrNull?.canEditCourseContent == true
 
         return SyllabusViewState.Loaded(
             syllabus = body,

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/CanvasContextPermission.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/CanvasContextPermission.kt
@@ -45,7 +45,9 @@ data class CanvasContextPermission(
         @SerializedName(STUDENT_VIEW)
         val canUseStudentView: Boolean = false,
         @SerializedName(MANAGE_CONTENT)
-        val canManageContent: Boolean = false
+        val canManageContent: Boolean = false,
+        @SerializedName(MANAGE_COURSE_CONTENT_EDIT)
+        val canEditCourseContent: Boolean = false
 ) : Parcelable {
     companion object {
         const val BECOME_USER = "become_user"
@@ -61,5 +63,6 @@ data class CanvasContextPermission(
         const val VIEW_ANALYTICS = "view_analytics"
         const val STUDENT_VIEW = "use_student_view"
         const val MANAGE_CONTENT = "manage_content"
+        const val MANAGE_COURSE_CONTENT_EDIT = "manage_course_content_edit"
     }
 }


### PR DESCRIPTION
Test plan:
- Test the Edit Syllabus in your prod and beta sandbox, edit button should be displayed in both cases. (Currently it only displays in prod)

refs: MBL-16425
affects: Teacher
release note: none

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Approve from product or not needed
