### PR TITLE
[MBL-16841][Student] Fix Dashboard card ordering in Offline mode

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/features/dashboard/DashboardRepository.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/dashboard/DashboardRepository.kt
@@ -42,7 +42,7 @@ class DashboardRepository(
     }
 
     suspend fun getDashboardCourses(forceNetwork: Boolean): List<DashboardCard> {
-        val dashboardCards = dataSource.getDashboardCards(forceNetwork)
+        val dashboardCards = dataSource.getDashboardCards(forceNetwork).sortedBy { it.position }
         if (isOnline()) {
             localDataSource.saveDashboardCards(dashboardCards)
         }

--- a/apps/student/src/test/java/com/instructure/student/features/dashboard/DashboardRepositoryTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/features/dashboard/DashboardRepositoryTest.kt
@@ -140,6 +140,30 @@ class DashboardRepositoryTest {
     }
 
     @Test
+    fun `Sort dashboard cards by position`() = runTest {
+        val dashboardCards = listOf(
+            DashboardCard(id = 1, position = 1),
+            DashboardCard(id = 2, position = 0),
+            DashboardCard(id = 3),
+            DashboardCard(id = 4, position = 2)
+        )
+
+        every { networkStateProvider.isOnline() } returns true
+        coEvery { networkDataSource.getDashboardCards(any()) } returns dashboardCards
+
+        val result = repository.getDashboardCourses(true)
+
+        val expectedResult = listOf(
+            DashboardCard(id = 2, position = 0),
+            DashboardCard(id = 1, position = 1),
+            DashboardCard(id = 4, position = 2),
+            DashboardCard(id = 3)
+        )
+
+        Assert.assertEquals(expectedResult, result)
+    }
+
+    @Test
     fun `Correctly filtered course ids are returned from getSyncedCourseIds`() = runTest {
         val entities = listOf(
             CourseSyncSettingsEntity(1, true, false, false, false, false),

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/DashboardCard.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/DashboardCard.kt
@@ -24,5 +24,6 @@ data class DashboardCard(
     val isK5Subject: Boolean = false,
     val shortName: String? = null,
     val originalName: String? = null,
-    val courseCode: String? = null
+    val courseCode: String? = null,
+    val position: Int = Int.MAX_VALUE // We should always get back the position, but in case it's missing we just put it at the end
 ) : CanvasModel<DashboardCard>()

--- a/libs/pandautils/schemas/com.instructure.pandautils.room.offline.OfflineDatabase/1.json
+++ b/libs/pandautils/schemas/com.instructure.pandautils.room.offline.OfflineDatabase/1.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "ef27ce4ab5b878a5dba74326f446ade2",
+    "identityHash": "31a8042dc789dc691642dab6a5b0f4fd",
     "entities": [
       {
         "tableName": "AssignmentDueDateEntity",
@@ -958,7 +958,7 @@
       },
       {
         "tableName": "DashboardCardEntity",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `isK5Subject` INTEGER NOT NULL, `shortName` TEXT, `originalName` TEXT, `courseCode` TEXT, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `isK5Subject` INTEGER NOT NULL, `shortName` TEXT, `originalName` TEXT, `courseCode` TEXT, `position` INTEGER NOT NULL, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -989,6 +989,12 @@
             "columnName": "courseCode",
             "affinity": "TEXT",
             "notNull": false
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
           }
         ],
         "primaryKey": {
@@ -3837,7 +3843,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ef27ce4ab5b878a5dba74326f446ade2')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '31a8042dc789dc691642dab6a5b0f4fd')"
     ]
   }
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/room/offline/entities/DashboardCardEntity.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/room/offline/entities/DashboardCardEntity.kt
@@ -27,7 +27,8 @@ data class DashboardCardEntity(
     val isK5Subject: Boolean,
     val shortName: String?,
     val originalName: String?,
-    val courseCode: String?
+    val courseCode: String?,
+    val position: Int
 ) {
     constructor(dashboardCard: DashboardCard) : this(
         dashboardCard.id,
@@ -35,6 +36,7 @@ data class DashboardCardEntity(
         dashboardCard.shortName,
         dashboardCard.originalName,
         dashboardCard.courseCode,
+        dashboardCard.position
     )
 
     fun toApiModel(): DashboardCard {
@@ -43,7 +45,8 @@ data class DashboardCardEntity(
             isK5Subject,
             shortName,
             originalName,
-            courseCode
+            courseCode,
+            position
         )
     }
 }


### PR DESCRIPTION
Test plan: Change the default Dashboard card ordering on web. Check that the offline mode ordering is the same as in online mode.

refs: MBL-16841
affects: Student
release note: none

## Checklist

- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
