### PR TITLE
[MBL-16496][Student] Grades loading indicator

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/GradesListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/GradesListFragment.kt
@@ -174,7 +174,7 @@ class GradesListFragment : ParentFragment(), Bookmarkable {
             // cached data, so fast.
             if (!showWhatIfCheckBox.isChecked) {
                 recyclerAdapter.whatIfGrade = null
-                recyclerAdapter.refresh()
+                recyclerAdapter.loadCachedData()
             } else {
                 // Only log when what if grades is checked on
                 Analytics.logEvent(AnalyticsEventConstants.WHAT_IF_GRADES)
@@ -252,7 +252,7 @@ class GradesListFragment : ParentFragment(), Bookmarkable {
                         recyclerAdapter.loadData()
                     } else {
                         if(termAdapter?.isEmpty == false) {
-                            recyclerAdapter.loadAssignmentsForGradingPeriod(termAdapter?.getItem(position)?.id ?: 0, true)
+                            recyclerAdapter.loadAssignmentsForGradingPeriod(termAdapter?.getItem(position)?.id ?: 0, true, true)
                             termSpinner.isEnabled = false
                             termAdapter?.isLoading = true
                             termAdapter?.notifyDataSetChanged()


### PR DESCRIPTION
Test plan: In the ticket. Instead of adding a loading indicator as the ticket suggests I added a cache loading to load the grades immediately when exiting "what if" mode.

refs: MBL-16496
affects: Student
release note: none

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Run E2E test suite or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
- [x] Approve from product or not needed
