### PR TITLE
[MBL-16587][Student] Acceptable Use Policy displayed on K5 webviews after accepting it after mobile login

### DIFF
--- a/libs/login-api-2/src/main/java/com/instructure/loginapi/login/features/acceptableusepolicy/AcceptableUsePolicyViewModel.kt
+++ b/libs/login-api-2/src/main/java/com/instructure/loginapi/login/features/acceptableusepolicy/AcceptableUsePolicyViewModel.kt
@@ -28,7 +28,10 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class AcceptableUsePolicyViewModel @Inject constructor(private val userManager: UserManager) : ViewModel() {
+class AcceptableUsePolicyViewModel @Inject constructor(
+    private val userManager: UserManager,
+    private val cookieManager: CookieManager
+) : ViewModel() {
 
     val data: LiveData<AcceptableUsePolicyViewData>
         get() = _data
@@ -79,7 +82,8 @@ class AcceptableUsePolicyViewModel @Inject constructor(private val userManager: 
                 val result = userManager.acceptUserTermsAsync().await()
                 _data.value = _data.value?.copy(loading = false)
                 if (result.isSuccess) {
-                    CookieManager.getInstance().apply { removeAllCookies {} }
+                    // Need to clear cookies, because on login, it is stored that the user has not accepted the Use Policy
+                    cookieManager.apply { removeAllCookies {} }
                     _events.value = Event(AcceptableUsePolicyAction.PolicyAccepted)
                 } else {
                     _events.value = Event(AcceptableUsePolicyAction.AcceptFailure)

--- a/libs/login-api-2/src/main/java/com/instructure/loginapi/login/features/acceptableusepolicy/AcceptableUsePolicyViewModel.kt
+++ b/libs/login-api-2/src/main/java/com/instructure/loginapi/login/features/acceptableusepolicy/AcceptableUsePolicyViewModel.kt
@@ -83,7 +83,7 @@ class AcceptableUsePolicyViewModel @Inject constructor(
                 _data.value = _data.value?.copy(loading = false)
                 if (result.isSuccess) {
                     // Need to clear cookies, because on login, it is stored that the user has not accepted the Use Policy
-                    cookieManager.apply { removeAllCookies {} }
+                    cookieManager.removeAllCookies {}
                     _events.value = Event(AcceptableUsePolicyAction.PolicyAccepted)
                 } else {
                     _events.value = Event(AcceptableUsePolicyAction.AcceptFailure)

--- a/libs/login-api-2/src/main/java/com/instructure/loginapi/login/features/acceptableusepolicy/AcceptableUsePolicyViewModel.kt
+++ b/libs/login-api-2/src/main/java/com/instructure/loginapi/login/features/acceptableusepolicy/AcceptableUsePolicyViewModel.kt
@@ -16,6 +16,7 @@
  */
 package com.instructure.loginapi.login.features.acceptableusepolicy
 
+import android.webkit.CookieManager
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -78,6 +79,7 @@ class AcceptableUsePolicyViewModel @Inject constructor(private val userManager: 
                 val result = userManager.acceptUserTermsAsync().await()
                 _data.value = _data.value?.copy(loading = false)
                 if (result.isSuccess) {
+                    CookieManager.getInstance().apply { removeAllCookies {} }
                     _events.value = Event(AcceptableUsePolicyAction.PolicyAccepted)
                 } else {
                     _events.value = Event(AcceptableUsePolicyAction.AcceptFailure)

--- a/libs/login-api-2/src/test/java/com/instructure/loginapi/login/features/acceptableusepolicy/AcceptableUsePolicyViewModelTest.kt
+++ b/libs/login-api-2/src/test/java/com/instructure/loginapi/login/features/acceptableusepolicy/AcceptableUsePolicyViewModelTest.kt
@@ -16,6 +16,7 @@
  */
 package com.instructure.loginapi.login.features.acceptableusepolicy
 
+import android.webkit.CookieManager
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
@@ -58,7 +59,9 @@ class AcceptableUsePolicyViewModelTest {
 
     private val testDispatcher = TestCoroutineDispatcher()
 
-    private val userManager: UserManager = mockk<UserManager>(relaxed = true)
+    private val userManager: UserManager = mockk(relaxed = true)
+
+    private val cookieManager: CookieManager = mockk(relaxed = true)
 
     private lateinit var viewModel: AcceptableUsePolicyViewModel
 
@@ -82,7 +85,7 @@ class AcceptableUsePolicyViewModelTest {
         }
 
         // When
-        viewModel = AcceptableUsePolicyViewModel(userManager)
+        viewModel = AcceptableUsePolicyViewModel(userManager, cookieManager)
 
         // Then
         val expectedData = AcceptableUsePolicyViewData(TERMS_OF_SERVICE, false, false)
@@ -97,7 +100,7 @@ class AcceptableUsePolicyViewModelTest {
         }
 
         // When
-        viewModel = AcceptableUsePolicyViewModel(userManager)
+        viewModel = AcceptableUsePolicyViewModel(userManager, cookieManager)
         viewModel.checkedChanged(true)
 
         // Then
@@ -113,7 +116,7 @@ class AcceptableUsePolicyViewModelTest {
         }
 
         // When
-        viewModel = AcceptableUsePolicyViewModel(userManager)
+        viewModel = AcceptableUsePolicyViewModel(userManager, cookieManager)
         viewModel.openPolicy()
 
         // Then
@@ -130,7 +133,7 @@ class AcceptableUsePolicyViewModelTest {
         }
 
         // When
-        viewModel = AcceptableUsePolicyViewModel(userManager)
+        viewModel = AcceptableUsePolicyViewModel(userManager, cookieManager)
         viewModel.openPolicy()
 
         // Then
@@ -147,7 +150,7 @@ class AcceptableUsePolicyViewModelTest {
         }
 
         // When
-        viewModel = AcceptableUsePolicyViewModel(userManager)
+        viewModel = AcceptableUsePolicyViewModel(userManager, cookieManager)
         viewModel.openPolicy()
 
         // Then
@@ -163,7 +166,7 @@ class AcceptableUsePolicyViewModelTest {
         }
 
         // When
-        viewModel = AcceptableUsePolicyViewModel(userManager)
+        viewModel = AcceptableUsePolicyViewModel(userManager, cookieManager)
         viewModel.acceptPolicy()
 
         // Then
@@ -179,7 +182,7 @@ class AcceptableUsePolicyViewModelTest {
         }
 
         // When
-        viewModel = AcceptableUsePolicyViewModel(userManager)
+        viewModel = AcceptableUsePolicyViewModel(userManager, cookieManager)
         viewModel.acceptPolicy()
 
         // Then

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/di/ApplicationModule.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/di/ApplicationModule.kt
@@ -20,6 +20,7 @@ import android.app.NotificationManager
 import android.content.ContentResolver
 import android.content.Context
 import android.content.res.Resources
+import android.webkit.CookieManager
 import androidx.work.WorkManager
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.instructure.canvasapi2.managers.OAuthManager
@@ -83,5 +84,11 @@ class ApplicationModule {
     @Singleton
     fun provideWorkManager(@ApplicationContext context: Context): WorkManager {
         return WorkManager.getInstance(context)
+    }
+
+    @Provides
+    @Singleton
+    fun provideCookieManager(): CookieManager {
+        return CookieManager.getInstance()
     }
 }


### PR DESCRIPTION
Test plan: Need to check if all webview where we load url (quiz, discussions etc.) works fine after accepting the use policy (in that particular login, when accepting it) in student and teacher also.

refs: MBL-16587
affects: Student, Teacher
release note: none

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Run E2E test suite or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
- [x] Approve from product or not needed
