### PR TITLE
[MBL-16456][Student][Teacher] Pages that import styles through global CSS does not load

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/PageDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/PageDetailsFragment.kt
@@ -126,12 +126,6 @@ class PageDetailsFragment : InternalWebviewFragment(), Bookmarkable {
                 }
             }
         }
-
-        val layoutParams = getCanvasWebView()?.layoutParams
-        layoutParams?.let {
-            it.height = ViewGroup.LayoutParams.WRAP_CONTENT
-            getCanvasWebView()?.layoutParams = it
-        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/apps/student/src/main/res/layout/fragment_webview.xml
+++ b/apps/student/src/main/res/layout/fragment_webview.xml
@@ -35,21 +35,12 @@
         app:theme="@style/ToolBarStyle"
         tools:targetApi="lollipop" />
 
-    <ScrollView
+    <com.instructure.pandautils.views.CanvasWebViewWrapper
+        android:id="@+id/canvasWebViewWrapper"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:fillViewport="true"
-        android:scrollbarStyle="outsideOverlay"
-        android:clipToPadding="false"
-        android:layout_below="@id/toolbar">
-
-        <com.instructure.pandautils.views.CanvasWebViewWrapper
-            android:id="@+id/canvasWebViewWrapper"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="@color/backgroundLightest"/>
-
-    </ScrollView>
+        android:layout_below="@id/toolbar"
+        android:background="@color/backgroundLightest" />
 
     <ProgressBar
         android:id="@+id/webViewLoading"

--- a/apps/teacher/src/main/res/layout/fragment_page_details.xml
+++ b/apps/teacher/src/main/res/layout/fragment_page_details.xml
@@ -32,21 +32,13 @@
         app:theme="@style/ToolBarStyle"
         tools:ignore="UnusedAttribute" />
 
-    <ScrollView
+    <com.instructure.pandautils.views.CanvasWebViewWrapper
+        android:id="@+id/canvasWebViewWraper"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:layout_below="@id/toolbar"
-        android:scrollbarStyle="outsideOverlay"
         android:layout_marginTop="8dp"
-        android:layout_marginBottom="8dp"
-        android:clipToPadding="false">
-
-        <com.instructure.pandautils.views.CanvasWebViewWrapper
-            android:id="@+id/canvasWebViewWraper"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-
-    </ScrollView>
+        android:layout_marginBottom="8dp" />
 
     <com.instructure.loginapi.login.view.CanvasLoadingView
         android:id="@+id/loading"


### PR DESCRIPTION
Test plan: In the ticket
- Smoke test also different pages in both apps in dark/light mode.
- The theme switcher should stick to the top of the screen.

refs: MBL-16456
affects: Student, Teacher
release note: Fixed a bug where pages with global CSS don't load

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
- [x] Approve from product or not needed
