### PR TITLE
[MBL-16736][Student] Submission comments with comment[attempt] value set as null are missing

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/drawer/comments/SubmissionCommentsPresenter.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/drawer/comments/SubmissionCommentsPresenter.kt
@@ -39,7 +39,7 @@ object SubmissionCommentsPresenter : Presenter<SubmissionCommentsModel, Submissi
 
         val tint = CanvasContext.emptyCourseContext(model.assignment.courseId).textAndIconColor
 
-        val comments = model.comments.filter { it.attempt == model.attemptId || !model.assignmentEnhancementsEnabled }.map { comment ->
+        val comments = model.comments.filter { it.attempt == null || it.attempt == model.attemptId || !model.assignmentEnhancementsEnabled }.map { comment ->
             val date = comment.createdAt ?: Date(0)
             CommentItemState.CommentItem(
                 id = comment.id,

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/SubmissionCommentsPresenterTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/SubmissionCommentsPresenterTest.kt
@@ -208,6 +208,18 @@ class SubmissionCommentsPresenterTest : Assert() {
         }
     }
 
+    @Test
+    fun `Always show comments when attemptId is null`() {
+        val comments = listOf(
+            submissionComment,
+            SubmissionComment(id=1, comment="No attempt", attempt = null)
+        )
+        val model = baseModel.copy(comments = comments)
+        val actualState = SubmissionCommentsPresenter.present(model, context)
+        assertEquals(3, actualState.commentStates.size)
+        assertEquals("No attempt", (actualState.commentStates[1] as CommentItemState.CommentItem).message)
+    }
+
     private fun dateFromCommentState(state: CommentItemState) : Date {
         return when(state) {
             is CommentItemState.CommentItem -> state.sortDate


### PR DESCRIPTION
Test plan: In the ticket. Also smoke test that the assignment enhancement feature works correctly when there is an attempt id, and in that case only those comments will be displayed.

refs: MBL-16736
affects: Student
release note: Fixed a bug where some submission comments were not visible.

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Run E2E test suite or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
- [x] Approve from product or not needed
