### PR TITLE
[MBL-16264][Student] Share Extension | Retry upload from progress screen

### DIFF
--- a/apps/teacher/src/main/AndroidManifest.xml
+++ b/apps/teacher/src/main/AndroidManifest.xml
@@ -210,6 +210,10 @@
         <activity android:name=".activities.TeacherLoginWithQRActivity"
             android:theme="@style/LoginFlowTheme.NoActionBar"/>
 
+        <activity
+            android:name="com.instructure.teacher.features.shareextension.TeacherShareExtensionActivity"
+            android:theme="@style/LoginFlowTheme.NoActionBar" />
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.provider"

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/shareextension/TeacherShareExtensionActivity.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/shareextension/TeacherShareExtensionActivity.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2023 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.instructure.teacher.features.shareextension
+
+import com.instructure.pandautils.features.shareextension.ShareExtensionActivity
+import com.instructure.teacher.activities.SplashActivity
+
+class TeacherShareExtensionActivity : ShareExtensionActivity() {
+
+    override fun exitActivity() {
+        val intent = SplashActivity.createIntent(this, intent?.extras)
+        startActivity(intent)
+        finish()
+    }
+}

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/shareextension/TeacherShareExtensionRouter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/shareextension/TeacherShareExtensionRouter.kt
@@ -3,11 +3,14 @@ package com.instructure.teacher.features.shareextension
 import android.content.Context
 import android.content.Intent
 import com.instructure.pandautils.features.shareextension.ShareExtensionRouter
+import com.instructure.pandautils.features.shareextension.WORKER_ID
 import java.util.*
 
 class TeacherShareExtensionRouter : ShareExtensionRouter {
 
     override fun routeToProgressScreen(context: Context, workerId: UUID): Intent {
-        return Intent()
+        val intent = Intent(context, TeacherShareExtensionActivity::class.java)
+        intent.putExtra(WORKER_ID, workerId)
+        return intent
     }
 }

--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -1301,6 +1301,7 @@
     <string name="a11y_closeProgress">Close progress dialog</string>
     <string name="fileUploadProgress">%1$s of %2$s</string>
     <string name="fileUploadProgressSubtitle">Uploading to Files</string>
