### PR TITLE
[MBL-16517] [Teacher] - Refactor API calls in E2E test cases

### DIFF
--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/AnnouncementsE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/AnnouncementsE2ETest.kt
@@ -34,9 +34,7 @@ class AnnouncementsE2ETest : TeacherTest() {
 
     override fun displaysPageObjects() = Unit
 
-    override fun enableAndConfigureAccessibilityChecks() {
-        //We don't want to see accessibility errors on E2E tests
-    }
+    override fun enableAndConfigureAccessibilityChecks() = Unit
 
     @E2E
     @Test

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/AssignmentE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/AssignmentE2ETest.kt
@@ -19,6 +19,9 @@ package com.instructure.teacher.ui.e2e
 import android.util.Log
 import com.instructure.canvas.espresso.E2E
 import com.instructure.dataseeding.api.SubmissionsApi
+import com.instructure.dataseeding.model.AssignmentApiModel
+import com.instructure.dataseeding.model.CanvasUserApiModel
+import com.instructure.dataseeding.model.CourseApiModel
 import com.instructure.dataseeding.model.SubmissionType
 import com.instructure.dataseeding.util.days
 import com.instructure.dataseeding.util.fromNow
@@ -127,14 +130,7 @@ class AssignmentE2ETest : TeacherTest() {
         )
 
         Log.d(PREPARATION_TAG,"Grade the previously seeded submission for ${gradedStudent.name} student.")
-        SubmissionsApi.gradeSubmission(
-                teacherToken = teacher.token,
-                courseId = course.id,
-                assignmentId = assignment[0].id,
-                studentId = gradedStudent.id,
-                postedGrade = "15",
-                excused = false
-        )
+        gradeSubmission(teacher, course, assignment, gradedStudent)
 
         Log.d(STEP_TAG,"Refresh the page. Assert that the number of 'Graded' is increased and the number of 'Not Submitted' and 'Needs Grading' are decreased.")
         assignmentDetailsPage.refresh()
@@ -216,6 +212,22 @@ class AssignmentE2ETest : TeacherTest() {
         Log.d(STEP_TAG,"Assert that the there is a due date with '$dueDateForEveryoneElse' value and another one with '$dueDateForStudentSpecially'.")
         assignmentDueDatesPage.assertDueDateTime("Due $dueDateForEveryoneElse")
         assignmentDueDatesPage.assertDueDateTime("Due $dueDateForStudentSpecially")
+    }
+
+    private fun gradeSubmission(
+        teacher: CanvasUserApiModel,
+        course: CourseApiModel,
+        assignment: List<AssignmentApiModel>,
+        gradedStudent: CanvasUserApiModel
+    ) {
+        SubmissionsApi.gradeSubmission(
+            teacherToken = teacher.token,
+            courseId = course.id,
+            assignmentId = assignment[0].id,
+            studentId = gradedStudent.id,
+            postedGrade = "15",
+            excused = false
+        )
     }
 
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/CommentLibraryE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/CommentLibraryE2ETest.kt
@@ -42,13 +42,9 @@ import org.junit.Test
 @HiltAndroidTest
 class CommentLibraryE2ETest : TeacherTest() {
 
-    override fun displaysPageObjects() {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-    }
+    override fun displaysPageObjects() = Unit
 
-    override fun enableAndConfigureAccessibilityChecks() {
-        //Intentionally empty, because we don't check accessibility in E2E tests.
-    }
+    override fun enableAndConfigureAccessibilityChecks() = Unit
 
     @E2E
     @Test

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/CourseSettingsE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/CourseSettingsE2ETest.kt
@@ -33,13 +33,9 @@ import org.junit.Test
 @HiltAndroidTest
 class CourseSettingsE2ETest : TeacherTest() {
 
-    override fun displaysPageObjects() {
-        TODO("not implemented")
-    }
+    override fun displaysPageObjects() = Unit
 
-    override fun enableAndConfigureAccessibilityChecks() {
-        //Intentionally empty, because we don't check accessibility in E2E tests.
-    }
+    override fun enableAndConfigureAccessibilityChecks() = Unit
 
     @E2E
     @Test
@@ -60,36 +56,24 @@ class CourseSettingsE2ETest : TeacherTest() {
         dashboardPage.openCourse(firstCourse)
         courseBrowserPage.clickSettingsButton()
 
-        Log.d(
-            STEP_TAG,
-            "Click on 'Set Home Page' menu and select another page as home page. Assert if home page has been changed."
-        )
+        Log.d(STEP_TAG, "Click on 'Set Home Page' menu and select another page as home page. Assert if home page has been changed.")
         courseSettingsPage.assertPageObjects()
         courseSettingsPage.clickSetHomePage()
         val newCourseHomePage: String = courseSettingsPage.selectNewHomePage()
         courseSettingsPage.assertHomePageChanged(newCourseHomePage)
 
         val newCourseName = "New Course Name"
-        Log.d(
-            STEP_TAG,
-            "Click on 'Course Name' menu and edit course's name to be $newCourseName. Assert that the course's name has been changed."
-        )
+        Log.d(STEP_TAG, "Click on 'Course Name' menu and edit course's name to be $newCourseName. Assert that the course's name has been changed.")
         courseSettingsPage.clickCourseName()
         courseSettingsPage.editCourseName(newCourseName)
         courseSettingsPage.assertCourseNameChanged(newCourseName)
 
-        Log.d(
-            STEP_TAG,
-            "Go back to course browser page and assert that the course's name has been changed there as well."
-        )
+        Log.d(STEP_TAG, "Go back to course browser page and assert that the course's name has been changed there as well.")
         Espresso.pressBack()
         courseBrowserPage.assertCourseBrowserPageDisplayed()
         courseBrowserPage.assertCourseTitle(newCourseName)
 
-        Log.d(
-            STEP_TAG,
-            "Navigate back to the courses list page and assert if the name of the first course's name has been changed there as well."
-        )
+        Log.d(STEP_TAG, "Navigate back to the courses list page and assert if the name of the first course's name has been changed there as well.")
         Espresso.pressBack()
         dashboardPage.waitForRender()
         dashboardPage.assertDisplaysCourse(newCourseName)
@@ -99,35 +83,26 @@ class CourseSettingsE2ETest : TeacherTest() {
         dashboardPage.openCourse(secondCourse)
         courseBrowserPage.clickSettingsButton()
 
-        Log.d(
-            STEP_TAG,
-            "Click on 'Set Home Page' menu and select another page as home page. Assert if home page has been changed."
-        )
+        Log.d(STEP_TAG, "Click on 'Set Home Page' menu and select another page as home page. Assert if home page has been changed.")
         courseSettingsPage.assertPageObjects()
         courseSettingsPage.clickSetHomePage()
         val secondCourseNewHomePage: String = courseSettingsPage.selectNewHomePage()
         courseSettingsPage.assertHomePageChanged(secondCourseNewHomePage)
 
-        Log.d(
-            STEP_TAG,
-            "Go back to course browser page and assert that the course's name has NOT been changed there."
-        )
+        Log.d(STEP_TAG, "Go back to course browser page and assert that" +
+                "the course's name has NOT been changed there.")
         Espresso.pressBack()
         courseBrowserPage.assertCourseBrowserPageDisplayed()
         courseBrowserPage.assertCourseTitle(secondCourse.name)
 
-        Log.d(
-            STEP_TAG,
-            "Navigate back to the courses list page and assert if the name of the second course's name has NOT been changed there as well."
-        )
+        Log.d(STEP_TAG, "Navigate back to the courses list page and assert if" +
+                "the name of the second course's name has NOT been changed there as well.")
         Espresso.pressBack()
         dashboardPage.waitForRender()
         dashboardPage.assertDisplaysCourse(secondCourse.name)
 
-        Log.d(
-            STEP_TAG,
-            "Refresh the courses list page and assert if the corresponding course names are displayed (new course name for first course and the original course name of the second course)."
-        )
+        Log.d(STEP_TAG, "Refresh the courses list page and assert if the corresponding course names are displayed" +
+                "(new course name for first course and the original course name of the second course).")
         refresh()
         dashboardPage.waitForRender()
         dashboardPage.assertDisplaysCourse(newCourseName)

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/InboxE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/InboxE2ETest.kt
@@ -70,10 +70,8 @@ class InboxE2ETest : TeacherTest() {
         Log.d(STEP_TAG,"Assert that the reply has successfully sent and it's displayed.")
         inboxMessagePage.assertHasReply()
 
-        Log.d(STEP_TAG,"Navigate back to Inbox Page.")
+        Log.d(STEP_TAG,"Navigate back to Inbox Page. Assert that the message is not unread anymore.")
         Espresso.pressBack()
-
-        Log.d(STEP_TAG, "Assert that the message is not unread anymore.")
         inboxPage.assertThereIsAnUnreadMessage(false)
 
         Log.d(STEP_TAG,"Add a new conversation message manually via UI. Click on 'New Message' ('+') button.")

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/LoginE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/LoginE2ETest.kt
@@ -48,6 +48,7 @@ class LoginE2ETest : TeacherTest() {
         val teacher2 = data.teachersList[1]
         val course = data.coursesList[0]
 
+        Log.d(STEP_TAG, "Login with user: ${teacher1.name}, login id: ${teacher1.loginId}.")
         loginWithUser(teacher1)
 
         Log.d(STEP_TAG,"Assert that the Dashboard Page is the landing page and it is loaded successfully.")
@@ -59,6 +60,7 @@ class LoginE2ETest : TeacherTest() {
         Log.d(STEP_TAG,"Log out with ${teacher1.name} student.")
         dashboardPage.logOut()
 
+        Log.d(STEP_TAG, "Login with user: ${teacher2.name}, login id: ${teacher2.loginId}.")
         loginWithUser(teacher2, true)
 
         Log.d(STEP_TAG,"Assert that the Dashboard Page is the landing page and it is loaded successfully.")
@@ -70,6 +72,7 @@ class LoginE2ETest : TeacherTest() {
         Log.d(STEP_TAG,"Assert that the previously logins has been displayed.")
         loginLandingPage.assertDisplaysPreviousLogins()
 
+        Log.d(STEP_TAG, "Login with user: ${teacher1.name}, login id: ${teacher1.loginId}.")
         loginWithUser(teacher1, true)
 
         Log.d(STEP_TAG,"Assert that the Dashboard Page is the landing page and it is loaded successfully.")
@@ -103,6 +106,7 @@ class LoginE2ETest : TeacherTest() {
         val student = data.studentsList[0]
         val parent = parentData.parentsList[0]
 
+        Log.d(STEP_TAG, "Login with user: ${student.name}, login id: ${student.loginId}.")
         loginWithUser(student)
 
         Log.d(STEP_TAG,"Assert that the user has been landed on 'Not a teacher?' Page.")
@@ -114,6 +118,7 @@ class LoginE2ETest : TeacherTest() {
         Log.d(STEP_TAG,"Assert the Teacher app's Login Landing Page's screen is displayed.")
         loginLandingPage.assertPageObjects()
 
+        Log.d(STEP_TAG, "Login with user: ${parent.name}, login id: ${parent.loginId}.")
         loginWithUser(parent, true)
 
         Log.d(STEP_TAG,"Assert that the user has been landed on 'Not a teacher?' Page.")
@@ -145,6 +150,7 @@ class LoginE2ETest : TeacherTest() {
         Log.d(STEP_TAG, "Log out with ${teacher1.name} student.")
         dashboardPage.logOut()
 
+        Log.d(STEP_TAG, "Login with user: ${teacher2.name}, login id: ${teacher2.loginId}, via the last saved school's button.")
         loginWithLastSavedSchool(teacher2)
 
         Log.d(STEP_TAG, "Assert that the Dashboard Page is the landing page and it is loaded successfully.")

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/ModulesE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/ModulesE2ETest.kt
@@ -5,8 +5,7 @@ import com.instructure.canvas.espresso.E2E
 import com.instructure.dataseeding.api.AssignmentsApi
 import com.instructure.dataseeding.api.ModulesApi
 import com.instructure.dataseeding.api.QuizzesApi
-import com.instructure.dataseeding.model.ModuleItemTypes
-import com.instructure.dataseeding.model.SubmissionType
+import com.instructure.dataseeding.model.*
 import com.instructure.dataseeding.util.days
 import com.instructure.dataseeding.util.fromNow
 import com.instructure.dataseeding.util.iso8601
@@ -24,9 +23,7 @@ import org.junit.Test
 class   ModulesE2ETest : TeacherTest() {
     override fun displaysPageObjects() = Unit
 
-    override fun enableAndConfigureAccessibilityChecks() {
-        //We don't want to see accessibility errors on E2E tests
-    }
+    override fun enableAndConfigureAccessibilityChecks() = Unit
 
     @E2E
     @Test
@@ -38,7 +35,7 @@ class   ModulesE2ETest : TeacherTest() {
         val teacher = data.teachersList[0]
         val course = data.coursesList[0]
 
-        Log.d(STEP_TAG, "Login with user: ${teacher.name}, login id: ${teacher.loginId}.")
+        Log.d(STEP_TAG, "Login with user: ${teacher.name}, login id: ${teacher.loginId}. Assert that ${course.name} course is displayed on the Dashboard.")
         tokenLogin(teacher)
         dashboardPage.waitForRender()
         dashboardPage.assertDisplaysCourse(course)
@@ -51,47 +48,18 @@ class   ModulesE2ETest : TeacherTest() {
         modulesPage.assertEmptyView()
 
         Log.d(PREPARATION_TAG, "Seeding 'Text Entry' assignment for ${course.name} course.")
-        val assignment = AssignmentsApi.createAssignment(AssignmentsApi.CreateAssignmentRequest(
-                courseId = course.id,
-                withDescription = true,
-                submissionTypes = listOf(SubmissionType.ONLINE_TEXT_ENTRY),
-                teacherToken = teacher.token,
-                dueAt = 1.days.fromNow.iso8601
-        ))
+        val assignment = createAssignment(course, teacher)
 
         Log.d(PREPARATION_TAG,"Seeding quiz for ${course.name} course.")
-        val quiz = QuizzesApi.createQuiz(QuizzesApi.CreateQuizRequest(
-                courseId = course.id,
-                withDescription = true,
-                dueAt = 3.days.fromNow.iso8601,
-                token = teacher.token,
-                published = true
-        ))
+        val quiz = createQuiz(course, teacher)
 
         Log.d(PREPARATION_TAG,"Seeding a module for ${course.name} course. It starts as unpublished.")
-        val module = ModulesApi.createModule(
-                courseId = course.id,
-                teacherToken = teacher.token,
-                unlockAt = null)
+        val module = createModule(course, teacher)
 
         Log.d(PREPARATION_TAG,"Associate ${assignment.name} assignment (and the quiz within it) with module: ${module.id}.")
-        ModulesApi.createModuleItem(
-                courseId = course.id,
-                moduleId = module.id,
-                teacherToken = teacher.token,
-                title = assignment.name,
-                type = ModuleItemTypes.ASSIGNMENT.stringVal,
-                contentId = assignment.id.toString()
-        )
+        createModuleAssignmentItem(course, module, teacher, assignment)
 
-        ModulesApi.createModuleItem(
-                courseId = course.id,
-                moduleId = module.id,
-                teacherToken = teacher.token,
-                title = quiz.title,
-                type = ModuleItemTypes.QUIZ.stringVal,
-                contentId = quiz.id.toString()
-        )
+        createModuleQuizItem(course, module, teacher, quiz)
 
         Log.d(STEP_TAG,"Refresh the page. Assert that ${module.name} module is displayed and it is unpublished by default.")
         modulesPage.refresh()
@@ -114,6 +82,79 @@ class   ModulesE2ETest : TeacherTest() {
         Log.d(STEP_TAG,"Assert that ${assignment.name} assignment and ${quiz.title} quiz are present as module items.")
         modulesPage.assertModuleItemIsPresent(assignment.name)
         modulesPage.assertModuleItemIsPresent(quiz.title)
+    }
+
+    private fun createModuleQuizItem(
+        course: CourseApiModel,
+        module: ModuleApiModel,
+        teacher: CanvasUserApiModel,
+        quiz: QuizApiModel
+    ) {
+        ModulesApi.createModuleItem(
+            courseId = course.id,
+            moduleId = module.id,
+            teacherToken = teacher.token,
+            title = quiz.title,
+            type = ModuleItemTypes.QUIZ.stringVal,
+            contentId = quiz.id.toString()
+        )
+    }
+
+    private fun createModuleAssignmentItem(
+        course: CourseApiModel,
+        module: ModuleApiModel,
+        teacher: CanvasUserApiModel,
+        assignment: AssignmentApiModel
+    ) {
+        ModulesApi.createModuleItem(
+            courseId = course.id,
+            moduleId = module.id,
+            teacherToken = teacher.token,
+            title = assignment.name,
+            type = ModuleItemTypes.ASSIGNMENT.stringVal,
+            contentId = assignment.id.toString()
+        )
+    }
+
+    private fun createModule(
+        course: CourseApiModel,
+        teacher: CanvasUserApiModel
+    ): ModuleApiModel {
+        return ModulesApi.createModule(
+            courseId = course.id,
+            teacherToken = teacher.token,
+            unlockAt = null
+        )
+    }
+
+    private fun createQuiz(
+        course: CourseApiModel,
+        teacher: CanvasUserApiModel
+    ): QuizApiModel {
+        return QuizzesApi.createQuiz(
+            QuizzesApi.CreateQuizRequest(
+                courseId = course.id,
+                withDescription = true,
+                dueAt = 3.days.fromNow.iso8601,
+                token = teacher.token,
+                published = true
+            )
+        )
+    }
+
+    private fun createAssignment(
+        course: CourseApiModel,
+        teacher: CanvasUserApiModel
+    ): AssignmentApiModel {
+        return AssignmentsApi.createAssignment(
+            AssignmentsApi.CreateAssignmentRequest(
+                courseId = course.id,
+                withDescription = true,
+                submissionTypes = listOf(SubmissionType.ONLINE_TEXT_ENTRY),
+                teacherToken = teacher.token,
+                dueAt = 1.days.fromNow.iso8601
+            )
+        )
     }
 
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/PagesE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/PagesE2ETest.kt
@@ -5,6 +5,9 @@ import androidx.test.espresso.Espresso
 import androidx.test.espresso.web.webdriver.Locator
 import com.instructure.canvas.espresso.E2E
 import com.instructure.dataseeding.api.PagesApi
+import com.instructure.dataseeding.model.CanvasUserApiModel
+import com.instructure.dataseeding.model.CourseApiModel
+import com.instructure.dataseeding.model.PageApiModel
 import com.instructure.panda_annotations.FeatureCategory
 import com.instructure.panda_annotations.Priority
 import com.instructure.panda_annotations.TestCategory
@@ -33,31 +36,13 @@ class PagesE2ETest : TeacherTest() {
         val course = data.coursesList[0]
 
         Log.d(PREPARATION_TAG,"Create an unpublished page for course: ${course.name}.")
-        val testPage1 = PagesApi.createCoursePage(
-                courseId = course.id,
-                published = false,
-                frontPage = false,
-                token = teacher.token,
-                body = "<h1 id=\"header1\">Unpublished Page Text</h1>"
-        )
+        val testPage1 = createCoursePage(course, teacher, published = false, frontPage = false, body = "<h1 id=\"header1\">Unpublished Page Text</h1>")
 
         Log.d(PREPARATION_TAG,"Create a published page for course: ${course.name}.")
-        val testPage2 = PagesApi.createCoursePage(
-                courseId = course.id,
-                published = true,
-                frontPage = false,
-                token = teacher.token,
-                body = "<h1 id=\"header1\">Regular Page Text</h1>"
-        )
+        val testPage2 = createCoursePage(course, teacher, published = true, frontPage = false, body = "<h1 id=\"header1\">Regular Page Text</h1>")
 
         Log.d(PREPARATION_TAG,"Create a front page for course: ${course.name}.")
-        val testPage3 = PagesApi.createCoursePage(
-                courseId = course.id,
-                published = true,
-                frontPage = true,
-                token = teacher.token,
-                body = "<h1 id=\"header1\">Front Page Text</h1>"
-        )
+        val testPage3 = createCoursePage(course, teacher, published = true, frontPage = true, body = "<h1 id=\"header1\">Front Page Text</h1>")
 
         Log.d(STEP_TAG, "Login with user: ${teacher.name}, login id: ${teacher.loginId}.")
         tokenLogin(teacher)
@@ -160,12 +145,30 @@ class PagesE2ETest : TeacherTest() {
 
         Log.d(STEP_TAG,"Assert that '$newPageTitle' page is displayed and published.")
         pageListPage.assertPageIsPublished(newPageTitle)
+
         Log.d(STEP_TAG,"Click on the Search icon and type some search query string which matches only with the previously created page's title.")
         pageListPage.openSearch()
         pageListPage.enterSearchQuery("Test")
+
         Log.d(STEP_TAG,"Assert that the '$newPageTitle' titled page is displayed and it is the only one.")
         pageListPage.assertPageIsPublished(newPageTitle)
         pageListPage.assertPageCount(1)
+    }
+
+    private fun createCoursePage(
+        course: CourseApiModel,
+        teacher: CanvasUserApiModel,
+        published: Boolean = true,
+        frontPage: Boolean = false,
+        body: String = EMPTY_STRING
+    ): PageApiModel {
+        return PagesApi.createCoursePage(
+            courseId = course.id,
+            published = published,
+            frontPage = frontPage,
+            token = teacher.token,
+            body = body
+        )
     }
 
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/PeopleE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/PeopleE2ETest.kt
@@ -20,6 +20,9 @@ import android.util.Log
 import androidx.test.espresso.Espresso
 import com.instructure.canvas.espresso.E2E
 import com.instructure.dataseeding.api.SubmissionsApi
+import com.instructure.dataseeding.model.AssignmentApiModel
+import com.instructure.dataseeding.model.CanvasUserApiModel
+import com.instructure.dataseeding.model.CourseApiModel
 import com.instructure.dataseeding.model.SubmissionType
 import com.instructure.dataseeding.util.days
 import com.instructure.dataseeding.util.fromNow
@@ -74,14 +77,7 @@ class PeopleE2ETest: TeacherTest() {
         )
 
         Log.d(PREPARATION_TAG,"Grade the previously seeded submission for ${assignments[0].name} assignment.")
-        SubmissionsApi.gradeSubmission(
-                teacherToken = teacher.token,
-                courseId = course.id,
-                assignmentId = assignments[0].id,
-                studentId = gradedStudent.id,
-                postedGrade = "10",
-                excused = false
-        )
+        gradeSubmission(teacher, course, assignments, gradedStudent)
 
         Log.d(STEP_TAG, "Login with user: ${teacher.name}, login id: ${teacher.loginId}.")
         tokenLogin(teacher)
@@ -122,6 +118,7 @@ class PeopleE2ETest: TeacherTest() {
         studentContextPage.assertStudentSubmission("1")
         studentContextPage.assertAssignmentListed(assignments[0].name)
 
+        Log.d(STEP_TAG, "Click on the '+' (aka. Compose new message) button.")
         studentContextPage.clickOnNewMessageButton()
 
         val subject = "Test Subject"
@@ -158,4 +155,20 @@ class PeopleE2ETest: TeacherTest() {
         Log.d(STEP_TAG,"Assert that the previously sent conversation is displayed.")
         inboxPage.assertHasConversation()
      }
+
+    private fun gradeSubmission(
+        teacher: CanvasUserApiModel,
+        course: CourseApiModel,
+        assignments: List<AssignmentApiModel>,
+        gradedStudent: CanvasUserApiModel
+    ) {
+        SubmissionsApi.gradeSubmission(
+            teacherToken = teacher.token,
+            courseId = course.id,
+            assignmentId = assignments[0].id,
+            studentId = gradedStudent.id,
+            postedGrade = "10",
+            excused = false
+        )
+    }
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/SettingsE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/SettingsE2ETest.kt
@@ -68,24 +68,17 @@ class SettingsE2ETest : TeacherTest() {
         editProfileSettingsPage.editUserName(newUserName)
         editProfileSettingsPage.clickOnSave()
 
-        Log.d(
-            STEP_TAG,
-            "Assert that the username has been changed to $newUserName on the Profile Settings Page."
-        )
+        Log.d(STEP_TAG, "Assert that the username has been changed to $newUserName on the Profile Settings Page.")
         try {
-            Log.d(
-                STEP_TAG,
-                "Check if the user has landed on Settings Page. If yes, navigate back to Profile Settings Page."
-            )
+            Log.d(STEP_TAG, "Check if the user has landed on Settings Page. If yes, navigate back to Profile Settings Page.")
             //Sometimes in Bitrise it's working different than locally, because in Bitrise sometimes the user has been navigated to Settings Page after saving a new name,
             settingsPage.assertPageObjects()
             settingsPage.openProfileSettingsPage()
         } catch (e: NoMatchingViewException) {
-            Log.d(
-                STEP_TAG,
-                "Did not throw the user back to the Settings Page, so the scenario can be continued."
-            )
+            Log.d(STEP_TAG, "Did not throw the user back to the Settings Page, so the scenario can be continued.")
         }
+
+        Log.d(STEP_TAG, "Assert that the Profile Settings Page is displayed and the username is '$newUserName'.")
         profileSettingsPage.assertPageObjects()
         profileSettingsPage.assertUserNameIs(newUserName)
 

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/SpeedGraderE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/SpeedGraderE2ETest.kt
@@ -26,6 +26,9 @@ import com.instructure.canvas.espresso.E2E
 import com.instructure.canvas.espresso.refresh
 import com.instructure.canvas.espresso.withCustomConstraints
 import com.instructure.dataseeding.api.SubmissionsApi
+import com.instructure.dataseeding.model.AssignmentApiModel
+import com.instructure.dataseeding.model.CanvasUserApiModel
+import com.instructure.dataseeding.model.CourseApiModel
 import com.instructure.dataseeding.model.SubmissionType
 import com.instructure.dataseeding.util.days
 import com.instructure.dataseeding.util.fromNow
@@ -90,14 +93,7 @@ class SpeedGraderE2ETest : TeacherTest() {
         )
 
         Log.d(PREPARATION_TAG,"Grade the previously seeded submission for ${gradedStudent.name} student.")
-        SubmissionsApi.gradeSubmission(
-                teacherToken = teacher.token,
-                courseId = course.id,
-                assignmentId = assignment[0].id,
-                studentId = gradedStudent.id,
-                postedGrade = "15",
-                excused = false
-        )
+        gradeSubmission(teacher, course, assignment, gradedStudent)
 
         Log.d(STEP_TAG, "Login with user: ${teacher.name}, login id: ${teacher.loginId}.")
         tokenLogin(teacher)
@@ -186,5 +182,21 @@ class SpeedGraderE2ETest : TeacherTest() {
         postSettingsPage.clickOnHideGradesButton()
         assignmentSubmissionListPage.assertGradesHidden(gradedStudent.name)
         assignmentSubmissionListPage.assertGradesHidden(student.name)
+    }
+
+    private fun gradeSubmission(
+        teacher: CanvasUserApiModel,
+        course: CourseApiModel,
+        assignment: List<AssignmentApiModel>,
+        gradedStudent: CanvasUserApiModel
+    ) {
+        SubmissionsApi.gradeSubmission(
+            teacherToken = teacher.token,
+            courseId = course.id,
+            assignmentId = assignment[0].id,
+            studentId = gradedStudent.id,
+            postedGrade = "15",
+            excused = false
+        )
     }
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/SyllabusE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/SyllabusE2ETest.kt
@@ -18,9 +18,7 @@ import org.junit.Test
 class SyllabusE2ETest : TeacherTest() {
     override fun displaysPageObjects() = Unit
 
-    override fun enableAndConfigureAccessibilityChecks() {
-        //We don't want to see accessibility errors on E2E tests
-    }
+    override fun enableAndConfigureAccessibilityChecks() = Unit
 
     @E2E
     @Test

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/TodoE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/TodoE2ETest.kt
@@ -19,6 +19,9 @@ package com.instructure.teacher.ui.e2e
 import android.util.Log
 import com.instructure.canvas.espresso.E2E
 import com.instructure.dataseeding.api.SubmissionsApi
+import com.instructure.dataseeding.model.AssignmentApiModel
+import com.instructure.dataseeding.model.CanvasUserApiModel
+import com.instructure.dataseeding.model.CourseApiModel
 import com.instructure.dataseeding.model.SubmissionType
 import com.instructure.dataseeding.util.days
 import com.instructure.dataseeding.util.fromNow
@@ -35,9 +38,7 @@ import org.junit.Test
 class TodoE2ETest : TeacherTest() {
     override fun displaysPageObjects() = Unit
 
-    override fun enableAndConfigureAccessibilityChecks() {
-        //We don't want to see accessibility errors on E2E tests
-    }
+    override fun enableAndConfigureAccessibilityChecks() = Unit
 
     @E2E
     @Test
@@ -82,17 +83,26 @@ class TodoE2ETest : TeacherTest() {
         todoPage.assertTodoElementIsDisplayed(course.name)
 
         Log.d(PREPARATION_TAG,"Grade the previously seeded submission for ${student.name} student.")
-        SubmissionsApi.gradeSubmission(
-                teacherToken = teacher.token,
-                courseId = course.id,
-                assignmentId = assignment[0].id,
-                studentId = student.id,
-                postedGrade = "15",
-                excused = false
-        )
+        gradeSubmission(teacher, course, assignment, student)
 
         Log.d(STEP_TAG,"Refresh the To Do Page. Assert that the empty view is displayed so that the To Do has disappeared because it has been graded.")
         todoPage.refresh()
         todoPage.assertEmptyView()
+    }
+
+    private fun gradeSubmission(
+        teacher: CanvasUserApiModel,
+        course: CourseApiModel,
+        assignment: List<AssignmentApiModel>,
+        student: CanvasUserApiModel
+    ) {
+        SubmissionsApi.gradeSubmission(
+            teacherToken = teacher.token,
+            courseId = course.id,
+            assignmentId = assignment[0].id,
+            studentId = student.id,
+            postedGrade = "15",
+            excused = false
+        )
     }
 }


### PR DESCRIPTION
Extract API calls from Teacher E2E tests into private methods. (Further improvements will be done with this in the future, see MBL-16533)

Put back filesE2E test from known bug to nightly

refs: MBL-16517
affects: Teacher
release note: none

Teacher E2E test run (successful): https://app.bitrise.io/build/ce38ab57-4a9e-4fa6-a924-f3159871e923