### PR TITLE
[MBL-16531][Student][Teacher] - Extend and major refactor on inbox E2E tests

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/InboxE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/InboxE2ETest.kt
@@ -37,13 +37,9 @@ import org.junit.Test
 
 @HiltAndroidTest
 class InboxE2ETest: StudentTest() {
-    override fun displaysPageObjects() {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-    }
+    override fun displaysPageObjects() = Unit
 
-    override fun enableAndConfigureAccessibilityChecks() {
-        //We don't want to see accessibility errors on E2E tests
-    }
+    override fun enableAndConfigureAccessibilityChecks() = Unit
 
     @E2E
     @Test
@@ -184,5 +180,143 @@ class InboxE2ETest: StudentTest() {
         inboxPage.assertConversationDisplayed(seededConversation)
         inboxPage.assertConversationNotDisplayed("Group Message")
 
+        Log.d(STEP_TAG, "Select '${seededConversation.subject}' conversation. Assert that the selected number of conversations on the toolbar is 1." +
+                "Unarchive it, and assert that it is not displayed in the 'ARCHIVED' scope any more.")
+        inboxPage.selectConversation(seededConversation)
+        inboxPage.assertSelectedConversationNumber("1")
+        inboxPage.clickUnArchive()
+        inboxPage.assertConversationNotDisplayed(seededConversation.subject)
+
+        Log.d(STEP_TAG,"Navigate to 'INBOX' scope and assert that ${seededConversation.subject} conversation is displayed.")
+        inboxPage.selectInboxScope(InboxApi.Scope.INBOX)
+        inboxPage.assertConversationDisplayed(seededConversation.subject)
+
+        Log.d(STEP_TAG, "Select both of the conversations (${seededConversation.subject} and $newGroupMessageSubject) and star them." +
+                "Assert that the selected number of conversations on the toolbar is 2 and both of the has been starred.")
+        inboxPage.selectConversations(listOf(seededConversation.subject, newGroupMessageSubject))
+        inboxPage.clickStar()
+        inboxPage.assertConversationStarred(seededConversation.subject)
+        inboxPage.assertConversationStarred(newGroupMessageSubject)
+
+        Log.d(STEP_TAG, "Mark them as read (since if at least there is one unread selected, we are showing the 'Mark as Read' icon). Assert that both of them are read.")
+        inboxPage.clickMarkAsRead()
+        inboxPage.assertUnreadMarkerVisibility(seededConversation.subject, ViewMatchers.Visibility.GONE)
+        inboxPage.assertUnreadMarkerVisibility(newGroupMessageSubject, ViewMatchers.Visibility.GONE)
+
+        Log.d(STEP_TAG, "Mark them as unread. Assert that both of them will became unread.")
+        inboxPage.clickMarkAsUnread()
+        inboxPage.assertUnreadMarkerVisibility(seededConversation.subject, ViewMatchers.Visibility.VISIBLE)
+        inboxPage.assertUnreadMarkerVisibility(newGroupMessageSubject, ViewMatchers.Visibility.VISIBLE)
+
+        Log.d(STEP_TAG, "Archive both of them. Assert that non of them are displayed in the 'INBOX' scope.")
+        inboxPage.clickArchive()
+        inboxPage.assertConversationNotDisplayed(seededConversation.subject)
+        inboxPage.assertConversationNotDisplayed(newGroupMessageSubject)
+
+        Log.d(STEP_TAG, "Navigate to 'ARCHIVED' scope and assert that both of the conversations are displayed there.")
+        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.assertConversationDisplayed(seededConversation.subject)
+        inboxPage.assertConversationDisplayed(newGroupMessageSubject)
+
+        Log.d(STEP_TAG, "Navigate to 'UNREAD' scope and assert that none of the conversations are displayed there, because a conversation cannot be archived and unread at the same time.")
+        inboxPage.selectInboxScope(InboxApi.Scope.UNREAD)
+        inboxPage.assertConversationNotDisplayed(seededConversation.subject)
+        inboxPage.assertConversationNotDisplayed(newGroupMessageSubject)
+
+        Log.d(STEP_TAG, "Navigate to 'UNREAD' scope and assert that both of the conversations are displayed there.")
+        inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
+        inboxPage.assertConversationDisplayed(seededConversation.subject)
+        inboxPage.assertConversationDisplayed(newGroupMessageSubject)
+
+        Log.d(STEP_TAG, "Select both of the conversations. Unstar them, and assert that none of them are displayed in the 'STARRED' scope.")
+        inboxPage.selectConversations(listOf(seededConversation.subject, newGroupMessageSubject))
+        inboxPage.clickUnstar()
+        inboxPage.assertConversationNotDisplayed(seededConversation.subject)
+        inboxPage.assertConversationNotDisplayed(newGroupMessageSubject)
+
+        Log.d(STEP_TAG, "Navigate to 'ARCHIVED' scope and assert that both of the conversations are displayed there.")
+        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.assertConversationDisplayed(seededConversation.subject)
+        inboxPage.assertConversationDisplayed(newGroupMessageSubject)
+
+        Log.d(STEP_TAG, "Select both of the conversations. Unarchive them, and assert that none of them are displayed in the 'ARCHIVED' scope.")
+        inboxPage.selectConversations(listOf(seededConversation.subject, newGroupMessageSubject))
+        inboxPage.clickUnArchive()
+        inboxPage.assertConversationNotDisplayed(seededConversation.subject)
+        inboxPage.assertConversationNotDisplayed(newGroupMessageSubject)
+
+        Log.d(STEP_TAG, "Navigate to 'INBOX' scope and assert that both of the conversations are displayed there.")
+        inboxPage.selectInboxScope(InboxApi.Scope.INBOX)
+        inboxPage.assertConversationDisplayed(seededConversation.subject)
+        inboxPage.assertConversationDisplayed(newGroupMessageSubject)
+
+        Log.d(STEP_TAG, "Select '${seededConversation.subject}' conversation and swipe it right to make it unread. Assert that the conversation became unread.")
+        inboxPage.selectConversation(seededConversation.subject)
+        inboxPage.swipeConversationRight(seededConversation)
+        inboxPage.assertUnreadMarkerVisibility(seededConversation.subject, ViewMatchers.Visibility.VISIBLE)
+
+        Log.d(STEP_TAG, "Select '${seededConversation.subject}' conversation and swipe it right again to make it read. Assert that the conversation became read.")
+        inboxPage.swipeConversationRight(seededConversation)
+        inboxPage.assertUnreadMarkerVisibility(seededConversation.subject, ViewMatchers.Visibility.GONE)
+
+        Log.d(STEP_TAG, "Swipe '${seededConversation.subject}' left and assert it is removed from the 'INBOX' scope because it has became archived.")
+        inboxPage.swipeConversationLeft(seededConversation)
+        inboxPage.assertConversationNotDisplayed(seededConversation.subject)
+
+        Log.d(STEP_TAG, "Navigate to 'ARCHIVED' scope. Assert that the '${seededConversation.subject}' conversation is displayed in the 'ARCHIVED' scope.")
+        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.assertConversationDisplayed(seededConversation.subject)
+
+        Log.d(STEP_TAG, "Swipe '${seededConversation.subject}' left and assert it is removed from the 'ARCHIVED' scope because it has became unarchived.")
+        inboxPage.swipeConversationLeft(seededConversation)
+        inboxPage.assertConversationNotDisplayed(seededConversation.subject)
+
+        Log.d(STEP_TAG, "Navigate to 'INBOX' scope. Assert that the '${seededConversation.subject}' conversation is displayed in the 'INBOX' scope.")
+        inboxPage.selectInboxScope(InboxApi.Scope.INBOX)
+        inboxPage.assertConversationDisplayed(seededConversation.subject)
+
+        Log.d(STEP_TAG, "Select both of the conversations. Star them and mark the unread.")
+        inboxPage.selectConversations(listOf(seededConversation.subject, newGroupMessageSubject))
+        inboxPage.clickStar()
+        inboxPage.assertSelectedConversationNumber("2")
+        inboxPage.clickMarkAsUnread()
+
+        Log.d(STEP_TAG, "Navigate to 'STARRED' scope. Assert that both of the conversation are displayed in the 'STARRED' scope.")
+        inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
+        inboxPage.assertConversationDisplayed(seededConversation.subject)
+        inboxPage.assertConversationDisplayed(newGroupMessageSubject)
+
+        Log.d(STEP_TAG, "Swipe '${seededConversation.subject}' left and assert it is removed from the 'STARRED' scope because it has became unstarred.")
+        inboxPage.swipeConversationLeft(seededConversation)
+        inboxPage.assertConversationNotDisplayed(seededConversation.subject)
+
+        Log.d(STEP_TAG, "Assert that '$newGroupMessageSubject' conversation is unread.")
+        inboxPage.assertUnreadMarkerVisibility(newGroupMessageSubject, ViewMatchers.Visibility.VISIBLE)
+
+        Log.d(STEP_TAG, "Swipe '$newGroupMessageSubject' conversation right and assert that it has became read.")
+        inboxPage.swipeConversationRight(newGroupMessageSubject)
+        inboxPage.assertUnreadMarkerVisibility(newGroupMessageSubject, ViewMatchers.Visibility.GONE)
+
+        Log.d(STEP_TAG, "Navigate to 'UNREAD' scope. Assert that only the '${seededConversation.subject}' conversation is displayed in the 'UNREAD' scope.")
+        inboxPage.selectInboxScope(InboxApi.Scope.UNREAD)
+        inboxPage.assertConversationDisplayed(seededConversation.subject)
+        inboxPage.assertConversationNotDisplayed(newGroupMessageSubject)
+
+        Log.d(STEP_TAG, "Swipe '${seededConversation.subject}' conversation left and assert it has been removed from the 'UNREAD' scope since it has became read.")
+        inboxPage.swipeConversationLeft(seededConversation)
+        inboxPage.assertConversationNotDisplayed(seededConversation.subject)
+
+        Log.d(STEP_TAG, "Navigate to 'ARCHIVED' scope. Assert that the '${seededConversation.subject}' conversation is displayed in the 'ARCHIVED' scope.")
+        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.assertConversationDisplayed(seededConversation.subject)
+
+        Log.d(STEP_TAG, "Navigate to 'INBOX' scope and seledct '$newGroupMessageSubject' conversation.")
+        inboxPage.selectInboxScope(InboxApi.Scope.INBOX)
+        inboxPage.selectConversation(newGroupMessageSubject)
+
+        Log.d(STEP_TAG, "Delete the '$newGroupMessageSubject' conversation and assert that it has been removed from the 'INBOX' scope.")
+        inboxPage.clickDelete()
+        inboxPage.confirmDelete()
+        inboxPage.assertConversationNotDisplayed(newGroupMessageSubject)
     }
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/InboxE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/InboxE2ETest.kt
@@ -22,7 +22,6 @@ import androidx.test.espresso.Espresso
 import androidx.test.espresso.matcher.ViewMatchers
 import com.instructure.canvas.espresso.E2E
 import com.instructure.canvas.espresso.refresh
-import com.instructure.canvasapi2.apis.InboxApi
 import com.instructure.dataseeding.api.ConversationsApi
 import com.instructure.dataseeding.api.GroupsApi
 import com.instructure.panda_annotations.FeatureCategory
@@ -174,7 +173,7 @@ class InboxE2ETest: StudentTest() {
         inboxPage.assertConversationNotDisplayed(seededConversation)
 
         Log.d(STEP_TAG,"Select 'Archived' conversation filter.")
-        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.filterInbox("Archived")
 
         Log.d(STEP_TAG,"Assert that ${seededConversation.subject} conversation is displayed by the 'Archived' filter, and other conversations are not displayed.")
         inboxPage.assertConversationDisplayed(seededConversation)
@@ -188,7 +187,7 @@ class InboxE2ETest: StudentTest() {
         inboxPage.assertConversationNotDisplayed(seededConversation.subject)
 
         Log.d(STEP_TAG,"Navigate to 'INBOX' scope and assert that ${seededConversation.subject} conversation is displayed.")
-        inboxPage.selectInboxScope(InboxApi.Scope.INBOX)
+        inboxPage.filterInbox("Inbox")
         inboxPage.assertConversationDisplayed(seededConversation.subject)
 
         Log.d(STEP_TAG, "Select both of the conversations (${seededConversation.subject} and $newGroupMessageSubject) and star them." +
@@ -214,17 +213,17 @@ class InboxE2ETest: StudentTest() {
         inboxPage.assertConversationNotDisplayed(newGroupMessageSubject)
 
         Log.d(STEP_TAG, "Navigate to 'ARCHIVED' scope and assert that both of the conversations are displayed there.")
-        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.filterInbox("Archived")
         inboxPage.assertConversationDisplayed(seededConversation.subject)
         inboxPage.assertConversationDisplayed(newGroupMessageSubject)
 
         Log.d(STEP_TAG, "Navigate to 'UNREAD' scope and assert that none of the conversations are displayed there, because a conversation cannot be archived and unread at the same time.")
-        inboxPage.selectInboxScope(InboxApi.Scope.UNREAD)
+        inboxPage.filterInbox("Unread")
         inboxPage.assertConversationNotDisplayed(seededConversation.subject)
         inboxPage.assertConversationNotDisplayed(newGroupMessageSubject)
 
-        Log.d(STEP_TAG, "Navigate to 'UNREAD' scope and assert that both of the conversations are displayed there.")
-        inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
+        Log.d(STEP_TAG, "Navigate to 'STARRED' scope and assert that both of the conversations are displayed there.")
+        inboxPage.filterInbox("Starred")
         inboxPage.assertConversationDisplayed(seededConversation.subject)
         inboxPage.assertConversationDisplayed(newGroupMessageSubject)
 
@@ -235,7 +234,7 @@ class InboxE2ETest: StudentTest() {
         inboxPage.assertConversationNotDisplayed(newGroupMessageSubject)
 
         Log.d(STEP_TAG, "Navigate to 'ARCHIVED' scope and assert that both of the conversations are displayed there.")
-        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.filterInbox("Archived")
         inboxPage.assertConversationDisplayed(seededConversation.subject)
         inboxPage.assertConversationDisplayed(newGroupMessageSubject)
 
@@ -246,7 +245,7 @@ class InboxE2ETest: StudentTest() {
         inboxPage.assertConversationNotDisplayed(newGroupMessageSubject)
 
         Log.d(STEP_TAG, "Navigate to 'INBOX' scope and assert that both of the conversations are displayed there.")
-        inboxPage.selectInboxScope(InboxApi.Scope.INBOX)
+        inboxPage.filterInbox("Inbox")
         inboxPage.assertConversationDisplayed(seededConversation.subject)
         inboxPage.assertConversationDisplayed(newGroupMessageSubject)
 
@@ -264,7 +263,7 @@ class InboxE2ETest: StudentTest() {
         inboxPage.assertConversationNotDisplayed(seededConversation.subject)
 
         Log.d(STEP_TAG, "Navigate to 'ARCHIVED' scope. Assert that the '${seededConversation.subject}' conversation is displayed in the 'ARCHIVED' scope.")
-        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.filterInbox("Archived")
         inboxPage.assertConversationDisplayed(seededConversation.subject)
 
         Log.d(STEP_TAG, "Swipe '${seededConversation.subject}' left and assert it is removed from the 'ARCHIVED' scope because it has became unarchived.")
@@ -272,7 +271,7 @@ class InboxE2ETest: StudentTest() {
         inboxPage.assertConversationNotDisplayed(seededConversation.subject)
 
         Log.d(STEP_TAG, "Navigate to 'INBOX' scope. Assert that the '${seededConversation.subject}' conversation is displayed in the 'INBOX' scope.")
-        inboxPage.selectInboxScope(InboxApi.Scope.INBOX)
+        inboxPage.filterInbox("Inbox")
         inboxPage.assertConversationDisplayed(seededConversation.subject)
 
         Log.d(STEP_TAG, "Select both of the conversations. Star them and mark the unread.")
@@ -282,7 +281,7 @@ class InboxE2ETest: StudentTest() {
         inboxPage.clickMarkAsUnread()
 
         Log.d(STEP_TAG, "Navigate to 'STARRED' scope. Assert that both of the conversation are displayed in the 'STARRED' scope.")
-        inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
+        inboxPage.filterInbox("Starred")
         inboxPage.assertConversationDisplayed(seededConversation.subject)
         inboxPage.assertConversationDisplayed(newGroupMessageSubject)
 
@@ -298,7 +297,7 @@ class InboxE2ETest: StudentTest() {
         inboxPage.assertUnreadMarkerVisibility(newGroupMessageSubject, ViewMatchers.Visibility.GONE)
 
         Log.d(STEP_TAG, "Navigate to 'UNREAD' scope. Assert that only the '${seededConversation.subject}' conversation is displayed in the 'UNREAD' scope.")
-        inboxPage.selectInboxScope(InboxApi.Scope.UNREAD)
+        inboxPage.filterInbox("Unread")
         inboxPage.assertConversationDisplayed(seededConversation.subject)
         inboxPage.assertConversationNotDisplayed(newGroupMessageSubject)
 
@@ -307,11 +306,11 @@ class InboxE2ETest: StudentTest() {
         inboxPage.assertConversationNotDisplayed(seededConversation.subject)
 
         Log.d(STEP_TAG, "Navigate to 'ARCHIVED' scope. Assert that the '${seededConversation.subject}' conversation is displayed in the 'ARCHIVED' scope.")
-        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.filterInbox("Archived")
         inboxPage.assertConversationDisplayed(seededConversation.subject)
 
         Log.d(STEP_TAG, "Navigate to 'INBOX' scope and seledct '$newGroupMessageSubject' conversation.")
-        inboxPage.selectInboxScope(InboxApi.Scope.INBOX)
+        inboxPage.filterInbox("Inbox")
         inboxPage.selectConversation(newGroupMessageSubject)
 
         Log.d(STEP_TAG, "Delete the '$newGroupMessageSubject' conversation and assert that it has been removed from the 'INBOX' scope.")

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/InboxInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/InboxInteractionTest.kt
@@ -645,12 +645,12 @@ class InboxInteractionTest : StudentTest() {
     @TestMetaData(Priority.IMPORTANT, FeatureCategory.INBOX, TestCategory.INTERACTION)
     fun testInbox_swipeToArchive() {
         val data = createInitialData()
-        data.addConversations(userId = student1.id, messageBody = "Short body")
         val conversation = data.addConversation(
             senderId = data.teachers.first().id,
             receiverIds = listOf(data.students.first().id),
             messageBody = "Body",
             messageSubject = "Subject")
+        data.addConversations(userId = student1.id, messageBody = "Short body")
 
         dashboardPage.clickInboxTab()
         inboxPage.swipeConversationLeft(conversation)
@@ -664,12 +664,12 @@ class InboxInteractionTest : StudentTest() {
     @TestMetaData(Priority.IMPORTANT, FeatureCategory.INBOX, TestCategory.INTERACTION)
     fun testInbox_swipeToUnstar() {
         val data = createInitialData()
-        data.addConversations(userId = student1.id, messageBody = "Short body")
         val conversation = data.addConversation(
             senderId = data.teachers.first().id,
             receiverIds = listOf(data.students.first().id),
             messageBody = "Body",
             messageSubject = "Subject")
+        data.addConversations(userId = student1.id, messageBody = "Short body")
         data.conversations[conversation.id] = conversation.copy(isStarred = true)
 
         dashboardPage.clickInboxTab()

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/InboxInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/InboxInteractionTest.kt
@@ -18,7 +18,6 @@ package com.instructure.student.ui.interaction
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.matcher.ViewMatchers
 import com.instructure.canvas.espresso.mockCanvas.*
-import com.instructure.canvasapi2.apis.InboxApi
 import com.instructure.canvasapi2.models.*
 import com.instructure.panda_annotations.FeatureCategory
 import com.instructure.panda_annotations.Priority
@@ -47,7 +46,8 @@ class InboxInteractionTest : StudentTest() {
         newMessagePage.setSubject(subject)
         newMessagePage.setMessage("Hodor, Hodor? Hodor!")
         newMessagePage.clickSend()
-        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+        //inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+        inboxPage.filterInbox("Sent")
         inboxPage.assertConversationDisplayed(subject)
     }
 
@@ -65,7 +65,8 @@ class InboxInteractionTest : StudentTest() {
         newMessagePage.setSubject(subject)
         newMessagePage.setMessage("Hodor, Hodor? Hodor!")
         newMessagePage.clickSend()
-        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+        //inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+        inboxPage.filterInbox("Sent")
         inboxPage.assertConversationDisplayed(subject)
     }
 
@@ -85,7 +86,8 @@ class InboxInteractionTest : StudentTest() {
         newMessagePage.setSubject(subject)
         newMessagePage.setMessage("Hodor, Hodor? Hodor!")
         newMessagePage.clickSend()
-        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+       // inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+        inboxPage.filterInbox("Sent")
         inboxPage.assertConversationDisplayed(subject)
     }
 
@@ -114,7 +116,8 @@ class InboxInteractionTest : StudentTest() {
             sentConversation,
             data
         )
-        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+       // inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+        inboxPage.filterInbox("Sent")
         inboxPage.openConversation(sentConversation)
         inboxConversationPage.assertAttachmentDisplayed(attachmentName)
     }
@@ -143,7 +146,8 @@ class InboxInteractionTest : StudentTest() {
             sentConversation,
             data
         )
-        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+       // inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+        inboxPage.filterInbox("Sent")
         inboxPage.openConversation(sentConversation)
         inboxConversationPage.assertAttachmentDisplayed(attachmentName)
     }
@@ -172,7 +176,8 @@ class InboxInteractionTest : StudentTest() {
             sentConversation,
             data
         )
-        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+      //  inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+        inboxPage.filterInbox("Sent")
         inboxPage.openConversation(sentConversation)
         inboxConversationPage.assertAttachmentDisplayed(attachmentName)
     }
@@ -232,7 +237,8 @@ class InboxInteractionTest : StudentTest() {
         val conversation = data.conversations.values.first {
             it.workflowState == Conversation.WorkflowState.UNREAD
         }
-        inboxPage.selectInboxScope(InboxApi.Scope.UNREAD)
+       // inboxPage.selectInboxScope(InboxApi.Scope.UNREAD)
+        inboxPage.filterInbox("Unread")
         inboxPage.assertConversationDisplayed(conversation.subject!!)
     }
 
@@ -246,7 +252,8 @@ class InboxInteractionTest : StudentTest() {
         val conversation = data.conversations.values.first {
             it.isStarred
         }
-        inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
+       // inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
+        inboxPage.filterInbox("Starred")
         inboxPage.assertConversationDisplayed(conversation.subject!!)
     }
 
@@ -260,7 +267,8 @@ class InboxInteractionTest : StudentTest() {
         val conversation = data.conversations.values.first {
             it.workflowState == Conversation.WorkflowState.UNREAD
         }
-        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+      //  inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+        inboxPage.filterInbox("Sent")
         inboxPage.assertConversationDisplayed(conversation.subject!!)
     }
 
@@ -274,7 +282,8 @@ class InboxInteractionTest : StudentTest() {
         val conversation = data.conversations.values.first {
             it.workflowState == Conversation.WorkflowState.ARCHIVED
         }
-        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+       // inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.filterInbox("Archived")
         inboxPage.assertConversationDisplayed(conversation.subject!!)
     }
 
@@ -304,7 +313,8 @@ class InboxInteractionTest : StudentTest() {
         newMessagePage.setSubject(subject)
         newMessagePage.setMessage("Hodor, Hodor? Hodor!")
         newMessagePage.clickSend()
-        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+      //  inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+        inboxPage.filterInbox("Sent")
         inboxPage.assertConversationDisplayed(subject)
     }
 
@@ -334,7 +344,8 @@ class InboxInteractionTest : StudentTest() {
         newMessagePage.setSubject(subject)
         newMessagePage.setMessage("Hodor, Hodor? Hodor!")
         newMessagePage.clickSend()
-        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+      //  inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+        inboxPage.filterInbox("Sent")
         inboxPage.assertConversationDisplayed(subject)
     }
 
@@ -438,7 +449,8 @@ class InboxInteractionTest : StudentTest() {
         inboxPage.assertConversationDisplayed(conversationSubject)
         inboxPage.openConversation(conversation)
         inboxConversationPage.archive() // Should kick you back to the main inbox page
-        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+      //  inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.filterInbox("Archived")
         inboxPage.assertConversationDisplayed(conversationSubject)
     }
 
@@ -519,7 +531,8 @@ class InboxInteractionTest : StudentTest() {
         inboxPage.assertConversationNotDisplayed(conversation1.subject ?: "")
         inboxPage.assertConversationNotDisplayed(conversation2.subject ?: "")
 
-        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        //inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.filterInbox("Archived")
         inboxPage.assertConversationDisplayed(conversation1.subject ?: "")
         inboxPage.assertConversationDisplayed(conversation2.subject ?: "")
     }
@@ -565,7 +578,8 @@ class InboxInteractionTest : StudentTest() {
         data.conversations[conversation2.id] = conversation2.copy(isStarred = true)
 
         dashboardPage.clickInboxTab()
-        inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
+        //inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
+        inboxPage.filterInbox("Starred")
         inboxPage.selectConversations(listOf(conversation1.subject!!, conversation2.subject!!))
         inboxPage.clickUnstar()
         inboxPage.assertConversationNotDisplayed(conversation1.subject ?: "")
@@ -589,6 +603,7 @@ class InboxInteractionTest : StudentTest() {
             messageSubject = "Subject 2")
 
         dashboardPage.clickInboxTab()
+
         inboxPage.selectConversations(listOf(conversation1.subject!!, conversation2.subject!!))
         inboxPage.clickMarkAsRead()
         inboxPage.assertUnreadMarkerVisibility(conversation1.subject ?: "", ViewMatchers.Visibility.GONE)
@@ -614,10 +629,13 @@ class InboxInteractionTest : StudentTest() {
             receiverIds = listOf(data.students.first().id),
             messageBody = "Body 2",
             messageSubject = "Subject 2")
+
         dashboardPage.clickInboxTab()
+
         inboxPage.selectConversations(listOf(conversation1.subject!!, conversation2.subject!!))
         inboxPage.clickDelete()
         inboxPage.confirmDelete()
+
         inboxPage.assertConversationNotDisplayed(conversation1.subject ?: "")
         inboxPage.assertConversationNotDisplayed(conversation2.subject ?: "")
     }
@@ -656,7 +674,8 @@ class InboxInteractionTest : StudentTest() {
         inboxPage.swipeConversationLeft(conversation)
         inboxPage.assertConversationNotDisplayed(conversation.subject ?: "")
 
-        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        //inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.filterInbox("Archived")
         inboxPage.assertConversationDisplayed(conversation.subject ?: "")
     }
 
@@ -673,7 +692,8 @@ class InboxInteractionTest : StudentTest() {
         data.conversations[conversation.id] = conversation.copy(isStarred = true)
 
         dashboardPage.clickInboxTab()
-        inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
+        //inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
+        inboxPage.filterInbox("Starred")
         inboxPage.swipeConversationLeft(conversation)
         inboxPage.assertConversationNotDisplayed(conversation.subject ?: "")
     }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/InboxInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/InboxInteractionTest.kt
@@ -17,20 +17,9 @@ package com.instructure.student.ui.interaction
 
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.matcher.ViewMatchers
-import com.instructure.canvas.espresso.mockCanvas.MockCanvas
-import com.instructure.canvas.espresso.mockCanvas.addConversation
-import com.instructure.canvas.espresso.mockCanvas.addConversations
-import com.instructure.canvas.espresso.mockCanvas.addConversationsToCourseMap
-import com.instructure.canvas.espresso.mockCanvas.addCoursePermissions
-import com.instructure.canvas.espresso.mockCanvas.addRecipientsToCourse
-import com.instructure.canvas.espresso.mockCanvas.addSentConversation
-import com.instructure.canvas.espresso.mockCanvas.init
+import com.instructure.canvas.espresso.mockCanvas.*
 import com.instructure.canvasapi2.apis.InboxApi
-import com.instructure.canvasapi2.models.Attachment
-import com.instructure.canvasapi2.models.CanvasContextPermission
-import com.instructure.canvasapi2.models.Conversation
-import com.instructure.canvasapi2.models.Course
-import com.instructure.canvasapi2.models.User
+import com.instructure.canvasapi2.models.*
 import com.instructure.panda_annotations.FeatureCategory
 import com.instructure.panda_annotations.Priority
 import com.instructure.panda_annotations.TestCategory
@@ -525,8 +514,7 @@ class InboxInteractionTest : StudentTest() {
             messageBody = "Body 2",
             messageSubject = "Subject 2")
         dashboardPage.clickInboxTab()
-        inboxPage.selectConversation(conversation1)
-        inboxPage.selectConversation(conversation2)
+        inboxPage.selectConversations(listOf(conversation1.subject!!, conversation2.subject!!))
         inboxPage.clickArchive()
         inboxPage.assertConversationNotDisplayed(conversation1.subject ?: "")
         inboxPage.assertConversationNotDisplayed(conversation2.subject ?: "")
@@ -552,8 +540,7 @@ class InboxInteractionTest : StudentTest() {
             messageBody = "Body 2",
             messageSubject = "Subject 2")
         dashboardPage.clickInboxTab()
-        inboxPage.selectConversation(conversation1)
-        inboxPage.selectConversation(conversation2)
+        inboxPage.selectConversations(listOf(conversation1.subject!!, conversation2.subject!!))
         inboxPage.clickStar()
         inboxPage.assertConversationStarred(conversation1.subject ?: "")
         inboxPage.assertConversationStarred(conversation2.subject ?: "")
@@ -579,8 +566,7 @@ class InboxInteractionTest : StudentTest() {
 
         dashboardPage.clickInboxTab()
         inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
-        inboxPage.selectConversation(conversation1)
-        inboxPage.selectConversation(conversation2)
+        inboxPage.selectConversations(listOf(conversation1.subject!!, conversation2.subject!!))
         inboxPage.clickUnstar()
         inboxPage.assertConversationNotDisplayed(conversation1.subject ?: "")
         inboxPage.assertConversationNotDisplayed(conversation2.subject ?: "")
@@ -603,8 +589,7 @@ class InboxInteractionTest : StudentTest() {
             messageSubject = "Subject 2")
 
         dashboardPage.clickInboxTab()
-        inboxPage.selectConversation(conversation1)
-        inboxPage.selectConversation(conversation2)
+        inboxPage.selectConversations(listOf(conversation1.subject!!, conversation2.subject!!))
         inboxPage.clickMarkAsRead()
         inboxPage.assertUnreadMarkerVisibility(conversation1.subject ?: "", ViewMatchers.Visibility.GONE)
         inboxPage.assertUnreadMarkerVisibility(conversation2.subject ?: "", ViewMatchers.Visibility.GONE)
@@ -630,8 +615,7 @@ class InboxInteractionTest : StudentTest() {
             messageBody = "Body 2",
             messageSubject = "Subject 2")
         dashboardPage.clickInboxTab()
-        inboxPage.selectConversation(conversation1)
-        inboxPage.selectConversation(conversation2)
+        inboxPage.selectConversations(listOf(conversation1.subject!!, conversation2.subject!!))
         inboxPage.clickDelete()
         inboxPage.confirmDelete()
         inboxPage.assertConversationNotDisplayed(conversation1.subject ?: "")

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
@@ -178,8 +178,8 @@ class InboxPage : BasePage(R.id.inboxPage) {
     fun selectConversation(conversationSubject: String) {
         waitForView(withId(R.id.inboxRecyclerView))
         val matcher = withText(conversationSubject)
-        scrollRecyclerView(R.id.inboxRecyclerView, matcher)
-        onView(matcher).longClick()
+        //scrollRecyclerView(R.id.inboxRecyclerView, matcher)
+        onView(matcher).scrollTo().longClick()
     }
 
     fun selectConversation(conversation: Conversation) {
@@ -258,6 +258,7 @@ class InboxPage : BasePage(R.id.inboxPage) {
     }
 
     fun selectConversations(conversations: List<String>) {
+        refresh()
         for(conversation in conversations) {
             selectConversation(conversation)
         }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
@@ -29,7 +29,6 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.instructure.canvas.espresso.refresh
 import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.canvas.espresso.waitForMatcherWithRefreshes
-import com.instructure.canvasapi2.apis.InboxApi
 import com.instructure.canvasapi2.models.Conversation
 import com.instructure.canvasapi2.models.Course
 import com.instructure.dataseeding.model.ConversationApiModel
@@ -90,17 +89,11 @@ class InboxPage : BasePage(R.id.inboxPage) {
         onView(matcher).click()
     }
 
-    fun selectInboxScope(scope: InboxApi.Scope) {
+    fun filterInbox(filterFor: String) {
         refresh()
         waitForView(withId(R.id.scopeFilterText))
         scopeButton.click()
-        when (scope) {
-            InboxApi.Scope.INBOX -> onViewWithText("Inbox").scrollTo().click()
-            InboxApi.Scope.UNREAD -> onViewWithText("Unread").scrollTo().click()
-            InboxApi.Scope.ARCHIVED -> onViewWithText("Archived").scrollTo().click()
-            InboxApi.Scope.STARRED -> onViewWithText("Starred").scrollTo().click()
-            InboxApi.Scope.SENT -> onViewWithText("Sent").scrollTo().click()
-        }
+        waitForViewWithText(filterFor).click()
     }
 
     fun selectInboxFilter(course: Course) {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
@@ -54,8 +54,8 @@ class InboxPage : BasePage(R.id.inboxPage) {
 
     fun assertConversationDisplayed(subject: String) {
         val matcher = withText(subject)
-        scrollRecyclerView(R.id.inboxRecyclerView, matcher)
-        onView(matcher).assertDisplayed()
+       // scrollRecyclerView(R.id.inboxRecyclerView, matcher)
+        onView(matcher).scrollTo().assertDisplayed()
     }
 
     fun assertConversationNotDisplayed(conversation: ConversationApiModel) {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
@@ -91,7 +91,7 @@ class InboxPage : BasePage(R.id.inboxPage) {
     }
 
     fun selectInboxScope(scope: InboxApi.Scope) {
-        onView(withId(R.id.swipeRefreshLayout)).swipeDown()
+        onView(withId(R.id.inboxRecyclerView)).swipeDown()
         waitForView(withId(R.id.scopeFilterText))
         scopeButton.click()
         when (scope) {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
@@ -91,6 +91,7 @@ class InboxPage : BasePage(R.id.inboxPage) {
     }
 
     fun selectInboxScope(scope: InboxApi.Scope) {
+        onView(withId(R.id.swipeRefreshLayout)).swipeDown()
         waitForView(withId(R.id.scopeFilterText))
         scopeButton.click()
         when (scope) {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
@@ -125,8 +125,8 @@ class InboxPage : BasePage(R.id.inboxPage) {
             hasSibling(withId(R.id.date)),
             hasSibling(allOf(withId(R.id.subjectView), withText(subject))))
         waitForMatcherWithRefreshes(matcher) // May need to refresh before the star shows up
-        scrollRecyclerView(R.id.inboxRecyclerView, matcher)
-        onView(matcher).assertDisplayed()
+       // scrollRecyclerView(R.id.inboxRecyclerView, matcher)
+        onView(matcher).scrollTo().assertDisplayed()
 
     }
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
@@ -228,8 +228,8 @@ class InboxPage : BasePage(R.id.inboxPage) {
     fun swipeConversationRight(conversationSubject: String) {
         waitForView(withId(R.id.inboxRecyclerView))
         val matcher = withText(conversationSubject)
-        scrollRecyclerView(R.id.inboxRecyclerView, matcher)
-        onView(matcher).swipeRight()
+      //  scrollRecyclerView(R.id.inboxRecyclerView, matcher)
+        onView(matcher).scrollTo().swipeRight()
     }
 
     fun swipeConversationRight(conversation: ConversationApiModel) {
@@ -243,8 +243,8 @@ class InboxPage : BasePage(R.id.inboxPage) {
     fun swipeConversationLeft(conversationSubject: String) {
         waitForView(withId(R.id.inboxRecyclerView))
         val matcher = withText(conversationSubject)
-        scrollRecyclerView(R.id.inboxRecyclerView, matcher)
-        onView(matcher).swipeLeft()
+      //  scrollRecyclerView(R.id.inboxRecyclerView, matcher)
+        onView(matcher).scrollTo().swipeLeft()
     }
 
     fun swipeConversationLeft(conversation: Conversation) {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
@@ -21,7 +21,10 @@ import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.hasSibling
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry
 import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.canvas.espresso.waitForMatcherWithRefreshes
@@ -29,23 +32,8 @@ import com.instructure.canvasapi2.apis.InboxApi
 import com.instructure.canvasapi2.models.Conversation
 import com.instructure.canvasapi2.models.Course
 import com.instructure.dataseeding.model.ConversationApiModel
-import com.instructure.espresso.OnViewWithId
-import com.instructure.espresso.RecyclerViewItemCountGreaterThanAssertion
-import com.instructure.espresso.WaitForViewWithId
-import com.instructure.espresso.assertDisplayed
-import com.instructure.espresso.click
-import com.instructure.espresso.longClick
-import com.instructure.espresso.page.BasePage
-import com.instructure.espresso.page.onView
-import com.instructure.espresso.page.onViewWithText
-import com.instructure.espresso.page.waitForView
-import com.instructure.espresso.page.waitForViewWithId
-import com.instructure.espresso.page.waitForViewWithText
-import com.instructure.espresso.page.withId
-import com.instructure.espresso.page.withText
-import com.instructure.espresso.scrollTo
-import com.instructure.espresso.swipeLeft
-import com.instructure.espresso.swipeRight
+import com.instructure.espresso.*
+import com.instructure.espresso.page.*
 import com.instructure.student.R
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.not
@@ -106,7 +94,7 @@ class InboxPage : BasePage(R.id.inboxPage) {
         waitForView(withId(R.id.scopeFilterText))
         scopeButton.click()
         when (scope) {
-            InboxApi.Scope.INBOX -> onViewWithText("All").scrollTo().click()
+            InboxApi.Scope.INBOX -> onViewWithText("Inbox").scrollTo().click()
             InboxApi.Scope.UNREAD -> onViewWithText("Unread").scrollTo().click()
             InboxApi.Scope.ARCHIVED -> onViewWithText("Archived").scrollTo().click()
             InboxApi.Scope.STARRED -> onViewWithText("Starred").scrollTo().click()
@@ -185,11 +173,19 @@ class InboxPage : BasePage(R.id.inboxPage) {
         inboxRecyclerView.check(RecyclerViewItemCountGreaterThanAssertion(count))
     }
 
-    fun selectConversation(conversation: Conversation) {
+    fun selectConversation(conversationSubject: String) {
         waitForView(withId(R.id.inboxRecyclerView))
-        val matcher = withText(conversation.subject)
+        val matcher = withText(conversationSubject)
         scrollRecyclerView(R.id.inboxRecyclerView, matcher)
         onView(matcher).longClick()
+    }
+
+    fun selectConversation(conversation: Conversation) {
+        selectConversation(conversation.subject!!)
+    }
+
+    fun selectConversation(conversation: ConversationApiModel) {
+        selectConversation(conversation.subject!!)
     }
 
     fun assertEditToolbarDisplayed() {
@@ -198,6 +194,10 @@ class InboxPage : BasePage(R.id.inboxPage) {
 
     fun clickArchive() {
         waitForViewWithId(R.id.inboxArchiveSelected).click()
+    }
+
+    fun clickUnArchive() {
+        waitForViewWithId(R.id.inboxUnarchiveSelected).click()
     }
 
     fun clickStar() {
@@ -223,20 +223,46 @@ class InboxPage : BasePage(R.id.inboxPage) {
     }
 
     fun confirmDelete() {
-        waitForViewWithText("DELETE")
+        waitForView(withText("DELETE") + withAncestor(R.id.buttonPanel)).click()
     }
-
-    fun swipeConversationRight(conversation: Conversation) {
+    fun swipeConversationRight(conversationSubject: String) {
         waitForView(withId(R.id.inboxRecyclerView))
-        val matcher = withText(conversation.subject)
+        val matcher = withText(conversationSubject)
         scrollRecyclerView(R.id.inboxRecyclerView, matcher)
         onView(matcher).swipeRight()
     }
 
-    fun swipeConversationLeft(conversation: Conversation) {
+    fun swipeConversationRight(conversation: ConversationApiModel) {
+        swipeConversationRight(conversation.subject!!)
+    }
+
+    fun swipeConversationRight(conversation: Conversation) {
+        swipeConversationRight(conversation.subject!!)
+    }
+
+    fun swipeConversationLeft(conversationSubject: String) {
         waitForView(withId(R.id.inboxRecyclerView))
-        val matcher = withText(conversation.subject)
+        val matcher = withText(conversationSubject)
         scrollRecyclerView(R.id.inboxRecyclerView, matcher)
         onView(matcher).swipeLeft()
     }
+
+    fun swipeConversationLeft(conversation: Conversation) {
+        swipeConversationLeft(conversation.subject!!)
+    }
+
+    fun swipeConversationLeft(conversation: ConversationApiModel) {
+        swipeConversationLeft(conversation.subject!!)
+    }
+
+    fun selectConversations(conversations: List<String>) {
+        for(conversation in conversations) {
+            selectConversation(conversation)
+        }
+    }
+
+    fun assertSelectedConversationNumber(selectedConversationNumber: String) {
+        onView(withText(selectedConversationNumber) + withAncestor(R.id.editToolbar))
+    }
+
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
@@ -26,6 +26,7 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry
+import com.instructure.canvas.espresso.refresh
 import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.canvas.espresso.waitForMatcherWithRefreshes
 import com.instructure.canvasapi2.apis.InboxApi
@@ -91,7 +92,7 @@ class InboxPage : BasePage(R.id.inboxPage) {
     }
 
     fun selectInboxScope(scope: InboxApi.Scope) {
-        onView(withId(R.id.inboxRecyclerView)).swipeDown()
+        refresh()
         waitForView(withId(R.id.scopeFilterText))
         scopeButton.click()
         when (scope) {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
@@ -54,7 +54,6 @@ class InboxPage : BasePage(R.id.inboxPage) {
 
     fun assertConversationDisplayed(subject: String) {
         val matcher = withText(subject)
-       // scrollRecyclerView(R.id.inboxRecyclerView, matcher)
         onView(matcher).scrollTo().assertDisplayed()
     }
 
@@ -125,7 +124,6 @@ class InboxPage : BasePage(R.id.inboxPage) {
             hasSibling(withId(R.id.date)),
             hasSibling(allOf(withId(R.id.subjectView), withText(subject))))
         waitForMatcherWithRefreshes(matcher) // May need to refresh before the star shows up
-       // scrollRecyclerView(R.id.inboxRecyclerView, matcher)
         onView(matcher).scrollTo().assertDisplayed()
 
     }
@@ -178,7 +176,6 @@ class InboxPage : BasePage(R.id.inboxPage) {
     fun selectConversation(conversationSubject: String) {
         waitForView(withId(R.id.inboxRecyclerView))
         val matcher = withText(conversationSubject)
-        //scrollRecyclerView(R.id.inboxRecyclerView, matcher)
         onView(matcher).scrollTo().longClick()
     }
 
@@ -230,7 +227,6 @@ class InboxPage : BasePage(R.id.inboxPage) {
     fun swipeConversationRight(conversationSubject: String) {
         waitForView(withId(R.id.inboxRecyclerView))
         val matcher = withText(conversationSubject)
-      //  scrollRecyclerView(R.id.inboxRecyclerView, matcher)
         onView(matcher).scrollTo().swipeRight()
     }
 
@@ -245,8 +241,8 @@ class InboxPage : BasePage(R.id.inboxPage) {
     fun swipeConversationLeft(conversationSubject: String) {
         waitForView(withId(R.id.inboxRecyclerView))
         val matcher = withText(conversationSubject)
-      //  scrollRecyclerView(R.id.inboxRecyclerView, matcher)
-        onView(matcher).scrollTo().swipeLeft()
+        onView(matcher).scrollTo()
+        onView(matcher).swipeLeft()
     }
 
     fun swipeConversationLeft(conversation: Conversation) {

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/InboxPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/InboxPageTest.kt
@@ -245,18 +245,17 @@ class InboxPageTest: TeacherTest() {
     @TestMetaData(Priority.IMPORTANT, FeatureCategory.INBOX, TestCategory.INTERACTION)
     fun swipeToUnstar() {
         val data = createInitialData()
-        data.addConversations(userId = data.teachers.first().id, messageBody = "Short body")
         val conversation = data.addConversation(
             senderId = data.students.first().id,
             receiverIds = listOf(data.teachers.first().id),
             messageBody = "Body",
             messageSubject = "Subject")
+        data.addConversations(userId = data.teachers.first().id, messageBody = "Short body")
         data.conversations[conversation.id] = conversation.copy(isStarred = true)
 
         navigateToInbox(data, data.teachers.first())
         inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
         inboxPage.swipeConversationLeft(conversation)
-        Thread.sleep(3000)
         inboxPage.assertConversationNotDisplayed(conversation.subject!!)
     }
 

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/InboxPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/InboxPageTest.kt
@@ -236,6 +236,7 @@ class InboxPageTest: TeacherTest() {
 
         navigateToInbox(data, data.teachers.first())
         inboxPage.swipeConversationLeft(conversation)
+        Thread.sleep(3000)
         inboxPage.assertConversationNotDisplayed(conversation.subject!!)
 
         inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
@@ -257,6 +258,7 @@ class InboxPageTest: TeacherTest() {
         navigateToInbox(data, data.teachers.first())
         inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
         inboxPage.swipeConversationLeft(conversation)
+        Thread.sleep(3000)
         inboxPage.assertConversationNotDisplayed(conversation.subject!!)
     }
 

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/InboxPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/InboxPageTest.kt
@@ -100,7 +100,7 @@ class InboxPageTest: TeacherTest() {
         inboxPage.assertConversationNotDisplayed(conversation1.subject!!)
         inboxPage.assertConversationNotDisplayed(conversation2.subject!!)
 
-        inboxPage.filterInbox("Archived")
+        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
         inboxPage.assertConversationDisplayed(conversation1.subject!!)
         inboxPage.assertConversationDisplayed(conversation2.subject!!)
     }
@@ -148,7 +148,7 @@ class InboxPageTest: TeacherTest() {
         data.conversations[conversation2.id] = conversation2.copy(isStarred = true)
 
         navigateToInbox(data, data.teachers.first())
-        inboxPage.filterInbox("Starred")
+        inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
         inboxPage.selectConversation(conversation1)
         inboxPage.selectConversation(conversation2)
         inboxPage.clickUnstar()
@@ -243,7 +243,7 @@ class InboxPageTest: TeacherTest() {
         inboxPage.swipeConversationLeft(conversation)
         inboxPage.assertConversationNotDisplayed(conversation.subject!!)
 
-        inboxPage.filterInbox("Archived")
+        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
         inboxPage.assertConversationDisplayed(conversation.subject!!)
     }
 
@@ -260,7 +260,7 @@ class InboxPageTest: TeacherTest() {
         data.conversations[conversation.id] = conversation.copy(isStarred = true)
 
         navigateToInbox(data, data.teachers.first())
-        inboxPage.filterInbox("Starred")
+        inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
         inboxPage.swipeConversationLeft(conversation)
         inboxPage.assertConversationNotDisplayed(conversation.subject!!)
     }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/InboxPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/InboxPageTest.kt
@@ -94,8 +94,7 @@ class InboxPageTest: TeacherTest() {
             messageSubject = "Subject 2")
 
         navigateToInbox(data, data.teachers.first())
-        inboxPage.selectConversation(conversation1)
-        inboxPage.selectConversation(conversation2)
+        inboxPage.selectConversations(listOf(conversation1.subject!!, conversation2.subject!!))
         inboxPage.clickArchive()
         inboxPage.assertConversationNotDisplayed(conversation1.subject!!)
         inboxPage.assertConversationNotDisplayed(conversation2.subject!!)
@@ -122,8 +121,7 @@ class InboxPageTest: TeacherTest() {
             messageSubject = "Subject 2")
 
         navigateToInbox(data, data.teachers.first())
-        inboxPage.selectConversation(conversation1)
-        inboxPage.selectConversation(conversation2)
+        inboxPage.selectConversations(listOf(conversation1.subject!!, conversation2.subject!!))
         inboxPage.clickStar()
         inboxPage.assertConversationStarred(conversation1.subject!!)
         inboxPage.assertConversationStarred(conversation2.subject!!)
@@ -149,8 +147,7 @@ class InboxPageTest: TeacherTest() {
 
         navigateToInbox(data, data.teachers.first())
         inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
-        inboxPage.selectConversation(conversation1)
-        inboxPage.selectConversation(conversation2)
+        inboxPage.selectConversations(listOf(conversation1.subject!!, conversation2.subject!!))
         inboxPage.clickUnstar()
         inboxPage.assertConversationNotDisplayed(conversation1.subject!!)
         inboxPage.assertConversationNotDisplayed(conversation2.subject!!)
@@ -173,8 +170,7 @@ class InboxPageTest: TeacherTest() {
             messageSubject = "Subject 2")
 
         navigateToInbox(data, data.teachers.first())
-        inboxPage.selectConversation(conversation1)
-        inboxPage.selectConversation(conversation2)
+        inboxPage.selectConversations(listOf(conversation1.subject!!, conversation2.subject!!))
         inboxPage.clickMarkAsRead()
         inboxPage.assertUnreadMarkerVisibility(conversation1.subject!!, ViewMatchers.Visibility.GONE)
         inboxPage.assertUnreadMarkerVisibility(conversation2.subject!!, ViewMatchers.Visibility.GONE)
@@ -201,8 +197,7 @@ class InboxPageTest: TeacherTest() {
             messageSubject = "Subject 2")
 
         navigateToInbox(data, data.teachers.first())
-        inboxPage.selectConversation(conversation1)
-        inboxPage.selectConversation(conversation2)
+        inboxPage.selectConversations(listOf(conversation1.subject!!, conversation2.subject!!))
         inboxPage.clickDelete()
         inboxPage.confirmDelete()
         inboxPage.assertConversationNotDisplayed(conversation1.subject!!)

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/InboxPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/InboxPageTest.kt
@@ -208,13 +208,12 @@ class InboxPageTest: TeacherTest() {
     @TestMetaData(Priority.IMPORTANT, FeatureCategory.INBOX, TestCategory.INTERACTION)
     fun swipeToReadUnread() {
         val data = createInitialData()
-        data.addConversations(userId = data.teachers.first().id, messageBody = "Short body")
-        val conversation = data.addConversation(
+         val conversation = data.addConversation(
             senderId = data.students.first().id,
             receiverIds = listOf(data.teachers.first().id),
             messageBody = "Body",
             messageSubject = "Subject")
-
+        data.addConversations(userId = data.teachers.first().id, messageBody = "Short body")
         navigateToInbox(data, data.teachers.first())
         inboxPage.swipeConversationRight(conversation)
         inboxPage.assertUnreadMarkerVisibility(conversation.subject!!, ViewMatchers.Visibility.GONE)
@@ -227,16 +226,15 @@ class InboxPageTest: TeacherTest() {
     @TestMetaData(Priority.IMPORTANT, FeatureCategory.INBOX, TestCategory.INTERACTION)
     fun swipeToArchive() {
         val data = createInitialData()
-        data.addConversations(userId = data.teachers.first().id, messageBody = "Short body")
         val conversation = data.addConversation(
             senderId = data.students.first().id,
             receiverIds = listOf(data.teachers.first().id),
             messageBody = "Body",
             messageSubject = "Subject")
+        data.addConversations(userId = data.teachers.first().id, messageBody = "Short body")
 
         navigateToInbox(data, data.teachers.first())
         inboxPage.swipeConversationLeft(conversation)
-        Thread.sleep(3000)
         inboxPage.assertConversationNotDisplayed(conversation.subject!!)
 
         inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/InboxPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/InboxPageTest.kt
@@ -22,7 +22,6 @@ import com.instructure.canvas.espresso.mockCanvas.MockCanvas
 import com.instructure.canvas.espresso.mockCanvas.addConversation
 import com.instructure.canvas.espresso.mockCanvas.addConversations
 import com.instructure.canvas.espresso.mockCanvas.init
-import com.instructure.canvasapi2.apis.InboxApi
 import com.instructure.canvasapi2.models.User
 import com.instructure.panda_annotations.FeatureCategory
 import com.instructure.panda_annotations.Priority
@@ -99,7 +98,7 @@ class InboxPageTest: TeacherTest() {
         inboxPage.assertConversationNotDisplayed(conversation1.subject!!)
         inboxPage.assertConversationNotDisplayed(conversation2.subject!!)
 
-        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.filterInbox("Archived")
         inboxPage.assertConversationDisplayed(conversation1.subject!!)
         inboxPage.assertConversationDisplayed(conversation2.subject!!)
     }
@@ -146,7 +145,7 @@ class InboxPageTest: TeacherTest() {
         data.conversations[conversation2.id] = conversation2.copy(isStarred = true)
 
         navigateToInbox(data, data.teachers.first())
-        inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
+        inboxPage.filterInbox("Starred")
         inboxPage.selectConversations(listOf(conversation1.subject!!, conversation2.subject!!))
         inboxPage.clickUnstar()
         inboxPage.assertConversationNotDisplayed(conversation1.subject!!)
@@ -237,7 +236,7 @@ class InboxPageTest: TeacherTest() {
         inboxPage.swipeConversationLeft(conversation)
         inboxPage.assertConversationNotDisplayed(conversation.subject!!)
 
-        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.filterInbox("Archived")
         inboxPage.assertConversationDisplayed(conversation.subject!!)
     }
 
@@ -254,7 +253,7 @@ class InboxPageTest: TeacherTest() {
         data.conversations[conversation.id] = conversation.copy(isStarred = true)
 
         navigateToInbox(data, data.teachers.first())
-        inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
+        inboxPage.filterInbox("Starred")
         inboxPage.swipeConversationLeft(conversation)
         inboxPage.assertConversationNotDisplayed(conversation.subject!!)
     }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/InboxE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/InboxE2ETest.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.matcher.ViewMatchers
 import com.instructure.canvas.espresso.E2E
-import com.instructure.canvasapi2.apis.InboxApi
 import com.instructure.dataseeding.api.ConversationsApi
 import com.instructure.dataseeding.api.GroupsApi
 import com.instructure.dataseeding.model.CanvasUserApiModel
@@ -90,7 +89,7 @@ class InboxE2ETest : TeacherTest() {
         addMessagePage.clickSendButton()
 
         Log.d(STEP_TAG,"Filter the Inbox by selecting 'Sent' category from the spinner on Inbox Page.")
-        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+        inboxPage.filterInbox("Sent")
 
         Log.d(STEP_TAG,"Assert that the previously sent conversation is displayed.")
         inboxPage.assertHasConversation()
@@ -110,8 +109,8 @@ class InboxE2ETest : TeacherTest() {
         Espresso.pressBack()
         inboxPage.assertHasConversation()
 
-        Log.d(STEP_TAG,"Filter the Inbox by selecting 'All' category from the spinner on Inbox Page.")
-        inboxPage.selectInboxScope(InboxApi.Scope.INBOX)
+        Log.d(STEP_TAG,"Filter the Inbox by selecting 'Inbox' category from the spinner on Inbox Page.")
+        inboxPage.filterInbox("Inbox")
 
         Log.d(STEP_TAG,"Refresh the page. Assert that the previously seeded Inbox conversation is displayed.")
         inboxPage.refresh()
@@ -138,12 +137,12 @@ class InboxE2ETest : TeacherTest() {
 
         Log.d(STEP_TAG,"Filter the Inbox by selecting 'Archived' category from the spinner on Inbox Page." +
                 "Assert that the previously archived conversation is displayed.")
-        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.filterInbox("Archived")
         inboxPage.assertHasConversation()
 
         Log.d(STEP_TAG,"Filter the Inbox by selecting 'Starred' category from the spinner on Inbox Page." +
                 "Assert that the '${seedConversation[0]}' conversation is displayed because it's still starred.")
-        inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
+        inboxPage.filterInbox("Starred")
         inboxPage.assertHasConversation()
 
         Log.d(STEP_TAG,"Click on the conversation.")
@@ -173,8 +172,8 @@ class InboxE2ETest : TeacherTest() {
             body = "Third body"
         )
 
-        Log.d(STEP_TAG,"Filter the Inbox by selecting 'Archived' category from the spinner on Inbox Page. Assert that the '${seedConversation[0]}' conversation is displayed.")
-        inboxPage.selectInboxScope(InboxApi.Scope.INBOX)
+        Log.d(STEP_TAG,"Filter the Inbox by selecting 'Inbox' category from the spinner on Inbox Page. Assert that the '${seedConversation[0]}' conversation is displayed.")
+        inboxPage.filterInbox("Inbox")
         inboxPage.assertHasConversation()
 
         Log.d(STEP_TAG, "Select '${seedConversation2[0].subject}' conversation. Unarchive it, and assert that it is not displayed in the 'ARCHIVED' scope any more.")
@@ -183,7 +182,7 @@ class InboxE2ETest : TeacherTest() {
         inboxPage.assertConversationNotDisplayed(seedConversation2[0].subject)
 
         Log.d(STEP_TAG, "Select 'ARCHIVED' scope and assert that '${seedConversation2[0].subject}' conversation is displayed in the 'ARCHIVED' scope.")
-        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.filterInbox("Archived")
         inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
 
         Log.d(STEP_TAG, "Select '${seedConversation2[0].subject}' conversation and unarchive it." +
@@ -194,7 +193,7 @@ class InboxE2ETest : TeacherTest() {
         inboxPage.assertConversationNotDisplayed(seedConversation2[0].subject)
 
         Log.d(STEP_TAG,"Navigate to 'INBOX' scope and assert that ${seedConversation2[0].subject} conversation is displayed.")
-        inboxPage.selectInboxScope(InboxApi.Scope.INBOX)
+        inboxPage.filterInbox("Inbox")
         inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
 
         Log.d(STEP_TAG, "Select both of the conversations (${seedConversation[0].subject} and ${seedConversation2[0].subject} and star them." +
@@ -221,17 +220,17 @@ class InboxE2ETest : TeacherTest() {
         inboxPage.assertConversationNotDisplayed(seedConversation3[0].subject)
 
         Log.d(STEP_TAG, "Navigate to 'ARCHIVED' scope and assert that both of the conversations are displayed there.")
-        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.filterInbox("Archived")
         inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
         inboxPage.assertConversationDisplayed(seedConversation3[0].subject)
 
         Log.d(STEP_TAG, "Navigate to 'UNREAD' scope and assert that none of the conversations are displayed there, because a conversation cannot be archived and unread at the same time.")
-        inboxPage.selectInboxScope(InboxApi.Scope.UNREAD)
+        inboxPage.filterInbox("Unread")
         inboxPage.assertConversationNotDisplayed(seedConversation2[0].subject)
         inboxPage.assertConversationNotDisplayed(seedConversation3[0].subject)
 
-        Log.d(STEP_TAG, "Navigate to 'UNREAD' scope and assert that both of the conversations are displayed there.")
-        inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
+        Log.d(STEP_TAG, "Navigate to 'STARRED' scope and assert that both of the conversations are displayed there.")
+        inboxPage.filterInbox("Starred")
         inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
         inboxPage.assertConversationDisplayed(seedConversation3[0].subject)
 
@@ -242,7 +241,7 @@ class InboxE2ETest : TeacherTest() {
         inboxPage.assertConversationNotDisplayed(seedConversation3[0].subject)
 
         Log.d(STEP_TAG, "Navigate to 'ARCHIVED' scope and assert that both of the conversations are displayed there.")
-        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.filterInbox("Archived")
         inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
         inboxPage.assertConversationDisplayed(seedConversation3[0].subject)
 
@@ -253,7 +252,7 @@ class InboxE2ETest : TeacherTest() {
         inboxPage.assertConversationNotDisplayed(seedConversation3[0].subject)
 
         Log.d(STEP_TAG, "Navigate to 'INBOX' scope and assert that both of the conversations are displayed there.")
-        inboxPage.selectInboxScope(InboxApi.Scope.INBOX)
+        inboxPage.filterInbox("Inbox")
         inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
         inboxPage.assertConversationDisplayed(seedConversation3[0].subject)
 
@@ -271,7 +270,7 @@ class InboxE2ETest : TeacherTest() {
         inboxPage.assertConversationNotDisplayed(seedConversation2[0].subject)
 
         Log.d(STEP_TAG, "Navigate to 'ARCHIVED' scope. Assert that the '${seedConversation2[0].subject}' conversation is displayed in the 'ARCHIVED' scope.")
-        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.filterInbox("Archived")
         inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
 
         Log.d(STEP_TAG, "Swipe '${seedConversation2[0].subject}' left and assert it is removed from the 'ARCHIVED' scope because it has became unarchived.")
@@ -279,7 +278,7 @@ class InboxE2ETest : TeacherTest() {
         inboxPage.assertConversationNotDisplayed(seedConversation2[0].subject)
 
         Log.d(STEP_TAG, "Navigate to 'INBOX' scope. Assert that the '${seedConversation2[0].subject}' conversation is displayed in the 'INBOX' scope.")
-        inboxPage.selectInboxScope(InboxApi.Scope.INBOX)
+        inboxPage.filterInbox("Inbox")
         inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
 
         Log.d(STEP_TAG, "Select both of the conversations. Star them and mark the unread.")
@@ -288,7 +287,7 @@ class InboxE2ETest : TeacherTest() {
         inboxPage.clickMarkAsUnread()
 
         Log.d(STEP_TAG, "Navigate to 'STARRED' scope. Assert that both of the conversation are displayed in the 'STARRED' scope.")
-        inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
+        inboxPage.filterInbox("Starred")
         inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
         inboxPage.assertConversationDisplayed(seedConversation3[0].subject)
 
@@ -304,7 +303,7 @@ class InboxE2ETest : TeacherTest() {
         inboxPage.assertUnreadMarkerVisibility(seedConversation3[0].subject, ViewMatchers.Visibility.GONE)
 
         Log.d(STEP_TAG, "Navigate to 'UNREAD' scope. Assert that only the '${seedConversation2[0].subject}' conversation is displayed in the 'UNREAD' scope.")
-        inboxPage.selectInboxScope(InboxApi.Scope.UNREAD)
+        inboxPage.filterInbox("Unread")
         inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
         inboxPage.assertConversationNotDisplayed(seedConversation3[0].subject)
 
@@ -313,11 +312,11 @@ class InboxE2ETest : TeacherTest() {
         inboxPage.assertConversationNotDisplayed(seedConversation2[0].subject)
 
         Log.d(STEP_TAG, "Navigate to 'ARCHIVED' scope. Assert that the '${seedConversation2[0].subject}' conversation is displayed in the 'ARCHIVED' scope.")
-        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.filterInbox("Archived")
         inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
 
-        Log.d(STEP_TAG, "Navigate to 'INBOX' scope and seledct '${seedConversation3[0].subject}' conversation.")
-        inboxPage.selectInboxScope(InboxApi.Scope.INBOX)
+        Log.d(STEP_TAG, "Navigate to 'INBOX' scope and select '${seedConversation3[0].subject}' conversation.")
+        inboxPage.filterInbox("Inbox")
         inboxPage.selectConversation(seedConversation3[0].subject)
 
         Log.d(STEP_TAG, "Delete the '${seedConversation3[0].subject}' conversation and assert that it has been removed from the 'INBOX' scope.")
@@ -326,7 +325,7 @@ class InboxE2ETest : TeacherTest() {
         inboxPage.assertConversationNotDisplayed(seedConversation3[0].subject)
 
         Log.d(STEP_TAG, "Navigate to 'ARCHIVED' scope. Assert that the '${seedConversation2[0].subject}' conversation is displayed in the 'ARCHIVED' scope.")
-        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.filterInbox("Archived")
 
         Log.d(STEP_TAG,"Click on the '${seedConversation2[0].subject}' conversation.")
         inboxPage.clickConversation(seedConversation2[0])

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/InboxE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/InboxE2ETest.kt
@@ -2,8 +2,9 @@ package com.instructure.teacher.ui.e2e
 
 import android.util.Log
 import androidx.test.espresso.Espresso
+import androidx.test.espresso.matcher.ViewMatchers
 import com.instructure.canvas.espresso.E2E
-import com.instructure.canvas.espresso.refresh
+import com.instructure.canvasapi2.apis.InboxApi
 import com.instructure.dataseeding.api.ConversationsApi
 import com.instructure.dataseeding.api.GroupsApi
 import com.instructure.dataseeding.model.CanvasUserApiModel
@@ -89,7 +90,7 @@ class InboxE2ETest : TeacherTest() {
         addMessagePage.clickSendButton()
 
         Log.d(STEP_TAG,"Filter the Inbox by selecting 'Sent' category from the spinner on Inbox Page.")
-        inboxPage.filterInbox("Sent")
+        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
 
         Log.d(STEP_TAG,"Assert that the previously sent conversation is displayed.")
         inboxPage.assertHasConversation()
@@ -110,7 +111,7 @@ class InboxE2ETest : TeacherTest() {
         inboxPage.assertHasConversation()
 
         Log.d(STEP_TAG,"Filter the Inbox by selecting 'All' category from the spinner on Inbox Page.")
-        inboxPage.filterInbox("Inbox")
+        inboxPage.selectInboxScope(InboxApi.Scope.INBOX)
 
         Log.d(STEP_TAG,"Refresh the page. Assert that the previously seeded Inbox conversation is displayed.")
         inboxPage.refresh()
@@ -137,12 +138,12 @@ class InboxE2ETest : TeacherTest() {
 
         Log.d(STEP_TAG,"Filter the Inbox by selecting 'Archived' category from the spinner on Inbox Page." +
                 "Assert that the previously archived conversation is displayed.")
-        inboxPage.filterInbox("Archived")
+        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
         inboxPage.assertHasConversation()
 
         Log.d(STEP_TAG,"Filter the Inbox by selecting 'Starred' category from the spinner on Inbox Page." +
                 "Assert that the '${seedConversation[0]}' conversation is displayed because it's still starred.")
-        inboxPage.filterInbox("Starred")
+        inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
         inboxPage.assertHasConversation()
 
         Log.d(STEP_TAG,"Click on the conversation.")
@@ -156,17 +157,184 @@ class InboxE2ETest : TeacherTest() {
         dashboardPage.assertPageObjects()
         inboxPage.assertInboxEmpty()
 
+        Log.d(PREPARATION_TAG, "Seed another Inbox conversation via API.")
+        val seedConversation2 = ConversationsApi.createConversation(
+            token = student1.token,
+            recipients = listOf(teacher.id.toString()),
+            subject = "Second conversation",
+            body = "Second body"
+        )
+
+        Log.d(PREPARATION_TAG, "Seed a third Inbox conversation via API.")
+        val seedConversation3 = ConversationsApi.createConversation(
+            token = student2.token,
+            recipients = listOf(teacher.id.toString()),
+            subject = "Third conversation",
+            body = "Third body"
+        )
+
         Log.d(STEP_TAG,"Filter the Inbox by selecting 'Archived' category from the spinner on Inbox Page. Assert that the '${seedConversation[0]}' conversation is displayed.")
-        inboxPage.filterInbox("Archived")
+        inboxPage.selectInboxScope(InboxApi.Scope.INBOX)
         inboxPage.assertHasConversation()
 
-        Log.d(STEP_TAG,"Click on the conversation.")
-        inboxPage.clickConversation(seedConversation[0])
+        Log.d(STEP_TAG, "Select '${seedConversation2[0].subject}' conversation. Unarchive it, and assert that it is not displayed in the 'ARCHIVED' scope any more.")
+        inboxPage.selectConversation(seedConversation2[0])
+        inboxPage.clickArchive()
+        inboxPage.assertConversationNotDisplayed(seedConversation2[0].subject)
 
-        Log.d(STEP_TAG, "Delete the '${seedConversation[0]}' conversation and assert that it has disappeared from the list.")
+        Log.d(STEP_TAG, "Select 'ARCHIVED' scope and assert that '${seedConversation2[0].subject}' conversation is displayed in the 'ARCHIVED' scope.")
+        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
+
+        Log.d(STEP_TAG, "Select '${seedConversation2[0].subject}' conversation and unarchive it." +
+                "Assert that the selected number of conversation on the toolbar is 1 and '${seedConversation2[0].subject}' conversation is not displayed in the 'ARCHIVED' scope.")
+        inboxPage.selectConversation(seedConversation2[0])
+        inboxPage.clickUnArchive()
+        inboxPage.assertSelectedConversationNumber("1")
+        inboxPage.assertConversationNotDisplayed(seedConversation2[0].subject)
+
+        Log.d(STEP_TAG,"Navigate to 'INBOX' scope and assert that ${seedConversation2[0].subject} conversation is displayed.")
+        inboxPage.selectInboxScope(InboxApi.Scope.INBOX)
+        inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
+
+        Log.d(STEP_TAG, "Select both of the conversations (${seedConversation[0].subject} and ${seedConversation2[0].subject} and star them." +
+                "Assert that both of the has been starred and the selected number of conversations on the toolbar shows 2")
+        inboxPage.selectConversations(listOf(seedConversation2[0].subject, seedConversation3[0].subject))
+        inboxPage.clickStar()
+        inboxPage.assertSelectedConversationNumber("2")
+        inboxPage.assertConversationStarred(seedConversation2[0].subject)
+        inboxPage.assertConversationStarred(seedConversation3[0].subject)
+
+        Log.d(STEP_TAG, "Mark them as read (since if at least there is one unread selected, we are showing the 'Mark as Read' icon). Assert that both of them are read.")
+        inboxPage.clickMarkAsRead()
+        inboxPage.assertUnreadMarkerVisibility(seedConversation2[0].subject, ViewMatchers.Visibility.GONE)
+        inboxPage.assertUnreadMarkerVisibility(seedConversation3[0].subject, ViewMatchers.Visibility.GONE)
+
+        Log.d(STEP_TAG, "Mark them as unread. Assert that both of them will became unread.")
+        inboxPage.clickMarkAsUnread()
+        inboxPage.assertUnreadMarkerVisibility(seedConversation2[0].subject, ViewMatchers.Visibility.VISIBLE)
+        inboxPage.assertUnreadMarkerVisibility(seedConversation3[0].subject, ViewMatchers.Visibility.VISIBLE)
+
+        Log.d(STEP_TAG, "Archive both of them. Assert that non of them are displayed in the 'INBOX' scope.")
+        inboxPage.clickArchive()
+        inboxPage.assertConversationNotDisplayed(seedConversation2[0].subject)
+        inboxPage.assertConversationNotDisplayed(seedConversation3[0].subject)
+
+        Log.d(STEP_TAG, "Navigate to 'ARCHIVED' scope and assert that both of the conversations are displayed there.")
+        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
+        inboxPage.assertConversationDisplayed(seedConversation3[0].subject)
+
+        Log.d(STEP_TAG, "Navigate to 'UNREAD' scope and assert that none of the conversations are displayed there, because a conversation cannot be archived and unread at the same time.")
+        inboxPage.selectInboxScope(InboxApi.Scope.UNREAD)
+        inboxPage.assertConversationNotDisplayed(seedConversation2[0].subject)
+        inboxPage.assertConversationNotDisplayed(seedConversation3[0].subject)
+
+        Log.d(STEP_TAG, "Navigate to 'UNREAD' scope and assert that both of the conversations are displayed there.")
+        inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
+        inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
+        inboxPage.assertConversationDisplayed(seedConversation3[0].subject)
+
+        Log.d(STEP_TAG, "Select both of the conversations. Unstar them, and assert that none of them are displayed in the 'STARRED' scope.")
+        inboxPage.selectConversations(listOf(seedConversation2[0].subject, seedConversation3[0].subject))
+        inboxPage.clickUnstar()
+        inboxPage.assertConversationNotDisplayed(seedConversation2[0].subject)
+        inboxPage.assertConversationNotDisplayed(seedConversation3[0].subject)
+
+        Log.d(STEP_TAG, "Navigate to 'ARCHIVED' scope and assert that both of the conversations are displayed there.")
+        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
+        inboxPage.assertConversationDisplayed(seedConversation3[0].subject)
+
+        Log.d(STEP_TAG, "Select both of the conversations. Unarchive them, and assert that none of them are displayed in the 'ARCHIVED' scope.")
+        inboxPage.selectConversations(listOf(seedConversation2[0].subject, seedConversation3[0].subject))
+        inboxPage.clickUnArchive()
+        inboxPage.assertConversationNotDisplayed(seedConversation2[0].subject)
+        inboxPage.assertConversationNotDisplayed(seedConversation3[0].subject)
+
+        Log.d(STEP_TAG, "Navigate to 'INBOX' scope and assert that both of the conversations are displayed there.")
+        inboxPage.selectInboxScope(InboxApi.Scope.INBOX)
+        inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
+        inboxPage.assertConversationDisplayed(seedConversation3[0].subject)
+
+        Log.d(STEP_TAG, "Select '${seedConversation2[0].subject}' conversation and swipe it right to make it unread. Assert that the conversation became unread.")
+        inboxPage.selectConversation(seedConversation2[0].subject)
+        inboxPage.swipeConversationRight(seedConversation2[0])
+        inboxPage.assertUnreadMarkerVisibility(seedConversation2[0].subject, ViewMatchers.Visibility.VISIBLE)
+
+        Log.d(STEP_TAG, "Select '${seedConversation2[0].subject}' conversation and swipe it right again to make it read. Assert that the conversation became read.")
+        inboxPage.swipeConversationRight(seedConversation2[0])
+        inboxPage.assertUnreadMarkerVisibility(seedConversation2[0].subject, ViewMatchers.Visibility.GONE)
+
+        Log.d(STEP_TAG, "Swipe '${seedConversation2[0].subject}' left and assert it is removed from the 'INBOX' scope because it has became archived.")
+        inboxPage.swipeConversationLeft(seedConversation2[0])
+        inboxPage.assertConversationNotDisplayed(seedConversation2[0].subject)
+
+        Log.d(STEP_TAG, "Navigate to 'ARCHIVED' scope. Assert that the '${seedConversation2[0].subject}' conversation is displayed in the 'ARCHIVED' scope.")
+        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
+
+        Log.d(STEP_TAG, "Swipe '${seedConversation2[0].subject}' left and assert it is removed from the 'ARCHIVED' scope because it has became unarchived.")
+        inboxPage.swipeConversationLeft(seedConversation2[0])
+        inboxPage.assertConversationNotDisplayed(seedConversation2[0].subject)
+
+        Log.d(STEP_TAG, "Navigate to 'INBOX' scope. Assert that the '${seedConversation2[0].subject}' conversation is displayed in the 'INBOX' scope.")
+        inboxPage.selectInboxScope(InboxApi.Scope.INBOX)
+        inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
+
+        Log.d(STEP_TAG, "Select both of the conversations. Star them and mark the unread.")
+        inboxPage.selectConversations(listOf(seedConversation2[0].subject, seedConversation3[0].subject))
+        inboxPage.clickStar()
+        inboxPage.clickMarkAsUnread()
+
+        Log.d(STEP_TAG, "Navigate to 'STARRED' scope. Assert that both of the conversation are displayed in the 'STARRED' scope.")
+        inboxPage.selectInboxScope(InboxApi.Scope.STARRED)
+        inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
+        inboxPage.assertConversationDisplayed(seedConversation3[0].subject)
+
+        Log.d(STEP_TAG, "Swipe '${seedConversation2[0].subject}' left and assert it is removed from the 'STARRED' scope because it has became unstarred.")
+        inboxPage.swipeConversationLeft(seedConversation2[0])
+        inboxPage.assertConversationNotDisplayed(seedConversation2[0].subject)
+
+        Log.d(STEP_TAG, "Assert that '${seedConversation3[0].subject}' conversation is unread.")
+        inboxPage.assertUnreadMarkerVisibility(seedConversation3[0].subject, ViewMatchers.Visibility.VISIBLE)
+
+        Log.d(STEP_TAG, "Swipe '${seedConversation3[0].subject}' conversation right and assert that it has became read.")
+        inboxPage.swipeConversationRight(seedConversation3[0].subject)
+        inboxPage.assertUnreadMarkerVisibility(seedConversation3[0].subject, ViewMatchers.Visibility.GONE)
+
+        Log.d(STEP_TAG, "Navigate to 'UNREAD' scope. Assert that only the '${seedConversation2[0].subject}' conversation is displayed in the 'UNREAD' scope.")
+        inboxPage.selectInboxScope(InboxApi.Scope.UNREAD)
+        inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
+        inboxPage.assertConversationNotDisplayed(seedConversation3[0].subject)
+
+        Log.d(STEP_TAG, "Swipe '${seedConversation2[0].subject}' conversation left and assert it has been removed from the 'UNREAD' scope since it has became read.")
+        inboxPage.swipeConversationLeft(seedConversation2[0])
+        inboxPage.assertConversationNotDisplayed(seedConversation2[0].subject)
+
+        Log.d(STEP_TAG, "Navigate to 'ARCHIVED' scope. Assert that the '${seedConversation2[0].subject}' conversation is displayed in the 'ARCHIVED' scope.")
+        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+        inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
+
+        Log.d(STEP_TAG, "Navigate to 'INBOX' scope and seledct '${seedConversation3[0].subject}' conversation.")
+        inboxPage.selectInboxScope(InboxApi.Scope.INBOX)
+        inboxPage.selectConversation(seedConversation3[0].subject)
+
+        Log.d(STEP_TAG, "Delete the '${seedConversation3[0].subject}' conversation and assert that it has been removed from the 'INBOX' scope.")
+        inboxPage.clickDelete()
+        inboxPage.confirmDelete()
+        inboxPage.assertConversationNotDisplayed(seedConversation3[0].subject)
+
+        Log.d(STEP_TAG, "Navigate to 'ARCHIVED' scope. Assert that the '${seedConversation2[0].subject}' conversation is displayed in the 'ARCHIVED' scope.")
+        inboxPage.selectInboxScope(InboxApi.Scope.ARCHIVED)
+
+        Log.d(STEP_TAG,"Click on the '${seedConversation2[0].subject}' conversation.")
+        inboxPage.clickConversation(seedConversation2[0])
+
+        Log.d(STEP_TAG, "Delete the '${seedConversation2[0]}' conversation and assert that it has disappeared from the list.")
         inboxMessagePage.deleteConversation()
-        refresh() //This is needed because Archive list (and the other 'specific' ones) does not refreshing automatically like the 'All'.
-        inboxPage.assertPageObjects()
+
+        Log.d(STEP_TAG, "Assert that the empty view is displayed.")
         inboxPage.assertInboxEmpty()
 
     }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/PeopleE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/PeopleE2ETest.kt
@@ -19,6 +19,7 @@ package com.instructure.teacher.ui.e2e
 import android.util.Log
 import androidx.test.espresso.Espresso
 import com.instructure.canvas.espresso.E2E
+import com.instructure.canvasapi2.apis.InboxApi
 import com.instructure.dataseeding.api.SubmissionsApi
 import com.instructure.dataseeding.model.AssignmentApiModel
 import com.instructure.dataseeding.model.CanvasUserApiModel
@@ -150,7 +151,7 @@ class PeopleE2ETest: TeacherTest() {
         inboxPage.assertInboxEmpty()
 
         Log.d(STEP_TAG,"Filter the Inbox by selecting 'Sent' category from the spinner on Inbox Page.")
-        inboxPage.filterInbox("Sent")
+        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
 
         Log.d(STEP_TAG,"Assert that the previously sent conversation is displayed.")
         inboxPage.assertHasConversation()

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/PeopleE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/PeopleE2ETest.kt
@@ -19,7 +19,6 @@ package com.instructure.teacher.ui.e2e
 import android.util.Log
 import androidx.test.espresso.Espresso
 import com.instructure.canvas.espresso.E2E
-import com.instructure.canvasapi2.apis.InboxApi
 import com.instructure.dataseeding.api.SubmissionsApi
 import com.instructure.dataseeding.model.AssignmentApiModel
 import com.instructure.dataseeding.model.CanvasUserApiModel
@@ -151,7 +150,7 @@ class PeopleE2ETest: TeacherTest() {
         inboxPage.assertInboxEmpty()
 
         Log.d(STEP_TAG,"Filter the Inbox by selecting 'Sent' category from the spinner on Inbox Page.")
-        inboxPage.selectInboxScope(InboxApi.Scope.SENT)
+        inboxPage.filterInbox("Sent")
 
         Log.d(STEP_TAG,"Assert that the previously sent conversation is displayed.")
         inboxPage.assertHasConversation()

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/InboxPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/InboxPage.kt
@@ -177,8 +177,8 @@ class InboxPage: BasePage() {
     fun swipeConversationRight(conversationSubject: String) {
         waitForView(withId(R.id.inboxRecyclerView))
         val matcher = withText(conversationSubject)
-        scrollRecyclerView(R.id.inboxRecyclerView, matcher)
-        onView(matcher).swipeRight()
+        //scrollRecyclerView(R.id.inboxRecyclerView, matcher)
+        onView(matcher).scrollTo().swipeRight()
     }
 
     fun swipeConversationRight(conversation: ConversationApiModel) {
@@ -192,8 +192,8 @@ class InboxPage: BasePage() {
     fun swipeConversationLeft(conversationSubject: String) {
         waitForView(withId(R.id.inboxRecyclerView))
         val matcher = withText(conversationSubject)
-        scrollRecyclerView(R.id.inboxRecyclerView, matcher)
-        onView(matcher).swipeLeft()
+        //scrollRecyclerView(R.id.inboxRecyclerView, matcher)
+        onView(matcher).scrollTo().swipeLeft()
     }
 
     fun swipeConversationLeft(conversation: Conversation) {

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/InboxPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/InboxPage.kt
@@ -123,8 +123,8 @@ class InboxPage: BasePage() {
     fun selectConversation(conversationSubject: String) {
         waitForView(withId(R.id.inboxRecyclerView))
         val matcher = withText(conversationSubject)
-        scrollRecyclerView(R.id.inboxRecyclerView, matcher)
-        onView(matcher).longClick()
+        //scrollRecyclerView(R.id.inboxRecyclerView, matcher)
+        onView(matcher).scrollTo().longClick()
     }
 
     fun selectConversation(conversation: Conversation) {
@@ -206,6 +206,7 @@ class InboxPage: BasePage() {
     }
 
     fun selectConversations(conversations: List<String>) {
+        refresh()
         for(conversation in conversations) {
             selectConversation(conversation)
         }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/InboxPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/InboxPage.kt
@@ -94,7 +94,6 @@ class InboxPage: BasePage() {
 
     fun assertConversationDisplayed(subject: String) {
         val matcher = withText(subject)
-        //scrollRecyclerView(R.id.inboxRecyclerView, matcher)
         onView(matcher).scrollTo().assertDisplayed()
     }
 
@@ -123,7 +122,6 @@ class InboxPage: BasePage() {
     fun selectConversation(conversationSubject: String) {
         waitForView(withId(R.id.inboxRecyclerView))
         val matcher = withText(conversationSubject)
-        //scrollRecyclerView(R.id.inboxRecyclerView, matcher)
         onView(matcher).scrollTo().longClick()
     }
 
@@ -178,7 +176,6 @@ class InboxPage: BasePage() {
     fun swipeConversationRight(conversationSubject: String) {
         waitForView(withId(R.id.inboxRecyclerView))
         val matcher = withText(conversationSubject)
-        //scrollRecyclerView(R.id.inboxRecyclerView, matcher)
         onView(matcher).scrollTo().swipeRight()
     }
 
@@ -193,8 +190,8 @@ class InboxPage: BasePage() {
     fun swipeConversationLeft(conversationSubject: String) {
         waitForView(withId(R.id.inboxRecyclerView))
         val matcher = withText(conversationSubject)
-        //scrollRecyclerView(R.id.inboxRecyclerView, matcher)
-        onView(matcher).scrollTo().swipeLeft()
+        onView(matcher).scrollTo()
+        onView(matcher).swipeLeft()
     }
 
     fun swipeConversationLeft(conversation: Conversation) {

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/InboxPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/InboxPage.kt
@@ -71,6 +71,7 @@ class InboxPage: BasePage() {
     }
 
     fun selectInboxScope(scope: InboxApi.Scope) {
+        onView(withId(R.id.swipeRefreshLayout)).swipeDown()
         waitForView(withId(R.id.scopeFilterText))
         onView(withId(R.id.scopeFilter)).click()
         when (scope) {

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/InboxPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/InboxPage.kt
@@ -71,7 +71,7 @@ class InboxPage: BasePage() {
     }
 
     fun selectInboxScope(scope: InboxApi.Scope) {
-        onView(withId(R.id.swipeRefreshLayout)).swipeDown()
+        onView(withId(R.id.inboxRecyclerView)).swipeDown()
         waitForView(withId(R.id.scopeFilterText))
         onView(withId(R.id.scopeFilter)).click()
         when (scope) {

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/InboxPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/InboxPage.kt
@@ -10,7 +10,6 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.canvas.espresso.waitForMatcherWithRefreshes
 import com.instructure.canvas.espresso.withCustomConstraints
-import com.instructure.canvasapi2.apis.InboxApi
 import com.instructure.canvasapi2.models.Conversation
 import com.instructure.dataseeding.model.ConversationApiModel
 import com.instructure.espresso.*
@@ -70,17 +69,11 @@ class InboxPage: BasePage() {
             .perform(withCustomConstraints(ViewActions.swipeDown(), isDisplayingAtLeast(50)))
     }
 
-    fun selectInboxScope(scope: InboxApi.Scope) {
+    fun filterInbox(filterFor: String) {
         refresh()
         waitForView(withId(R.id.scopeFilterText))
         onView(withId(R.id.scopeFilter)).click()
-        when (scope) {
-            InboxApi.Scope.INBOX -> onViewWithText("Inbox").scrollTo().click()
-            InboxApi.Scope.UNREAD -> onViewWithText("Unread").scrollTo().click()
-            InboxApi.Scope.ARCHIVED -> onViewWithText("Archived").scrollTo().click()
-            InboxApi.Scope.STARRED -> onViewWithText("Starred").scrollTo().click()
-            InboxApi.Scope.SENT -> onViewWithText("Sent").scrollTo().click()
-        }
+        waitForViewWithText(filterFor).click()
     }
 
     fun assertThereIsAnUnreadMessage(unread: Boolean) {

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/InboxPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/InboxPage.kt
@@ -94,8 +94,8 @@ class InboxPage: BasePage() {
 
     fun assertConversationDisplayed(subject: String) {
         val matcher = withText(subject)
-        scrollRecyclerView(R.id.inboxRecyclerView, matcher)
-        onView(matcher).assertDisplayed()
+        //scrollRecyclerView(R.id.inboxRecyclerView, matcher)
+        onView(matcher).scrollTo().assertDisplayed()
     }
 
     fun assertConversationNotDisplayed(subject: String) {

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/InboxPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/InboxPage.kt
@@ -71,7 +71,7 @@ class InboxPage: BasePage() {
     }
 
     fun selectInboxScope(scope: InboxApi.Scope) {
-        onView(withId(R.id.inboxRecyclerView)).swipeDown()
+        refresh()
         waitForView(withId(R.id.scopeFilterText))
         onView(withId(R.id.scopeFilter)).click()
         when (scope) {

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/InboxPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/InboxPage.kt
@@ -10,6 +10,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.canvas.espresso.waitForMatcherWithRefreshes
 import com.instructure.canvas.espresso.withCustomConstraints
+import com.instructure.canvasapi2.apis.InboxApi
 import com.instructure.canvasapi2.models.Conversation
 import com.instructure.dataseeding.model.ConversationApiModel
 import com.instructure.espresso.*
@@ -69,9 +70,16 @@ class InboxPage: BasePage() {
             .perform(withCustomConstraints(ViewActions.swipeDown(), isDisplayingAtLeast(50)))
     }
 
-    fun filterInbox(filterFor: String) {
+    fun selectInboxScope(scope: InboxApi.Scope) {
+        waitForView(withId(R.id.scopeFilterText))
         onView(withId(R.id.scopeFilter)).click()
-        waitForViewWithText(filterFor).click()
+        when (scope) {
+            InboxApi.Scope.INBOX -> onViewWithText("Inbox").scrollTo().click()
+            InboxApi.Scope.UNREAD -> onViewWithText("Unread").scrollTo().click()
+            InboxApi.Scope.ARCHIVED -> onViewWithText("Archived").scrollTo().click()
+            InboxApi.Scope.STARRED -> onViewWithText("Starred").scrollTo().click()
+            InboxApi.Scope.SENT -> onViewWithText("Sent").scrollTo().click()
+        }
     }
 
     fun assertThereIsAnUnreadMessage(unread: Boolean) {
@@ -111,11 +119,19 @@ class InboxPage: BasePage() {
         }
     }
 
-    fun selectConversation(conversation: Conversation) {
+    fun selectConversation(conversationSubject: String) {
         waitForView(withId(R.id.inboxRecyclerView))
-        val matcher = ViewMatchers.withText(conversation.subject)
+        val matcher = withText(conversationSubject)
         scrollRecyclerView(R.id.inboxRecyclerView, matcher)
         onView(matcher).longClick()
+    }
+
+    fun selectConversation(conversation: Conversation) {
+        selectConversation(conversation.subject!!)
+    }
+
+    fun selectConversation(conversation: ConversationApiModel) {
+        selectConversation(conversation.subject!!)
     }
 
     fun assertEditToolbarDisplayed() {
@@ -124,6 +140,10 @@ class InboxPage: BasePage() {
 
     fun clickArchive() {
         waitForViewWithId(R.id.inboxArchiveSelected).click()
+    }
+
+    fun clickUnArchive() {
+        waitForViewWithId(R.id.inboxUnarchiveSelected).click()
     }
 
     fun clickStar() {
@@ -151,20 +171,46 @@ class InboxPage: BasePage() {
     }
 
     fun confirmDelete() {
-        waitForViewWithText("DELETE")
+        waitForView(withText("DELETE") + withAncestor(R.id.buttonPanel)).click()
     }
 
-    fun swipeConversationRight(conversation: Conversation) {
+    fun swipeConversationRight(conversationSubject: String) {
         waitForView(withId(R.id.inboxRecyclerView))
-        val matcher = ViewMatchers.withText(conversation.subject)
+        val matcher = withText(conversationSubject)
         scrollRecyclerView(R.id.inboxRecyclerView, matcher)
         onView(matcher).swipeRight()
     }
 
-    fun swipeConversationLeft(conversation: Conversation) {
+    fun swipeConversationRight(conversation: ConversationApiModel) {
+        swipeConversationRight(conversation.subject!!)
+    }
+
+    fun swipeConversationRight(conversation: Conversation) {
+        swipeConversationRight(conversation.subject!!)
+    }
+
+    fun swipeConversationLeft(conversationSubject: String) {
         waitForView(withId(R.id.inboxRecyclerView))
-        val matcher = ViewMatchers.withText(conversation.subject)
+        val matcher = withText(conversationSubject)
         scrollRecyclerView(R.id.inboxRecyclerView, matcher)
         onView(matcher).swipeLeft()
+    }
+
+    fun swipeConversationLeft(conversation: Conversation) {
+        swipeConversationLeft(conversation.subject!!)
+    }
+
+    fun swipeConversationLeft(conversation: ConversationApiModel) {
+        swipeConversationLeft(conversation.subject!!)
+    }
+
+    fun selectConversations(conversations: List<String>) {
+        for(conversation in conversations) {
+            selectConversation(conversation)
+        }
+    }
+
+    fun assertSelectedConversationNumber(selectedConversationNumber: String) {
+        onView(withText(selectedConversationNumber) + withAncestor(R.id.editToolbar))
     }
 }

--- a/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/api/ConversationsApi.kt
+++ b/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/api/ConversationsApi.kt
@@ -34,8 +34,8 @@ object ConversationsApi {
     private fun conversationsService(token: String): ConversationsService
             = CanvasNetworkAdapter.retrofitWithToken(token).create(ConversationsApi.ConversationsService::class.java)
 
-    fun createConversation(token: String, recipients: List<String>): List<ConversationApiModel> {
-        val conversation = CreateConversation(recipients, Randomizer.randomConversationSubject(), Randomizer.randomConversationBody())
+    fun createConversation(token: String, recipients: List<String>, subject: String = Randomizer.randomConversationSubject(), body: String = Randomizer.randomConversationBody()): List<ConversationApiModel> {
+        val conversation = CreateConversation(recipients, subject, body)
         return conversationsService(token)
                 .createConversation(conversation)
                 .execute()

--- a/libs/pandautils/src/main/res/menu/menu_inbox_edit.xml
+++ b/libs/pandautils/src/main/res/menu/menu_inbox_edit.xml
@@ -25,7 +25,7 @@
 
     <item
         android:id="@+id/inboxUnarchiveSelected"
-        android:title="@string/archiveSelected"
+        android:title="@string/unarchiveSelected"
         android:icon="@drawable/ic_unarchive"
         app:showAsAction="always"/>
 


### PR DESCRIPTION
Extend InboxE2E test in both apps, Student and Teacher with new Inbox features (archive, unread/read, star/unstar)

remove deprecated function (filterInbox)

add methods to page objects.

**_IMPORTANT: This pull request also contains the fix of the Inbox interaction test fails on landscape mode._**


Teacher successful E2E test run: https://app.bitrise.io/build/6640e317-4743-4130-9860-fc39b3fadb74

Student successful E2E test run:  https://app.bitrise.io/build/5d034279-5b5f-42a0-971e-494589b876bb

refs: MBL-16531
affects: Student, Teacher
release note: none