### PR TITLE
[MBL-16452][Student][Teacher] Restricted PDFs fail to open in Android

### DIFF
--- a/buildSrc/src/main/java/GlobalDependencies.kt
+++ b/buildSrc/src/main/java/GlobalDependencies.kt
@@ -30,7 +30,7 @@ object Versions {
     /* Others */
     const val APOLLO = "2.5.9"
     const val CRASHLYTICS = "17.2.1"
-    const val PSPDFKIT = "8.3.0"
+    const val PSPDFKIT = "8.4.1"
     const val PHOTO_VIEW = "2.3.0"
     const val MOBIUS = "1.2.1"
     const val SQLDELIGHT = "1.4.3"


### PR DESCRIPTION
Test plan: 
- Repro steps for the bug are in the ticket.
- I have updated PSPDFKit so smoke test all the usages:
  - PDF opening in the Student/Teacher app
  - Annotating PDF submissions as a teacher
  - Submitting Student Annotation submission types
  - Opening PDFs in the student app from Files, making annotations and submitting to an assignment

refs: MBL-16452
affects: Student, Teacher
release note: Fixed a bug where restricted PDFs didn't open

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
- [x] Approve from product or not needed
