### PR TITLE
[MBL-16756][Teacher] Assignment list does not update when an item was published/unpublished

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/QuizDetailsFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/QuizDetailsFragment.kt
@@ -42,6 +42,7 @@ import com.instructure.teacher.activities.InternalWebViewActivity
 import com.instructure.teacher.databinding.FragmentQuizDetailsBinding
 import com.instructure.teacher.dialog.NoInternetConnectionDialog
 import com.instructure.teacher.events.AssignmentGradedEvent
+import com.instructure.teacher.events.AssignmentUpdatedEvent
 import com.instructure.teacher.events.QuizUpdatedEvent
 import com.instructure.teacher.events.post
 import com.instructure.teacher.factory.QuizDetailsPresenterFactory
@@ -462,7 +463,10 @@ class QuizDetailsFragment : BasePresenterFragment<
     @Subscribe(threadMode = ThreadMode.MAIN, sticky = true)
     fun onQuizEdited(event: QuizUpdatedEvent) {
         event.once(javaClass.simpleName) {
-            if (it == presenter.mQuiz.id) needToForceNetwork = true
+            if (it == presenter.mQuiz.id) {
+                needToForceNetwork = true
+                AssignmentUpdatedEvent(presenter.mQuiz.assignmentId, javaClass.simpleName).post()
+            }
         }
     }
 


### PR DESCRIPTION
Test plan: in the ticket. The issue only appeared in case of quiz.

refs: MBL-16756
affects: Teacher
release note: none

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [ ] Run E2E test suite or not needed
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] A11y checked
- [ ] Approve from product or not needed
