### PR TITLE
[MBL-16735][Student] Submission view crashes on config change

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/annnotation/AnnotationSubmissionUploadFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/annnotation/AnnotationSubmissionUploadFragment.kt
@@ -57,7 +57,7 @@ class AnnotationSubmissionUploadFragment : Fragment() {
 
         viewModel.pdfUrl.observe(viewLifecycleOwner, {
             binding.annotationSubmissionViewContainer.addView(
-                PdfStudentSubmissionView(requireActivity(), it, studentAnnotationSubmit = true)
+                PdfStudentSubmissionView(requireActivity(), it, childFragmentManager, studentAnnotationSubmit = true)
             )
         })
 

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/AnnotationSubmissionViewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/AnnotationSubmissionViewFragment.kt
@@ -52,7 +52,8 @@ class AnnotationSubmissionViewFragment : Fragment() {
                 PdfStudentSubmissionView(
                     requireActivity(),
                     it,
-                    studentAnnotationView = true
+                    childFragmentManager,
+                    studentAnnotationView = true,
                 )
             )
         }

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/PdfStudentSubmissionView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/PdfStudentSubmissionView.kt
@@ -25,6 +25,7 @@ import android.view.LayoutInflater
 import android.widget.FrameLayout
 import android.widget.ImageView
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import com.instructure.annotations.PdfSubmissionView
 import com.instructure.canvasapi2.managers.CanvaDocsManager
 import com.instructure.canvasapi2.models.ApiValues
@@ -60,8 +61,9 @@ import org.greenrobot.eventbus.ThreadMode
 class PdfStudentSubmissionView(
         context: Context,
         private val pdfUrl: String,
+        private val fragmentManager: FragmentManager,
         private val studentAnnotationSubmit: Boolean = false,
-        private val studentAnnotationView: Boolean = false
+        private val studentAnnotationView: Boolean = false,
 ) : PdfSubmissionView(context, studentAnnotationView), AnnotationManager.OnAnnotationCreationModeChangeListener, AnnotationManager.OnAnnotationEditingModeChangeListener {
 
     private val binding: ViewPdfStudentSubmissionBinding
@@ -124,7 +126,7 @@ class PdfStudentSubmissionView(
     }
 
     override fun showNoInternetDialog() {
-        NoInternetConnectionDialog.show(supportFragmentManager)
+        NoInternetConnectionDialog.show(fragmentManager)
     }
 
     init {
@@ -178,13 +180,13 @@ class PdfStudentSubmissionView(
 
     @SuppressLint("CommitTransaction")
     override fun setFragment(fragment: Fragment) {
-        if (isAttachedToWindow) supportFragmentManager.beginTransaction().replace(binding.content.id, fragment).commitNowAllowingStateLoss()
+        if (isAttachedToWindow) fragmentManager.beginTransaction().replace(binding.content.id, fragment).commitNowAllowingStateLoss()
     }
 
     override fun removeContentFragment() {
-        val contentFragment = supportFragmentManager.findFragmentById(binding.content.id)
+        val contentFragment = fragmentManager.findFragmentById(binding.content.id)
         if (contentFragment != null) {
-            supportFragmentManager.beginTransaction().remove(contentFragment).commitAllowingStateLoss()
+            fragmentManager.beginTransaction().remove(contentFragment).commitAllowingStateLoss()
         }
     }
 

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/PdfSubmissionViewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/content/PdfSubmissionViewFragment.kt
@@ -28,7 +28,7 @@ class PdfSubmissionViewFragment : Fragment() {
     private var pdfUrl by StringArg()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return PdfStudentSubmissionView(requireContext(), pdfUrl)
+        return PdfStudentSubmissionView(requireContext(), pdfUrl, childFragmentManager)
     }
 
     companion object {


### PR DESCRIPTION
Test plan: In the ticket + Smoke test viewing different types of submissions.

refs: MBL-16735
affects: Student
release note: Fixed a crash on the submission details screen.

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Run E2E test suite or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
- [x] Approve from product or not needed
