### PR TITLE
[MBL-16834][Student] Offline mode: Select/Deselect all button is disappearing when change orientation or put the app in the background

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/offline/offlinecontent/OfflineContentFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/offline/offlinecontent/OfflineContentFragment.kt
@@ -86,6 +86,10 @@ class OfflineContentFragment : Fragment(), FragmentInteractions {
                 viewModel.toggleSelection()
             }
         }
+
+        viewModel.data.value?.let { data ->
+            updateMenuText(data.selectedCount)
+        }
     }
 
     override fun getFragment(): Fragment = this


### PR DESCRIPTION
Test plan:
1. *Manage Offline Content* menu item on *Dashboard*
2. Rotate the screen

refs: MBL-16834
affects: Student
release note: none

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-android/assets/53480952/815a1855-364c-46a9-85a3-998989dd92f3" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-android/assets/53480952/91f1864c-83d2-45a2-8767-25d5c897d27e" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
