### PR TITLE
[MBL-16668][Student] Video media comments cannot be played from Files

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/activity/VideoViewActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/VideoViewActivity.kt
@@ -62,7 +62,7 @@ class VideoViewActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_video_view)
+        setContentView(binding.root)
         binding.playerView.requestFocus()
         mediaDataSourceFactory = buildDataSourceFactory(true)
         mainHandler = Handler()


### PR DESCRIPTION
Test plan: Open an mp4 file from Files

refs: MBL-16668
affects: Student
release note: Fixed video playback from files

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Run E2E test suite or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
- [x] Approve from product or not needed
