### PR TITLE
[MBL-16428][Teacher] - Fix Modules Empty list color anomaly

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/CourseBrowserFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/CourseBrowserFragment.kt
@@ -241,7 +241,7 @@ class CourseBrowserFragment : BaseSyncFragment<
                 )
                 Tab.MODULES_ID -> {
                     val bundle = ModuleListFragment.makeBundle(presenter.canvasContext)
-                    RouteMatcher.route(requireContext(), Route(ModuleListFragment::class.java, null, bundle))
+                    RouteMatcher.route(requireContext(), Route(ModuleListFragment::class.java, presenter.canvasContext, bundle))
                 }
                 Tab.STUDENT_VIEW -> {
                     Analytics.logEvent(AnalyticsEventConstants.STUDENT_VIEW_TAPPED)


### PR DESCRIPTION
Fix null canvasContext object in Modules (which made color diff anomaly on split view on tablet when there was no module selected).

refs: MBL-16428
affects: Teacher
release note: none

--- edit or delete this section ---
## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="" maxHeight=500>
<img width="648" alt="image" src="https://user-images.githubusercontent.com/92309696/205971632-967d52ce-10cf-4019-bac2-479897b5fa45.png">
</td>
<td><img src="" maxHeight=500>
<img width="649" alt="image" src="https://user-images.githubusercontent.com/92309696/205971121-6b9d1d9e-d54c-48ac-a32e-55d2ec6b3f75.png">
</td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Approve from product or not needed
