### PR TITLE
[MBL-16512][Student][Teacher] Only the first 100 course discussions from the api results show in the mobile app

### DIFF
--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/ExhaustiveCallback.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/ExhaustiveCallback.kt
@@ -42,7 +42,7 @@ abstract class ExhaustiveCallback<MODEL, out ITEM>(
         response.body()?.let {
             val items = extractItems(it)
             extractedItems.addAll(items)
-            if (items.isNotEmpty() && moreCallsExist(linkHeaders)) {
+            if (moreCallsExist(linkHeaders)) {
                 getNextPage(this, getNextUrl(linkHeaders), type.isCache)
             } else {
                 finished = true


### PR DESCRIPTION
Test plan: In the ticket. Ticket only mentions the student app, but this change affects the teacher as well and probably it has the same problem. There was no test user for teacher.

refs: MBL-16512
affects: Student, Teacher
release note: none

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
- [x] Approve from product or not needed
