### PR TITLE
[MBL-16553][Student][Teacher] Previous user crash

### DIFF
--- a/libs/login-api-2/src/main/java/com/instructure/loginapi/login/activities/BaseLoginLandingPageActivity.kt
+++ b/libs/login-api-2/src/main/java/com/instructure/loginapi/login/activities/BaseLoginLandingPageActivity.kt
@@ -171,7 +171,7 @@ abstract class BaseLoginLandingPageActivity : AppCompatActivity(), ErrorReportDi
                         navigation.startLogin(viewModel, true)
                     }
 
-                    override fun onRemovePreviousUserClick(user: SignedInUser, position: Int) {
+                    override fun onRemovePreviousUserClick(user: SignedInUser) {
                         PreviousUsersUtils.remove(this@BaseLoginLandingPageActivity, user)
                     }
 

--- a/libs/login-api-2/src/main/java/com/instructure/loginapi/login/adapter/PreviousUsersAdapter.kt
+++ b/libs/login-api-2/src/main/java/com/instructure/loginapi/login/adapter/PreviousUsersAdapter.kt
@@ -32,7 +32,7 @@ class PreviousUsersAdapter(
 ) : RecyclerView.Adapter<PreviousUserHolder>() {
     interface PreviousUsersEvents {
         fun onPreviousUserClick(user: SignedInUser)
-        fun onRemovePreviousUserClick(user: SignedInUser, position: Int)
+        fun onRemovePreviousUserClick(user: SignedInUser)
         fun onNowEmpty()
     }
 
@@ -47,10 +47,10 @@ class PreviousUsersAdapter(
             user = user,
             onUserClick = { callback.onPreviousUserClick(user) },
             onUserRemove = {
-                callback.onRemovePreviousUserClick(user, position)
-                previousUsers.removeAt(position)
+                callback.onRemovePreviousUserClick(user)
+                previousUsers.remove(user)
                 notifyItemRemoved(position)
-                if (previousUsers.size == 0) {
+                if (previousUsers.isEmpty()) {
                     callback.onNowEmpty()
                 }
             }


### PR DESCRIPTION
Test plan: the crash occurred when there was at least 2 previous user, and we removed them from top to bottom

refs: MBL-16553
affects: Student, Teacher
release note: none

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Run E2E test suite or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
- [x] Approve from product or not needed
