### PR TITLE
[MBL-16532][Student][Teacher] Can add self from recipients list

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/InboxComposeMessageFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/InboxComposeMessageFragment.kt
@@ -32,7 +32,6 @@ import com.instructure.canvasapi2.managers.GroupManager
 import com.instructure.canvasapi2.managers.InboxManager
 import com.instructure.canvasapi2.models.*
 import com.instructure.canvasapi2.utils.APIHelper
-import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.canvasapi2.utils.isValid
 import com.instructure.canvasapi2.utils.weave.*
 import com.instructure.interactions.router.Route
@@ -442,14 +441,12 @@ class InboxComposeMessageFragment : ParentFragment(), FileUploadDialogParent {
     }
 
     private fun addInitialRecipients(initialRecipientIds: List<Long>) {
-        val myId = ApiPrefs.user?.id?.toString().orEmpty()
-        val isMonologue = initialRecipientIds.size == 1
         val recipients = initialRecipientIds
             .mapNotNull { longId ->
                 val id = longId.toString()
                 participants.find {
-                    // Map IDs to participants (excluding the current user if not monologue)
-                    it.stringId == id && (isMonologue || it.stringId != myId)
+                    // Map IDs to participants
+                    it.stringId == id
                 }
             }
             .minus(chips.recipients)
@@ -458,10 +455,9 @@ class InboxComposeMessageFragment : ParentFragment(), FileUploadDialogParent {
 
     private fun addRecipients(newRecipients: List<Recipient>) {
         val selectedRecipients = chips.recipients
-        val myId = ApiPrefs.user?.id?.toString().orEmpty()
         val recipients = newRecipients.filter { recipient ->
-            // Skip existing recipients and self
-            recipient.stringId != myId && selectedRecipients.none { it.stringId == recipient.stringId }
+            // Skip existing recipients
+            selectedRecipients.none { it.stringId == recipient.stringId }
         }
         chips.addRecipients(recipients)
     }

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/AddMessageFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/AddMessageFragment.kt
@@ -28,7 +28,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.work.WorkInfo
 import com.instructure.canvasapi2.models.*
 import com.instructure.canvasapi2.utils.APIHelper
-import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.interactions.router.Route
 import com.instructure.pandautils.analytics.SCREEN_VIEW_INBOX_COMPOSE
 import com.instructure.pandautils.analytics.ScreenView
@@ -419,12 +418,11 @@ class AddMessageFragment : BasePresenterFragment<AddMessagePresenter, AddMessage
 
     private fun addInitialRecipients(initialRecipientIds: List<Long>) {
         val selectedRecipients = chips.recipients
-        val myId = ApiPrefs.user?.id?.toString().orEmpty()
         val recipients = initialRecipientIds
             .map { it.toString() }
             .filter { id ->
-                // Skip existing recipients and self
-                id != myId && selectedRecipients.none { it.stringId == id }
+                // Skip existing recipients
+                selectedRecipients.none { it.stringId == id }
             }
             .mapNotNull { presenter.getParticipantById(it) }
         chips.addRecipients(recipients)
@@ -432,11 +430,10 @@ class AddMessageFragment : BasePresenterFragment<AddMessagePresenter, AddMessage
 
     private fun addRecipients(newRecipients: List<Recipient>) {
         val selectedRecipients = chips.recipients
-        val myId = ApiPrefs.user?.id?.toString().orEmpty()
         val recipients = newRecipients.filter { recipient ->
-            // Skip existing recipients and self
+            // Skip existing recipients
             val stringId = recipient.stringId
-            stringId != myId && selectedRecipients.none { it.stringId == stringId }
+            selectedRecipients.none { it.stringId == stringId }
         }
         chips.addRecipients(recipients)
     }


### PR DESCRIPTION
refs: MBL-16532
affects: Student, Teacher
release note: Users can add themself to a message from the recipient selector screen.

test plan: See ticket.

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Run E2E test suite or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
- [x] Approve from product or not needed