+    <string name="fileUploadFailedSubtitle">One or more files failed to upload. Check your internet connection and retry to submit.</string>
     <string name="submissionProgressSubtitle">Uploading submission to \"%s\"</string>
 
     <string name="dashboardNotificationUploadingSubmissionTitle">Uploading Submission</string>

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/dashboard/notifications/DashboardNotificationsViewData.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/dashboard/notifications/DashboardNotificationsViewData.kt
@@ -57,7 +57,7 @@ data class AnnouncementViewData(
 data class UploadViewData(
     val title: String,
     val subTitle: String,
-    val icon: Int,
+    @DrawableRes val icon: Int,
     @ColorRes val backgroundColorTint: Int,
     val isUploading: Boolean
 )

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/dashboard/notifications/DashboardNotificationsViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/dashboard/notifications/DashboardNotificationsViewModel.kt
@@ -231,11 +231,10 @@ class DashboardNotificationsViewModel @Inject constructor(
 
     private suspend fun getUploads(fileUploadEntities: List<DashboardFileUploadEntity>?) = fileUploadEntities?.mapNotNull { fileUploadEntity ->
         val workerId = UUID.fromString(fileUploadEntity.workerId)
-        workManager.getWorkInfoById(workerId).await()?.let { workinfo ->
+        workManager.getWorkInfoById(workerId).await()?.let { workInfo ->
             val icon: Int
             val background: Int
-
-            when (workinfo.state) {
+            when (workInfo.state) {
                 WorkInfo.State.FAILED -> {
                     icon = R.drawable.ic_exclamation_mark
                     background = R.color.backgroundDanger
@@ -252,7 +251,7 @@ class DashboardNotificationsViewModel @Inject constructor(
 
             val uploadViewData = UploadViewData(
                 fileUploadEntity.title.orEmpty(), fileUploadEntity.subtitle.orEmpty(),
-                icon, background, workinfo.state == WorkInfo.State.RUNNING
+                icon, background, workInfo.state == WorkInfo.State.RUNNING
             )
 
             UploadItemViewModel(

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/dashboard/notifications/DashboardNotificationsViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/dashboard/notifications/DashboardNotificationsViewModel.kt
@@ -36,11 +36,13 @@ import com.instructure.pandautils.features.dashboard.notifications.itemviewmodel
 import com.instructure.pandautils.features.dashboard.notifications.itemviewmodels.ConferenceItemViewModel
 import com.instructure.pandautils.features.dashboard.notifications.itemviewmodels.InvitationItemViewModel
 import com.instructure.pandautils.features.dashboard.notifications.itemviewmodels.UploadItemViewModel
+import com.instructure.pandautils.features.file.upload.FileUploadUtilsHelper
 import com.instructure.pandautils.models.ConferenceDashboardBlacklist
 import com.instructure.pandautils.mvvm.Event
 import com.instructure.pandautils.mvvm.ItemViewModel
 import com.instructure.pandautils.mvvm.ViewState
 import com.instructure.pandautils.room.daos.DashboardFileUploadDao
+import com.instructure.pandautils.room.daos.FileUploadInputDao
 import com.instructure.pandautils.room.entities.DashboardFileUploadEntity
 import com.instructure.pandautils.utils.orDefault
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -62,7 +64,9 @@ class DashboardNotificationsViewModel @Inject constructor(
     private val conferenceDashboardBlacklist: ConferenceDashboardBlacklist,
     private val apiPrefs: ApiPrefs,
     private val workManager: WorkManager,
-    private val dashboardFileUploadDao: DashboardFileUploadDao
+    private val dashboardFileUploadDao: DashboardFileUploadDao,
+    private val fileUploadInputDao: FileUploadInputDao,
+    private val fileUploadUtilsHelper: FileUploadUtilsHelper
 ) : ViewModel() {
 
     val state: LiveData<ViewState>
@@ -227,11 +231,11 @@ class DashboardNotificationsViewModel @Inject constructor(
 
     private suspend fun getUploads(fileUploadEntities: List<DashboardFileUploadEntity>?) = fileUploadEntities?.mapNotNull { fileUploadEntity ->
         val workerId = UUID.fromString(fileUploadEntity.workerId)
-        workManager.getWorkInfoById(workerId).await()?.let {
+        workManager.getWorkInfoById(workerId).await()?.let { workinfo ->
             val icon: Int
             val background: Int
 
-            when (it.state) {
+            when (workinfo.state) {
                 WorkInfo.State.FAILED -> {
                     icon = R.drawable.ic_exclamation_mark
                     background = R.color.backgroundDanger
@@ -248,7 +252,7 @@ class DashboardNotificationsViewModel @Inject constructor(
 
             val uploadViewData = UploadViewData(
                 fileUploadEntity.title.orEmpty(), fileUploadEntity.subtitle.orEmpty(),
-                icon, background, it.state == WorkInfo.State.RUNNING
+                icon, background, workinfo.state == WorkInfo.State.RUNNING
             )
 
             UploadItemViewModel(
@@ -256,7 +260,15 @@ class DashboardNotificationsViewModel @Inject constructor(
                 workManager = workManager,
                 data = uploadViewData,
                 open = { uuid -> _events.postValue(Event(DashboardNotificationsActions.OpenProgressDialog(uuid))) },
-                remove = { viewModelScope.launch { dashboardFileUploadDao.delete(fileUploadEntity) } }
+                remove = {
+                    viewModelScope.launch {
+                        dashboardFileUploadDao.delete(fileUploadEntity)
+                        fileUploadInputDao.findByWorkerId(workerId.toString())?.let {
+                            fileUploadUtilsHelper.deleteCachedFiles(it.filePaths)
+                            fileUploadInputDao.delete(it)
+                        }
+                    }
+                }
             )
         }
     }.orEmpty()

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadDialogViewData.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadDialogViewData.kt
@@ -16,12 +16,11 @@
 
 package com.instructure.pandautils.features.file.upload
 
-import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.work.WorkInfo
 import com.instructure.canvasapi2.models.postmodels.FileSubmitObject
 import com.instructure.pandautils.features.file.upload.itemviewmodels.FileItemViewModel
-import java.util.UUID
+import java.util.*
 
 data class FileUploadDialogViewData(
         val allowedExtensions: String?,
@@ -32,11 +31,6 @@ data class FileItemViewData(
         val fileName: String,
         val fileSize: String,
         val fullPath: String
-)
-
-data class FileUploadData(
-        val uri: Uri,
-        val fileSubmitObject: FileSubmitObject
 )
 
 sealed class FileUploadAction {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadDialogViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadDialogViewModel.kt
@@ -37,6 +37,7 @@ import com.instructure.pandautils.utils.humanReadableByteCount
 import com.instructure.pandautils.utils.orDefault
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import java.io.File
 import java.util.*
 import javax.inject.Inject
 
@@ -275,7 +276,7 @@ class FileUploadDialogViewModel @Inject constructor(
                 }
             }
 
-            val uris = filesToUpload.map { it.uri }
+            val uris = filesToUpload.map { Uri.fromFile(File(it.fileSubmitObject.fullPath)) }
 
             startUpload(uris)
         }
@@ -290,8 +291,7 @@ class FileUploadDialogViewModel @Inject constructor(
             if (uploadType == FileUploadType.DISCUSSION) {
                 _events.value = Event(FileUploadAction.AttachmentSelectedAction(FileUploadDialogFragment.EVENT_ON_FILE_SELECTED, getAttachmentUri()))
             } else {
-                val worker = OneTimeWorkRequestBuilder<FileUploadWorker>()
-                    .build()
+                val worker = OneTimeWorkRequestBuilder<FileUploadWorker>().build()
 
                 val input = getInputData(worker.id, uris)
                 fileUploadInputDao.insert(input)

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadUtilsHelper.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadUtilsHelper.kt
@@ -21,6 +21,9 @@ import android.content.Context
 import android.net.Uri
 import com.instructure.canvasapi2.models.postmodels.FileSubmitObject
 import com.instructure.pandautils.utils.FileUploadUtils
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
 
 class FileUploadUtilsHelper(
     private val fileUploadUtils: FileUploadUtils,
@@ -41,5 +44,13 @@ class FileUploadUtilsHelper(
 
     fun getFileSubmitObjectByFileUri(fileUri: Uri, fileName: String, mimeType: String): FileSubmitObject? {
         return fileUploadUtils.getFileSubmitObjectByFileUri(fileUri, fileName, mimeType)
+    }
+
+    suspend fun deleteCachedFiles(uriStrings: List<String>) = withContext(Dispatchers.IO) {
+        uriStrings.forEach { uriString ->
+            Uri.parse(uriString).path?.let {
+                File(it).delete()
+            }
+        }
     }
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadUtilsHelper.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadUtilsHelper.kt
@@ -22,7 +22,11 @@ import android.net.Uri
 import com.instructure.canvasapi2.models.postmodels.FileSubmitObject
 import com.instructure.pandautils.utils.FileUploadUtils
 
-class FileUploadUtilsHelper(private val fileUploadUtils: FileUploadUtils, private val context: Context, private val contentResolver: ContentResolver) {
+class FileUploadUtilsHelper(
+    private val fileUploadUtils: FileUploadUtils,
+    private val context: Context,
+    private val contentResolver: ContentResolver
+) {
     fun getFileMimeType(fileUri: Uri): String {
         return fileUploadUtils.getFileMimeType(contentResolver, fileUri)
     }
@@ -33,5 +37,9 @@ class FileUploadUtilsHelper(private val fileUploadUtils: FileUploadUtils, privat
 
     fun getFileSubmitObjectFromInputStream(fileUri: Uri, fileName: String, mimeType: String): FileSubmitObject? {
         return fileUploadUtils.getFileSubmitObjectFromInputStream(context, fileUri, fileName, mimeType)
+    }
+
+    fun getFileSubmitObjectByFileUri(fileUri: Uri, fileName: String, mimeType: String): FileSubmitObject? {
+        return fileUploadUtils.getFileSubmitObjectByFileUri(fileUri, fileName, mimeType)
     }
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/worker/FileUploadWorker.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/worker/FileUploadWorker.kt
@@ -42,7 +42,6 @@ import com.instructure.pandautils.utils.FileUploadUtils
 import com.instructure.pandautils.utils.toJson
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import java.io.File
 import java.util.*
 
 @HiltWorker
@@ -55,7 +54,8 @@ class FileUploadWorker @AssistedInject constructor(
     private val mediaCommentDao: MediaCommentDao,
     private val authorDao: AuthorDao,
     private val dashboardFileUploadDao: DashboardFileUploadDao,
-    private val apiPrefs: ApiPrefs
+    private val apiPrefs: ApiPrefs,
+    private val fileUploadUtilsHelper: FileUploadUtilsHelper
 ) : CoroutineWorker(context, workerParameters) {
 
     private val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -162,7 +162,7 @@ class FileUploadWorker @AssistedInject constructor(
 
             insertDashboardUpload(successTitle, subtitle)
             fileUploadInputDao.delete(inputData)
-            deleteCachedFiles(inputData.filePaths)
+            fileUploadUtilsHelper.deleteCachedFiles(inputData.filePaths)
             return result
         } catch (e: Exception) {
             val failedTitle = context.getString(
@@ -188,14 +188,6 @@ class FileUploadWorker @AssistedInject constructor(
                 subtitle = subtitle
             )
         )
-    }
-
-    private fun deleteCachedFiles(uriStrings: List<String>) {
-        uriStrings.forEach { uriString ->
-            Uri.parse(uriString).path?.let {
-                File(it).delete()
-            }
-        }
     }
 
     private suspend fun insertSubmissionComment(submissionComment: SubmissionComment): Long {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/worker/FileUploadWorker.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/worker/FileUploadWorker.kt
@@ -79,6 +79,7 @@ class FileUploadWorker @AssistedInject constructor(
     private val workDataBuilder = Data.Builder()
 
     override suspend fun doWork(): Result {
+        var title = ""
         var subtitle = ""
         try {
             val inputData = fileUploadInputDao.findByWorkerId(id.toString()) ?: throw IllegalArgumentException()
@@ -88,7 +89,7 @@ class FileUploadWorker @AssistedInject constructor(
             fullSize = fileSubmitObjects.sumOf { it.size }
             uploadCount = fileSubmitObjects.size
 
-            val title = if (action == ACTION_ASSIGNMENT_SUBMISSION) {
+            title = if (action == ACTION_ASSIGNMENT_SUBMISSION) {
                 context.getString(R.string.dashboardNotificationUploadingSubmissionTitle)
             } else {
                 context.resources.getQuantityString(R.plurals.dashboardNotificationUploadingFilesTitle, uploadCount)
@@ -152,7 +153,7 @@ class FileUploadWorker @AssistedInject constructor(
                 }
             }
 
-            val successTitle = context.getString(
+            title = context.getString(
                 if (action == ACTION_ASSIGNMENT_SUBMISSION) {
                     R.string.dashboardNotificationSubmissionUploadSuccessTitle
                 } else {
@@ -160,21 +161,21 @@ class FileUploadWorker @AssistedInject constructor(
                 }
             )
 
-            insertDashboardUpload(successTitle, subtitle)
             fileUploadInputDao.delete(inputData)
             fileUploadUtilsHelper.deleteCachedFiles(inputData.filePaths)
             return result
         } catch (e: Exception) {
-            val failedTitle = context.getString(
+            title = context.getString(
                 if (action == ACTION_ASSIGNMENT_SUBMISSION) {
                     R.string.dashboardNotificationSubmissionUploadFailedTitle
                 } else {
                     R.string.dashboardNotificationUploadingFilesFailedTitle
                 }
             )
-            insertDashboardUpload(failedTitle, subtitle)
             e.printStackTrace()
             return Result.failure(workDataBuilder.build())
+        } finally {
+            insertDashboardUpload(title, subtitle)
         }
     }
 

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/shareextension/progress/ShareExtensionProgressDialogFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/shareextension/progress/ShareExtensionProgressDialogFragment.kt
@@ -110,12 +110,8 @@ class ShareExtensionProgressDialogFragment : DialogFragment() {
             .setTitle(title)
             .setMessage(message)
             .setNegativeButton(R.string.no) { _, _ -> }
-            .setPositiveButton(R.string.yes) { _, _ ->
-                uuid?.let {
-                    viewModel.cancelUpload(it)
-                }
-                viewModel.onCloseClicked()
-            }.show()
+            .setPositiveButton(R.string.yes) { _, _ -> viewModel.cancelUpload() }
+            .show()
     }
 
     companion object {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/shareextension/progress/ShareExtensionProgressDialogFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/shareextension/progress/ShareExtensionProgressDialogFragment.kt
@@ -31,7 +31,6 @@ import com.instructure.pandautils.R
 import com.instructure.pandautils.databinding.FragmentShareExtensionProgressDialogBinding
 import com.instructure.pandautils.features.shareextension.ShareExtensionViewModel
 import com.instructure.pandautils.utils.NullableSerializableArg
-import com.instructure.pandautils.utils.ThemePrefs
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.*
 
@@ -83,10 +82,6 @@ class ShareExtensionProgressDialogFragment : DialogFragment() {
             is ShareExtensionProgressAction.CancelUpload -> {
                 cancelClicked(action.title, action.message)
             }
-            is ShareExtensionProgressAction.ShowErrorDialog -> {
-                dismiss()
-                shareExtensionViewModel.showErrorDialog(action.fileUploadType)
-            }
         }
     }
 
@@ -95,19 +90,10 @@ class ShareExtensionProgressDialogFragment : DialogFragment() {
 
         val dialog = AlertDialog.Builder(requireContext())
             .setView(binding.root)
-            .setNegativeButton(R.string.utils_cancel, null)
             .setCancelable(false)
             .create()
 
         dialog.setCanceledOnTouchOutside(false)
-
-        dialog.setOnShowListener {
-            val negative = dialog.getButton(DialogInterface.BUTTON_NEGATIVE)
-            negative.setTextColor(ThemePrefs.textButtonColor)
-            negative.setOnClickListener {
-                viewModel.cancelClicked()
-            }
-        }
 
         dialog.window?.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
 

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/shareextension/progress/ShareExtensionProgressDialogViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/shareextension/progress/ShareExtensionProgressDialogViewModel.kt
@@ -105,7 +105,7 @@ class ShareExtensionProgressDialogViewModel @Inject constructor(
                     FileProgressViewData(
                         it.name,
                         it.size.humanReadableByteCount(),
-                        getIconDrawableRes(it.contentType, !uploadedFilesMap.containsKey(it.name)),
+                        getIconDrawableRes(it.contentType, (failed && !uploadedFilesMap.containsKey(it.name))),
                         getFileUploadStatus(uploadedFilesMap, it, failed)
                     )
                 }
@@ -134,7 +134,10 @@ class ShareExtensionProgressDialogViewModel @Inject constructor(
                         this.items.find { it.data.name == fileToUpload.name }.apply {
                             if (this?.data?.status != status) {
                                 this?.data?.status = status
-                                this?.data?.icon = getIconDrawableRes(fileToUpload.contentType, !uploadedFilesMap.containsKey(this?.data?.name))
+                                this?.data?.icon = getIconDrawableRes(
+                                    fileToUpload.contentType,
+                                    (failed && !uploadedFilesMap.containsKey(this?.data?.name))
+                                )
                                 this?.data?.notifyPropertyChanged(BR.status)
                                 this?.data?.notifyPropertyChanged(BR.icon)
                                 this?.data?.notifyPropertyChanged(BR.iconTint)

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/shareextension/progress/ShareExtensionProgressDialogViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/shareextension/progress/ShareExtensionProgressDialogViewModel.kt
@@ -112,7 +112,7 @@ class ShareExtensionProgressDialogViewModel @Inject constructor(
 
                 viewData = ShareExtensionProgressViewData(
                     items = itemViewData.map { FileProgressItemViewModel(it) },
-                    dialogTitle = if (assignmentName.isNullOrEmpty()) resources.getString(R.string.fileUpload) else resources.getString(R.string.submission),
+                    dialogTitle = resources.getString(if (assignmentName.isNullOrEmpty()) R.string.fileUpload else R.string.submission),
                     subtitle = subtitle,
                     maxSize = maxSize.humanReadableByteCount(),
                     currentSize = currentSize.humanReadableByteCount(),

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/shareextension/progress/ShareExtensionProgressDialogViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/shareextension/progress/ShareExtensionProgressDialogViewModel.kt
@@ -6,10 +6,8 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModel
-import androidx.work.Data
-import androidx.work.WorkInfo
-import androidx.work.WorkManager
-import androidx.work.hasKeyWithValueOfType
+import androidx.lifecycle.viewModelScope
+import androidx.work.*
 import com.instructure.canvasapi2.models.postmodels.FileSubmitObject
 import com.instructure.pandautils.BR
 import com.instructure.pandautils.R
@@ -18,16 +16,21 @@ import com.instructure.pandautils.features.file.upload.worker.FileUploadWorker
 import com.instructure.pandautils.features.shareextension.progress.itemviewmodels.FileProgressItemViewModel
 import com.instructure.pandautils.mvvm.Event
 import com.instructure.pandautils.mvvm.ViewState
+import com.instructure.pandautils.room.daos.DashboardFileUploadDao
+import com.instructure.pandautils.room.daos.FileUploadInputDao
 import com.instructure.pandautils.utils.fromJson
 import com.instructure.pandautils.utils.humanReadableByteCount
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import java.util.*
 import javax.inject.Inject
 
 @HiltViewModel
 class ShareExtensionProgressDialogViewModel @Inject constructor(
     private val workManager: WorkManager,
-    private val resources: Resources
+    private val resources: Resources,
+    private val fileUploadInputDao: FileUploadInputDao,
+    private val dashboardFileUploadDao: DashboardFileUploadDao
 ) : ViewModel() {
 
     val state: LiveData<ViewState>
@@ -55,10 +58,10 @@ class ShareExtensionProgressDialogViewModel @Inject constructor(
                 _events.postValue(Event((ShareExtensionProgressAction.ShowSuccessDialog(fileUploadType))))
             }
             WorkInfo.State.RUNNING -> {
-                updateViewData(it.progress)
+                updateViewData(it.progress, false)
             }
             WorkInfo.State.FAILED -> {
-                _events.postValue(Event(ShareExtensionProgressAction.ShowErrorDialog(fileUploadType)))
+                updateViewData(it.outputData, true)
             }
             else -> {}
         }
@@ -72,82 +75,113 @@ class ShareExtensionProgressDialogViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
-        workerId?.let {
-            workManager.getWorkInfoByIdLiveData(it).removeObserver(observer)
-        }
+        workerId?.let { workManager.getWorkInfoByIdLiveData(it).removeObserver(observer) }
     }
 
-    private fun updateViewData(progress: Data) {
+    private fun updateViewData(progress: Data, failed: Boolean) {
         if (allDataPresent(progress)) {
             _state.postValue(ViewState.Success)
 
             val maxSize = progress.getLong(FileUploadWorker.PROGRESS_DATA_FULL_SIZE, 1L)
             val currentSize = progress.getLong(FileUploadWorker.PROGRESS_DATA_UPLOADED_SIZE, 0L)
-            val assignmentName =
-                if (progress.hasKeyWithValueOfType<String>(FileUploadWorker.PROGRESS_DATA_ASSIGNMENT_NAME)) {
-                    progress.getString(FileUploadWorker.PROGRESS_DATA_ASSIGNMENT_NAME)
-                } else null
+            val assignmentName = progress.getString(FileUploadWorker.PROGRESS_DATA_ASSIGNMENT_NAME)
             fileUploadType = if (assignmentName.isNullOrEmpty()) FileUploadType.USER else FileUploadType.ASSIGNMENT
+            val subtitle = if (failed) {
+                resources.getString(R.string.fileUploadFailedSubtitle)
+            } else if (assignmentName.isNullOrEmpty()) {
+                resources.getString(R.string.fileUploadProgressSubtitle)
+            } else {
+                resources.getString(R.string.submissionProgressSubtitle, assignmentName)
+            }
 
-            val uploadedMap = progress.getStringArray(FileUploadWorker.PROGRESS_DATA_UPLOADED_FILES).orEmpty()
-                .map { it.fromJson<FileSubmitObject>() }
-                .associateBy { it.name }
+            val filesToUpload = progress.getStringArray(FileUploadWorker.PROGRESS_DATA_FILES_TO_UPLOAD)
+                .orEmpty().map { it.fromJson<FileSubmitObject>() }
+
+            val uploadedFilesMap = progress.getStringArray(FileUploadWorker.PROGRESS_DATA_UPLOADED_FILES)
+                .orEmpty().map { it.fromJson<FileSubmitObject>() }.associateBy { it.name }
 
             if (viewData == null) {
-                itemViewData =
-                    progress.getStringArray(FileUploadWorker.PROGRESS_DATA_FILES_TO_UPLOAD).orEmpty().toList()
-                        .map { it.fromJson<FileSubmitObject>() }
-                        .map {
-                            FileProgressViewData(
-                                it.name,
-                                it.size.humanReadableByteCount(),
-                                getIconDrawableRes(it.contentType),
-                                uploadedMap.containsKey(it.name)
-                            )
-                        }
+                itemViewData = filesToUpload.map {
+                    FileProgressViewData(
+                        it.name,
+                        it.size.humanReadableByteCount(),
+                        getIconDrawableRes(it.contentType, failed),
+                        getFileUploadStatus(uploadedFilesMap, it, failed)
+                    )
+                }
 
                 viewData = ShareExtensionProgressViewData(
                     items = itemViewData.map { FileProgressItemViewModel(it) },
-                    dialogTitle = if (assignmentName.isNullOrEmpty()) resources.getString(R.string.fileUpload) else resources.getString(
-                        R.string.submission
-                    ),
-                    subtitle = if (assignmentName.isNullOrEmpty()) resources.getString(R.string.fileUploadProgressSubtitle) else resources.getString(
-                        R.string.submissionProgressSubtitle,
-                        assignmentName
-                    ),
+                    dialogTitle = if (assignmentName.isNullOrEmpty()) resources.getString(R.string.fileUpload) else resources.getString(R.string.submission),
+                    subtitle = subtitle,
                     maxSize = maxSize.humanReadableByteCount(),
                     currentSize = currentSize.humanReadableByteCount(),
                     progressInt = ((currentSize.toDouble() / maxSize.toDouble()) * 100.0).toInt(),
-                    percentage = "${String.format("%.1f", currentSize.toDouble() / maxSize.toDouble() * 100.0)}%"
-                )
-                viewData?.let {
+                    percentage = "${String.format("%.1f", currentSize.toDouble() / maxSize.toDouble() * 100.0)}%",
+                    retryVisible = failed
+                ).also {
                     _data.postValue(it)
                 }
             } else {
                 viewData?.apply {
+                    this.subtitle = subtitle
                     this.currentSize = currentSize.humanReadableByteCount()
                     this.progressInt = ((currentSize.toDouble() / maxSize.toDouble()) * 100).toInt()
-                    this.percentage =
-                        "${String.format("%.1f", currentSize.toDouble() / maxSize.toDouble() * 100.0)}%"
-                    uploadedMap.forEach { uploadedEntry ->
-                        this.items.find { itemViewModel ->
-                            itemViewModel.data.name == uploadedEntry.key
-                        }.apply {
-                            this?.data?.uploaded = true
-                            this?.data?.notifyPropertyChanged(BR.uploaded)
+                    this.percentage = "${String.format("%.1f", currentSize.toDouble() / maxSize.toDouble() * 100.0)}%"
+                    this.retryVisible = failed
+                    filesToUpload.forEach { fileToUpload ->
+                        val status = getFileUploadStatus(uploadedFilesMap, fileToUpload, failed)
+                        this.items.find { it.data.name == fileToUpload.name }.apply {
+                            if (this?.data?.status != status) {
+                                this?.data?.status = status
+                                this?.data?.icon = getIconDrawableRes(fileToUpload.contentType, failed)
+                                this?.data?.notifyPropertyChanged(BR.status)
+                                this?.data?.notifyPropertyChanged(BR.icon)
+                                this?.data?.notifyPropertyChanged(BR.iconTint)
+                            }
                         }
                     }
                     notifyPropertyChanged(BR.currentSize)
                     notifyPropertyChanged(BR.progressInt)
                     notifyPropertyChanged(BR.percentage)
+                    notifyPropertyChanged(BR.subtitle)
+                    notifyPropertyChanged(BR.retryVisible)
                 }
             }
+        }
+    }
 
+    private fun getFileUploadStatus(
+        uploadedFilesMap: Map<String, FileSubmitObject>,
+        fileToUpload: FileSubmitObject,
+        failed: Boolean
+    ): FileProgressStatus {
+        return if (uploadedFilesMap.containsKey(fileToUpload.name)) {
+            FileProgressStatus.UPLOADED
+        } else if (failed) {
+            FileProgressStatus.FAILED
+        } else {
+            FileProgressStatus.IN_PROGRESS
+        }
+    }
+
+    fun onRetryClick() {
+        viewModelScope.launch {
+            fileUploadInputDao.findByWorkerId(workerId.toString())?.let {
+                val worker = OneTimeWorkRequestBuilder<FileUploadWorker>().build()
+                fileUploadInputDao.insert(it.copy(workerId = worker.id.toString()))
+                fileUploadInputDao.delete(it)
+                dashboardFileUploadDao.deleteByWorkerId(it.workerId)
+                workManager.enqueue(worker)
+                setUUID(worker.id)
+            }
         }
     }
 
     private fun allDataPresent(progress: Data): Boolean {
-        return progress.hasKeyWithValueOfType<Long>(FileUploadWorker.PROGRESS_DATA_FULL_SIZE) && progress.hasKeyWithValueOfType<Array<String>>(
+        return progress.hasKeyWithValueOfType<Long>(
+            FileUploadWorker.PROGRESS_DATA_FULL_SIZE
+        ) && progress.hasKeyWithValueOfType<Array<String>>(
             FileUploadWorker.PROGRESS_DATA_FILES_TO_UPLOAD
         )
     }
@@ -157,8 +191,9 @@ class ShareExtensionProgressDialogViewModel @Inject constructor(
     }
 
     @DrawableRes
-    private fun getIconDrawableRes(contentType: String): Int {
+    private fun getIconDrawableRes(contentType: String, failed: Boolean): Int {
         return when {
+            failed -> R.drawable.ic_warning
             contentType.contains("image") -> R.drawable.ic_image
             contentType.contains("video") -> R.drawable.ic_media
             contentType.contains("pdf") -> R.drawable.ic_pdf

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/shareextension/progress/ShareExtensionProgressDialogViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/shareextension/progress/ShareExtensionProgressDialogViewModel.kt
@@ -105,7 +105,7 @@ class ShareExtensionProgressDialogViewModel @Inject constructor(
                     FileProgressViewData(
                         it.name,
                         it.size.humanReadableByteCount(),
-                        getIconDrawableRes(it.contentType, failed),
+                        getIconDrawableRes(it.contentType, !uploadedFilesMap.containsKey(it.name)),
                         getFileUploadStatus(uploadedFilesMap, it, failed)
                     )
                 }
@@ -134,7 +134,7 @@ class ShareExtensionProgressDialogViewModel @Inject constructor(
                         this.items.find { it.data.name == fileToUpload.name }.apply {
                             if (this?.data?.status != status) {
                                 this?.data?.status = status
-                                this?.data?.icon = getIconDrawableRes(fileToUpload.contentType, failed)
+                                this?.data?.icon = getIconDrawableRes(fileToUpload.contentType, !uploadedFilesMap.containsKey(this?.data?.name))
                                 this?.data?.notifyPropertyChanged(BR.status)
                                 this?.data?.notifyPropertyChanged(BR.icon)
                                 this?.data?.notifyPropertyChanged(BR.iconTint)

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/shareextension/progress/ShareExtensionProgressViewData.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/shareextension/progress/ShareExtensionProgressViewData.kt
@@ -9,14 +9,14 @@ import com.instructure.pandautils.features.file.upload.FileUploadType
 import com.instructure.pandautils.features.shareextension.progress.itemviewmodels.FileProgressItemViewModel
 
 data class ShareExtensionProgressViewData(
-    val items: List<FileProgressItemViewModel>,
+    @get:Bindable var items: List<FileProgressItemViewModel>,
     val dialogTitle: String,
     @get:Bindable var subtitle: String?,
-    val maxSize: String,
+    @get:Bindable var maxSize: String,
     @get:Bindable var progressInt: Int,
     @get:Bindable var percentage: String,
     @get:Bindable var currentSize: String,
-    @get:Bindable var retryVisible: Boolean
+    @get:Bindable var failed: Boolean
 ) : BaseObservable()
 
 enum class FileProgressStatus(@ColorRes val tint: Int, @DrawableRes val drawable: Int) {
@@ -29,7 +29,8 @@ data class FileProgressViewData(
     val name: String,
     val size: String,
     @get:Bindable @DrawableRes var icon: Int,
-    @get:Bindable var status: FileProgressStatus
+    @get:Bindable var status: FileProgressStatus,
+    val onStatusIconClick: (FileProgressViewData) -> Unit
 ) : BaseObservable() {
     @Bindable
     @ColorRes

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/shareextension/progress/ShareExtensionProgressViewData.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/shareextension/progress/ShareExtensionProgressViewData.kt
@@ -1,31 +1,43 @@
 package com.instructure.pandautils.features.shareextension.progress
 
+import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.databinding.BaseObservable
 import androidx.databinding.Bindable
+import com.instructure.pandautils.R
 import com.instructure.pandautils.features.file.upload.FileUploadType
 import com.instructure.pandautils.features.shareextension.progress.itemviewmodels.FileProgressItemViewModel
 
 data class ShareExtensionProgressViewData(
     val items: List<FileProgressItemViewModel>,
     val dialogTitle: String,
-    val subtitle: String?,
+    @get:Bindable var subtitle: String?,
     val maxSize: String,
     @get:Bindable var progressInt: Int,
     @get:Bindable var percentage: String,
-    @get:Bindable var currentSize: String
+    @get:Bindable var currentSize: String,
+    @get:Bindable var retryVisible: Boolean
 ) : BaseObservable()
+
+enum class FileProgressStatus(@ColorRes val tint: Int, @DrawableRes val drawable: Int) {
+    IN_PROGRESS(R.color.backgroundSuccess, R.drawable.ic_checkmark),
+    UPLOADED(R.color.backgroundSuccess, R.drawable.ic_checkmark),
+    FAILED(R.color.textDarkest, R.drawable.ic_close)
+}
 
 data class FileProgressViewData(
     val name: String,
     val size: String,
-    @DrawableRes val icon: Int,
-    @get:Bindable var uploaded: Boolean
-) : BaseObservable()
+    @get:Bindable @DrawableRes var icon: Int,
+    @get:Bindable var status: FileProgressStatus
+) : BaseObservable() {
+    @Bindable
+    @ColorRes
+    fun getIconTint() = if (status == FileProgressStatus.FAILED) R.color.textDanger else R.color.textDarkest
+}
 
 sealed class ShareExtensionProgressAction {
     object Close : ShareExtensionProgressAction()
     data class CancelUpload(val title: String, val message: String) : ShareExtensionProgressAction()
     data class ShowSuccessDialog(val fileUploadType: FileUploadType) : ShareExtensionProgressAction()
-    data class ShowErrorDialog(val fileUploadType: FileUploadType) : ShareExtensionProgressAction()
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/room/daos/DashboardFileUploadDao.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/room/daos/DashboardFileUploadDao.kt
@@ -15,4 +15,7 @@ interface DashboardFileUploadDao {
 
     @Query("SELECT * FROM DashboardFileUploadEntity WHERE userId = :userId")
     fun getAll(userId: Long): LiveData<List<DashboardFileUploadEntity>>
+
+    @Query("DELETE FROM DashboardFileUploadEntity WHERE workerId = :workerId")
+    suspend fun deleteByWorkerId(workerId: String)
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/FileUploadUtils.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/FileUploadUtils.kt
@@ -184,6 +184,15 @@ object FileUploadUtils {
                 fileName = "$fileName.$extension"
             }
 
+            // add file version if needed
+            var version = 1
+            var fileNameFile = File(getTempFilePath(context, fileName))
+            val ext = fileName.substring(fileName.lastIndexOf("."))
+            while (fileNameFile.exists()) {
+                fileName = "${filename.dropLast(ext.length)}(${version++})$ext"
+                fileNameFile = File(getTempFilePath(context, fileName))
+            }
+
             // create a temp file to copy the uri contents into
             val tempFilePath = getTempFilePath(context, fileName)
             output = FileOutputStream(tempFilePath)

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/FileUploadUtils.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/FileUploadUtils.kt
@@ -214,6 +214,18 @@ object FileUploadUtils {
         } else FileSubmitObject(fileName, 0, mimeType!!, "", errorMessage, FileSubmitObject.STATE.NORMAL)
     }
 
+    fun getFileSubmitObjectByFileUri(uri: Uri?, filename: String, mimeType: String?): FileSubmitObject? {
+        return uri?.path?.let {
+            val file = File(it)
+            FileSubmitObject(
+                name = filename,
+                size = file.length(),
+                contentType = mimeType.orEmpty(),
+                fullPath = file.absolutePath
+            )
+        }
+    }
+
     fun getFileNameWithDefault(resolver: ContentResolver, uri: Uri): String {
         var fileName: String? = ""
         val scheme = uri.scheme

--- a/libs/pandautils/src/main/res/layout/fragment_share_extension_progress_dialog.xml
+++ b/libs/pandautils/src/main/res/layout/fragment_share_extension_progress_dialog.xml
@@ -168,12 +168,20 @@
                 android:background="@color/backgroundMedium"
                 app:layout_constraintTop_toBottomOf="@id/cancel" />
 
-            <LinearLayout
+            <ScrollView
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                app:itemViewModels="@{viewModel.data.items}"
-                app:layout_constraintTop_toBottomOf="@id/itemsDivider" />
+                android:layout_height="0dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintHeight_default="wrap"
+                app:layout_constraintTop_toBottomOf="@id/itemsDivider">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    app:itemViewModels="@{viewModel.data.items}" />
+
+            </ScrollView>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/libs/pandautils/src/main/res/layout/fragment_share_extension_progress_dialog.xml
+++ b/libs/pandautils/src/main/res/layout/fragment_share_extension_progress_dialog.xml
@@ -90,7 +90,7 @@
                 android:max="100"
                 android:progress="@{viewModel.data.progressInt}"
                 android:progressTint="@color/backgroundInfo"
-                android:visibility="@{viewModel.data.retryVisible ? View.GONE : View.VISIBLE}"
+                android:visibility="@{viewModel.data.failed ? View.GONE : View.VISIBLE}"
                 app:layout_constraintTop_toBottomOf="@id/subtitle"
                 tools:progress="25" />
 
@@ -102,7 +102,7 @@
                 android:text="@{viewModel.data.percentage}"
                 android:textColor="@color/textDarkest"
                 android:textSize="12sp"
-                android:visibility="@{viewModel.data.retryVisible ? View.GONE : View.VISIBLE}"
+                android:visibility="@{viewModel.data.failed ? View.GONE : View.VISIBLE}"
                 app:layout_constraintStart_toStartOf="@id/progressBar"
                 app:layout_constraintTop_toBottomOf="@id/progressBar"
                 tools:text="32.7%" />
@@ -115,7 +115,7 @@
                 android:text="@{@string/fileUploadProgress(viewModel.data.currentSize, viewModel.data.maxSize)}"
                 android:textColor="@color/textDark"
                 android:textSize="12sp"
-                android:visibility="@{viewModel.data.retryVisible ? View.GONE : View.VISIBLE}"
+                android:visibility="@{viewModel.data.failed ? View.GONE : View.VISIBLE}"
                 app:layout_constraintStart_toEndOf="@id/percentage"
                 app:layout_constraintTop_toTopOf="@id/percentage"
                 tools:text="16 MB of 49.3 MB" />
@@ -140,7 +140,7 @@
                 android:textColor="@{ThemePrefs.INSTANCE.textButtonColor}"
                 android:textSize="12sp"
                 android:textStyle="bold"
-                android:visibility="@{viewModel.data.retryVisible ? View.VISIBLE : View.GONE}"
+                android:visibility="@{viewModel.data.failed ? View.VISIBLE : View.GONE}"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/buttonBarrier" />
 

--- a/libs/pandautils/src/main/res/layout/fragment_share_extension_progress_dialog.xml
+++ b/libs/pandautils/src/main/res/layout/fragment_share_extension_progress_dialog.xml
@@ -22,6 +22,8 @@
 
         <import type="android.view.View" />
 
+        <import type="com.instructure.pandautils.utils.ThemePrefs" />
+
         <variable
             name="viewModel"
             type="com.instructure.pandautils.features.shareextension.progress.ShareExtensionProgressDialogViewModel" />
@@ -72,9 +74,8 @@
                 android:id="@+id/subtitle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="16dp"
+                android:layout_marginHorizontal="16dp"
                 android:layout_marginTop="16dp"
-                android:layout_marginEnd="16dp"
                 android:text="@{viewModel.data.subtitle}"
                 app:layout_constraintTop_toBottomOf="@id/divider"
                 tools:text="Uploading submission for Assignment Name" />
@@ -84,12 +85,12 @@
                 style="?android:attr/progressBarStyleHorizontal"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="16dp"
+                android:layout_marginHorizontal="16dp"
                 android:layout_marginTop="12dp"
-                android:layout_marginEnd="16dp"
                 android:max="100"
                 android:progress="@{viewModel.data.progressInt}"
                 android:progressTint="@color/backgroundInfo"
+                android:visibility="@{viewModel.data.retryVisible ? View.GONE : View.VISIBLE}"
                 app:layout_constraintTop_toBottomOf="@id/subtitle"
                 tools:progress="25" />
 
@@ -101,20 +102,63 @@
                 android:text="@{viewModel.data.percentage}"
                 android:textColor="@color/textDarkest"
                 android:textSize="12sp"
+                android:visibility="@{viewModel.data.retryVisible ? View.GONE : View.VISIBLE}"
                 app:layout_constraintStart_toStartOf="@id/progressBar"
                 app:layout_constraintTop_toBottomOf="@id/progressBar"
                 tools:text="32.7%" />
 
             <TextView
+                android:id="@+id/size"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="12sp"
+                android:layout_marginStart="12dp"
                 android:text="@{@string/fileUploadProgress(viewModel.data.currentSize, viewModel.data.maxSize)}"
                 android:textColor="@color/textDark"
                 android:textSize="12sp"
+                android:visibility="@{viewModel.data.retryVisible ? View.GONE : View.VISIBLE}"
                 app:layout_constraintStart_toEndOf="@id/percentage"
                 app:layout_constraintTop_toTopOf="@id/percentage"
                 tools:text="16 MB of 49.3 MB" />
+
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/buttonBarrier"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:barrierDirection="bottom"
+                app:constraint_referenced_ids="subtitle, size" />
+
+            <TextView
+                android:id="@+id/retry"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:layout_marginEnd="16dp"
+                android:background="?android:selectableItemBackground"
+                android:onClick="@{() -> viewModel.onRetryClick()}"
+                android:text="@string/retry"
+                android:textAllCaps="true"
+                android:textColor="@{ThemePrefs.INSTANCE.textButtonColor}"
+                android:textSize="12sp"
+                android:textStyle="bold"
+                android:visibility="@{viewModel.data.retryVisible ? View.VISIBLE : View.GONE}"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/buttonBarrier" />
+
+            <TextView
+                android:id="@+id/cancel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:layout_marginEnd="16dp"
+                android:background="?android:selectableItemBackground"
+                android:onClick="@{() -> viewModel.cancelClicked()}"
+                android:text="@string/cancel"
+                android:textAllCaps="true"
+                android:textColor="@{ThemePrefs.INSTANCE.textButtonColor}"
+                android:textSize="12sp"
+                android:textStyle="bold"
+                app:layout_constraintEnd_toStartOf="@id/retry"
+                app:layout_constraintTop_toBottomOf="@id/buttonBarrier" />
 
             <View
                 android:id="@+id/itemsDivider"
@@ -122,7 +166,7 @@
                 android:layout_height="1dp"
                 android:layout_marginTop="16dp"
                 android:background="@color/backgroundMedium"
-                app:layout_constraintTop_toBottomOf="@id/percentage" />
+                app:layout_constraintTop_toBottomOf="@id/cancel" />
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -136,6 +180,8 @@
         <com.instructure.pandautils.views.EmptyView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:paddingVertical="16dp"
             app:emptyViewState="@{viewModel.state}" />
     </FrameLayout>
+
 </layout>

--- a/libs/pandautils/src/main/res/layout/fragment_share_extension_status_dialog.xml
+++ b/libs/pandautils/src/main/res/layout/fragment_share_extension_status_dialog.xml
@@ -112,6 +112,7 @@
             android:textAllCaps="true"
             android:textColor="@color/backgroundInfo"
             android:textSize="12sp"
+            android:textStyle="bold"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/description" />
 

--- a/libs/pandautils/src/main/res/layout/item_dashboard_upload.xml
+++ b/libs/pandautils/src/main/res/layout/item_dashboard_upload.xml
@@ -117,6 +117,7 @@
                 android:contentDescription="@string/dismiss"
                 android:onClick="@{() -> itemViewModel.remove()}"
                 android:src="@drawable/ic_close"
+                android:visibility="@{itemViewModel.data.uploading ? View.GONE : View.VISIBLE}"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 app:tint="@color/textDarkest" />

--- a/libs/pandautils/src/main/res/layout/item_file_progress.xml
+++ b/libs/pandautils/src/main/res/layout/item_file_progress.xml
@@ -6,6 +6,8 @@
 
         <import type="android.view.View" />
 
+        <import type="com.instructure.pandautils.features.shareextension.progress.FileProgressStatus" />
+
         <variable
             name="itemViewModel"
             type="com.instructure.pandautils.features.shareextension.progress.itemviewmodels.FileProgressItemViewModel" />
@@ -28,7 +30,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:tint="@color/textDarkest"
+            app:tint="@{itemViewModel.data.iconTint}"
             tools:src="@drawable/ic_media" />
 
         <TextView
@@ -70,14 +72,14 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:progressTint="@color/backgroundInfo"
-                android:visibility="@{itemViewModel.data.uploaded ? View.GONE : View.VISIBLE}" />
+                android:visibility="@{itemViewModel.data.status == FileProgressStatus.IN_PROGRESS ? View.VISIBLE : View.GONE}" />
 
             <ImageView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:src="@drawable/ic_checkmark"
-                android:visibility="@{itemViewModel.data.uploaded ? View.VISIBLE : View.GONE}"
-                app:tint="@color/backgroundSuccess"
+                app:imageRes="@{itemViewModel.data.status.drawable}"
+                android:visibility="@{itemViewModel.data.status == FileProgressStatus.IN_PROGRESS ? View.GONE : View.VISIBLE}"
+                app:imageTint="@{context.getColor(itemViewModel.data.status.tint)}"
                 tools:visibility="gone" />
         </FrameLayout>
 

--- a/libs/pandautils/src/main/res/layout/item_file_progress.xml
+++ b/libs/pandautils/src/main/res/layout/item_file_progress.xml
@@ -77,8 +77,9 @@
             <ImageView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                app:imageRes="@{itemViewModel.data.status.drawable}"
+                android:onClick="@{() -> itemViewModel.data.onStatusIconClick.invoke(itemViewModel.data)}"
                 android:visibility="@{itemViewModel.data.status == FileProgressStatus.IN_PROGRESS ? View.GONE : View.VISIBLE}"
+                app:imageRes="@{itemViewModel.data.status.drawable}"
                 app:imageTint="@{context.getColor(itemViewModel.data.status.tint)}"
                 tools:visibility="gone" />
         </FrameLayout>

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/dashboard/notifications/DashboardNotificationsViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/dashboard/notifications/DashboardNotificationsViewModelTest.kt
@@ -35,9 +35,11 @@ import com.instructure.pandautils.features.dashboard.notifications.itemviewmodel
 import com.instructure.pandautils.features.dashboard.notifications.itemviewmodels.ConferenceItemViewModel
 import com.instructure.pandautils.features.dashboard.notifications.itemviewmodels.InvitationItemViewModel
 import com.instructure.pandautils.features.dashboard.notifications.itemviewmodels.UploadItemViewModel
+import com.instructure.pandautils.features.file.upload.FileUploadUtilsHelper
 import com.instructure.pandautils.features.file.upload.worker.FileUploadWorker
 import com.instructure.pandautils.models.ConferenceDashboardBlacklist
 import com.instructure.pandautils.room.daos.DashboardFileUploadDao
+import com.instructure.pandautils.room.daos.FileUploadInputDao
 import com.instructure.pandautils.room.entities.DashboardFileUploadEntity
 import io.mockk.coEvery
 import io.mockk.every
@@ -76,6 +78,8 @@ class DashboardNotificationsViewModelTest {
     private val conferenceDashboardBlacklist: ConferenceDashboardBlacklist = mockk(relaxed = true)
     private val apiPrefs: ApiPrefs = mockk(relaxed = true)
     private val workManager: WorkManager = mockk(relaxed = true)
+    private val fileUploadInputDao: FileUploadInputDao = mockk(relaxed = true)
+    private val fileUploadUtilsHelper: FileUploadUtilsHelper = mockk(relaxed = true)
     private val dashboardFileUploadDao: DashboardFileUploadDao = mockk(relaxed = true)
     private lateinit var uploadsLiveData: MutableLiveData<List<DashboardFileUploadEntity>>
 
@@ -130,7 +134,9 @@ class DashboardNotificationsViewModelTest {
             conferenceDashboardBlacklist,
             apiPrefs,
             workManager,
-            dashboardFileUploadDao
+            dashboardFileUploadDao,
+            fileUploadInputDao,
+            fileUploadUtilsHelper
         )
 
         viewModel.data.observe(lifecycleOwner, {})

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/file/upload/FileUploadViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/file/upload/FileUploadViewModelTest.kt
@@ -30,6 +30,8 @@ import com.instructure.pandautils.R
 import com.instructure.pandautils.room.daos.FileUploadInputDao
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
@@ -181,6 +183,9 @@ class FileUploadViewModelTest {
 
         every { fileUploadUtilsHelper.getFileSubmitObjectFromInputStream(any(), any(), any()) } returns submitObject
 
+        mockkStatic(Uri::class)
+        every { Uri.fromFile(any()) } returns uri
+
         viewModel.setData(assignment, arrayListOf(), FileUploadType.ASSIGNMENT, course, -1L, -1L, -1, -1L, -1L, null)
 
         viewModel.data.observe(lifecycleOwner) {}
@@ -190,6 +195,8 @@ class FileUploadViewModelTest {
         viewModel.uploadFiles()
 
         assert(viewModel.events.value?.getContentIfNotHandled() is FileUploadAction.UploadStarted)
+
+        unmockkStatic(Uri::class)
     }
 
     @Test

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/shareextension/progress/ShareExtensionProgressViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/shareextension/progress/ShareExtensionProgressViewModelTest.kt
@@ -12,6 +12,7 @@ import androidx.work.WorkManager
 import com.instructure.canvasapi2.models.postmodels.FileSubmitObject
 import com.instructure.pandautils.R
 import com.instructure.pandautils.features.file.upload.FileUploadType
+import com.instructure.pandautils.features.file.upload.FileUploadUtilsHelper
 import com.instructure.pandautils.features.file.upload.worker.FileUploadWorker
 import com.instructure.pandautils.mvvm.ViewState
 import com.instructure.pandautils.room.daos.DashboardFileUploadDao
@@ -46,6 +47,7 @@ class ShareExtensionProgressViewModelTest {
     private val resources: Resources = mockk(relaxed = true)
     private val fileUploadInputDao: FileUploadInputDao = mockk(relaxed = true)
     private val dashboardFileUploadDao: DashboardFileUploadDao = mockk(relaxed = true)
+    private val fileUploadUtilsHelper: FileUploadUtilsHelper = mockk(relaxed = true)
 
     private lateinit var mockLiveData: MutableLiveData<WorkInfo>
     private lateinit var viewModel: ShareExtensionProgressDialogViewModel
@@ -168,13 +170,13 @@ class ShareExtensionProgressViewModelTest {
                 "1 B",
                 R.drawable.ic_attachment,
                 FileProgressStatus.IN_PROGRESS
-            ),
+            ) {},
             FileProgressViewData(
                 "Test 2",
                 "1 B",
                 R.drawable.ic_attachment,
                 FileProgressStatus.IN_PROGRESS
-            )
+            ) {}
         )
 
         viewModel.setUUID(uuid)
@@ -224,13 +226,13 @@ class ShareExtensionProgressViewModelTest {
                 "1 B",
                 R.drawable.ic_attachment,
                 FileProgressStatus.UPLOADED
-            ),
+            ) {},
             FileProgressViewData(
                 "Test 2",
                 "1 B",
                 R.drawable.ic_attachment,
                 FileProgressStatus.IN_PROGRESS
-            )
+            ) {}
         )
 
         viewModel.setUUID(uuid)
@@ -301,13 +303,13 @@ class ShareExtensionProgressViewModelTest {
                 "1 B",
                 R.drawable.ic_attachment,
                 FileProgressStatus.UPLOADED
-            ),
+            ) {},
             FileProgressViewData(
                 "Test 2",
                 "1 B",
                 R.drawable.ic_warning,
                 FileProgressStatus.FAILED
-            )
+            ) {}
         )
 
         viewModel.setUUID(uuid)
@@ -321,7 +323,7 @@ class ShareExtensionProgressViewModelTest {
 
         assertEquals("Submission", viewData?.dialogTitle)
         assertEquals("Error", viewData?.subtitle)
-        assertEquals(true, viewData?.retryVisible)
+        assertEquals(true, viewData?.failed)
     }
 
     @Test
@@ -353,7 +355,7 @@ class ShareExtensionProgressViewModelTest {
         val viewData = viewModel.data.value
         assertEquals("File Upload", viewData?.dialogTitle)
         assertEquals("Error", viewData?.subtitle)
-        assertEquals(true, viewData?.retryVisible)
+        assertEquals(true, viewData?.failed)
 
         viewModel.onRetryClick()
 
@@ -386,7 +388,7 @@ class ShareExtensionProgressViewModelTest {
 
         val successViewData = viewModel.data.value
         assertEquals("Uploading files", successViewData?.subtitle)
-        assertEquals(false, successViewData?.retryVisible)
+        assertEquals(false, successViewData?.failed)
 
         mockLiveData.postValue(
             WorkInfo(
@@ -409,6 +411,6 @@ class ShareExtensionProgressViewModelTest {
     }
 
     private fun createViewModel(): ShareExtensionProgressDialogViewModel {
-        return ShareExtensionProgressDialogViewModel(workManager, resources, fileUploadInputDao, dashboardFileUploadDao)
+        return ShareExtensionProgressDialogViewModel(workManager, resources, fileUploadInputDao, dashboardFileUploadDao, fileUploadUtilsHelper)
     }
 }

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/shareextension/progress/ShareExtensionProgressViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/shareextension/progress/ShareExtensionProgressViewModelTest.kt
@@ -79,8 +79,6 @@ class ShareExtensionProgressViewModelTest {
 
     @Test
     fun `Show error on progress dialog when upload failed`() {
-        every { resources.getString(R.string.fileUploadFailedSubtitle) } returns "Error"
-
         viewModel.setUUID(uuid)
 
         val outputData = Data.Builder()
@@ -268,8 +266,6 @@ class ShareExtensionProgressViewModelTest {
 
     @Test
     fun `Failed upload maps correctly`() {
-        every { resources.getString(R.string.fileUploadFailedSubtitle) } returns "Error"
-
         val filesToUpload = listOf(
             FileSubmitObject(name = "Test 1", size = 1L, contentType = "text/file", fullPath = ""),
             FileSubmitObject(name = "Test 2", size = 1L, contentType = "text/file", fullPath = "")
@@ -328,8 +324,6 @@ class ShareExtensionProgressViewModelTest {
 
     @Test
     fun `Failed upload retry`() {
-        every { resources.getString(R.string.fileUploadFailedSubtitle) } returns "Error"
-
         val filesToUpload = listOf(
             FileSubmitObject(name = "Test 1", size = 1L, contentType = "text/file", fullPath = "")
         ).map { it.toJson() }.toTypedArray()
@@ -408,6 +402,7 @@ class ShareExtensionProgressViewModelTest {
         every { resources.getString(R.string.fileUpload) } returns "File Upload"
         every { resources.getString(R.string.submission) } returns "Submission"
         every { resources.getString(R.string.fileUploadProgressSubtitle) } returns "Uploading to Files"
+        every { resources.getString(R.string.fileUploadFailedSubtitle) } returns "Error"
     }
 
     private fun createViewModel(): ShareExtensionProgressDialogViewModel {


### PR DESCRIPTION
Test plan: smoke test share extension uploads, and other file uploads using the file upload dialog (teacher speedgrader comments too)

refs: MBL-16264
affects: Student
release note: Added proper failed screen and retry logic for share extension.

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Run E2E test suite or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
- [x] Approve from product or not needed
