### PR TITLE
[MBL-16727][Student] 'Go To Modules' link opens a new screen which overflows the previous one

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/CourseModuleProgressionFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/CourseModuleProgressionFragment.kt
@@ -89,6 +89,7 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
     private var assetId: String by StringArg(key = ASSET_ID)
     private var assetType: String by StringArg(key = ASSET_TYPE, default = ModuleItemAsset.MODULE_ITEM.assetType)
     private var route: Route by ParcelableArg(key = ROUTE)
+    private var navigatedFromModules: Boolean by BooleanArg(key = NAVIGATED_FROM_MODULES)
 
     // Default number will get reset
     private var itemsCount = 3
@@ -635,7 +636,7 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
         // so we need to find the correct one overall
         val moduleItem = getCurrentModuleItem(position) ?: getCurrentModuleItem(0) // Default to the first item, band-aid for NPE
 
-        val fragment = ModuleUtility.getFragment(moduleItem!!, canvasContext as Course, modules[groupPos], isDiscussionRedesignEnabled)
+        val fragment = ModuleUtility.getFragment(moduleItem!!, canvasContext as Course, modules[groupPos], isDiscussionRedesignEnabled, navigatedFromModules)
         var args: Bundle? = fragment!!.arguments
         if (args == null) {
             args = Bundle()
@@ -748,6 +749,7 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
         private const val ASSET_ID = "asset_id"
         private const val ASSET_TYPE = "asset_type"
         private const val ROUTE = "route"
+        private const val NAVIGATED_FROM_MODULES = "navigated_from_modules"
 
 
         //we don't want to add subheaders or external tools into the list. subheaders don't do anything and we
@@ -762,6 +764,7 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
             return Route(null, CourseModuleProgressionFragment::class.java, canvasContext, canvasContext.makeBundle(Bundle().apply {
                 putInt(GROUP_POSITION, groupPos)
                 putInt(CHILD_POSITION, childPos)
+                putBoolean(NAVIGATED_FROM_MODULES, true)
             }))
         }
 

--- a/apps/student/src/main/java/com/instructure/student/fragment/PageDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/PageDetailsFragment.kt
@@ -61,6 +61,7 @@ class PageDetailsFragment : InternalWebviewFragment(), Bookmarkable {
     private var pageName: String? by NullableStringArg(key = PAGE_NAME)
     private var page: Page by ParcelableArg(default = Page(), key = PAGE)
     private var pageUrl: String? by NullableStringArg(key = PAGE_URL)
+    private var navigatedFromModules: Boolean by BooleanArg(key = NAVIGATED_FROM_MODULES)
 
     // Flag for the webview client to know whether or not we should clear the history
     private var isUpdated = false
@@ -185,7 +186,7 @@ class PageDetailsFragment : InternalWebviewFragment(), Bookmarkable {
         setPageObject(page)
 
         if (page.lockInfo != null) {
-            val lockedMessage = LockInfoHTMLHelper.getLockedInfoHTML(page.lockInfo!!, requireContext(), R.string.lockedPageDesc)
+            val lockedMessage = LockInfoHTMLHelper.getLockedInfoHTML(page.lockInfo!!, requireContext(), R.string.lockedPageDesc, !navigatedFromModules)
             populateWebView(lockedMessage, getString(R.string.pages))
             return
         }
@@ -323,6 +324,7 @@ class PageDetailsFragment : InternalWebviewFragment(), Bookmarkable {
         const val PAGE_NAME = "pageDetailsName"
         const val PAGE = "pageDetails"
         const val PAGE_URL = "pageUrl"
+        const val NAVIGATED_FROM_MODULES = "navigated_from_modules"
 
         fun newInstance(route: Route): PageDetailsFragment? {
             return if (validRoute(route)) PageDetailsFragment().apply {
@@ -345,8 +347,9 @@ class PageDetailsFragment : InternalWebviewFragment(), Bookmarkable {
             return Route(null, PageDetailsFragment::class.java, canvasContext, canvasContext.makeBundle(Bundle().apply { if (pageName != null) putString(PAGE_NAME, pageName) }))
         }
 
-        fun makeRoute(canvasContext: CanvasContext, pageName: String?, pageUrl: String?): Route {
+        fun makeRoute(canvasContext: CanvasContext, pageName: String?, pageUrl: String?, navigatedFromModules: Boolean): Route {
             return Route(null, PageDetailsFragment::class.java, canvasContext, canvasContext.makeBundle(Bundle().apply {
+                putBoolean(NAVIGATED_FROM_MODULES, navigatedFromModules)
                 if (pageName != null)
                     putString(PAGE_NAME, pageName)
                 if (pageUrl != null)

--- a/apps/student/src/main/java/com/instructure/student/util/LockInfoHTMLHelper.kt
+++ b/apps/student/src/main/java/com/instructure/student/util/LockInfoHTMLHelper.kt
@@ -25,7 +25,7 @@ import com.instructure.student.R
 import java.util.*
 
 object LockInfoHTMLHelper {
-    fun getLockedInfoHTML(lockInfo: LockInfo, context: Context, explanationFirstLine: Int): String {
+    fun getLockedInfoHTML(lockInfo: LockInfo, context: Context, explanationFirstLine: Int, addModulesLink: Boolean = true): String {
         /* Note: if the html that this is going in isn't based on html_wrapper.html (it will have something
         like -- String html = CanvasAPI.getAssetsFile(getSherlockActivity(), "html_wrapper.html");) this will
         not look as good. The blue button will just be a link. */
@@ -55,11 +55,13 @@ object LockInfoHTMLHelper {
         }
 
         // Make sure we know what the protocol is (http or https)
-        lockInfo.contextModule?.let { module ->
-            // Create the url to modules for this course
-            val url = "$protocol://$domain/courses/${module.contextId}/modules"
-            // Create the button and link it to modules
-            lockedMessage += """<center><a href="$url" class="button blue">${context.resources.getString(R.string.goToModules)}</a></center>"""
+        if (addModulesLink) {
+            lockInfo.contextModule?.let { module ->
+                // Create the url to modules for this course
+                val url = "$protocol://$domain/courses/${module.contextId}/modules"
+                // Create the button and link it to modules
+                lockedMessage += """<center><a href="$url" class="button blue">${context.resources.getString(R.string.goToModules)}</a></center>"""
+            }
         }
         return lockedMessage
     }

--- a/apps/student/src/main/java/com/instructure/student/util/ModuleUtility.kt
+++ b/apps/student/src/main/java/com/instructure/student/util/ModuleUtility.kt
@@ -37,8 +37,8 @@ import com.instructure.student.fragment.PageDetailsFragment.Companion.makeRoute
 import java.util.*
 
 object ModuleUtility {
-    fun getFragment(item: ModuleItem, course: Course, moduleObject: ModuleObject?, isDiscussionRedesignEnabled: Boolean): Fragment? = when (item.type) {
-        "Page" -> PageDetailsFragment.newInstance(makeRoute(course, item.title, item.pageUrl))
+    fun getFragment(item: ModuleItem, course: Course, moduleObject: ModuleObject?, isDiscussionRedesignEnabled: Boolean, navigatedFromModules: Boolean): Fragment? = when (item.type) {
+        "Page" -> PageDetailsFragment.newInstance(makeRoute(course, item.title, item.pageUrl, navigatedFromModules))
         "Assignment" -> AssignmentDetailsFragment.newInstance(makeRoute(course, getAssignmentId(item)))
         "Discussion" -> {
             if (isDiscussionRedesignEnabled) {

--- a/apps/student/src/test/java/com/instructure/student/test/util/ModuleUtilityTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/util/ModuleUtilityTest.kt
@@ -88,6 +88,7 @@ class ModuleUtilityTest : TestCase() {
         val expectedBundle = Bundle()
         expectedBundle.putParcelable(Const.CANVAS_CONTEXT, course)
         expectedBundle.putString(PageDetailsFragment.PAGE_NAME, "hello-world")
+        expectedBundle.putBoolean(PageDetailsFragment.NAVIGATED_FROM_MODULES, false)
 
         val parentFragment = callGetFragment(moduleItem, course, null)
         TestCase.assertNotNull(parentFragment)

--- a/apps/student/src/test/java/com/instructure/student/test/util/ModuleUtilityTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/util/ModuleUtilityTest.kt
@@ -246,6 +246,6 @@ class ModuleUtilityTest : TestCase() {
     }
 
     private fun callGetFragment(moduleItem: ModuleItem, course: Course, moduleObject: ModuleObject?): Fragment? {
-        return ModuleUtility.getFragment(moduleItem, course, moduleObject, false)
+        return ModuleUtility.getFragment(moduleItem, course, moduleObject, false, false)
     }
 }


### PR DESCRIPTION
Test plan: In the ticket

refs: MBL-16727
affects: Student
release note: none

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Run E2E test suite or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
- [x] Approve from product or not needed
