### PR TITLE
[MBL-16650][Student] Left Side menu font remains k5 when logging in with a user after a k5 login

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
@@ -240,9 +240,9 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
         navigationDrawerBinding = NavigationDrawerBinding.bind(binding.root)
         canvasLoadingBinding = LoadingCanvasViewBinding.bind(binding.root)
-        super.onCreate(savedInstanceState)
         setContentView(binding.root)
         val masqueradingUserId: Long = intent.getLongExtra(Const.QR_CODE_MASQUERADE_ID, 0L)
         if (masqueradingUserId != 0L) {


### PR DESCRIPTION
Test plan: Steps are in the ticket.

refs: MBL-16650
affects: Student
release note: none

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-android/assets/53480952/376ff729-c6e5-4cac-b3e9-04dde163a86e" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-android/assets/53480952/b9c694c5-c82a-46cf-b31c-ce862da5ac1f" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
