### PR TITLE
[MBL-16621][Student][Teacher] Increase target api level to 33

### DIFF
--- a/apps/student/src/main/AndroidManifest.xml
+++ b/apps/student/src/main/AndroidManifest.xml
@@ -39,6 +39,7 @@
 
     <uses-permission android:name="android.permission.GET_ACCOUNTS"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <instrumentation
         android:name="com.google.android.apps.common.testing.testrunner.GoogleInstrumentationTestRunner"

--- a/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
@@ -17,6 +17,7 @@
 @file:Suppress("EXPERIMENTAL_FEATURE_WARNING")
 package com.instructure.student.activity
 
+import android.Manifest
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
@@ -32,6 +33,7 @@ import android.widget.CompoundButton
 import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.IdRes
 import androidx.annotation.PluralsRes
 import androidx.appcompat.app.ActionBarDrawerToggle
@@ -135,6 +137,8 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
     private var colorOverlayJob: Job? = null
 
     private val bottomNavScreensStack: Deque<String> = ArrayDeque()
+
+    private val notificationsPermissionContract = registerForActivityResult(ActivityResultContracts.RequestPermission()) {}
 
     override fun contentResId(): Int = R.layout.activity_navigation
 
@@ -271,6 +275,23 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
             val themeSelector = ThemeSelectorBottomSheet()
             themeSelector.show(supportFragmentManager, ThemeSelectorBottomSheet::javaClass.name)
             ThemePrefs.themeSelectionShown = true
+        }
+
+        requestNotificationsPermission()
+    }
+
+    private fun requestNotificationsPermission() {
+        if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+            if (shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
+                AlertDialog.Builder(this)
+                    .setMessage(getString(R.string.allowNotificationsMessageStudent, getString(R.string.student_app_name)))
+                    .setTitle(R.string.allowNotificationsTitle)
+                    .setPositiveButton(R.string.ok, { _, _ -> })
+                    .setOnDismissListener { notificationsPermissionContract.launch(Manifest.permission.POST_NOTIFICATIONS) }
+                    .showThemed()
+            } else {
+                notificationsPermissionContract.launch(Manifest.permission.POST_NOTIFICATIONS)
+            }
         }
     }
 

--- a/apps/student/src/main/java/com/instructure/student/features/elementary/course/ElementaryCoursePagerAdapter.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/elementary/course/ElementaryCoursePagerAdapter.kt
@@ -25,7 +25,7 @@ import android.widget.ProgressBar
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager.widget.PagerAdapter
 import com.instructure.canvasapi2.utils.ApiPrefs
-import com.instructure.pandautils.utils.setDarkModeSupport
+import com.instructure.pandautils.utils.enableAlgorithmicDarkening
 import com.instructure.pandautils.utils.setGone
 import com.instructure.pandautils.utils.setVisible
 import com.instructure.pandautils.views.CanvasWebView
