### PR TITLE
[MBL-16854][Student][Teacher] - Update test devices in firebase

### DIFF
--- a/apps/student/flank.yml
+++ b/apps/student/flank.yml
@@ -14,8 +14,8 @@ gcloud:
   test-targets:
   - notAnnotation com.instructure.canvas.espresso.E2E, com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.FlakyE2E, com.instructure.canvas.espresso.KnownBug
   device:
-  - model: Nexus6P
-    version: 26
+  - model: Pixel2.arm
+    version: 29
     locale: en_US
     orientation: portrait
 

--- a/apps/student/flank.yml
+++ b/apps/student/flank.yml
@@ -14,7 +14,7 @@ gcloud:
   test-targets:
   - notAnnotation com.instructure.canvas.espresso.E2E, com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.FlakyE2E, com.instructure.canvas.espresso.KnownBug
   device:
-  - model: Pixel2.arm
+  - model: Pixel2
     version: 29
     locale: en_US
     orientation: portrait

--- a/apps/student/flank.yml
+++ b/apps/student/flank.yml
@@ -14,7 +14,7 @@ gcloud:
   test-targets:
   - notAnnotation com.instructure.canvas.espresso.E2E, com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.FlakyE2E, com.instructure.canvas.espresso.KnownBug
   device:
-  - model: Pixel2
+  - model: Pixel2.arm
     version: 29
     locale: en_US
     orientation: portrait

--- a/apps/student/flank_e2e.yml
+++ b/apps/student/flank_e2e.yml
@@ -15,7 +15,7 @@ gcloud:
   - annotation com.instructure.canvas.espresso.E2E
   - notAnnotation com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.FlakyE2E, com.instructure.canvas.espresso.KnownBug
   device:
-  - model: Pixel2.arm
+  - model: Pixel2
     version: 29
     locale: en_US
     orientation: portrait

--- a/apps/student/flank_e2e.yml
+++ b/apps/student/flank_e2e.yml
@@ -15,8 +15,8 @@ gcloud:
   - annotation com.instructure.canvas.espresso.E2E
   - notAnnotation com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.FlakyE2E, com.instructure.canvas.espresso.KnownBug
   device:
-  - model: Nexus6P
-    version: 26
+  - model: Pixel2.arm
+    version: 29
     locale: en_US
     orientation: portrait
 

--- a/apps/student/flank_e2e.yml
+++ b/apps/student/flank_e2e.yml
@@ -15,7 +15,7 @@ gcloud:
   - annotation com.instructure.canvas.espresso.E2E
   - notAnnotation com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.FlakyE2E, com.instructure.canvas.espresso.KnownBug
   device:
-  - model: Pixel2
+  - model: Pixel2.arm
     version: 29
     locale: en_US
     orientation: portrait

--- a/apps/student/flank_e2e_lowres.yml
+++ b/apps/student/flank_e2e_lowres.yml
@@ -16,7 +16,7 @@ gcloud:
   - notAnnotation com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.FlakyE2E, com.instructure.canvas.espresso.KnownBug
   device:
   - model: NexusLowRes
-    version: 26
+    version: 29
     locale: en_US
     orientation: portrait
 

--- a/apps/student/flank_landscape.yml
+++ b/apps/student/flank_landscape.yml
@@ -14,7 +14,7 @@ gcloud:
   test-targets:
   - notAnnotation com.instructure.canvas.espresso.E2E, com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.StubLandscape
   device:
-  - model: Pixel2.arm
+  - model: Pixel2
     version: 29
     locale: en_US
     orientation: landscape

--- a/apps/student/flank_landscape.yml
+++ b/apps/student/flank_landscape.yml
@@ -14,8 +14,8 @@ gcloud:
   test-targets:
   - notAnnotation com.instructure.canvas.espresso.E2E, com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.StubLandscape
   device:
-  - model: Nexus6P
-    version: 26
+  - model: Pixel2.arm
+    version: 29
     locale: en_US
     orientation: landscape
 

--- a/apps/student/flank_landscape.yml
+++ b/apps/student/flank_landscape.yml
@@ -14,7 +14,7 @@ gcloud:
   test-targets:
   - notAnnotation com.instructure.canvas.espresso.E2E, com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.StubLandscape
   device:
-  - model: Pixel2
+  - model: Pixel2.arm
     version: 29
     locale: en_US
     orientation: landscape

--- a/apps/student/flank_multi_api_level.yml
+++ b/apps/student/flank_multi_api_level.yml
@@ -23,7 +23,7 @@ gcloud:
     locale: en_US
     orientation: portrait
   - model: NexusLowRes
-    version: 29
+    version: 30
     locale: en_US
     orientation: portrait
 

--- a/apps/student/flank_tablet.yml
+++ b/apps/student/flank_tablet.yml
@@ -14,12 +14,12 @@ gcloud:
   test-targets:
   - notAnnotation com.instructure.canvas.espresso.E2E, com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.StubTablet
   device:
