### PR TITLE
[Student][MBL-16445] Crash on NavigationActivity

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/discussion/router/DiscussionRouterFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/discussion/router/DiscussionRouterFragment.kt
@@ -1,6 +1,8 @@
 package com.instructure.pandautils.features.discussion.router
 
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -68,7 +70,7 @@ class DiscussionRouterFragment : Fragment() {
             }
             is DiscussionRouterAction.ShowToast -> {
                 toast(action.toast, Toast.LENGTH_SHORT)
-                requireActivity().onBackPressed()
+                Handler(Looper.getMainLooper()).post { requireActivity().onBackPressed() }
             }
         }
     }


### PR DESCRIPTION
Test plan: You can reproduce the crash by setting the error value as the initial value in the `DiscussionRouterViewModel` events. Smoke test discussion routing in both apps.

refs: MBL-16445
affects: Student
release note: none

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
- [x] Approve from product or not needed