@@ -65,7 +65,7 @@ class ElementaryCoursePagerAdapter(
         val baseContext = (webView.context as ContextWrapper).baseContext
         val activity = (baseContext as? FragmentActivity)
         activity?.let { webView.addVideoClient(it) }
-        webView.setDarkModeSupport()
+        webView.enableAlgorithmicDarkening()
         webView.setZoomSettings(false)
         webView.canvasWebViewClientCallback = object : CanvasWebView.CanvasWebViewClientCallback {
             override fun openMediaFromWebView(mime: String, url: String, filename: String) {

--- a/apps/student/src/main/java/com/instructure/student/fragment/BasicQuizViewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/BasicQuizViewFragment.kt
@@ -88,7 +88,7 @@ class BasicQuizViewFragment : InternalWebviewFragment() {
 
         // Make sure we are prepared to handle file uploads for quizzes that allow them
         setupFilePicker()
-        binding.canvasWebViewWrapper.webView.setDarkModeSupport()
+        binding.canvasWebViewWrapper.webView.enableAlgorithmicDarkening()
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {

--- a/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
@@ -113,7 +113,6 @@ open class InternalWebviewFragment : ParentFragment() {
         originalUserAgentString = canvasWebViewWrapper.webView.settings.userAgentString
         canvasWebViewWrapper.webView.settings.userAgentString = ApiPrefs.userAgent
         canvasWebViewWrapper.webView.setInitialScale(100)
-        canvasWebViewWrapper.webView.setDarkModeSupport(webThemeDarkeningOnly = true)
         webViewLoading.setVisible(true)
 
         canvasWebViewWrapper.webView.canvasWebChromeClientCallback =

--- a/apps/student/src/main/java/com/instructure/student/fragment/LockedModuleItemFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/LockedModuleItemFragment.kt
@@ -33,7 +33,6 @@ import com.instructure.pandautils.utils.Const
 import com.instructure.pandautils.utils.ParcelableArg
 import com.instructure.pandautils.utils.StringArg
 import com.instructure.pandautils.utils.ViewStyler
-import com.instructure.pandautils.utils.setDarkModeSupport
 import com.instructure.pandautils.utils.setupAsBackButton
 import com.instructure.pandautils.views.CanvasWebView
 import com.instructure.student.R
@@ -72,7 +71,6 @@ class LockedModuleItemFragment : ParentFragment() {
     override fun applyTheme() { }
 
     private fun setupWebView(canvasWebView: CanvasWebView) {
-        canvasWebView.setDarkModeSupport(webThemeDarkeningOnly = true)
         canvasWebView.settings.loadWithOverviewMode = true
         canvasWebView.settings.displayZoomControls = false
         canvasWebView.settings.setSupportZoom(true)

--- a/apps/student/src/main/java/com/instructure/student/fragment/StudioWebViewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/StudioWebViewFragment.kt
@@ -50,7 +50,7 @@ class StudioWebViewFragment : InternalWebviewFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        getCanvasWebView().setDarkModeSupport()
+        getCanvasWebView().enableAlgorithmicDarkening()
         getCanvasWebView().addJavascriptInterface(JSInterface(), "HtmlViewer")
 
         getCanvasWebView().canvasWebViewClientCallback = object : CanvasWebView.CanvasWebViewClientCallback {

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/DiscussionSubmissionViewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/DiscussionSubmissionViewFragment.kt
@@ -30,7 +30,7 @@ import com.instructure.canvasapi2.utils.weave.StatusCallbackError
 import com.instructure.canvasapi2.utils.weave.awaitApi
 import com.instructure.pandautils.binding.viewBinding
 import com.instructure.pandautils.utils.StringArg
-import com.instructure.pandautils.utils.setDarkModeSupport
+import com.instructure.pandautils.utils.enableAlgorithmicDarkening
 import com.instructure.pandautils.utils.setGone
 import com.instructure.pandautils.utils.setVisible
 import com.instructure.pandautils.views.CanvasWebView
@@ -61,7 +61,7 @@ class DiscussionSubmissionViewFragment : Fragment() {
     override fun onStart() {
         super.onStart()
         binding.progressBar.announceForAccessibility(getString(R.string.loading))
-        binding.discussionSubmissionWebView.setDarkModeSupport()
+        binding.discussionSubmissionWebView.enableAlgorithmicDarkening()
         binding.discussionSubmissionWebView.webChromeClient = object : WebChromeClient() {
             override fun onProgressChanged(view: WebView?, newProgress: Int) {
                 super.onProgressChanged(view, newProgress)

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/QuizSubmissionViewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/QuizSubmissionViewFragment.kt
@@ -30,7 +30,7 @@ class QuizSubmissionViewFragment : InternalWebviewFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         getCanvasLoading().setVisible() // Set visible so we can test it
         binding.canvasWebViewWrapper.apply {
-            webView.setDarkModeSupport()
+            webView.enableAlgorithmicDarkening()
             webView.setInitialScale(100)
             setInvisible() // Set invisible so we can test it
             webView.webChromeClient = object : WebChromeClient() {

--- a/apps/teacher/src/main/AndroidManifest.xml
+++ b/apps/teacher/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" /> <!-- For Studio -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <uses-feature
         android:name="android.hardware.camera"

--- a/apps/teacher/src/main/java/com/instructure/teacher/activities/FeedbackActivity.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/activities/FeedbackActivity.kt
@@ -14,7 +14,6 @@ import com.instructure.pandautils.analytics.ScreenView
 import com.instructure.pandautils.binding.viewBinding
 import com.instructure.pandautils.utils.ThemePrefs
 import com.instructure.pandautils.utils.ViewStyler
-import com.instructure.pandautils.utils.setDarkModeSupport
 import com.instructure.teacher.R
 import com.instructure.teacher.databinding.ActivityFeedbackBinding
 import com.instructure.teacher.utils.setupBackButton
@@ -45,7 +44,6 @@ class FeedbackActivity : AppCompatActivity() {
         webView.webChromeClient = WebChromeClient()
         webView.settings.javaScriptEnabled = true
         webView.settings.setSupportZoom(false)
-        webView.setDarkModeSupport(webThemeDarkeningOnly = true)
         webView.loadUrl(buildUrl())
     }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/activities/InitActivity.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/activities/InitActivity.kt
@@ -16,13 +16,16 @@
 
 package com.instructure.teacher.activities
 
+import android.Manifest
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.os.Bundle
 import android.view.View
 import android.widget.CompoundButton
 import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.IdRes
 import androidx.annotation.PluralsRes
 import androidx.appcompat.app.AlertDialog
@@ -132,6 +135,8 @@ class InitActivity : BasePresenterActivity<InitActivityPresenter, InitActivityVi
     private val isDrawerOpen: Boolean
         get() = binding.drawerLayout.isDrawerOpen(GravityCompat.START)
 
+    private val notificationsPermissionContract = registerForActivityResult(ActivityResultContracts.RequestPermission()) {}
+
     override fun onStart() {
         super.onStart()
         EventBus.getDefault().register(this)
@@ -182,6 +187,23 @@ class InitActivity : BasePresenterActivity<InitActivityPresenter, InitActivityVi
             val themeSelector = ThemeSelectorBottomSheet()
             themeSelector.show(supportFragmentManager, ThemeSelectorBottomSheet::javaClass.name)
             ThemePrefs.themeSelectionShown = true
+        }
+
+        requestNotificationsPermission()
+    }
+
+    private fun requestNotificationsPermission() {
+        if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+            if (shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
+                AlertDialog.Builder(this)
+                    .setMessage(getString(R.string.allowNotificationsMessageTeacher, getString(R.string.app_name)))
+                    .setTitle(R.string.allowNotificationsTitle)
+                    .setPositiveButton(R.string.ok, { _, _ -> })
+                    .setOnDismissListener { notificationsPermissionContract.launch(Manifest.permission.POST_NOTIFICATIONS) }
+                    .showThemed()
+            } else {
+                notificationsPermissionContract.launch(Manifest.permission.POST_NOTIFICATIONS)
+            }
         }
     }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/AttendanceListFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/AttendanceListFragment.kt
@@ -103,7 +103,7 @@ class AttendanceListFragment : BaseSyncFragment<
     }
 
     private fun setupViews() = with(binding) {
-        webView.setDarkModeSupport()
+        webView.enableAlgorithmicDarkening()
         toolbar.setupMenu(R.menu.menu_attendance) { menuItem ->
             when(menuItem.itemId) {
                 R.id.menuFilterSections -> { /* Do Nothing */ }

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/InternalWebViewFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/InternalWebViewFragment.kt
@@ -124,7 +124,6 @@ open class InternalWebViewFragment : BaseFragment() {
 
         setupToolbar(courseBackgroundColor)
 
-        canvasWebView.setDarkModeSupport(webThemeDarkeningOnly = true)
         canvasWebView.settings.loadWithOverviewMode = true
         canvasWebView.settings.displayZoomControls = false
         canvasWebView.settings.setSupportZoom(true)

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/QuizPreviewWebviewFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/QuizPreviewWebviewFragment.kt
@@ -24,7 +24,7 @@ import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.pandautils.analytics.SCREEN_VIEW_QUIZ_PREVIEW
 import com.instructure.pandautils.analytics.ScreenView
 import com.instructure.pandautils.utils.ViewStyler
-import com.instructure.pandautils.utils.setDarkModeSupport
+import com.instructure.pandautils.utils.enableAlgorithmicDarkening
 import com.instructure.pandautils.utils.setGone
 import com.instructure.pandautils.utils.setVisible
 import com.instructure.pandautils.views.CanvasWebView
@@ -56,7 +56,7 @@ class QuizPreviewWebviewFragment : InternalWebViewFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) = with(binding) {
         setShouldLoadUrl(false)
         super.onActivityCreated(savedInstanceState)
-        canvasWebView.setDarkModeSupport()
+        canvasWebView.enableAlgorithmicDarkening()
 
         canvasWebView.canvasWebViewClientCallback = object : CanvasWebView.CanvasWebViewClientCallback {
             override fun openMediaFromWebView(mime: String, url: String, filename: String) =

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/SimpleWebViewFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/SimpleWebViewFragment.kt
@@ -17,7 +17,7 @@
 package com.instructure.teacher.fragments
 
 import android.os.Bundle
-import com.instructure.pandautils.utils.setDarkModeSupport
+import com.instructure.pandautils.utils.enableAlgorithmicDarkening
 import com.instructure.pandautils.utils.setGone
 
 /**
@@ -38,7 +38,7 @@ class SimpleWebViewFragment : InternalWebViewFragment() {
         setShouldRouteInternally(false)
         binding.canvasWebView.setInitialScale(100)
         super.onActivityCreated(savedInstanceState)
-        binding.canvasWebView.setDarkModeSupport()
+        binding.canvasWebView.enableAlgorithmicDarkening()
 
         loadUrl(url)
         toolbar?.setGone()

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/SpeedGraderQuizWebViewFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/SpeedGraderQuizWebViewFragment.kt
@@ -60,7 +60,7 @@ class SpeedGraderQuizWebViewFragment : InternalWebViewFragment() {
         setShouldLoadUrl(false)
         canvasWebView.setInitialScale(100)
         super.onActivityCreated(savedInstanceState)
-        canvasWebView.setDarkModeSupport()
+        canvasWebView.enableAlgorithmicDarkening()
 
         val originalCallback = canvasWebView.canvasWebViewClientCallback!!
         canvasWebView.canvasWebViewClientCallback = object : CanvasWebView.CanvasWebViewClientCallback by originalCallback {

--- a/buildSrc/src/main/java/GlobalDependencies.kt
+++ b/buildSrc/src/main/java/GlobalDependencies.kt
@@ -4,7 +4,7 @@ object Versions {
     /* SDK Versions */
     const val COMPILE_SDK = 33
     const val MIN_SDK = 26
-    const val TARGET_SDK = 31
+    const val TARGET_SDK = 33
 
     /* Build/tooling */
     const val ANDROID_GRADLE_TOOLS = "7.1.3"

--- a/libs/DocumentScanner/build.gradle
+++ b/libs/DocumentScanner/build.gradle
@@ -13,12 +13,12 @@ repositories {
 }
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.3"
+    compileSdkVersion Versions.COMPILE_SDK
+    buildToolsVersion Versions.BUILD_TOOLS
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion Versions.TARGET_SDK
         versionCode libraryVersionCode
         versionName libraryVersionName
 

--- a/libs/DocumentScanner/src/main/AndroidManifest.xml
+++ b/libs/DocumentScanner/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     package="com.zynksoftware.documentscanner">
 
     <uses-permission android:name="android.permission.CAMERA"/>
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
     <uses-permission android:name="android.permission.READ_PHONE_STATE" tools:node="remove"/>
 
     <application

--- a/libs/DocumentScanner/src/main/java/com/zynksoftware/documentscanner/ui/camerascreen/CameraScreenFragment.kt
+++ b/libs/DocumentScanner/src/main/java/com/zynksoftware/documentscanner/ui/camerascreen/CameraScreenFragment.kt
@@ -112,7 +112,7 @@ internal class CameraScreenFragment: BaseFragment<FragmentCameraScreenBinding>(F
 
     private fun checkForStoragePermissions() {
         RxPermissions(this)
-            .requestEach(Manifest.permission.READ_EXTERNAL_STORAGE)
+            .requestEach(Manifest.permission.READ_MEDIA_IMAGES)
             .subscribe { permission ->
                 when {
                     permission.granted -> {

--- a/libs/login-api-2/src/main/java/com/instructure/loginapi/login/activities/BaseLoginSignInActivity.kt
+++ b/libs/login-api-2/src/main/java/com/instructure/loginapi/login/activities/BaseLoginSignInActivity.kt
@@ -18,7 +18,6 @@ package com.instructure.loginapi.login.activities
 
 import android.annotation.SuppressLint
 import android.content.DialogInterface
-import android.content.Intent
 import android.content.pm.ApplicationInfo
 import android.graphics.Color
 import android.net.Uri
@@ -35,7 +34,6 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.Toolbar
-import androidx.lifecycle.Observer
 import com.instructure.canvasapi2.RequestInterceptor.Companion.acceptedLanguageString
 import com.instructure.canvasapi2.StatusCallback
 import com.instructure.canvasapi2.managers.OAuthManager.getToken
@@ -60,7 +58,6 @@ import com.instructure.loginapi.login.databinding.ActivitySignInBinding
 import com.instructure.loginapi.login.dialog.AuthenticationDialog
 import com.instructure.loginapi.login.dialog.AuthenticationDialog.Companion.newInstance
 import com.instructure.loginapi.login.dialog.AuthenticationDialog.OnAuthenticationSet
-import com.instructure.loginapi.login.features.acceptableusepolicy.AcceptableUsePolicyActivity
 import com.instructure.loginapi.login.model.DomainVerificationResult
 import com.instructure.loginapi.login.model.SignedInUser
 import com.instructure.loginapi.login.snicker.SnickerDoodle
@@ -74,7 +71,6 @@ import com.instructure.loginapi.login.util.PreviousUsersUtils.add
 import com.instructure.loginapi.login.util.SavedLoginInfo
 import com.instructure.loginapi.login.viewmodel.LoginViewModel
 import com.instructure.pandautils.binding.viewBinding
-import com.instructure.pandautils.mvvm.Event
 import com.instructure.pandautils.utils.*
 import com.instructure.pandautils.utils.ViewStyler.themeStatusBar
 import retrofit2.Call
@@ -140,7 +136,6 @@ abstract class BaseLoginSignInActivity : AppCompatActivity(), OnAuthenticationSe
         webView.settings.cacheMode = WebSettings.LOAD_NO_CACHE
         webView.settings.domStorageEnabled = true
         webView.settings.userAgentString = Utils.generateUserAgent(this, userAgent())
-        webView.setDarkModeSupport(webThemeDarkeningOnly = true)
         webView.webViewClient = mWebViewClient
         if (0 != applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) {
             WebView.setWebContentsDebuggingEnabled(true)

--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -1391,4 +1391,7 @@
     <string name="a11y_selectionModeDeactivated">Selection mode deactivated.</string>
     <string name="a11y_avatarContentDescription">Avatar of %s</string>
     <string name="inboxUndo">Undo</string>
+    <string name="allowNotificationsTitle">Allow Notifications</string>
+    <string name="allowNotificationsMessageStudent">%s wants to send you notifications about important updates regarding your assignments, inbox, submissions, file uploads. You can allow or deny notifications after clicking OK.</string>
+    <string name="allowNotificationsMessageTeacher">%s wants to send you notifications about important updates regarding your inbox, file uploads, etc. You can allow or deny notifications after clicking OK.</string>
 </resources>

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/discussion/details/DiscussionDetailsWebViewFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/discussion/details/DiscussionDetailsWebViewFragment.kt
@@ -79,7 +79,7 @@ class DiscussionDetailsWebViewFragment : Fragment() {
         }
         setupFilePicker()
         binding.discussionWebView.addVideoClient(requireActivity())
-        binding.discussionWebView.setDarkModeSupport()
+        binding.discussionWebView.enableAlgorithmicDarkening()
         binding.discussionWebView.canvasWebViewClientCallback = object : CanvasWebView.CanvasWebViewClientCallback {
             override fun openMediaFromWebView(mime: String, url: String, filename: String) {
                 webViewRouter.openMedia(url)

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/fragments/HtmlContentFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/fragments/HtmlContentFragment.kt
@@ -28,7 +28,6 @@ import com.instructure.pandautils.navigation.WebViewRouter
 import com.instructure.pandautils.utils.StringArg
 import com.instructure.pandautils.utils.ThemePrefs
 import com.instructure.pandautils.utils.ViewStyler
-import com.instructure.pandautils.utils.setDarkModeSupport
 import com.instructure.pandautils.utils.setupAsCloseButton
 import com.instructure.pandautils.views.CanvasWebView
 import dagger.hilt.android.AndroidEntryPoint
@@ -66,7 +65,6 @@ class HtmlContentFragment : Fragment() {
     }
 
     private fun setupWebView(canvasWebView: CanvasWebView) {
-        canvasWebView.setDarkModeSupport(webThemeDarkeningOnly = true)
         canvasWebView.settings.loadWithOverviewMode = true
         canvasWebView.settings.displayZoomControls = false
         canvasWebView.settings.setSupportZoom(true)

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/WebViewExtensions.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/WebViewExtensions.kt
@@ -17,10 +17,8 @@ package com.instructure.pandautils.utils
 
 import android.content.Context
 import android.content.Intent
-import android.content.res.Configuration
 import android.net.Uri
 import android.webkit.JavascriptInterface
-import android.webkit.WebSettings
 import android.webkit.WebView
 import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewFeature
@@ -90,24 +88,8 @@ class JsGoogleDocsInterface(private val context: Context) {
     }
 }
 
-fun WebView.setDarkModeSupport(webThemeDarkeningOnly: Boolean = false) {
-    if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
-        val nightModeFlags: Int = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
-        if (nightModeFlags == Configuration.UI_MODE_NIGHT_YES) {
-            WebSettingsCompat.setForceDark(settings, WebSettingsCompat.FORCE_DARK_ON)
-            if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK_STRATEGY)) {
-                setForceDarkStrategy(webThemeDarkeningOnly, settings)
-            }
-        } else {
-            WebSettingsCompat.setForceDark(settings, WebSettingsCompat.FORCE_DARK_OFF)
-        }
-    }
-}
-
-private fun setForceDarkStrategy(webThemeDarkeningOnly: Boolean, settings: WebSettings) {
-    if (webThemeDarkeningOnly) {
-        WebSettingsCompat.setForceDarkStrategy(settings, WebSettingsCompat.DARK_STRATEGY_WEB_THEME_DARKENING_ONLY)
-    } else {
-        WebSettingsCompat.setForceDarkStrategy(settings, WebSettingsCompat.DARK_STRATEGY_PREFER_WEB_THEME_OVER_USER_AGENT_DARKENING)
+fun WebView.enableAlgorithmicDarkening() {
+    if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
+        WebSettingsCompat.setAlgorithmicDarkeningAllowed(settings, true)
     }
 }


### PR DESCRIPTION
Test plan:
- Smoke test both apps
- Briefly go through the behavior changes and check if all changes are covered in our apps: https://developer.android.com/about/versions/13/behavior-changes-13

Things that had to be changed:
- Dark mode handling is different in WebViews. Check all the WebViews that the content theme is correct (both html loading and url loading).
- Android 13 or newer devices now need to ask for notification permission. Verify that a newly installed app is asking for permission and verify the correct behavior when allowing and when denying the permission.
- Verify that after denying the permission the app will ask once again with a more detailed explanation (this is standard Android behavior).
- Verify that file permissions work correctly (this change affects only the document scanner when instead of taking a photo we open a file from the device)

refs: MBL-16621
affects: Student, Teacher
release note: none

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [ ] Run E2E test suite or not needed
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] A11y checked
- [ ] Approve from product or not needed
