### PR TITLE
[MBL-16429][Student][Teacher] Dark mode content (which switched to light) set back to dark after reply

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/DiscussionDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/DiscussionDetailsFragment.kt
@@ -724,15 +724,15 @@ class DiscussionDetailsFragment : ParentFragment(), Bookmarkable {
         discussionRepliesWebViewWrapper.setVisible()
         discussionProgressBar.setGone()
 
-        loadHeaderHtmlJob = discussionRepliesWebViewWrapper.webView.loadHtmlWithIframes(requireContext(), html, {
+        setupRepliesWebView()
+
+        loadRepliesHtmlJob = discussionRepliesWebViewWrapper.webView.loadHtmlWithIframes(requireContext(), html, {
             discussionRepliesWebViewWrapper.loadDataWithBaseUrl(CanvasWebView.getReferrer(true), html, "text/html", "UTF-8", null)
         })
 
         swipeRefreshLayout.isRefreshing = false
         discussionTopicRepliesTitle.setVisible(discussionTopicHeader.shouldShowReplies)
         postBeforeViewingRepliesTextView.setGone()
-
-        setupRepliesWebView()
     }
     //endregion Loading
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/DiscussionsDetailsFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/DiscussionsDetailsFragment.kt
@@ -449,7 +449,7 @@ class DiscussionsDetailsFragment : BasePresenterFragment<
         discussionRepliesWebViewWrapper.webView.onResume()
 
         setupWebView(discussionTopicHeaderWebViewWrapper.webView, false)
-        setupWebView(discussionRepliesWebViewWrapper.webView, true, addDarkTheme = true)
+        setupWebView(discussionRepliesWebViewWrapper.webView, true, addDarkTheme = !discussionRepliesWebViewWrapper.themeSwitched)
         discussionRepliesWebViewWrapper.onThemeChanged = { themeChanged, html ->
             setupWebView(discussionRepliesWebViewWrapper.webView, true, addDarkTheme = !themeChanged)
             discussionRepliesWebViewWrapper.loadDataWithBaseUrl(CanvasWebView.getReferrer(true), html, "text/html", "UTF-8", null)


### PR DESCRIPTION
Test plan: In the ticket

refs: MBL-16429
affects: Student, Teacher
release note: none

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
- [x] Approve from product or not needed
