### PR TITLE
[MBL-16646][Student] Student cannot modify locked page module items but pencil is displayed

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/BasicQuizViewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/BasicQuizViewFragment.kt
@@ -102,8 +102,8 @@ class BasicQuizViewFragment : InternalWebviewFragment() {
         }
         val uri = Uri.parse(baseURL)
         val host = uri.host ?: ""
-        getCanvasWebView().settings.javaScriptCanOpenWindowsAutomatically = true
-        getCanvasWebView().webViewClient = object : WebViewClient() {
+        getCanvasWebView()?.settings?.javaScriptCanOpenWindowsAutomatically = true
+        getCanvasWebView()?.webViewClient = object : WebViewClient() {
             override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean = handleOverrideURlLoading(view, request?.url?.toString())
             override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean = handleOverrideURlLoading(view, url)
 
@@ -141,7 +141,7 @@ class BasicQuizViewFragment : InternalWebviewFragment() {
     }
 
     private fun setupFilePicker() {
-        getCanvasWebView().setCanvasWebChromeClientShowFilePickerCallback(object : CanvasWebView.VideoPickerCallback {
+        getCanvasWebView()?.setCanvasWebChromeClientShowFilePickerCallback(object : CanvasWebView.VideoPickerCallback {
             override fun requestStartActivityForResult(intent: Intent, requestCode: Int) {
                 startActivityForResult(intent, requestCode)
             }
@@ -167,13 +167,13 @@ class BasicQuizViewFragment : InternalWebviewFragment() {
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onRequestPermissionsResult(result: PermissionRequester.PermissionResult) {
         if (PermissionUtils.allPermissionsGrantedResultSummary(result.grantResults)) {
-            getCanvasWebView().clearPickerCallback()
+            getCanvasWebView()?.clearPickerCallback()
             Toast.makeText(requireContext(), R.string.pleaseTryAgain, Toast.LENGTH_SHORT).show()
         }
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        if (!getCanvasWebView().handleOnActivityResult(requestCode, resultCode, data)) {
+        if (getCanvasWebView()?.handleOnActivityResult(requestCode, resultCode, data) == false) {
             super.onActivityResult(requestCode, resultCode, data)
         }
     }
@@ -213,7 +213,7 @@ class BasicQuizViewFragment : InternalWebviewFragment() {
             val authenticatedUrl = tryOrNull {
                 awaitApi<AuthenticatedSession> { OAuthManager.getAuthenticatedSession(url, it) }.sessionUrl
             }
-            getCanvasWebView().loadUrl(authenticatedUrl ?: url, APIHelper.referrer)
+            getCanvasWebView()?.loadUrl(authenticatedUrl ?: url, APIHelper.referrer)
         }
     }
 
@@ -222,7 +222,7 @@ class BasicQuizViewFragment : InternalWebviewFragment() {
         quizDetailsJob?.cancel()
     }
 
-    override fun handleBackPressed() = getCanvasWebView().handleGoBack() ?: false
+    override fun handleBackPressed() = getCanvasWebView()?.handleGoBack() ?: false
 
     companion object {
 

--- a/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
@@ -345,7 +345,7 @@ open class InternalWebviewFragment : ParentFragment() {
     }
 
     fun getCanvasLoading(): ProgressBar = binding.webViewLoading
-    fun getCanvasWebView(): CanvasWebView = binding.canvasWebViewWrapper.webView
+    fun getCanvasWebView(): CanvasWebView? = if (view != null) binding.canvasWebViewWrapper.webView else null
     fun getIsUnsupportedFeature(): Boolean = isUnsupportedFeature
     private fun getReferer(): Map<String, String> = mutableMapOf(Pair("Referer", ApiPrefs.domain))
 

--- a/apps/student/src/main/java/com/instructure/student/fragment/PageDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/PageDetailsFragment.kt
@@ -102,19 +102,19 @@ class PageDetailsFragment : InternalWebviewFragment(), Bookmarkable {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        getCanvasWebView().canvasEmbeddedWebViewCallback = object : CanvasWebView.CanvasEmbeddedWebViewCallback {
+        getCanvasWebView()?.canvasEmbeddedWebViewCallback = object : CanvasWebView.CanvasEmbeddedWebViewCallback {
             override fun shouldLaunchInternalWebViewFragment(url: String): Boolean = true
             override fun launchInternalWebViewFragment(url: String) = InternalWebviewFragment.loadInternalWebView(activity, InternalWebviewFragment.makeRoute(canvasContext, url, isLTITool))
         }
 
         // Add to the webview client for clearing webview history after an update to prevent going back to old data
-        val callback = getCanvasWebView().canvasWebViewClientCallback
+        val callback = getCanvasWebView()?.canvasWebViewClientCallback
         callback?.let {
-            getCanvasWebView().canvasWebViewClientCallback = object : CanvasWebView.CanvasWebViewClientCallback by it {
+            getCanvasWebView()?.canvasWebViewClientCallback = object : CanvasWebView.CanvasWebViewClientCallback by it {
                 override fun onPageFinishedCallback(webView: WebView, url: String) {
                     it.onPageFinishedCallback(webView, url)
                     // Only clear history after an update
-                    if (isUpdated) getCanvasWebView().clearHistory()
+                    if (isUpdated) getCanvasWebView()?.clearHistory()
                 }
 
                 override fun openMediaFromWebView(mime: String, url: String, filename: String) {
@@ -289,12 +289,16 @@ class PageDetailsFragment : InternalWebviewFragment(), Bookmarkable {
     }
 
     private fun checkCanEdit() = with(binding) {
-        if (page.editingRoles?.contains("public") == true) {
-            toolbar.menu?.findItem(R.id.menu_edit)?.isVisible = true
-        } else if (page.editingRoles?.contains("student") == true && (canvasContext as? Course)?.isStudent == true) {
-            toolbar.menu?.findItem(R.id.menu_edit)?.isVisible = true
-        } else if (page.editingRoles?.contains("teacher") == true && (canvasContext as? Course)?.isTeacher == true) {
-            toolbar.menu?.findItem(R.id.menu_edit)?.isVisible = true
+        val course = canvasContext as? Course
+        val editingRoles = page.editingRoles.orEmpty()
+        if (course?.isStudent == true) {
+            if (page.lockInfo == null && (editingRoles.contains("public") || editingRoles.contains("student"))) {
+                toolbar.menu?.findItem(R.id.menu_edit)?.isVisible = true
+            }
+        } else if (course?.isTeacher == true) {
+            if ((editingRoles.contains("public") || editingRoles.contains("teacher"))) {
+                toolbar.menu?.findItem(R.id.menu_edit)?.isVisible = true
+            }
         }
     }
 

--- a/apps/student/src/main/java/com/instructure/student/fragment/StudioWebViewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/StudioWebViewFragment.kt
@@ -50,10 +50,10 @@ class StudioWebViewFragment : InternalWebviewFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        getCanvasWebView().enableAlgorithmicDarkening()
-        getCanvasWebView().addJavascriptInterface(JSInterface(), "HtmlViewer")
+        getCanvasWebView()?.enableAlgorithmicDarkening()
+        getCanvasWebView()?.addJavascriptInterface(JSInterface(), "HtmlViewer")
 
-        getCanvasWebView().canvasWebViewClientCallback = object : CanvasWebView.CanvasWebViewClientCallback {
+        getCanvasWebView()?.canvasWebViewClientCallback = object : CanvasWebView.CanvasWebViewClientCallback {
             override fun openMediaFromWebView(mime: String, url: String, filename: String) {
                 openMedia(mime, url, filename, canvasContext)
             }
@@ -80,7 +80,7 @@ class StudioWebViewFragment : InternalWebviewFragment() {
             }
         }
 
-        getCanvasWebView().setCanvasWebChromeClientShowFilePickerCallback(object : CanvasWebView.VideoPickerCallback {
+        getCanvasWebView()?.setCanvasWebChromeClientShowFilePickerCallback(object : CanvasWebView.VideoPickerCallback {
             override fun requestStartActivityForResult(intent: Intent, requestCode: Int) {
                 startActivityForResult(intent, requestCode)
             }
@@ -99,8 +99,8 @@ class StudioWebViewFragment : InternalWebviewFragment() {
     override fun handleBackPressed(): Boolean {
         if (canGoBack()) {
             // This prevents a silly bug where the Studio WebView cannot go back far enough to pop its fragment
-            val webBackForwardList = getCanvasWebView().copyBackForwardList()
-            val historyUrl = webBackForwardList.getItemAtIndex(webBackForwardList.currentIndex - 1)?.url
+            val webBackForwardList = getCanvasWebView()?.copyBackForwardList()
+            val historyUrl = webBackForwardList?.getItemAtIndex(webBackForwardList.currentIndex - 1)?.url
             if (historyUrl != null && historyUrl.contains("external_tools/") && historyUrl.contains("resource_selection")) {
                 navigation?.popCurrentFragment()
                 return true
@@ -116,7 +116,7 @@ class StudioWebViewFragment : InternalWebviewFragment() {
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
         if (PermissionUtils.allPermissionsGrantedResultSummary(grantResults)) {
-            getCanvasWebView().clearPickerCallback()
+            getCanvasWebView()?.clearPickerCallback()
             Toast.makeText(requireContext(), R.string.pleaseTryAgain, Toast.LENGTH_SHORT).show()
         }
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
@@ -143,7 +143,7 @@ class StudioWebViewFragment : InternalWebviewFragment() {
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        if ((getCanvasWebView().handleOnActivityResult(requestCode, resultCode, data)) != true) {
+        if ((getCanvasWebView()?.handleOnActivityResult(requestCode, resultCode, data)) != true) {
             super.onActivityResult(requestCode, resultCode, data)
         }
     }


### PR DESCRIPTION
Test plan: Steps in the ticket. I also found and fixed a view binding issue. When you edit a page and close it then reopen it again the app crashes.

refs: MBL-16646
affects: Student
release note: none

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Run E2E test suite or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
- [x] Approve from product or not needed
