### PR TITLE
[MBL-16438][Student][Teacher] Discussion replies in dark mode

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/DiscussionDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/DiscussionDetailsFragment.kt
@@ -18,6 +18,8 @@ package com.instructure.student.fragment
 
 import android.annotation.SuppressLint
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -783,17 +785,20 @@ class DiscussionDetailsFragment : ParentFragment(), Bookmarkable {
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN, sticky = true)
     fun onDiscussionReplyCreated(event: DiscussionEntryEvent) {
-        event.once(discussionTopicHeader.id.toString()) {
-            populateDiscussionData(true, event.topLevelReplyPosted)
+        populateDiscussionData(true, event.topLevelReplyPosted)
 
-            discussionTopicHeader.incrementDiscussionSubentryCount() // Update subentry count
-            discussionTopicHeader.lastReplyDate?.time = Date().time // Update last post time
-            if (!groupDiscussion) {
-                DiscussionTopicHeaderEvent(discussionTopicHeader).post()
-            }
-            // needed for when discussions are in modules
-            applyTheme()
+        discussionTopicHeader.incrementDiscussionSubentryCount() // Update subentry count
+        discussionTopicHeader.lastReplyDate?.time = Date().time // Update last post time
+        if (!groupDiscussion) {
+            DiscussionTopicHeaderEvent(discussionTopicHeader).post()
         }
+        // needed for when discussions are in modules
+        applyTheme()
+
+        // We don't want to remove the event immediately because more screens might need to process it
+        Handler(Looper.getMainLooper()).postDelayed({
+            EventBus.getDefault().removeStickyEvent(event)
+        }, 100)
     }
 
     @Suppress("unused")

--- a/apps/student/src/main/java/com/instructure/student/fragment/DiscussionDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/DiscussionDetailsFragment.kt
@@ -383,20 +383,8 @@ class DiscussionDetailsFragment : ParentFragment(), Bookmarkable {
                 openMedia(canvasContext, url, filename)
             }
 
-            override fun onPageStartedCallback(webView: WebView, url: String) {
-                // This executes a JavaScript to add the dark theme.
-                // It won't work exactl when the page starts to load, because the html document is not yet created,
-                // so we add a little delay to make sure the script can modify the document.
-                if (addDarkTheme) {
-                    webView.postDelayed({ webView.addDarkThemeToHtmlDocument() }, 100)
-                }
-            }
-            override fun onPageFinishedCallback(webView: WebView, url: String) {
-                // This is just a fallback if in some cases the document wouldn't be loaded after the delay
-                if (addDarkTheme) {
-                    webView.addDarkThemeToHtmlDocument()
-                }
-            }
+            override fun onPageStartedCallback(webView: WebView, url: String) = Unit
+            override fun onPageFinishedCallback(webView: WebView, url: String) = Unit
         }
 
         webView.addVideoClient(requireActivity())
@@ -574,8 +562,6 @@ class DiscussionDetailsFragment : ParentFragment(), Bookmarkable {
             // Need to check here again in case we were only routed with a url instead of a whole discussionTopicHeader.
             updateToGroupIfNecessary()
 
-            determinePermissions()
-
             loadDiscussionTopicHeaderViews(discussionTopicHeader)
             addAccessibilityButton()
 
@@ -737,11 +723,6 @@ class DiscussionDetailsFragment : ParentFragment(), Bookmarkable {
         postBeforeViewingRepliesTextView.setGone()
     }
     //endregion Loading
-
-    private fun determinePermissions() {
-        // Might still be needed once COMMS-868 is implemented, TBD
-        //TODO: determine what permissions are available to student relative to course and discussion.
-    }
 
     private fun setupAssignmentDetails(assignment: Assignment) = with(assignment) {
         pointsTextView.setVisible()

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/DiscussionsDetailsFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/DiscussionsDetailsFragment.kt
@@ -516,20 +516,8 @@ class DiscussionsDetailsFragment : BasePresenterFragment<
                 showToast(R.string.downloadingFile)
                 RouteMatcher.openMedia(activity, url)
             }
-            override fun onPageStartedCallback(webView: WebView, url: String) {
-                // This executes a JavaScript to add the dark theme.
-                // It won't work exactl when the page starts to load, because the html document is not yet created,
-                // so we add a little delay to make sure the script can modify the document.
-                if (addDarkTheme) {
-                    webView.postDelayed({ webView.addDarkThemeToHtmlDocument() }, 100)
-                }
-            }
-            override fun onPageFinishedCallback(webView: WebView, url: String) {
-                // This is just a fallback if in some cases the document wouldn't be loaded after the delay
-                if (addDarkTheme) {
-                    webView.addDarkThemeToHtmlDocument()
-                }
-            }
+            override fun onPageStartedCallback(webView: WebView, url: String) = Unit
+            override fun onPageFinishedCallback(webView: WebView, url: String) = Unit
         }
 
         webView.addVideoClient(requireActivity())

--- a/libs/pandautils/src/main/assets/discussion_html_header_item.html
+++ b/libs/pandautils/src/main/assets/discussion_html_header_item.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta name="viewport" charset="utf-8" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
 		<style>
+			{$DARK_THEME}
 
 			body {
 				margin: 0px;

--- a/libs/pandautils/src/main/assets/discussion_html_header_item_rtl.html
+++ b/libs/pandautils/src/main/assets/discussion_html_header_item_rtl.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta name="viewport" charset="utf-8" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
 		<style>
+			{$DARK_THEME}
 
 			body {
 				direction: rtl;

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/WebViewExtensions.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/WebViewExtensions.kt
@@ -111,23 +111,3 @@ private fun setForceDarkStrategy(webThemeDarkeningOnly: Boolean, settings: WebSe
         WebSettingsCompat.setForceDarkStrategy(settings, WebSettingsCompat.DARK_STRATEGY_PREFER_WEB_THEME_OVER_USER_AGENT_DARKENING)
     }
 }
-
-fun WebView.addDarkThemeToHtmlDocument() {
-    val css = """
-                    @media (prefers-color-scheme: dark) {
-                        html {
-                            filter: invert(100%) hue-rotate(180deg);
-                        }
-                        img:not(.ignore-color-scheme), video:not(.ignore-color-scheme), iframe:not(.ignore-color-scheme), .ignore-color-scheme {
-                            filter: invert(100%) hue-rotate(180deg) !important;
-                        }
-                    }
-                    """
-    val cssString = css.split("\n").joinToString(" ")
-    val js = """
-                    var element = document.createElement('style');
-                    element.innerHTML = '$cssString)';
-                    document.head.appendChild(element);
-                """
-    evaluateJavascript(js, {})
-}

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/views/CanvasWebViewWrapper.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/views/CanvasWebViewWrapper.kt
@@ -111,7 +111,8 @@ class CanvasWebViewWrapper @JvmOverloads constructor(
     fun loadDataWithBaseUrl(url: String?, data: String, mimeType: String?, encoding: String?, history: String?) {
         html = data
         initVisibility(data)
-        binding.contentWebView.loadDataWithBaseURL(url, data, mimeType, encoding, history)
+        val formattedHtml = formatHtml(data)
+        binding.contentWebView.loadDataWithBaseURL(url, formattedHtml, mimeType, encoding, history)
     }
 
     private fun initVisibility(html: String) {
@@ -121,6 +122,29 @@ class CanvasWebViewWrapper @JvmOverloads constructor(
         } else {
             binding.themeSwitchButton.setGone()
         }
+    }
+
+    private fun formatHtml(data: String): String {
+        val nightModeFlags: Int = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        val darkTheme = nightModeFlags == Configuration.UI_MODE_NIGHT_YES && !themeSwitched
+
+        val style = if (darkTheme) {
+            """
+                @media (prefers-color-scheme: dark) {
+                        html {
+                            filter: invert(100%) hue-rotate(180deg);
+                        }
+                        img:not(.ignore-color-scheme), video:not(.ignore-color-scheme), iframe:not(.ignore-color-scheme), .ignore-color-scheme {
+                            filter: invert(100%) hue-rotate(180deg) !important;
+                        }
+                    }
+            """.trimIndent()
+        } else {
+            ""
+        }
+
+        return data
+            .replace("{\$DARK_THEME}", style)
     }
 
 }


### PR DESCRIPTION
Test plan:
- Verify that nested discussion replies (when you need to open a new screen to see more replies) work correctly in both themes, and new nested replies update correctly.
- Verify that replies are added to the correct discussion item.
- Smoke test discussions in both apps.

refs: MBL-16438
affects: Student, Teacher
release note: Fixed discussion replies in dark mode

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
- [x] Approve from product or not needed


[MBL-16438]: https://instructure.atlassian.net/browse/MBL-16438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