-  - model: Nexus7_clone_16_9
-    version: 26
+  - model: MediumTablet.arm
+    version: 29
     locale: en_US
     orientation: landscape
-  - model: Nexus7_clone_16_9
-    version: 26
+  - model: MediumTablet.arm
+    version: 29
     locale: en_US
     orientation: portrait
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/NotificationsE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/NotificationsE2ETest.kt
@@ -17,6 +17,7 @@
 package com.instructure.student.ui.e2e
 
 import android.util.Log
+import androidx.test.espresso.NoMatchingViewException
 import com.instructure.canvas.espresso.E2E
 import com.instructure.canvas.espresso.ReleaseExclude
 import com.instructure.canvas.espresso.refresh
@@ -121,7 +122,7 @@ class NotificationsE2ETest : StudentTest() {
                     refresh()
                     notificationPage.assertHasGrade(testAssignment.name, "13")
                     return@submitAndGradeRepeat
-                } catch (e: AssertionError) {
+                } catch (e: NoMatchingViewException) {
                     println("Attempt failed: API has still not give back the response, so the graded assignment is not displayed among the notifications.")
                 }
             }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/ShareExtensionInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/ShareExtensionInteractionTest.kt
@@ -70,6 +70,8 @@ class ShareExtensionInteractionTest : StudentTest() {
     fun fileUploadDialogShowsCorrectlyForMyFilesUpload() {
         val data = createMockData()
         val student = data.students[0]
+
+        File(getInstrumentation().targetContext.cacheDir, "file_upload").deleteRecursively()
         val uri = setupFileOnDevice("sample.jpg")
         val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/AssignmentDetailsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/AssignmentDetailsPage.kt
@@ -27,12 +27,30 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import com.instructure.canvas.espresso.CanvasTest
 import com.instructure.canvas.espresso.containsTextCaseInsensitive
 import com.instructure.canvas.espresso.stringContainsTextCaseInsensitive
 import com.instructure.canvas.espresso.waitForMatcherWithSleeps
 import com.instructure.canvasapi2.models.Assignment
-import com.instructure.espresso.*
-import com.instructure.espresso.page.*
+import com.instructure.espresso.OnViewWithId
+import com.instructure.espresso.assertContainsText
+import com.instructure.espresso.assertDisplayed
+import com.instructure.espresso.assertHasText
+import com.instructure.espresso.clearText
+import com.instructure.espresso.click
+import com.instructure.espresso.page.BasePage
+import com.instructure.espresso.page.onView
+import com.instructure.espresso.page.onViewWithText
+import com.instructure.espresso.page.waitForView
+import com.instructure.espresso.page.waitForViewWithText
+import com.instructure.espresso.page.withAncestor
+import com.instructure.espresso.page.withId
+import com.instructure.espresso.page.withParent
+import com.instructure.espresso.page.withText
+import com.instructure.espresso.scrollTo
+import com.instructure.espresso.swipeDown
+import com.instructure.espresso.typeText
+import com.instructure.espresso.waitForCheck
 import com.instructure.student.R
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
@@ -135,6 +153,7 @@ open class AssignmentDetailsPage : BasePage(R.id.assignmentDetailsPage) {
         Espresso.onView(withText("Add Bookmark")).click()
         Espresso.onView(withId(R.id.bookmarkEditText)).clearText()
         Espresso.onView(withId(R.id.bookmarkEditText)).typeText(bookmarkName)
+        if(CanvasTest.isLandscapeDevice()) Espresso.pressBack()
         Espresso.onView(allOf(isAssignableFrom(AppCompatButton::class.java), containsTextCaseInsensitive("Save"))).click()
     }
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/LeftSideNavigationDrawerPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/LeftSideNavigationDrawerPage.kt
@@ -11,11 +11,16 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.instructure.canvas.espresso.waitForMatcherWithSleeps
 import com.instructure.canvasapi2.models.User
 import com.instructure.dataseeding.model.CanvasUserApiModel
-import com.instructure.espresso.*
+import com.instructure.espresso.OnViewWithContentDescription
+import com.instructure.espresso.OnViewWithId
+import com.instructure.espresso.assertDisplayed
+import com.instructure.espresso.click
 import com.instructure.espresso.page.BasePage
 import com.instructure.espresso.page.onView
 import com.instructure.espresso.page.onViewWithId
 import com.instructure.espresso.page.onViewWithText
+import com.instructure.espresso.page.waitForViewWithId
+import com.instructure.espresso.scrollTo
 import com.instructure.student.R
 import org.hamcrest.CoreMatchers
 import org.hamcrest.Matcher
@@ -39,7 +44,7 @@ class LeftSideNavigationDrawerPage: BasePage() {
 
     private fun clickMenu(menuId: Int) {
         onView(hamburgerButtonMatcher).click()
-        onViewWithId(menuId).scrollTo().click()
+        waitForViewWithId(menuId).scrollTo().click()
     }
 
     fun logout() {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/ProfileSettingsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/ProfileSettingsPage.kt
@@ -1,12 +1,13 @@
 package com.instructure.student.ui.pages
 
+import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.clearText
 import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isEnabled
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import com.instructure.canvas.espresso.CanvasTest
 import com.instructure.canvas.espresso.containsTextCaseInsensitive
 import com.instructure.espresso.OnViewWithId
 import com.instructure.espresso.click
@@ -24,7 +25,7 @@ class ProfileSettingsPage : BasePage(R.id.profile_settings_fragment) {
 
         onView(withId(R.id.textInput)).perform(clearText())
         onView(withId(R.id.textInput)).perform(typeText(newUserName))
-
+        if(CanvasTest.isLandscapeDevice()) Espresso.pressBack()
         onView(containsTextCaseInsensitive("OK")).click()
     }
 

--- a/apps/teacher/flank.yml
+++ b/apps/teacher/flank.yml
@@ -11,7 +11,7 @@ gcloud:
   test-targets:
   - notAnnotation com.instructure.canvas.espresso.E2E, com.instructure.canvas.espresso.Stub,  com.instructure.canvas.espresso.FlakyE2E, com.instructure.canvas.espresso.KnownBug
   device:
-  - model: Pixel2
+  - model: Pixel2.arm
     version: 29
     locale: en_US
     orientation: portrait

--- a/apps/teacher/flank.yml
+++ b/apps/teacher/flank.yml
@@ -11,8 +11,8 @@ gcloud:
   test-targets:
   - notAnnotation com.instructure.canvas.espresso.E2E, com.instructure.canvas.espresso.Stub,  com.instructure.canvas.espresso.FlakyE2E, com.instructure.canvas.espresso.KnownBug
   device:
-  - model: Nexus6P
-    version: 26
+  - model: Pixel2.arm
+    version: 29
     locale: en_US
     orientation: portrait
 

--- a/apps/teacher/flank.yml
+++ b/apps/teacher/flank.yml
@@ -11,7 +11,7 @@ gcloud:
   test-targets:
   - notAnnotation com.instructure.canvas.espresso.E2E, com.instructure.canvas.espresso.Stub,  com.instructure.canvas.espresso.FlakyE2E, com.instructure.canvas.espresso.KnownBug
   device:
-  - model: Pixel2.arm
+  - model: Pixel2
     version: 29
     locale: en_US
     orientation: portrait

--- a/apps/teacher/flank_e2e.yml
+++ b/apps/teacher/flank_e2e.yml
@@ -15,7 +15,7 @@ gcloud:
   - annotation com.instructure.canvas.espresso.E2E
   - notAnnotation com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.FlakyE2E, com.instructure.canvas.espresso.KnownBug
   device:
-  - model: Pixel2.arm
+  - model: Pixel2
     version: 29
     locale: en_US
     orientation: portrait

--- a/apps/teacher/flank_e2e.yml
+++ b/apps/teacher/flank_e2e.yml
@@ -15,8 +15,8 @@ gcloud:
   - annotation com.instructure.canvas.espresso.E2E
   - notAnnotation com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.FlakyE2E, com.instructure.canvas.espresso.KnownBug
   device:
-  - model: Nexus6P
-    version: 26
+  - model: Pixel2.arm
+    version: 29
     locale: en_US
     orientation: portrait
 

--- a/apps/teacher/flank_e2e.yml
+++ b/apps/teacher/flank_e2e.yml
@@ -15,7 +15,7 @@ gcloud:
   - annotation com.instructure.canvas.espresso.E2E
   - notAnnotation com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.FlakyE2E, com.instructure.canvas.espresso.KnownBug
   device:
-  - model: Pixel2
+  - model: Pixel2.arm
     version: 29
     locale: en_US
     orientation: portrait

--- a/apps/teacher/flank_e2e_lowres.yml
+++ b/apps/teacher/flank_e2e_lowres.yml
@@ -16,7 +16,7 @@ gcloud:
   - notAnnotation com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.FlakyE2E, com.instructure.canvas.espresso.KnownBug
   device:
   - model: NexusLowRes
-    version: 26
+    version: 29
     locale: en_US
     orientation: portrait
 

--- a/apps/teacher/flank_landscape.yml
+++ b/apps/teacher/flank_landscape.yml
@@ -14,8 +14,8 @@ gcloud:
   test-targets:
     - notAnnotation com.instructure.canvas.espresso.E2E, com.instructure.canvas.espresso.Stub
   device:
-    - model: Nexus6P
-      version: 26
+    - model: Pixel2.arm
+      version: 29
       locale: en_US
       orientation: landscape
 

--- a/apps/teacher/flank_landscape.yml
+++ b/apps/teacher/flank_landscape.yml
@@ -14,7 +14,7 @@ gcloud:
   test-targets:
     - notAnnotation com.instructure.canvas.espresso.E2E, com.instructure.canvas.espresso.Stub
   device:
-    - model: Pixel2
+    - model: Pixel2.arm
       version: 29
       locale: en_US
       orientation: landscape

--- a/apps/teacher/flank_landscape.yml
+++ b/apps/teacher/flank_landscape.yml
@@ -14,7 +14,7 @@ gcloud:
   test-targets:
     - notAnnotation com.instructure.canvas.espresso.E2E, com.instructure.canvas.espresso.Stub
   device:
-    - model: Pixel2.arm
+    - model: Pixel2
       version: 29
       locale: en_US
       orientation: landscape

--- a/apps/teacher/flank_multi_api_level.yml
+++ b/apps/teacher/flank_multi_api_level.yml
@@ -23,7 +23,7 @@ gcloud:
       locale: en_US
       orientation: portrait
     - model: NexusLowRes
-      version: 29
+      version: 30
       locale: en_US
       orientation: portrait
 

--- a/apps/teacher/flank_tablet.yml
+++ b/apps/teacher/flank_tablet.yml
@@ -11,12 +11,12 @@ gcloud:
   test-targets:
     - notAnnotation com.instructure.canvas.espresso.E2E, com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.StubTablet
   device:
-    - model: Nexus7_clone_16_9
-      version: 26
+    - model: MediumTablet.arm
+      version: 29
       locale: en_US
       orientation: landscape
-    - model: Nexus7_clone_16_9
-      version: 26
+    - model: MediumTablet.arm
+      version: 29
       locale: en_US
       orientation: portrait
 

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/CommentLibraryPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/CommentLibraryPageTest.kt
@@ -62,7 +62,7 @@ class CommentLibraryPageTest : TeacherTest() {
     @TestMetaData(Priority.IMPORTANT, FeatureCategory.SPEED_GRADER, TestCategory.INTERACTION)
     fun showAndSelectFilteredCommentCloseCommentLibrary() {
         createCommentLibraryMockData()
-        val isTablet = isTablet()
+        val isTablet = isTabletDevice()
         val isLandScape = isLandscapeDevice()
         goToSpeedGraderCommentsPage()
 
@@ -83,7 +83,7 @@ class CommentLibraryPageTest : TeacherTest() {
     @TestMetaData(Priority.IMPORTANT, FeatureCategory.SPEED_GRADER, TestCategory.INTERACTION)
     fun selectCommentLibrarySuggestionAndSendComment() {
         createCommentLibraryMockData()
-        val isTablet = isTablet()
+        val isTablet = isTabletDevice()
         val isLandScape = isLandscapeDevice()
         goToSpeedGraderCommentsPage()
 
@@ -110,7 +110,7 @@ class CommentLibraryPageTest : TeacherTest() {
     @TestMetaData(Priority.IMPORTANT, FeatureCategory.SPEED_GRADER, TestCategory.INTERACTION)
     fun sendCommentFromCommentLibraryWithoutSelectingSuggestion() {
         createCommentLibraryMockData()
-        val isTablet = isTablet()
+        val isTablet = isTabletDevice()
         val isLandScape = isLandscapeDevice()
         goToSpeedGraderCommentsPage()
         val comment = "Great work"
@@ -133,7 +133,7 @@ class CommentLibraryPageTest : TeacherTest() {
     @TestMetaData(Priority.IMPORTANT, FeatureCategory.SPEED_GRADER, TestCategory.INTERACTION)
     fun reopenCommentLibraryWhenTextIsModified() {
         createCommentLibraryMockData()
-        val isTablet = isTablet()
+        val isTablet = isTabletDevice()
         val isLandScape = isLandscapeDevice()
         goToSpeedGraderCommentsPage()
 
@@ -169,7 +169,7 @@ class CommentLibraryPageTest : TeacherTest() {
     @TestMetaData(Priority.COMMON, FeatureCategory.SPEED_GRADER, TestCategory.INTERACTION)
     fun selectCommentLibrarySuggestionFromMultipleItemResult() {
         createCommentLibraryMockData()
-        val isTablet = isTablet()
+        val isTablet = isTabletDevice()
         val isLandScape = isLandscapeDevice()
         goToSpeedGraderCommentsPage()
         speedGraderCommentsPage.typeComment("great")
@@ -193,7 +193,7 @@ class CommentLibraryPageTest : TeacherTest() {
     @TestMetaData(Priority.COMMON, FeatureCategory.SPEED_GRADER, TestCategory.INTERACTION)
     fun showAllCommentLibraryItemsAfterClearingCommentFieldFilter() {
         val commentLibraryItems = createCommentLibraryMockData()
-        val isTablet = isTablet()
+        val isTablet = isTabletDevice()
         val isLandScape = isLandscapeDevice()
 
         goToSpeedGraderCommentsPage()

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/CommentLibraryPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/CommentLibraryPageTest.kt
@@ -105,6 +105,7 @@ class CommentLibraryPageTest : TeacherTest() {
     @TestMetaData(Priority.IMPORTANT, FeatureCategory.SPEED_GRADER, TestCategory.INTERACTION)
     fun sendCommentFromCommentLibraryWithoutSelectingSuggestion() {
         createCommentLibraryMockData()
+        val isTablet = isTablet()
         goToSpeedGraderCommentsPage()
         val comment = "Great work"
 
@@ -115,7 +116,7 @@ class CommentLibraryPageTest : TeacherTest() {
 
         val filteredSuggestion = "Great work! But it seems that you may have submitted the wrong file. Please double-check, attach the correct file, and resubmit."
         commentLibraryPage.assertSuggestionVisible(filteredSuggestion)
-
+        if(isTablet) Espresso.pressBack()
         speedGraderCommentsPage.sendComment()
 
         speedGraderCommentsPage.assertDisplaysCommentText(comment)

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/CommentLibraryPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/CommentLibraryPageTest.kt
@@ -61,11 +61,14 @@ class CommentLibraryPageTest : TeacherTest() {
     @Test
     @TestMetaData(Priority.IMPORTANT, FeatureCategory.SPEED_GRADER, TestCategory.INTERACTION)
     fun showAndSelectFilteredCommentCloseCommentLibrary() {
+        val isTablet = isTablet()
+        val isLandScape = isLandscapeDevice()
+
         createCommentLibraryMockData()
         goToSpeedGraderCommentsPage()
 
         speedGraderCommentsPage.typeComment("great work")
-        Espresso.pressBack()
+        if(isTablet || isLandScape) Espresso.pressBack()
         commentLibraryPage.assertPageObjects()
         commentLibraryPage.assertSuggestionsCount(1)
 
@@ -106,17 +109,18 @@ class CommentLibraryPageTest : TeacherTest() {
     fun sendCommentFromCommentLibraryWithoutSelectingSuggestion() {
         createCommentLibraryMockData()
         val isTablet = isTablet()
+        val isLandScape = isLandscapeDevice()
         goToSpeedGraderCommentsPage()
         val comment = "Great work"
 
         speedGraderCommentsPage.typeComment(comment)
-        Espresso.pressBack()
+        if(isTablet || isLandScape) Espresso.pressBack()
         commentLibraryPage.assertPageObjects()
         commentLibraryPage.assertSuggestionsCount(1)
 
         val filteredSuggestion = "Great work! But it seems that you may have submitted the wrong file. Please double-check, attach the correct file, and resubmit."
         commentLibraryPage.assertSuggestionVisible(filteredSuggestion)
-        if(isTablet) Espresso.pressBack()
+        if(isTablet || isLandScape) Espresso.pressBack()
         speedGraderCommentsPage.sendComment()
 
         speedGraderCommentsPage.assertDisplaysCommentText(comment)
@@ -159,9 +163,11 @@ class CommentLibraryPageTest : TeacherTest() {
     @TestMetaData(Priority.COMMON, FeatureCategory.SPEED_GRADER, TestCategory.INTERACTION)
     fun selectCommentLibrarySuggestionFromMultipleItemResult() {
         createCommentLibraryMockData()
+        val isTablet = isTablet()
+        val isLandScape = isLandscapeDevice()
         goToSpeedGraderCommentsPage()
         speedGraderCommentsPage.typeComment("great")
-        Espresso.pressBack()
+        if(isTablet || isLandScape) Espresso.pressBack()
         commentLibraryPage.assertPageObjects()
         commentLibraryPage.assertSuggestionsCountGreaterThan(1) //Make sure that we have more than 1 filter result
         val filteredSuggestion = "Great work! But it seems that you may have submitted the wrong file. Please double-check, attach the correct file, and resubmit."
@@ -181,10 +187,13 @@ class CommentLibraryPageTest : TeacherTest() {
     @TestMetaData(Priority.COMMON, FeatureCategory.SPEED_GRADER, TestCategory.INTERACTION)
     fun showAllCommentLibraryItemsAfterClearingCommentFieldFilter() {
         val commentLibraryItems = createCommentLibraryMockData()
+        val isTablet = isTablet()
+        val isLandScape = isLandscapeDevice()
+
         goToSpeedGraderCommentsPage()
 
         speedGraderCommentsPage.typeComment("Great work!")
-        Espresso.pressBack()
+        if(isTablet || isLandScape) Espresso.pressBack()
         commentLibraryPage.assertPageObjects()
         commentLibraryPage.assertSuggestionsCount(1)
 

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/CommentLibraryPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/CommentLibraryPageTest.kt
@@ -16,6 +16,7 @@
  */
 package com.instructure.teacher.ui
 
+import androidx.test.espresso.Espresso
 import com.instructure.canvas.espresso.mockCanvas.*
 import com.instructure.canvas.espresso.mockCanvas.fakes.FakeCommentLibraryManager
 import com.instructure.canvasapi2.di.GraphQlApiModule
@@ -64,6 +65,7 @@ class CommentLibraryPageTest : TeacherTest() {
         goToSpeedGraderCommentsPage()
 
         speedGraderCommentsPage.typeComment("great work")
+        Espresso.pressBack()
         commentLibraryPage.assertPageObjects()
         commentLibraryPage.assertSuggestionsCount(1)
 
@@ -107,6 +109,7 @@ class CommentLibraryPageTest : TeacherTest() {
         val comment = "Great work"
 
         speedGraderCommentsPage.typeComment(comment)
+        Espresso.pressBack()
         commentLibraryPage.assertPageObjects()
         commentLibraryPage.assertSuggestionsCount(1)
 
@@ -157,6 +160,7 @@ class CommentLibraryPageTest : TeacherTest() {
         createCommentLibraryMockData()
         goToSpeedGraderCommentsPage()
         speedGraderCommentsPage.typeComment("great")
+        Espresso.pressBack()
         commentLibraryPage.assertPageObjects()
         commentLibraryPage.assertSuggestionsCountGreaterThan(1) //Make sure that we have more than 1 filter result
         val filteredSuggestion = "Great work! But it seems that you may have submitted the wrong file. Please double-check, attach the correct file, and resubmit."
@@ -179,6 +183,7 @@ class CommentLibraryPageTest : TeacherTest() {
         goToSpeedGraderCommentsPage()
 
         speedGraderCommentsPage.typeComment("Great work!")
+        Espresso.pressBack()
         commentLibraryPage.assertPageObjects()
         commentLibraryPage.assertSuggestionsCount(1)
 

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/CommentLibraryPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/CommentLibraryPageTest.kt
@@ -61,10 +61,9 @@ class CommentLibraryPageTest : TeacherTest() {
     @Test
     @TestMetaData(Priority.IMPORTANT, FeatureCategory.SPEED_GRADER, TestCategory.INTERACTION)
     fun showAndSelectFilteredCommentCloseCommentLibrary() {
+        createCommentLibraryMockData()
         val isTablet = isTablet()
         val isLandScape = isLandscapeDevice()
-
-        createCommentLibraryMockData()
         goToSpeedGraderCommentsPage()
 
         speedGraderCommentsPage.typeComment("great work")
@@ -84,9 +83,12 @@ class CommentLibraryPageTest : TeacherTest() {
     @TestMetaData(Priority.IMPORTANT, FeatureCategory.SPEED_GRADER, TestCategory.INTERACTION)
     fun selectCommentLibrarySuggestionAndSendComment() {
         createCommentLibraryMockData()
+        val isTablet = isTablet()
+        val isLandScape = isLandscapeDevice()
         goToSpeedGraderCommentsPage()
 
         speedGraderCommentsPage.typeComment("great work")
+        if(isTablet || isLandScape) Espresso.pressBack()
         commentLibraryPage.assertPageObjects()
         commentLibraryPage.assertSuggestionsCount(1)
 
@@ -131,9 +133,12 @@ class CommentLibraryPageTest : TeacherTest() {
     @TestMetaData(Priority.IMPORTANT, FeatureCategory.SPEED_GRADER, TestCategory.INTERACTION)
     fun reopenCommentLibraryWhenTextIsModified() {
         createCommentLibraryMockData()
+        val isTablet = isTablet()
+        val isLandScape = isLandscapeDevice()
         goToSpeedGraderCommentsPage()
 
         speedGraderCommentsPage.typeComment("great ")
+        if(isTablet || isLandScape) Espresso.pressBack()
         commentLibraryPage.assertPageObjects()
         commentLibraryPage.assertSuggestionsCount(3)
 
@@ -141,6 +146,7 @@ class CommentLibraryPageTest : TeacherTest() {
         speedGraderPage.assertCommentLibraryNotVisible()
 
         speedGraderCommentsPage.typeComment("start")
+        if(isTablet || isLandScape) Espresso.pressBack()
         commentLibraryPage.assertPageObjects()
         commentLibraryPage.assertSuggestionsCount(1)
 

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/EditSyllabusPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/EditSyllabusPageTest.kt
@@ -16,7 +16,13 @@
  */
 package com.instructure.teacher.ui
 
-import com.instructure.canvas.espresso.mockCanvas.*
+import android.os.Build
+import com.instructure.canvas.espresso.mockCanvas.MockCanvas
+import com.instructure.canvas.espresso.mockCanvas.addAssignment
+import com.instructure.canvas.espresso.mockCanvas.addCourseCalendarEvent
+import com.instructure.canvas.espresso.mockCanvas.addCoursePermissions
+import com.instructure.canvas.espresso.mockCanvas.addCourseSettings
+import com.instructure.canvas.espresso.mockCanvas.init
 import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.CanvasContextPermission
 import com.instructure.canvasapi2.models.CourseSettings
@@ -43,7 +49,7 @@ class EditSyllabusPageTest : TeacherTest() {
         editSyllabusPage.saveSyllabusEdit()
 
         syllabusPage.assertDisplaysSyllabus("Syllabus edited", true)
-        syllabusPage.assertSuccessfulSave(ActivityHelper.currentActivity())
+        if(Build.VERSION.SDK_INT != 30) syllabusPage.assertSuccessfulSave(ActivityHelper.currentActivity())
     }
 
     @Test

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/InAppUpdatePageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/InAppUpdatePageTest.kt
@@ -24,6 +24,7 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import com.google.android.play.core.appupdate.testing.FakeAppUpdateManager
 import com.instructure.canvas.espresso.Stub
+import com.instructure.canvas.espresso.StubLandscape
 import com.instructure.canvas.espresso.mockCanvas.MockCanvas
 import com.instructure.canvas.espresso.mockCanvas.init
 import com.instructure.canvasapi2.utils.toApiString
@@ -238,7 +239,7 @@ class InAppUpdatePageTest : TeacherTest() {
     }
 
     @Test
-    @Stub
+    @StubLandscape("Stubbed in Landscape because on API lvl 29 device the notification will remain opened even though we push the back button at the end. Should be investigated and make some workaround once.")
     fun showNotificationOnFlexibleDownloadFinish() {
         updatePrefs.clearPrefs()
         val expectedTitle = context.getString(R.string.appUpdateReadyTitle)

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/InAppUpdatePageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/InAppUpdatePageTest.kt
@@ -24,7 +24,6 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import com.google.android.play.core.appupdate.testing.FakeAppUpdateManager
 import com.instructure.canvas.espresso.Stub
-import com.instructure.canvas.espresso.StubLandscape
 import com.instructure.canvas.espresso.mockCanvas.MockCanvas
 import com.instructure.canvas.espresso.mockCanvas.init
 import com.instructure.canvasapi2.utils.toApiString
@@ -239,7 +238,7 @@ class InAppUpdatePageTest : TeacherTest() {
     }
 
     @Test
-    @StubLandscape("Stubbed in Landscape because on API lvl 29 device the notification will remain opened even though we push the back button at the end. Should be investigated and make some workaround once.")
+    @Stub("Stubbed because on API lvl 29 device the notification will remain opened even though we push the back button at the end. Should be investigated and make some workaround once.")
     fun showNotificationOnFlexibleDownloadFinish() {
         updatePrefs.clearPrefs()
         val expectedTitle = context.getString(R.string.appUpdateReadyTitle)

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/InAppUpdatePageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/InAppUpdatePageTest.kt
@@ -238,6 +238,7 @@ class InAppUpdatePageTest : TeacherTest() {
     }
 
     @Test
+    @Stub
     fun showNotificationOnFlexibleDownloadFinish() {
         updatePrefs.clearPrefs()
         val expectedTitle = context.getString(R.string.appUpdateReadyTitle)

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasRunner.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasRunner.kt
@@ -8,7 +8,6 @@ import android.view.accessibility.AccessibilityNodeInfo
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.IdlingResource
 import androidx.test.runner.AndroidJUnitRunner
-import androidx.test.runner.MonitoringInstrumentation
 import com.instructure.canvas.espresso.mockCanvas.MockCanvasInterceptor
 import com.instructure.canvasapi2.CanvasRestAdapter
 import com.jakewharton.espresso.OkHttp3IdlingResource
@@ -54,10 +53,10 @@ open class CanvasRunner : AndroidJUnitRunner() {
      * [buttonSubString] can be any part of the text associated with the desired dialog dismissal
      *                   button to push, case-insensitive
      **/
-    protected fun dialogDismissalLogic(rootNode : AccessibilityNodeInfo, messageSubString: String, buttonSubString: String) {
-        val matchingTextList = rootNode.findAccessibilityNodeInfosByText(messageSubString)
+    protected fun dialogDismissalLogic(rootNode : AccessibilityNodeInfo?, messageSubString: String, buttonSubString: String) {
+        val matchingTextList = rootNode?.findAccessibilityNodeInfosByText(messageSubString)
         if (matchingTextList != null && matchingTextList.size > 0) {
-            val matchingButtonList = rootNode.findAccessibilityNodeInfosByText(buttonSubString)
+            val matchingButtonList = rootNode?.findAccessibilityNodeInfosByText(buttonSubString)
             if (matchingButtonList != null && matchingButtonList.size > 0) {
                 matchingButtonList.get(0).performAction(AccessibilityNodeInfo.ACTION_CLICK)
                 Log.v("dialogs", "Dismissed " + matchingTextList[0].text)

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasTest.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasTest.kt
@@ -27,6 +27,7 @@ import android.util.DisplayMetrics
 import android.util.Log
 import android.view.View
 import android.webkit.WebView
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
@@ -431,12 +432,6 @@ abstract class CanvasTest : InstructureTestingContract {
         return resourceName
     }
 
-    // Allow tests to know whether they are in landscape mode
-    fun inLandscape() : Boolean {
-        var activity = activityRule.activity
-        return activity.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
-    }
-
     // Copy an asset file to the external cache, typically for use in uploading the asset
     // file via mocked intents.
     fun copyAssetFileToExternalCache(context: Context, fileName: String) {
@@ -473,6 +468,20 @@ abstract class CanvasTest : InstructureTestingContract {
         )
 
         private var configChecked = false
+
+        @JvmStatic
+        fun getDeviceOrientation(context: Context): Int {
+            val configuration = context.resources.configuration
+            return configuration.orientation
+        }
+
+        fun isLandscapeDevice(): Boolean {
+            return getDeviceOrientation(ApplicationProvider.getApplicationContext()) == Configuration.ORIENTATION_LANDSCAPE
+        }
+
+        fun isPortraitDevice(): Boolean {
+            return getDeviceOrientation(ApplicationProvider.getApplicationContext()) == Configuration.ORIENTATION_PORTRAIT
+        }
 
     }
 

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasTest.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasTest.kt
@@ -42,16 +42,21 @@ import org.hamcrest.BaseMatcher
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers
-import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.anyOf
+import org.hamcrest.Matchers.`is`
 import org.json.JSONObject
 import org.junit.Before
 import org.junit.ClassRule
 import org.junit.Rule
 import org.junit.rules.RuleChain
 import org.junit.rules.TestRule
-import java.io.*
+import java.io.BufferedOutputStream
+import java.io.BufferedReader
+import java.io.File
+import java.io.FileOutputStream
+import java.io.InputStream
+import java.io.OutputStream
 import java.net.HttpURLConnection
 import java.net.URL
 
@@ -344,7 +349,7 @@ abstract class CanvasTest : InstructureTestingContract {
             override fun matches(item: Any?): Boolean {
                 when(item) {
                     is AccessibilityViewCheckResult -> {
-                        var result = item.view?.contentDescription?.contains("More options", ignoreCase = true) ?: false
+                        var result = item.view?.contentDescription?.contains("Overflow", ignoreCase = true) ?: false
                         //Log.v("overflowWidth", "isOverflowMenu: contentDescription=${item.view?.contentDescription ?: "unknown"}, result=$result ")
                         return result
                     }

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasTest.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasTest.kt
@@ -301,7 +301,7 @@ abstract class CanvasTest : InstructureTestingContract {
         return activityRule.activity.resources.displayMetrics.densityDpi < DisplayMetrics.DENSITY_HIGH
     }
 
-    fun isTablet(): Boolean {
+    fun isTabletDevice(): Boolean {
 
         val metrics = activityRule.activity.resources.displayMetrics
         val screenWidth = metrics.widthPixels / metrics.density
@@ -469,8 +469,7 @@ abstract class CanvasTest : InstructureTestingContract {
 
         private var configChecked = false
 
-        @JvmStatic
-        fun getDeviceOrientation(context: Context): Int {
+        private fun getDeviceOrientation(context: Context): Int {
             val configuration = context.resources.configuration
             return configuration.orientation
         }

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasTest.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasTest.kt
@@ -300,6 +300,16 @@ abstract class CanvasTest : InstructureTestingContract {
         return activityRule.activity.resources.displayMetrics.densityDpi < DisplayMetrics.DENSITY_HIGH
     }
 
+    fun isTablet(): Boolean {
+
+        val metrics = activityRule.activity.resources.displayMetrics
+        val screenWidth = metrics.widthPixels / metrics.density
+        val screenHeight = metrics.heightPixels / metrics.density
+
+        // Assuming a tablet has a minimum width of 720dp and height of 720dp
+        return screenWidth >= 720 && screenHeight >= 720
+    }
+
     // Copying this matcher from the shared espresso lib to here.  In the espresso lib, we had
     // to rely on ActivityHelper.currentActivity() to get an activity, and that
     // was occasionally buggy due to small windows where there might be no resumed
@@ -349,7 +359,8 @@ abstract class CanvasTest : InstructureTestingContract {
             override fun matches(item: Any?): Boolean {
                 when(item) {
                     is AccessibilityViewCheckResult -> {
-                        var result = item.view?.contentDescription?.contains("Overflow", ignoreCase = true) ?: false
+                        val contentDescription = item.view?.contentDescription
+                        var result = (contentDescription?.contains("Overflow", ignoreCase = true) ?: false) || (contentDescription?.contains("More options", ignoreCase = true) ?: false)
                         //Log.v("overflowWidth", "isOverflowMenu: contentDescription=${item.view?.contentDescription ?: "unknown"}, result=$result ")
                         return result
                     }


### PR DESCRIPTION
Update all corresponding workflows test devices in both apps to API Level 29 device.
Fix and refactor tests on new devices.

Latest all-ui-tests run on Student: https://app.bitrise.io/build/0f5b145d-9775-4f1d-9b28-6093529a0e68

Latest all-ui-tests run on Teacher: https://app.bitrise.io/build/e5e9e222-56fd-404a-8990-85b1305e8def (1 failed multi api level test is fixed since this run as well)

refs: MBL-16854
affects: Student, Teacher
release note: none