### PR TITLE
[MBL-16685][Teacher] Tablet: Unexpected error when trying to navigate back from inbox message attachment view

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/activities/InitActivity.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/activities/InitActivity.kt
@@ -450,6 +450,8 @@ class InitActivity : BasePresenterActivity<InitActivityPresenter, InitActivityVi
         addDetailFragment(RouteResolver.getDetailFragment(route.canvasContext, route))
     }
 
+    // This case can only happen in Inbox, there is no other master/detial interaction on this Activity.
+    // Detail fragments are intentionally not added to the back stack, because back navigation would be confusing.
     private fun addDetailFragment(fragment: Fragment?) {
         if (fragment == null) throw IllegalStateException("InitActivity.class addDetailFragment was null")
 
@@ -462,10 +464,6 @@ class InitActivity : BasePresenterActivity<InitActivityPresenter, InitActivityVi
         if (identityMatch(currentFragment, fragment)) return
 
         ft.replace(R.id.detail, fragment, fragment.javaClass.simpleName)
-        if (currentFragment != null && currentFragment !is EmptyFragment) {
-            //Add to back stack if not empty fragment and a fragment exists
-            ft.addToBackStack(fragment.javaClass.simpleName)
-        }
         ft.commit()
     }
 
@@ -518,8 +516,10 @@ class InitActivity : BasePresenterActivity<InitActivityPresenter, InitActivityVi
         binding.container.setGone()
         val fm = supportFragmentManager
         val ft = fm.beginTransaction()
-        if (clearBackStack && fm.backStackEntryCount > 0) {
-            fm.popBackStackImmediate(fm.getBackStackEntryAt(0).id, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+        if (clearBackStack) {
+            if (fm.backStackEntryCount > 0) {
+                fm.popBackStackImmediate(fm.getBackStackEntryAt(0).id, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+            }
         } else {
             ft.addToBackStack(null)
         }
@@ -574,7 +574,6 @@ class InitActivity : BasePresenterActivity<InitActivityPresenter, InitActivityVi
         } else {
             if (binding.masterDetailContainer.isVisible) {
                 if ((supportFragmentManager.findFragmentById(R.id.master) as? NavigationCallbacks)?.onHandleBackPressed() == true) return
-                super.onBackPressed()
             }
             super.onBackPressed()
         }

--- a/apps/teacher/src/main/java/com/instructure/teacher/router/RouteMatcher.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/router/RouteMatcher.kt
@@ -122,6 +122,8 @@ object RouteMatcher : BaseRouteMatcher() {
         fullscreenFragments.add(LtiLaunchFragment::class.java)
         fullscreenFragments.add(SpeedGraderQuizWebViewFragment::class.java)
         fullscreenFragments.add(HtmlContentFragment::class.java)
+        fullscreenFragments.add(ViewPdfFragment::class.java)
+        fullscreenFragments.add(ViewHtmlFragment::class.java)
 
         // Bottom Sheet Fragments
         bottomSheetFragments.add(EditAssignmentDetailsFragment::class.java)

--- a/apps/teacher/src/main/java/com/instructure/teacher/utils/ModelExtensions.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/utils/ModelExtensions.kt
@@ -56,7 +56,7 @@ val Attachment.isMediaSubmissionPlaceholder: Boolean get() = id == MEDIA_PLACEHO
 
 @JvmName("viewAttachment")
 fun Attachment.view(context: Context) {
-    viewMedia(context, filename!!, contentType!!, url, thumbnailUrl, displayName, iconRes)
+    viewMedia(context, filename!!, contentType!!, url, thumbnailUrl, displayName, iconRes, fullScreen = true)
 }
 
 /**
@@ -65,14 +65,18 @@ fun Attachment.view(context: Context) {
  * file list)
  */
 
-fun viewMedia(context: Context, filename: String, contentType: String, url: String?, thumbnailUrl: String?, displayName: String?, iconRes: Int, toolbarColor: Int = 0, editableFile: EditableFile? = null) {
+fun viewMedia(context: Context, filename: String, contentType: String, url: String?, thumbnailUrl: String?, displayName: String?, iconRes: Int, toolbarColor: Int = 0, editableFile: EditableFile? = null, fullScreen: Boolean = false) {
     val extension = filename.substringAfterLast('.')
     when {
     // PDF
         contentType == "application/pdf" -> {
             PdfFragment()
             val bundle = ViewPdfFragment.newInstance(url ?: "", toolbarColor, editableFile).nonNullArgs
-            RouteMatcher.route(context, Route(null, ViewPdfFragment::class.java, null, bundle))
+            if (fullScreen) {
+                RouteMatcher.route(context, Route(ViewPdfFragment::class.java, null, bundle))
+            } else {
+                RouteMatcher.route(context, Route(null, ViewPdfFragment::class.java, null, bundle))
+            }
         }
     // Audio/Video
         contentType.startsWith("video") || contentType.startsWith("audio") -> {
@@ -83,12 +87,20 @@ fun viewMedia(context: Context, filename: String, contentType: String, url: Stri
         contentType.startsWith("image") -> {
             val title = displayName ?: filename
             val bundle = ViewImageFragment.newInstance(title, Uri.parse(url), contentType, true, toolbarColor, editableFile).nonNullArgs
-            RouteMatcher.route(context, Route(null, ViewImageFragment::class.java, null, bundle))
+            if (fullScreen) {
+                RouteMatcher.route(context, Route(ViewImageFragment::class.java, null, bundle))
+            } else {
+                RouteMatcher.route(context, Route(null, ViewImageFragment::class.java, null, bundle))
+            }
         }
     // HTML
         contentType == "text/html" || extension == "htm" || extension == "html" -> {
             val bundle = ViewHtmlFragment.makeDownloadBundle(url ?: "", filename, toolbarColor, editableFile)
-            RouteMatcher.route(context, Route(null, ViewHtmlFragment::class.java, null, bundle))
+            if (fullScreen) {
+                RouteMatcher.route(context, Route(ViewHtmlFragment::class.java, null, bundle))
+            } else {
+                RouteMatcher.route(context, Route(null, ViewHtmlFragment::class.java, null, bundle))
+            }
         }
     // Multipart (Unknown)
         contentType == "multipart/form-data" -> {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/activities/BasePresenterActivity.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/activities/BasePresenterActivity.kt
@@ -57,7 +57,7 @@ abstract class BasePresenterActivity<PRESENTER : Presenter<VIEW>, VIEW> : Presen
             if (supportFragmentManager.backStackEntryCount > 0) {
                 val fragments = supportFragmentManager.fragments
                 if (fragments.isNotEmpty()) {
-                    return fragments[supportFragmentManager.backStackEntryCount - 1]
+                    return fragments.getOrNull(supportFragmentManager.backStackEntryCount - 1)
                 }
             } else {
                 return supportFragmentManager.fragments.lastOrNull()


### PR DESCRIPTION
Test plan: Repro steps in the ticket.
- I changed how the attachment handling works on tablet, now they open in fullscreen.
- Inbox master/detail back navigation was also fixed, previously the app crashed after opening several messages and then going back. Now the details screens are not added to the back stack.

- Smoke test Inbox navigation on phone as well.

refs: MBL-16685
affects: Teacher
release note: none

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [ ] Run E2E test suite or not needed
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] A11y checked
- [ ] Approve from product or not needed
