### PR TITLE
[MBL-16713][Student] Distribution score graph does not appear on app

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/binding/BindingAdapters.kt
+++ b/apps/student/src/main/java/com/instructure/student/binding/BindingAdapters.kt
@@ -21,6 +21,8 @@ import androidx.databinding.BindingAdapter
 import com.google.android.material.tabs.TabLayout
 import com.instructure.student.features.elementary.course.ElementaryCourseTab
 import com.instructure.student.mobius.assignmentDetails.ui.gradeCell.DonutChartView
+import com.instructure.student.mobius.assignmentDetails.ui.gradeCell.GradeCellViewState
+import com.instructure.student.mobius.assignmentDetails.ui.gradeCell.GradeStatisticsView
 
 @BindingAdapter("tabs")
 fun bindCourseTabs(tabLayout: TabLayout, tabs: List<ElementaryCourseTab>?) {
@@ -38,4 +40,12 @@ fun DonutChartView.setProgress(progress: Float, @ColorInt color: Int, @ColorInt 
     setColor(color)
     setTrackColor(trackColor)
     setPercentage(progress, true)
+}
+
+@BindingAdapter("stats", "color")
+fun GradeStatisticsView.setStatistics(stats: GradeCellViewState.GradeStats?, @ColorInt color: Int) {
+    stats?.let {
+        setStats(stats)
+        setAccentColor(color)
+    }
 }

--- a/apps/student/src/main/java/com/instructure/student/features/assignmentdetails/gradecellview/GradeCellViewData.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/assignmentdetails/gradecellview/GradeCellViewData.kt
@@ -9,6 +9,7 @@ import com.instructure.pandautils.utils.ThemedColor
 import com.instructure.pandautils.utils.getContentDescriptionForMinusGradeString
 import com.instructure.pandautils.utils.orDefault
 import com.instructure.student.R
+import com.instructure.student.mobius.assignmentDetails.ui.gradeCell.GradeCellViewState
 
 data class GradeCellViewData(
     val courseColor: ThemedColor,
@@ -22,7 +23,8 @@ data class GradeCellViewData(
     val gradeCellContentDescription: String = "",
     val outOf: String = "",
     val latePenalty: String = "",
-    val finalGrade: String = ""
+    val finalGrade: String = "",
+    val stats: GradeCellViewState.GradeStats? = null
 ) {
     val backgroundColorWithAlpha = ColorUtils.setAlphaComponent(courseColor.backgroundColor(), (.25 * 255).toInt())
 
@@ -143,6 +145,28 @@ data class GradeCellViewData(
                         finalGrade = resources.getString(R.string.finalGradeFormatted, submission.grade)
                     }
 
+                    val stats = assignment.scoreStatistics?.let { stats ->
+                        GradeCellViewState.GradeStats(
+                            score = submission.score,
+                            outOf = assignment.pointsPossible,
+                            min = stats.min,
+                            max = stats.max,
+                            mean = stats.mean,
+                            minText = resources.getString(
+                                R.string.scoreStatisticsLow,
+                                NumberHelper.formatDecimal(stats.min, 1, true)
+                            ),
+                            maxText = resources.getString(
+                                R.string.scoreStatisticsHigh,
+                                NumberHelper.formatDecimal(stats.max, 1, true)
+                            ),
+                            meanText = resources.getString(
+                                R.string.scoreStatisticsMean,
+                                NumberHelper.formatDecimal(stats.mean, 1, true)
+                            )
+                        )
+                    }
+
                     GradeCellViewData(
                         courseColor = courseColor,
                         state = State.GRADED,
@@ -153,7 +177,8 @@ data class GradeCellViewData(
                         gradeCellContentDescription = gradeCellContentDescription,
                         outOf = outOfText,
                         latePenalty = latePenalty,
-                        finalGrade = finalGrade
+                        finalGrade = finalGrade,
+                        stats = stats
                     )
                 }
             }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/gradeCell/GradeStatisticsView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/ui/gradeCell/GradeStatisticsView.kt
@@ -2,7 +2,6 @@ package com.instructure.student.mobius.assignmentDetails.ui.gradeCell
 
 import android.content.Context
 import android.graphics.Canvas
-import android.graphics.Color
 import android.graphics.Paint
 import android.util.AttributeSet
 import android.view.View
@@ -14,7 +13,7 @@ import com.instructure.student.R
 class GradeStatisticsView(context: Context, attrs: AttributeSet) : View(context, attrs) {
     private var stats: GradeCellViewState.GradeStats? = null
 
-    private val sidePadding: Float = context.DP(16)
+    private val sidePadding: Float = context.DP(2)
     private val endMarkerHeight: Float = context.DP(16)
     private val minMaxHeight: Float = context.DP(16)
     private val scoreCircleRadius: Float = context.DP(7)
@@ -22,7 +21,7 @@ class GradeStatisticsView(context: Context, attrs: AttributeSet) : View(context,
 
     private val linePaint: Paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         style = Paint.Style.STROKE
-        strokeCap = Paint.Cap.ROUND
+        strokeCap = Paint.Cap.SQUARE
         isAntiAlias = true
         strokeWidth = context.DP(2)
         color = ContextCompat.getColor(context, R.color.backgroundMedium)
@@ -30,7 +29,7 @@ class GradeStatisticsView(context: Context, attrs: AttributeSet) : View(context,
 
     private val darkLinePaint: Paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         style = Paint.Style.STROKE
-        strokeCap = Paint.Cap.ROUND
+        strokeCap = Paint.Cap.SQUARE
         isAntiAlias = true
         strokeWidth = context.DP(3)
         color = ContextCompat.getColor(context, R.color.textDark)
@@ -38,7 +37,7 @@ class GradeStatisticsView(context: Context, attrs: AttributeSet) : View(context,
 
     private val meanLinePaint: Paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         style = Paint.Style.STROKE
-        strokeCap = Paint.Cap.ROUND
+        strokeCap = Paint.Cap.SQUARE
         isAntiAlias = true
         strokeWidth = context.DP(3)
         color = ContextCompat.getColor(context, R.color.textDarkest)

--- a/apps/student/src/main/res/layout/view_student_enhanced_grade_cell.xml
+++ b/apps/student/src/main/res/layout/view_student_enhanced_grade_cell.xml
@@ -169,12 +169,13 @@
             android:layout_height="130dp"
             android:layout_marginTop="@dimen/grade_cell_chart_top_margin"
             android:layout_marginEnd="12dp"
-            android:layout_marginBottom="20dp"
+            android:layout_marginBottom="8dp"
             android:visibility="@{viewData.state == viewData.State.GRADED ? View.VISIBLE : View.GONE}"
             app:color="@{viewData.showIncompleteIcon ? @color/textDark : viewData.courseColor.backgroundColor()}"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/statisticsView"
             app:layout_constraintEnd_toStartOf="@id/guideline"
             app:layout_constraintTop_toBottomOf="@id/gradeLabel"
+            app:layout_goneMarginBottom="20dp"
             app:progress="@{viewData.chartPercent}"
             app:trackColor="@{viewData.backgroundColorWithAlpha}" />
 
@@ -310,6 +311,62 @@
             app:layout_constraintStart_toEndOf="@id/chart"
             app:layout_constraintTop_toBottomOf="@id/latePenalty"
             tools:text="Final Grade: 73 pts" />
+
+        <com.instructure.student.mobius.assignmentDetails.ui.gradeCell.GradeStatisticsView
+            android:id="@+id/statisticsView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="@{viewData.stats == null ? View.GONE : View.VISIBLE}"
+            app:color="@{viewData.courseColor.backgroundColor()}"
+            app:layout_constraintBottom_toTopOf="@id/minLabel"
+            app:layout_constraintTop_toBottomOf="@id/chart"
+            app:stats="@{viewData.stats}" />
+
+        <TextView
+            android:id="@+id/minLabel"
+            style="@style/TextFont.Medium"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="4dp"
+            android:text="@{viewData.stats.minText}"
+            android:textColor="@color/textDark"
+            android:visibility="@{viewData.stats == null ? View.GONE : View.VISIBLE}"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/meanLabel"
+            app:layout_constraintHorizontal_chainStyle="spread_inside"
+            app:layout_constraintStart_toStartOf="@id/statisticsView"
+            app:layout_constraintTop_toBottomOf="@id/statisticsView"
+            tools:text="Low: 1.0" />
+
+        <TextView
+            android:id="@+id/meanLabel"
+            style="@style/TextFont.Medium"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="4dp"
+            android:text="@{viewData.stats.meanText}"
+            android:textColor="@color/textDark"
+            android:visibility="@{viewData.stats == null ? View.GONE : View.VISIBLE}"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/maxLabel"
+            app:layout_constraintStart_toEndOf="@id/minLabel"
+            app:layout_constraintTop_toBottomOf="@id/statisticsView"
+            tools:text="Mean: 7.2" />
+
+        <TextView
+            android:id="@+id/maxLabel"
+            style="@style/TextFont.Medium"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="4dp"
+            android:text="@{viewData.stats.maxText}"
+            android:textColor="@color/textDark"
+            android:visibility="@{viewData.stats == null ? View.GONE : View.VISIBLE}"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@+id/statisticsView"
+            app:layout_constraintStart_toEndOf="@id/meanLabel"
+            app:layout_constraintTop_toBottomOf="@id/statisticsView"
+            tools:text="High: 9.5" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/apps/student/src/main/res/layout/view_student_grade_cell.xml
+++ b/apps/student/src/main/res/layout/view_student_grade_cell.xml
@@ -191,9 +191,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
-            android:orientation="horizontal"
-            android:paddingStart="16dp"
-            android:paddingEnd="16dp">
+            android:orientation="horizontal">
 
             <TextView
                 android:id="@+id/minLabel"


### PR DESCRIPTION
Test plan: in the ticket, also check if the score chart still looks good on the rubric screen

refs: MBL-16713
affects: Student
release note: Added score graph to the grade cell on assignment details screen.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/109959688/236840929-25eb0f56-998a-4bc7-a31c-133dc19719bd.jpg" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/109959688/236841037-5ddec4f2-83e5-42cf-8ad8-fde9fe4c4f78.jpg" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [ ] Run E2E test suite or not needed
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] A11y checked
- [ ] Approve from product or not needed
