### PR TITLE
[Student][Teacher][MBL-16439] Dark Mode | Paperclip icon for viewing attachments is dark on black

### DIFF
--- a/apps/student/src/main/res/layout/fragment_discussions_details.xml
+++ b/apps/student/src/main/res/layout/fragment_discussions_details.xml
@@ -313,6 +313,7 @@
                             android:padding="14dp"
                             android:scaleType="centerInside"
                             android:visibility="gone"
+                            app:tint="@color/textDarkest"
                             app:srcCompat="@drawable/ic_attachment" />
 
                     </LinearLayout>

--- a/apps/teacher/src/main/res/layout/fragment_discussions_details.xml
+++ b/apps/teacher/src/main/res/layout/fragment_discussions_details.xml
@@ -412,6 +412,7 @@
                         android:contentDescription="@string/attachment"
                         android:padding="8dp"
                         android:visibility="gone"
+                        app:tint="@color/textDarkest"
                         app:srcCompat="@drawable/ic_attachment"/>
 
                 </LinearLayout>


### PR DESCRIPTION
Test plan: In the ticket

refs: MBL-16439
affects: Student, Teacher
release note: none

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
- [x] Approve from product or not needed
