### PR TITLE
[MBL-16725][Student] Unable to place widgets due to light/dark theme selection

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/activity/StudentViewStarterActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/StudentViewStarterActivity.kt
@@ -36,7 +36,7 @@ class StudentViewStarterActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_student_view_starter)
+        setContentView(binding.root)
         binding.loadingView.setOverrideColor(ContextCompat.getColor(this, R.color.login_studentAppTheme))
 
         val extras = intent.extras!!

--- a/apps/student/src/main/java/com/instructure/student/activity/WidgetSetupActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/WidgetSetupActivity.kt
@@ -39,7 +39,7 @@ class WidgetSetupActivity : AppCompatActivity() {
         // Sets the result canceled so if the user decides not to setup the widget it does not get added
         setResult(Activity.RESULT_CANCELED)
 
-        setContentView(R.layout.activity_widget_setup)
+        setContentView(binding.root)
 
         binding.cardDark.setOnClickListener(cardClickListener)
         binding.cardLight.setOnClickListener(cardClickListener)

--- a/apps/student/src/main/java/com/instructure/student/features/documentscanning/DocumentScanningActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/documentscanning/DocumentScanningActivity.kt
@@ -40,13 +40,13 @@ import java.util.*
 @AndroidEntryPoint
 class DocumentScanningActivity : ScanActivity() {
 
-    private val binding by viewBinding(ActivityDocumentScanningBinding::inflate)
+    private lateinit var binding: ActivityDocumentScanningBinding
 
     private val viewModel: DocumentScanningViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val binding = DataBindingUtil.setContentView<ActivityDocumentScanningBinding>(this, R.layout.activity_document_scanning)
+        binding = DataBindingUtil.setContentView<ActivityDocumentScanningBinding>(this, R.layout.activity_document_scanning)
         binding.lifecycleOwner = this
         binding.viewModel = viewModel
 


### PR DESCRIPTION
Test plan: In the ticket. I also fixed the other similar activity binding errors. (Document scanner toolbar was not showing the correct title.)

refs: MBL-16725
affects: Student
release note: Fixed a bug where users could not add widgets to the home screen.

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Run E2E test suite or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
- [x] Approve from product or not needed
