### PR TITLE
[MBL-16490][Teacher] Weird behaviour of the comment input field while changing orientation

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/view/SubmissionContentView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/view/SubmissionContentView.kt
@@ -268,8 +268,7 @@ class SubmissionContentView(
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         // Resize sliding panel and content, don't if keyboard based annotations are active or selected
-        // we only do this if the oldw == w so we won't be resizing on rotation
-        if (oldh > 0 && oldh != h && oldw == w && !activity.isCurrentlyAnnotating && pdfFragment?.selectedAnnotations?.isEmpty() != false) {
+        if (oldh > 0 && oldh != h && !activity.isCurrentlyAnnotating && pdfFragment?.selectedAnnotations?.isEmpty() != false) {
             val newState = when {
                 context.isTablet -> slidingUpPanelLayout?.panelState ?: SlidingUpPanelLayout.PanelState.ANCHORED
                 h < oldh -> SlidingUpPanelLayout.PanelState.EXPANDED


### PR DESCRIPTION
Test plan: In the ticket, smoke test the page on phone as well - they did not resize the field on orientation change intentionally, but I don't understand why

refs: MBL-16490
affects: Teacher
release note: none

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/109959688/217876215-9ad3f35f-6989-447d-9286-0c15ddfd5161.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/109959688/217875386-f4b97dc7-57f2-4a30-9292-86b82e42575a.png" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [ ] A11y checked
- [x] Approve from product or not needed
