### PR TITLE
Rollback lowres devices to API lvl 26

### DIFF
--- a/apps/student/flank_e2e_lowres.yml
+++ b/apps/student/flank_e2e_lowres.yml
@@ -16,7 +16,7 @@ gcloud:
   - notAnnotation com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.FlakyE2E, com.instructure.canvas.espresso.KnownBug
   device:
   - model: NexusLowRes
-    version: 29
+    version: 26
     locale: en_US
     orientation: portrait
 

--- a/apps/teacher/flank_e2e_lowres.yml
+++ b/apps/teacher/flank_e2e_lowres.yml
@@ -16,7 +16,7 @@ gcloud:
   - notAnnotation com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.FlakyE2E, com.instructure.canvas.espresso.KnownBug
   device:
   - model: NexusLowRes
-    version: 29
+    version: 26
     locale: en_US
     orientation: portrait
 


### PR DESCRIPTION
 Because API level 29 low resolution device is too flaky in Firebase Test Lab