### PR TITLE
[MBL-16680][Student] Announcement/Discussion Details screen bookmark does nothing

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/router/RouteMatcher.kt
+++ b/apps/student/src/main/java/com/instructure/student/router/RouteMatcher.kt
@@ -139,6 +139,7 @@ object RouteMatcher : BaseRouteMatcher() {
         // Discussions
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/discussion_topics"), DiscussionListFragment::class.java))
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/discussion_topics/:${RouterParams.MESSAGE_ID}"), DiscussionListFragment::class.java, CourseModuleProgressionFragment::class.java))
+        routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/discussion_topics/:${RouterParams.MESSAGE_ID}"), DiscussionListFragment::class.java, DiscussionRouterFragment::class.java)) // Route for bookmarking
 
         // Pages
         routes.add(Route(courseOrGroup("/:${RouterParams.COURSE_ID}/pages"), PageListFragment::class.java))
@@ -499,7 +500,11 @@ object RouteMatcher : BaseRouteMatcher() {
 
     fun generateUrl(type: CanvasContext.Type, masterCls: Class<out Fragment>?, detailCls: Class<out Fragment>?, replacementParams: HashMap<String, String>?, queryParams: HashMap<String, String>?): String? {
         val domain = ApiPrefs.fullDomain
-        val urlRoute = getInternalRoute(masterCls, detailCls)
+
+        // Workaround for the discussion details because we bookmark a different class that we use for routing
+        val detailsClass = if (detailCls == DiscussionDetailsFragment::class.java) DiscussionRouterFragment::class.java else detailCls
+
+        val urlRoute = getInternalRoute(masterCls, detailsClass)
         if(urlRoute != null) {
             var path = urlRoute.createUrl(replacementParams)
             if (path.contains(COURSE_OR_GROUP_REGEX)) {


### PR DESCRIPTION
Test plan: In the ticket. Keep in mind that this only applies to the old discussions/announcements. Redesign never supported bookmarks.

refs: MBL-16680
affects: Student
release note: none

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Run E2E test suite or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
- [x] Approve from product or not needed
