### PR TITLE
[MBL-16689][Student] -  Negative Login Test Cases Implementation

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/LoginE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/LoginE2ETest.kt
@@ -205,6 +205,47 @@ class LoginE2ETest : StudentTest() {
         leftSideNavigationDrawerPage.logout()
     }
 
+    @E2E
+    @Test
+    @TestMetaData(Priority.IMPORTANT, FeatureCategory.LOGIN, TestCategory.E2E)
+    fun testInvalidAndEmptyLoginCredentialsE2E() {
+
+        val INVALID_USERNAME = "invalidusercred@test.com"
+        val INVALID_PASSWORD = "invalidpw"
+        val INVALID_CREDENTIALS_ERROR_MESSAGE = "Invalid username or password. Trouble logging in?"
+        val NO_PASSWORD_GIVEN_ERROR_MESSAGE = "No password was given"
+        val DOMAIN = "mobileqa.beta"
+
+        Log.d(STEP_TAG, "Click 'Find My School' button.")
+        loginLandingPage.clickFindMySchoolButton()
+
+        Log.d(STEP_TAG,"Enter domain: $DOMAIN.instructure.com.")
+        loginFindSchoolPage.enterDomain(DOMAIN)
+
+        Log.d(STEP_TAG,"Click on 'Next' button on the Toolbar.")
+        loginFindSchoolPage.clickToolbarNextMenuItem()
+
+        Log.d(STEP_TAG, "Try to login with invalid, non-existing credentials ($INVALID_USERNAME, $INVALID_PASSWORD)." +
+                "Assert that the invalid credentials error message is displayed.")
+        loginSignInPage.loginAs(INVALID_USERNAME, INVALID_PASSWORD)
+        loginSignInPage.assertLoginErrorMessage(INVALID_CREDENTIALS_ERROR_MESSAGE)
+
+        Log.d(STEP_TAG, "Try to login with no credentials typed in either of the username and password field." +
+                "Assert that the no password was given error message is displayed.")
+        loginSignInPage.loginAs(EMPTY_STRING, EMPTY_STRING)
+        loginSignInPage.assertLoginErrorMessage(NO_PASSWORD_GIVEN_ERROR_MESSAGE)
+
+        Log.d(STEP_TAG, "Try to login with leaving only the password field empty." +
+                "Assert that the no password was given error message is displayed.")
+        loginSignInPage.loginAs(INVALID_USERNAME, EMPTY_STRING)
+        loginSignInPage.assertLoginErrorMessage(NO_PASSWORD_GIVEN_ERROR_MESSAGE)
+
+        Log.d(STEP_TAG, "Try to login with leaving only the username field empty." +
+                "Assert that the invalid credentials error message is displayed.")
+        loginSignInPage.loginAs(EMPTY_STRING, INVALID_PASSWORD)
+        loginSignInPage.assertLoginErrorMessage(INVALID_CREDENTIALS_ERROR_MESSAGE)
+    }
+
     // Verify that students can sign into vanity domain
     @E2E
     @Test

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/LoginSignInPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/LoginSignInPage.kt
@@ -16,9 +16,11 @@
  */
 package com.instructure.student.ui.pages
 
+import androidx.test.espresso.web.assertion.WebViewAssertions.webMatches
 import androidx.test.espresso.web.sugar.Web
 import androidx.test.espresso.web.sugar.Web.onWebView
 import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
+import androidx.test.espresso.web.webdriver.DriverAtoms.getText
 import androidx.test.espresso.web.webdriver.DriverAtoms.webClick
 import androidx.test.espresso.web.webdriver.DriverAtoms.webKeys
 import androidx.test.espresso.web.webdriver.Locator
@@ -27,6 +29,7 @@ import com.instructure.espresso.OnViewWithId
 import com.instructure.espresso.assertDisplayed
 import com.instructure.espresso.page.BasePage
 import com.instructure.student.R
+import org.hamcrest.CoreMatchers.containsString
 
 @Suppress("unused")
 class LoginSignInPage: BasePage() {
@@ -36,6 +39,7 @@ class LoginSignInPage: BasePage() {
     private val LOGIN_BUTTON_CSS = "button[type=\"submit\"]"
     private val FORGOT_PASSWORD_BUTTON_CSS = "a[class=\"forgot-password flip-to-back\"]"
     private val AUTHORIZE_BUTTON_CSS = "button[type=\"submit\"]"
+    private val LOGIN_ERROR_MESSAGE_HOLDER_CSS = "div[class='error']"
 
     private val signInRoot by OnViewWithId(R.id.signInRoot, autoAssert = false)
     private val toolbar by OnViewWithId(R.id.toolbar, autoAssert = false)
@@ -60,6 +64,10 @@ class LoginSignInPage: BasePage() {
 
     private fun authorizeButton(): Web.WebInteraction<*> {
         return onWebView().withElement(findElement(Locator.CSS_SELECTOR, AUTHORIZE_BUTTON_CSS))
+    }
+
+    private fun loginErrorMessageHolder(): Web.WebInteraction<*> {
+        return onWebView().withElement(findElement(Locator.CSS_SELECTOR, LOGIN_ERROR_MESSAGE_HOLDER_CSS))
     }
 
     //endregion
@@ -96,11 +104,15 @@ class LoginSignInPage: BasePage() {
         forgotPasswordButton().perform(webClick())
     }
 
+    fun assertLoginErrorMessage(errorMessage: String) {
+        loginErrorMessageHolder().check(webMatches(getText(), containsString(errorMessage)))
+    }
+
     fun loginAs(user: CanvasUserApiModel) {
         loginAs(user.loginId, user.password)
     }
 
-    private fun loginAs(loginId: String, password: String) {
+    fun loginAs(loginId: String, password: String) {
         enterEmail(loginId)
         enterPassword(password)
         clickLoginButton()


### PR DESCRIPTION
Implement negative login test case (invalid, and empty credentials will displayed the corresponding error message).

refs: MBL-16689
affects: Student
release note: none