### PR TITLE
Update PULL_REQUEST_TEMPLATE - add 'Run E2E test suite or not needed' reminder

### DIFF
--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -12,6 +12,7 @@
 ## Checklist
 
 - [ ] Follow-up e2e test ticket created or not needed
+- [ ] Run E2E test suite or not needed
 - [ ] Tested in dark mode
 - [ ] Tested in light mode
 - [ ] A11y checked

--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -1,4 +1,11 @@
 --- edit or delete this section ---
+
+Test plan:
+
+refs: 
+affects: 
+release note:
+
 ## Screenshots
 
 <table>


### PR DESCRIPTION
Update PR template by adding a "Run E2E test suite or not needed" checkbox to remind us to run the E2E test suite in case if we think a development could affect existing features. (Mainly it's needed on stories, especially in case of we are "rewriting", or redesigning some existing (regression) feature)

