### PR TITLE
[MBL-16873][Student] - Extend PagesE2E test with testing editable, non-editable pages

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/PagesE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/PagesE2ETest.kt
@@ -52,43 +52,70 @@ class PagesE2ETest: StudentTest() {
         val teacher = data.teachersList[0]
         val course = data.coursesList[0]
 
-        Log.d(PREPARATION_TAG,"Seed an UNPUBLISHED page for ${course.name} course.")
+        Log.d(PREPARATION_TAG,"Seed an UNPUBLISHED page for '${course.name}' course.")
         val pageUnpublished = createCoursePage(course, teacher, published = false, frontPage = false)
 
-        Log.d(PREPARATION_TAG,"Seed a PUBLISHED page for ${course.name} course.")
-        val pagePublished = createCoursePage(course, teacher, published = true, frontPage = false, body = "<h1 id=\"header1\">Regular Page Text</h1>")
+        Log.d(PREPARATION_TAG,"Seed a PUBLISHED page for '${course.name}' course.")
+        val pagePublished = createCoursePage(course, teacher, published = true, frontPage = false, editingRoles = "teachers,students", body = "<h1 id=\"header1\">Regular Page Text</h1>")
 
-        Log.d(PREPARATION_TAG,"Seed a PUBLISHED, FRONT page for ${course.name} course.")
-        val pagePublishedFront = createCoursePage(course, teacher, published = true, frontPage = true, body = "<h1 id=\"header1\">Front Page Text</h1>")
+        Log.d(PREPARATION_TAG,"Seed a PUBLISHED, but NOT editable page for '${course.name}' course.")
+        val pageNotEditable = createCoursePage(course, teacher, published = true, frontPage = false, body = "<h1 id=\"header1\">Regular Page Text</h1>")
 
-        Log.d(STEP_TAG,"Login with user: ${student.name}, login id: ${student.loginId}.")
+        Log.d(PREPARATION_TAG,"Seed a PUBLISHED, FRONT page for '${course.name}' course.")
+        val pagePublishedFront = createCoursePage(course, teacher, published = true, frontPage = true, editingRoles = "public", body = "<h1 id=\"header1\">Front Page Text</h1>")
+
+        Log.d(STEP_TAG,"Login with user: '${student.name}', login id: '${student.loginId}'.")
         tokenLogin(student)
         dashboardPage.waitForRender()
 
-        Log.d(STEP_TAG,"Select ${course.name} course and navigate to Modules Page.")
+        Log.d(STEP_TAG,"Select '${course.name}' course and navigate to Modules Page.")
         dashboardPage.selectCourse(course)
         courseBrowserPage.selectPages()
 
-        Log.d(STEP_TAG,"Assert that ${pagePublishedFront.title} published front page is displayed.")
+        Log.d(STEP_TAG,"Assert that '${pagePublishedFront.title}' published front page is displayed.")
         pageListPage.assertFrontPageDisplayed(pagePublishedFront)
 
-        Log.d(STEP_TAG,"Assert that ${pagePublished.title} published page is displayed.")
+        Log.d(STEP_TAG,"Assert that '${pagePublished.title}' published page is displayed.")
         pageListPage.assertRegularPageDisplayed(pagePublished)
 
-        Log.d(STEP_TAG,"Assert that ${pageUnpublished.title} unpublished page is NOT displayed.")
+        Log.d(STEP_TAG,"Assert that '${pageUnpublished.title}' unpublished page is NOT displayed.")
         pageListPage.assertPageNotDisplayed(pageUnpublished)
 
-        Log.d(STEP_TAG,"Open ${pagePublishedFront.title} page. Assert that it is really a front (published) page via web view assertions.")
+        Log.d(STEP_TAG,"Open '${pagePublishedFront.title}' page. Assert that it is really a front (published) page via web view assertions.")
         pageListPage.selectFrontPage(pagePublishedFront)
         canvasWebViewPage.runTextChecks(WebViewTextCheck(Locator.ID, "header1", "Front Page Text"))
 
         Log.d(STEP_TAG,"Navigate back to Pages page.")
         Espresso.pressBack()
 
-        Log.d(STEP_TAG,"Open ${pagePublished.title} page. Assert that it is really a regular published page via web view assertions.")
+        Log.d(STEP_TAG, "Select '${pageNotEditable.title}' page. Assert that it is not editable as a student, then navigate back to Page List page.")
+        pageListPage.selectRegularPage(pageNotEditable)
+        canvasWebViewPage.assertDoesNotEditable()
+        Espresso.pressBack()
+
+        Log.d(STEP_TAG,"Open '${pagePublished.title}' page. Assert that it is really a regular published page via web view assertions.")
         pageListPage.selectRegularPage(pagePublished)
         canvasWebViewPage.runTextChecks(WebViewTextCheck(Locator.ID, "header1", "Regular Page Text"))
 
+        Log.d(STEP_TAG, "Click on the 'Pencil' icon and edit the body. Click on 'Save' button.")
+        canvasWebViewPage.clickEditPencilIcon()
+        canvasWebViewPage.typeInRCEEditor("<h1 id=\"header1\">Page Text Mod</h1>")
+        canvasWebViewPage.clickOnSave()
+
+        Log.d(STEP_TAG, "Assert that the new, edited text is displayed in the page body.")
+        canvasWebViewPage.runTextChecks(WebViewTextCheck(Locator.ID, "header1", "Page Text Mod"))
+
+        Log.d(STEP_TAG, "Navigate back to Page List page. Select '${pagePublishedFront.title}' front page.")
+        Espresso.pressBack()
+        pageListPage.selectFrontPage(pagePublishedFront)
+
+        Log.d(STEP_TAG, "Click on the 'Pencil' icon and edit the body. Click on 'Save' button.")
+        canvasWebViewPage.clickEditPencilIcon()
+        canvasWebViewPage.typeInRCEEditor("<h1 id=\"header1\">Front Page Text Mod</h1>")
+        canvasWebViewPage.clickOnSave()
+
+        Log.d(STEP_TAG, "Assert that the new, edited text is displayed in the page body.")
+        canvasWebViewPage.runTextChecks(WebViewTextCheck(Locator.ID, "header1", "Front Page Text Mod"))
     }
 
     private fun createCoursePage(
@@ -96,11 +123,13 @@ class PagesE2ETest: StudentTest() {
         teacher: CanvasUserApiModel,
         published: Boolean,
         frontPage: Boolean,
+        editingRoles: String? = null,
         body: String = Randomizer.randomPageBody()
     ) = PagesApi.createCoursePage(
         courseId = course.id,
         published = published,
         frontPage = frontPage,
+        editingRoles = editingRoles,
         token = teacher.token,
         body = body
     )

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/CanvasWebViewPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/CanvasWebViewPage.kt
@@ -17,6 +17,8 @@
 package com.instructure.student.ui.pages
 
 import androidx.annotation.StringRes
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
+import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.web.assertion.WebViewAssertions.webMatches
 import androidx.test.espresso.web.model.Atoms.getCurrentUrl
@@ -28,8 +30,17 @@ import androidx.test.espresso.web.webdriver.DriverAtoms.webScrollIntoView
 import androidx.test.espresso.web.webdriver.Locator
 import com.instructure.canvas.espresso.withElementRepeat
 import com.instructure.espresso.assertVisible
-import com.instructure.espresso.page.*
+import com.instructure.espresso.click
+import com.instructure.espresso.page.BasePage
+import com.instructure.espresso.page.onView
+import com.instructure.espresso.page.onViewWithId
+import com.instructure.espresso.page.plus
+import com.instructure.espresso.page.waitForView
+import com.instructure.espresso.page.withAncestor
+import com.instructure.espresso.page.withId
+import com.instructure.espresso.page.withText
 import com.instructure.student.R
+import com.instructure.student.ui.utils.TypeInRCETextEditor
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.containsString
 
@@ -93,6 +104,23 @@ open class CanvasWebViewPage : BasePage(R.id.contentWebView) {
     fun waitForWebView() {
         waitForView(allOf(withId(R.id.contentWebView), isDisplayed()))
     }
+
+    fun clickEditPencilIcon() {
+        onView(withId(R.id.menu_edit)).click()
+    }
+
+    fun assertDoesNotEditable() {
+        onView(withId(R.id.menu_edit)).check(doesNotExist())
+    }
+
+    fun typeInRCEEditor(textToType: String) {
+        waitForView(ViewMatchers.withId(R.id.rce_webView)).perform(TypeInRCETextEditor(textToType))
+    }
+
+    fun clickOnSave() {
+        onViewWithId(R.id.menuSavePage).click()
+    }
+
 }
 
 /** data class that encapsulates info for a webview text check */

--- a/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/api/PagesApi.kt
+++ b/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/api/PagesApi.kt
@@ -41,10 +41,11 @@ object PagesApi {
             courseId: Long,
             published: Boolean,
             frontPage: Boolean,
+            editingRoles: String? = null,
             token: String,
             body: String = Randomizer.randomPageBody()
     ): PageApiModel {
-        val page = CreatePageWrapper(CreatePage(Randomizer.randomPageTitle(), body, published, frontPage))
+        val page = CreatePageWrapper(CreatePage(Randomizer.randomPageTitle(), body, published, frontPage, editingRoles))
 
         return pagesService(token)
                 .createCoursePage(courseId, page)

--- a/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/model/PageApiModel.kt
+++ b/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/model/PageApiModel.kt
@@ -26,7 +26,9 @@ data class PageApiModel(
         val body: String,
         val published: Boolean,
         @SerializedName("front_page")
-        val frontPage: Boolean
+        val frontPage: Boolean,
+        @SerializedName("editing_roles")
+        val editingRoles: String
 )
 
 data class CreatePage(
@@ -34,7 +36,9 @@ data class CreatePage(
         val body: String,
         val published: Boolean,
         @SerializedName("front_page")
-        val frontPage: Boolean
+        val frontPage: Boolean,
+        @SerializedName("editing_roles")
+        val editingRoles: String? = null
 )
 
 data class CreatePageWrapper(


### PR DESCRIPTION
Extend PagesE2E test with testing editable, non-editable pages
Add some needed webview methods as well.
Extend API calls to handle editing_roles parameter.

refs: MBL-16873
affects: Student
release note: none
