### PR TITLE
[MBL-16893][Teacher] Tablet: Refactor Syllabus fragment split view

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/ui/SyllabusView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/syllabus/ui/SyllabusView.kt
@@ -42,6 +42,7 @@ import com.instructure.teacher.features.syllabus.edit.EditSyllabusFragment
 import com.instructure.teacher.fragments.AssignmentDetailsFragment
 import com.instructure.teacher.mobius.common.ui.MobiusView
 import com.instructure.teacher.router.RouteMatcher
+import com.instructure.teacher.utils.setupBackButton
 import com.instructure.teacher.utils.setupMenu
 import com.spotify.mobius.functions.Consumer
 import org.greenrobot.eventbus.EventBus
@@ -94,6 +95,7 @@ class SyllabusView(
         binding.toolbar.apply {
             title = context.getString(com.instructure.pandares.R.string.syllabus)
             subtitle = canvasContext.name
+            setupBackButton(activity)
         }
 
         binding.syllabusPager.adapter = SyllabusTabAdapter(getTabTitles())

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/CourseBrowserFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/CourseBrowserFragment.kt
@@ -253,7 +253,7 @@ class CourseBrowserFragment : BaseSyncFragment<
                     presenter.handleStudentViewClick()
                 }
                 Tab.SYLLABUS_ID -> {
-                    RouteMatcher.route(requireContext(), Route(null, SyllabusFragment::class.java, presenter.canvasContext, presenter.canvasContext.makeBundle()))
+                    RouteMatcher.route(requireContext(), Route(SyllabusFragment::class.java, presenter.canvasContext, presenter.canvasContext.makeBundle()))
                 }
                 else -> {
                     if (tab.type == Tab.TYPE_EXTERNAL) {

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/QuizListFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/QuizListFragment.kt
@@ -116,8 +116,12 @@ class QuizListFragment : BaseExpandableSyncFragment<
 
     override fun createAdapter(): QuizListAdapter {
         return QuizListAdapter(requireContext(), presenter, canvasContext.textAndIconColor) { quiz ->
-            val args = QuizDetailsFragment.makeBundle(quiz)
-            RouteMatcher.route(requireContext(), Route(null, QuizDetailsFragment::class.java, canvasContext, args))
+            if (RouteMatcher.canRouteInternally(requireActivity(), quiz.htmlUrl, ApiPrefs.domain, false)) {
+                RouteMatcher.routeUrl(requireActivity(), quiz.htmlUrl!!, ApiPrefs.domain)
+            } else {
+                val args = QuizDetailsFragment.makeBundle(quiz)
+                RouteMatcher.route(requireContext(), Route(null, QuizDetailsFragment::class.java, canvasContext, args))
+            }
         }
     }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/QuizListFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/QuizListFragment.kt
@@ -116,12 +116,8 @@ class QuizListFragment : BaseExpandableSyncFragment<
 
     override fun createAdapter(): QuizListAdapter {
         return QuizListAdapter(requireContext(), presenter, canvasContext.textAndIconColor) { quiz ->
-            if (RouteMatcher.canRouteInternally(requireActivity(), quiz.htmlUrl, ApiPrefs.domain, false)) {
-                RouteMatcher.routeUrl(requireActivity(), quiz.htmlUrl!!, ApiPrefs.domain)
-            } else {
-                val args = QuizDetailsFragment.makeBundle(quiz)
-                RouteMatcher.route(requireContext(), Route(null, QuizDetailsFragment::class.java, canvasContext, args))
-            }
+            val args = QuizDetailsFragment.makeBundle(quiz)
+            RouteMatcher.route(requireContext(), Route(null, QuizDetailsFragment::class.java, canvasContext, args))
         }
     }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/router/RouteMatcher.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/router/RouteMatcher.kt
@@ -126,6 +126,7 @@ object RouteMatcher : BaseRouteMatcher() {
         fullscreenFragments.add(ViewPdfFragment::class.java)
         fullscreenFragments.add(ViewHtmlFragment::class.java)
         fullscreenFragments.add(EditDashboardFragment::class.java)
+        fullscreenFragments.add(CourseBrowserFragment::class.java)
 
         // Bottom Sheet Fragments
         bottomSheetFragments.add(EditAssignmentDetailsFragment::class.java)


### PR DESCRIPTION
Test plan: In the ticket

refs: MBL-16893
affects: Teacher
release note: none

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-android/assets/53480952/03a9474a-07f7-4fbd-9a51-814ec0bcc08a" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-android/assets/53480952/1fa60fd3-6070-4917-bab8-0064bcb4cc1c" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
