### PR TITLE
[MBL-16709][Student] Module items do not unlock until refresh

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/CourseModuleProgressionFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/CourseModuleProgressionFragment.kt
@@ -335,8 +335,9 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
 
                 // Update the state of the next module to indicate in the list that it is unlocked
                 modules.getOrNull(modules.indexOf(module) + 1)?.let {
-                    val nextModuleUpdatedState = if (isModuleCompleted && it.state != State.Completed.apiString) State.Unlocked.apiString else module.state
-                    ModuleUpdatedEvent(it.copy(state = nextModuleUpdatedState)).post()
+                    if (isModuleCompleted && it.state != State.Completed.apiString) {
+                        ModuleUpdatedEvent(it.copy(state = State.Unlocked.apiString)).post()
+                    }
                 }
             }
         } catch {


### PR DESCRIPTION
Test plan: in the ticket

refs: MBL-16709
affects: Student
release note: none

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Run E2E test suite or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
- [x] Approve from product or not needed
