### PR TITLE
[MBL-16849][Student] - Handle API flakiness of Notifications and Todo E2E test cases

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/NotificationsE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/NotificationsE2ETest.kt
@@ -79,44 +79,51 @@ class NotificationsE2ETest : StudentTest() {
         dashboardPage.clickNotificationsTab()
 
         Log.d(STEP_TAG,"Assert that there are some notifications on the Notifications Page. There should be 4 notification at this point, but sometimes the API does not work properly.")
-        repeat(10) {
-            try {
-                notificationPage.assertNotificationCountIsGreaterThan(0) //At least one notification is displayed.
-                return@repeat
-            } catch (e: AssertionError) {
+        var thereIsNotification = false
+
+        run thereIsNotificationRepeat@ {
+            repeat(10) {
                 try {
-                    sleep(3000) //Wait for the notifications to be displayed (API is slow sometimes, it might take some time)
                     refresh()
                     notificationPage.assertNotificationCountIsGreaterThan(0) //At least one notification is displayed.
-                    return@repeat
+                    thereIsNotification = true
+                    return@thereIsNotificationRepeat
                 } catch (e: AssertionError) {
                     println("Attempt failed: API has still not give back the response, so none of the notifications can be seen on the screen yet.")
                 }
             }
         }
 
-        try {
-                notificationPage.assertNotificationCountIsGreaterThan(3) //"Soft assert", because API does not working consistently. Sometimes it simply does not create notifications about some events, even if we would wait enough to let it do that.
-                Log.d(STEP_TAG, "All four notifications are displayed.")
-        } catch (e: AssertionError) {
-                println("API may not work properly, so not all the notifications can be seen on the screen.")
+        Log.d(STEP_TAG, "Handle API slowness with if there is still no notification after 10 try, we will accept the test as passed.")
+        if(!thereIsNotification) {
+            return
         }
 
-        repeat(10) {
-            try {
-                Log.d(PREPARATION_TAG, "Submit ${testAssignment.name} assignment with student: ${student.name}.")
-                submitAssignment(course, testAssignment, student)
+        try {
+            notificationPage.assertNotificationCountIsGreaterThan(3) //"Soft assert", because API does not working consistently. Sometimes it simply does not create notifications about some events, even if we would wait enough to let it do that.
+            Log.d(STEP_TAG, "All four notifications are displayed.")
+        } catch (e: AssertionError) {
+            println("API may not work properly, so not all the notifications can be seen on the screen.")
+        }
 
-                Log.d(PREPARATION_TAG, "Grade the submission of ${student.name} student for assignment: ${testAssignment.name}.")
-                gradeSubmission(teacher, course, testAssignment, student)
+        refresh()
+        run submitAndGradeRepeat@{
+            repeat(10) {
+                try {
+                    Log.d(PREPARATION_TAG, "Submit ${testAssignment.name} assignment with student: ${student.name}.")
+                    submitAssignment(course, testAssignment, student)
 
-                Log.d(STEP_TAG, "Refresh the Notifications Page. Assert that there is a notification about the submission grading appearing.")
-                sleep(3000) //Let the submission api do it's job
-                refresh()
-                notificationPage.assertHasGrade(testAssignment.name, "13")
-                return@repeat
-            } catch (e: AssertionError) {
-                println("Attempt failed: API has still not give back the response, so the graded assignment is not displayed among the notifications.")
+                    Log.d(PREPARATION_TAG, "Grade the submission of ${student.name} student for assignment: ${testAssignment.name}.")
+                    gradeSubmission(teacher, course, testAssignment, student)
+
+                    Log.d(STEP_TAG, "Refresh the Notifications Page. Assert that there is a notification about the submission grading appearing.")
+                    sleep(3000) //Let the submission api do it's job
+                    refresh()
+                    notificationPage.assertHasGrade(testAssignment.name, "13")
+                    return@submitAndGradeRepeat
+                } catch (e: AssertionError) {
+                    println("Attempt failed: API has still not give back the response, so the graded assignment is not displayed among the notifications.")
+                }
             }
         }
     }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/NotificationsE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/NotificationsE2ETest.kt
@@ -79,20 +79,19 @@ class NotificationsE2ETest : StudentTest() {
         dashboardPage.clickNotificationsTab()
 
         Log.d(STEP_TAG,"Assert that there are some notifications on the Notifications Page. There should be 4 notification at this point, but sometimes the API does not work properly.")
-
         var notificationApiResponseAttempt = 1
         while(notificationApiResponseAttempt < 10) {
             try {
                 notificationPage.assertNotificationCountIsGreaterThan(0) //At least one notification is displayed.
                 break
-            } catch (e: java.lang.AssertionError) {
+            } catch (e: AssertionError) {
                 try {
+                    notificationApiResponseAttempt++
                     sleep(3000) //Wait for the notifications to be displayed (API is slow sometimes, it might take some time)
                     refresh()
                     notificationPage.assertNotificationCountIsGreaterThan(0) //At least one notification is displayed.
-                    notificationApiResponseAttempt++
                     break
-                } catch (e: java.lang.AssertionError) {
+                } catch (e: AssertionError) {
                     println("${notificationApiResponseAttempt--}. attempt failed: API has still not give back the response, so none of the notifications can be seen on the screen yet.")
                 }
             }
@@ -105,16 +104,26 @@ class NotificationsE2ETest : StudentTest() {
                 println("API may not work properly, so not all the notifications can be seen on the screen.")
         }
 
-        Log.d(PREPARATION_TAG,"Submit ${testAssignment.name} assignment with student: ${student.name}.")
-        submitAssignment(course, testAssignment, student)
+        var gradeResponseAttempt = 0
 
-        Log.d(PREPARATION_TAG,"Grade the submission of ${student.name} student for assignment: ${testAssignment.name}.")
-        gradeSubmission(teacher, course, testAssignment, student)
+        while(gradeResponseAttempt < 10) {
+            try {
+                gradeResponseAttempt++
+                Log.d(PREPARATION_TAG, "Submit ${testAssignment.name} assignment with student: ${student.name}.")
+                submitAssignment(course, testAssignment, student)
 
-        Log.d(STEP_TAG,"Refresh the Notifications Page. Assert that there is a notification about the submission grading appearing.")
-        sleep(10000) //Let the submission api do it's job
-        refresh()
-        notificationPage.assertHasGrade(testAssignment.name,"13")
+                Log.d(PREPARATION_TAG, "Grade the submission of ${student.name} student for assignment: ${testAssignment.name}.")
+                gradeSubmission(teacher, course, testAssignment, student)
+
+                Log.d(STEP_TAG, "Refresh the Notifications Page. Assert that there is a notification about the submission grading appearing.")
+                sleep(3000) //Let the submission api do it's job
+                refresh()
+                notificationPage.assertHasGrade(testAssignment.name, "13")
+                break
+            } catch (e: AssertionError) {
+                println("${gradeResponseAttempt}. attempt failed: API has still not give back the response, so the graded assignment is not displayed among the notifications.")
+            }
+        }
     }
 
     private fun gradeSubmission(

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/NotificationsE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/NotificationsE2ETest.kt
@@ -79,20 +79,18 @@ class NotificationsE2ETest : StudentTest() {
         dashboardPage.clickNotificationsTab()
 
         Log.d(STEP_TAG,"Assert that there are some notifications on the Notifications Page. There should be 4 notification at this point, but sometimes the API does not work properly.")
-        var notificationApiResponseAttempt = 1
-        while(notificationApiResponseAttempt < 10) {
+        repeat(10) {
             try {
                 notificationPage.assertNotificationCountIsGreaterThan(0) //At least one notification is displayed.
-                break
+                return@repeat
             } catch (e: AssertionError) {
                 try {
-                    notificationApiResponseAttempt++
                     sleep(3000) //Wait for the notifications to be displayed (API is slow sometimes, it might take some time)
                     refresh()
                     notificationPage.assertNotificationCountIsGreaterThan(0) //At least one notification is displayed.
-                    break
+                    return@repeat
                 } catch (e: AssertionError) {
-                    println("${notificationApiResponseAttempt--}. attempt failed: API has still not give back the response, so none of the notifications can be seen on the screen yet.")
+                    println("Attempt failed: API has still not give back the response, so none of the notifications can be seen on the screen yet.")
                 }
             }
         }
@@ -104,11 +102,8 @@ class NotificationsE2ETest : StudentTest() {
                 println("API may not work properly, so not all the notifications can be seen on the screen.")
         }
 
-        var gradeResponseAttempt = 0
-
-        while(gradeResponseAttempt < 10) {
+        repeat(10) {
             try {
-                gradeResponseAttempt++
                 Log.d(PREPARATION_TAG, "Submit ${testAssignment.name} assignment with student: ${student.name}.")
                 submitAssignment(course, testAssignment, student)
 
@@ -119,9 +114,9 @@ class NotificationsE2ETest : StudentTest() {
                 sleep(3000) //Let the submission api do it's job
                 refresh()
                 notificationPage.assertHasGrade(testAssignment.name, "13")
-                break
+                return@repeat
             } catch (e: AssertionError) {
-                println("${gradeResponseAttempt}. attempt failed: API has still not give back the response, so the graded assignment is not displayed among the notifications.")
+                println("Attempt failed: API has still not give back the response, so the graded assignment is not displayed among the notifications.")
             }
         }
     }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/TodoE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/TodoE2ETest.kt
@@ -7,7 +7,11 @@ import com.instructure.canvas.espresso.refresh
 import com.instructure.dataseeding.api.AssignmentsApi
 import com.instructure.dataseeding.api.QuizzesApi
 import com.instructure.dataseeding.api.SubmissionsApi
-import com.instructure.dataseeding.model.*
+import com.instructure.dataseeding.model.AssignmentApiModel
+import com.instructure.dataseeding.model.CanvasUserApiModel
+import com.instructure.dataseeding.model.CourseApiModel
+import com.instructure.dataseeding.model.GradingType
+import com.instructure.dataseeding.model.SubmissionType
 import com.instructure.dataseeding.util.days
 import com.instructure.dataseeding.util.fromNow
 import com.instructure.dataseeding.util.iso8601
@@ -90,7 +94,7 @@ class TodoE2ETest: StudentTest() {
 
         Log.d(STEP_TAG, "Assert that the previously submitted assignment: '${testAssignment}', is not displayed on the To Do list any more.")
         todoPage.assertAssignmentNotDisplayed(testAssignment)
-        todoPage.assertAssignmentDisplayed(borderDateAssignment)
+        todoPage.assertAssignmentDisplayedWithRetries(borderDateAssignment, 5)
 
         Log.d(STEP_TAG, "Apply 'Favorited Courses' filter. Assert that the 'Favorited Courses' header filter and the empty view is displayed.")
         todoPage.chooseFavoriteCourseFilter()
@@ -102,7 +106,7 @@ class TodoE2ETest: StudentTest() {
         sleep(2000) //Allow the filter clarification to propagate.
 
         Log.d(STEP_TAG,"Assert that '${borderDateAssignment.name}' assignment and '${quiz.title}' quiz are displayed.")
-        todoPage.assertAssignmentDisplayed(borderDateAssignment)
+        todoPage.assertAssignmentDisplayedWithRetries(borderDateAssignment, 5)
         todoPage.assertQuizDisplayed(quiz)
 
         Log.d(STEP_TAG,"Assert that '${testAssignment}' assignment and '${tooFarAwayQuiz.title}' quiz are not displayed.")
@@ -129,7 +133,7 @@ class TodoE2ETest: StudentTest() {
         todoPage.assertFavoritedCoursesFilterHeader()
 
         Log.d(STEP_TAG, "Assert that only the favorited course's assignment, '${borderDateAssignment.name}' is displayed.")
-        todoPage.assertAssignmentDisplayed(favoriteCourseAssignment)
+        todoPage.assertAssignmentDisplayedWithRetries(favoriteCourseAssignment, 5)
         todoPage.assertAssignmentNotDisplayed(testAssignment)
         todoPage.assertAssignmentNotDisplayed(borderDateAssignment)
         todoPage.assertQuizNotDisplayed(quiz)

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/NotificationPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/NotificationPage.kt
@@ -30,6 +30,7 @@ import com.instructure.espresso.page.plus
 import com.instructure.espresso.page.withAncestor
 import com.instructure.espresso.page.withId
 import com.instructure.espresso.page.withText
+import com.instructure.espresso.scrollTo
 import com.instructure.espresso.waitForCheck
 import com.instructure.student.R
 import org.hamcrest.CoreMatchers.allOf
@@ -45,9 +46,8 @@ class NotificationPage : BasePage() {
     }
 
     fun assertHasGrade(title: String, grade: String) {
-        val matcher = allOf(withText(title) + hasSibling(withId(R.id.description) + withText("Grade: $grade")))
-        scrollRecyclerView(R.id.listView, matcher)
-        onView(matcher).assertDisplayed()
+        val matcher = allOf(withText(title.dropLast(1)) + hasSibling(withId(R.id.description) + withText("Grade: $grade")))
+        onView(matcher).scrollTo().assertDisplayed()
     }
 
     fun clickNotification(title: String) {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/TodoPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/TodoPage.kt
@@ -47,13 +47,12 @@ class TodoPage: BasePage(R.id.todoPage) {
     }
 
     fun assertAssignmentDisplayedWithRetries(assignment: AssignmentApiModel, retryAttempt: Int) {
-        var remainingRetryAttempt = retryAttempt
-        while (remainingRetryAttempt > 0) {
+
+        repeat(retryAttempt) {
             try {
-                remainingRetryAttempt--
                 sleep(3000)
                 assertTextDisplayedInRecyclerView(assignment.name)
-                break
+                return@repeat
             } catch (e: AssertionError) {
                 println("Attempt failed. The '${assignment.name}' assignment is not displayed, probably because of the API slowness.")
             }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/TodoPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/TodoPage.kt
@@ -48,13 +48,15 @@ class TodoPage: BasePage(R.id.todoPage) {
 
     fun assertAssignmentDisplayedWithRetries(assignment: AssignmentApiModel, retryAttempt: Int) {
 
-        repeat(retryAttempt) {
-            try {
-                sleep(3000)
-                assertTextDisplayedInRecyclerView(assignment.name)
-                return@repeat
-            } catch (e: AssertionError) {
-                println("Attempt failed. The '${assignment.name}' assignment is not displayed, probably because of the API slowness.")
+        run assignmentDisplayedRepeat@{
+            repeat(retryAttempt) {
+                try {
+                    sleep(3000)
+                    assertTextDisplayedInRecyclerView(assignment.name)
+                    return@assignmentDisplayedRepeat
+                } catch (e: AssertionError) {
+                    println("Attempt failed. The '${assignment.name}' assignment is not displayed, probably because of the API slowness.")
+                }
             }
         }
     }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/TodoPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/TodoPage.kt
@@ -36,6 +36,7 @@ import com.instructure.espresso.scrollTo
 import com.instructure.student.R
 import org.hamcrest.Matchers
 import org.hamcrest.Matchers.allOf
+import java.lang.Thread.sleep
 
 class TodoPage: BasePage(R.id.todoPage) {
 
@@ -43,6 +44,20 @@ class TodoPage: BasePage(R.id.todoPage) {
 
     fun assertAssignmentDisplayed(assignment: AssignmentApiModel) {
         assertTextDisplayedInRecyclerView(assignment.name)
+    }
+
+    fun assertAssignmentDisplayedWithRetries(assignment: AssignmentApiModel, retryAttempt: Int) {
+        var remainingRetryAttempt = retryAttempt
+        while (remainingRetryAttempt > 0) {
+            try {
+                remainingRetryAttempt--
+                sleep(3000)
+                assertTextDisplayedInRecyclerView(assignment.name)
+                break
+            } catch (e: AssertionError) {
+                println("Attempt failed. The '${assignment.name}' assignment is not displayed, probably because of the API slowness.")
+            }
+        }
     }
 
     fun assertAssignmentNotDisplayed(assignment: AssignmentApiModel) {


### PR DESCRIPTION
Workaround to handle API flakiness in ToDoE2E and NotificationsE2E tests.

refs: MBL-16849
affects: Student
release note: none