### PR TITLE
[MBL-16733][Student] - Groups can independently selected on Edit Dashboard Page test implementation

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/DashboardE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/DashboardE2ETest.kt
@@ -57,10 +57,13 @@ class DashboardE2ETest : StudentTest() {
 
         Log.d(PREPARATION_TAG,"Seed some group info.")
         val groupCategory = GroupsApi.createCourseGroupCategory(data.coursesList[0].id, teacher.token)
+        val groupCategory2 = GroupsApi.createCourseGroupCategory(data.coursesList[0].id, teacher.token)
         val group = GroupsApi.createGroup(groupCategory.id, teacher.token)
+        val group2 = GroupsApi.createGroup(groupCategory2.id, teacher.token)
 
         Log.d(PREPARATION_TAG,"Create group membership for ${student.name} student.")
         GroupsApi.createGroupMembership(group.id, student.id, teacher.token)
+        GroupsApi.createGroupMembership(group2.id, student.id, teacher.token)
 
         Log.d(STEP_TAG,"Login with user: ${student.name}, login id: ${student.loginId}.")
         tokenLogin(student)
@@ -93,6 +96,10 @@ class DashboardE2ETest : StudentTest() {
             dashboardPage.assertDisplaysCourse(course)
         }
 
+        Log.d(STEP_TAG, "Assert that both of the groups '${group.name}' and '${group2.name}' are displayed because they are independent from the courses.")
+        dashboardPage.assertDisplaysGroup(group, course1)
+        dashboardPage.assertDisplaysGroup(group2, course1)
+
         Log.d(STEP_TAG,"Click on 'Edit Dashboard' button. Assert that the Edit Dashboard Page is loaded.")
         dashboardPage.clickEditDashboard()
         editDashboardPage.assertPageObjects()
@@ -105,6 +112,10 @@ class DashboardE2ETest : StudentTest() {
                 "Assert that the other course, '${course2.name}' is not displayed since it's not favoured.")
         dashboardPage.assertDisplaysCourse(course1)
         dashboardPage.assertCourseNotDisplayed(course2)
+
+        Log.d(STEP_TAG, "Assert that both of the groups '${group.name}' and '${group2.name}' are displayed because they are independent from the courses.")
+        dashboardPage.assertDisplaysGroup(group, course1)
+        dashboardPage.assertDisplaysGroup(group2, course1)
 
         Log.d(STEP_TAG,"Opens ${course1.name} course and assert if Course Details Page has been opened. Navigate back to Dashboard Page.")
         dashboardPage.selectCourse(course1)
@@ -144,6 +155,9 @@ class DashboardE2ETest : StudentTest() {
         dashboardPage.assertPageObjects()
         dashboardPage.assertDisplaysCourse(newNickname)
 
+        Log.d(STEP_TAG,"Assert that ${group.name} groups is displayed and the '$newNickname' is displayed as the corresponding course name of the group.")
+        dashboardPage.assertDisplaysGroup(group, newNickname)
+
         Log.d(STEP_TAG, "Click on 'Edit nickname' menu of '$newNickname' course.")
         dashboardPage.clickCourseOverflowMenu(newNickname, "Edit nickname")
 
@@ -153,6 +167,9 @@ class DashboardE2ETest : StudentTest() {
         Log.d(STEP_TAG, "Wait for Dashboard Page to be reloaded. Assert that if there is no nickname for a course, the course's full name, '${course1.name}' will be displayed.")
         dashboardPage.assertPageObjects()
         dashboardPage.assertDisplaysCourse(course1.name)
+
+        Log.d(STEP_TAG,"Assert that ${group.name} groups is displayed and the '${data.coursesList[0]}' is displayed as the corresponding course name of the group.")
+        dashboardPage.assertDisplaysGroup(group, data.coursesList[0])
 
         Log.d(STEP_TAG, "Toggle OFF 'Show Grades' and navigate back to Dashboard Page.")
         leftSideNavigationDrawerPage.setShowGrades(false)
@@ -168,6 +185,44 @@ class DashboardE2ETest : StudentTest() {
         dashboardPage.assertCourseGrade(course1.name, "N/A")
         dashboardPage.assertCourseGrade(course2.name, "N/A")
 
+        Log.d(STEP_TAG,"Click on 'Edit Dashboard' button.")
+        dashboardPage.clickEditDashboard()
+        editDashboardPage.assertPageObjects()
+
+        Log.d(STEP_TAG, "Assert that the group 'mass' select button's label is 'Select All'.")
+        editDashboardPage.swipeUp()
+        editDashboardPage.assertGroupMassSelectButtonIsDisplayed(false)
+
+        Log.d(STEP_TAG, "Favorite '${group.name}' course and navigate back to Dashboard Page.")
+        editDashboardPage.favoriteGroup(group.name)
+        Espresso.pressBack()
+
+        Log.d(STEP_TAG,"Assert that only the favoured group, '${group.name}' is displayed." +
+                "Assert that the other group, '${group2.name}' is not displayed since it's not favoured.")
+        dashboardPage.assertDisplaysGroup(group, course1)
+        dashboardPage.assertGroupNotDisplayed(group2)
+
+        Log.d(STEP_TAG,"Click on 'Edit Dashboard' button.")
+        dashboardPage.clickEditDashboard()
+        editDashboardPage.assertPageObjects()
+        Thread.sleep(2000) //It can be flaky without this 2 seconds
+        editDashboardPage.swipeUp()
+
+        Log.d(STEP_TAG, "Assert that the group 'mass' select button's label is 'Unselect All'.")
+        editDashboardPage.assertGroupMassSelectButtonIsDisplayed(true)
+
+        Log.d(STEP_TAG, "Toggle off favourite star icon of '${group.name}' group." +
+                "Assert that the 'mass' select button's label is 'Select All'.")
+        editDashboardPage.unfavoriteGroup(group.name)
+        editDashboardPage.assertGroupMassSelectButtonIsDisplayed(false)
+
+        Log.d(STEP_TAG, "Navigate back to Dashboard Page.")
+        Espresso.pressBack()
+
+        Log.d(STEP_TAG,"Assert that both of the groups, '${group.name}' and '${group2.name}' are displayed" +
+                "since if there is no group selected on the Edit Dashboard page, we are showing all of them (this is the same logics as with the courses).")
+        dashboardPage.assertDisplaysGroup(group, course1)
+        dashboardPage.assertDisplaysGroup(group2, course1)
     }
 
     @E2E

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DashboardPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DashboardPage.kt
@@ -93,6 +93,10 @@ class DashboardPage : BasePage(R.id.dashboardPage) {
         assertDisplaysGroupCommon(group.name, course.name)
     }
 
+    fun assertDisplaysGroup(group: GroupApiModel, courseName: String) {
+        assertDisplaysGroupCommon(group.name, courseName)
+    }
+
     fun assertDisplaysGroup(group: Group, course: Course) {
         assertDisplaysGroupCommon(group.name!!, course.name)
     }
@@ -100,7 +104,7 @@ class DashboardPage : BasePage(R.id.dashboardPage) {
     private fun assertDisplaysGroupCommon(groupName: String, courseName: String) {
         val groupNameMatcher = allOf(withText(groupName), withId(R.id.groupNameView))
         onView(groupNameMatcher).scrollTo().assertDisplayed()
-        val groupDescriptionMatcher = allOf(withText(courseName), withId(R.id.groupCourseView))
+        val groupDescriptionMatcher = allOf(withText(courseName), withId(R.id.groupCourseView), hasSibling(groupNameMatcher))
         onView(groupDescriptionMatcher).scrollTo().assertDisplayed()
     }
 
@@ -245,12 +249,21 @@ class DashboardPage : BasePage(R.id.dashboardPage) {
     }
 
     fun clickEditDashboard() {
-        onView(withId(R.id.editDashboardTextView)).click()
+        onView(withId(R.id.editDashboardTextView)).scrollTo().click()
     }
 
     fun assertCourseNotDisplayed(course: CourseApiModel) {
         val matcher = allOf(
             withText(course.name),
+            withId(R.id.titleTextView),
+            withAncestor(R.id.swipeRefreshLayout)
+        )
+        onView(matcher).check(doesNotExist())
+    }
+
+    fun assertGroupNotDisplayed(group: GroupApiModel) {
+        val matcher = allOf(
+            withText(group.name),
             withId(R.id.titleTextView),
             withAncestor(R.id.swipeRefreshLayout)
         )
@@ -264,7 +277,7 @@ class DashboardPage : BasePage(R.id.dashboardPage) {
 
     fun clickCourseOverflowMenu(courseTitle: String, menuTitle: String) {
         val courseOverflowMatcher = withId(R.id.overflow) + withAncestor(withId(R.id.cardView) + withDescendant(withId(R.id.titleTextView) + withText(courseTitle)))
-        onView(courseOverflowMatcher).click()
+        onView(courseOverflowMatcher).scrollTo().click()
         waitForView(withId(R.id.title) + withText(menuTitle)).click()
     }
 
@@ -272,7 +285,7 @@ class DashboardPage : BasePage(R.id.dashboardPage) {
         val siblingMatcher = allOf(withId(R.id.textContainer), withDescendant(withId(R.id.titleTextView) + withText(courseName)))
         val matcher = allOf(withId(R.id.gradeLayout), withDescendant(withId(R.id.gradeTextView) + withText(courseGrade)), hasSibling(siblingMatcher))
 
-        onView(matcher).assertDisplayed()
+        onView(matcher).scrollTo().assertDisplayed()
     }
 
     fun assertCourseGradeNotDisplayed(courseName: String, courseGrade: String) {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/EditDashboardPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/EditDashboardPage.kt
@@ -23,7 +23,13 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.instructure.canvasapi2.models.Course
 import com.instructure.espresso.assertDisplayed
 import com.instructure.espresso.click
-import com.instructure.espresso.page.*
+import com.instructure.espresso.page.BasePage
+import com.instructure.espresso.page.onView
+import com.instructure.espresso.page.plus
+import com.instructure.espresso.page.withId
+import com.instructure.espresso.page.withText
+import com.instructure.espresso.scrollTo
+import com.instructure.espresso.swipeUp
 import com.instructure.student.R
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.containsString
@@ -51,8 +57,7 @@ class EditDashboardPage : BasePage(R.id.editDashboardPage) {
     fun unfavoriteCourse(courseName: String) {
         val childMatcher = withContentDescription("Remove from dashboard")
         val itemMatcher = allOf(
-                withContentDescription(containsString(", favorite")),
-                withContentDescription(containsString(courseName)),
+                withContentDescription(containsString("Course $courseName, favorite")),
                 hasDescendant(childMatcher))
 
         onView(withParent(itemMatcher) + childMatcher).click()
@@ -65,18 +70,34 @@ class EditDashboardPage : BasePage(R.id.editDashboardPage) {
     fun favoriteCourse(courseName: String) {
         val childMatcher = withContentDescription("Add to dashboard")
         val itemMatcher = allOf(
-            withContentDescription(containsString(", not favorite")),
-            withContentDescription(containsString(courseName)),
+            withContentDescription(containsString("Course $courseName, not favorite")),
             hasDescendant(childMatcher))
 
         onView(withParent(itemMatcher) + childMatcher).click()
     }
 
+    fun favoriteGroup(groupName: String) {
+        val childMatcher = withContentDescription("Add to dashboard")
+        val itemMatcher = allOf(
+            withContentDescription(containsString("Group $groupName, not favorite")),
+            hasDescendant(childMatcher))
+
+        onView(withParent(itemMatcher) + childMatcher).scrollTo().click()
+    }
+
+    fun unfavoriteGroup(groupName: String) {
+        val childMatcher = withContentDescription("Remove from dashboard")
+        val itemMatcher = allOf(
+            withContentDescription(containsString("Group $groupName, favorite")),
+            hasDescendant(childMatcher))
+
+        onView(withParent(itemMatcher) + childMatcher).scrollTo().click()
+    }
+
     fun assertCourseFavorited(course: Course) {
         val childMatcher = withContentDescription("Remove from dashboard")
         val itemMatcher = allOf(
-                withContentDescription(containsString(", favorite")),
-                withContentDescription(containsString(course.name)),
+                withContentDescription(containsString("Course ${course.name}, favorite")),
                 hasDescendant(childMatcher))
         onView(itemMatcher).assertDisplayed()
     }
@@ -109,6 +130,23 @@ class EditDashboardPage : BasePage(R.id.editDashboardPage) {
 
             onView(withParent(itemMatcher) + childMatcher).assertDisplayed()
         }
+    }
+
+    fun assertGroupMassSelectButtonIsDisplayed(someSelected: Boolean) {
+        if (someSelected) {
+            val itemMatcher = withContentDescription("Remove all from dashboard")
+            val parentMatcher = allOf(hasDescendant(withText("All groups")), hasDescendant(itemMatcher))
+            onView(withParent(parentMatcher) + itemMatcher).scrollTo().assertDisplayed()
+        }
+        else {
+            val itemMatcher = withContentDescription("Add all to dashboard")
+            val parentMatcher = allOf(hasDescendant(withText("All groups")), hasDescendant(itemMatcher))
+            onView(withParent(parentMatcher) + itemMatcher).scrollTo().assertDisplayed()
+        }
+    }
+
+    fun swipeUp() {
+        onView(withId(R.id.swipeRefreshLayout) + withParent(withId(R.id.editDashboardPage))).swipeUp()
     }
 
 }

--- a/libs/pandautils/src/main/res/layout/fragment_edit_dashboard.xml
+++ b/libs/pandautils/src/main/res/layout/fragment_edit_dashboard.xml
@@ -45,6 +45,7 @@
         </com.google.android.material.appbar.AppBarLayout>
 
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/swipeRefreshLayout"
             android:layout_width="0dp"
             android:layout_height="0dp"
             app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
Extend DashboardE2E test to test the new group favorizing/unfavorizing logics (that the groups should be displayed independently from courses)
Add new id for swipeRefreshLayout in edit dashboard fragment
Implement some necessary page object methods

refs: MBL-16733
affects: Student
release note: none