### PR TITLE
[MBL-16942][Teacher] - Fix PeopleListFragment accepts few letters as search query

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/PeopleListFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/PeopleListFragment.kt
@@ -184,8 +184,14 @@ class PeopleListFragment : BaseSyncFragment<User, PeopleListPresenter, PeopleLis
     override fun onQueryTextSubmit(query: String): Boolean = false
 
     override fun onQueryTextChange(newText: String): Boolean {
-        adapter.clear()
-        presenter.searchPeopleList(newText)
+        val searchQuery = newText.trim().takeIf { it.length > 2 }.orEmpty()
+        if(searchQuery.isBlank()) {
+            presenter.searchPeopleList(searchQuery)
+        }
+        else {
+            adapter.clear()
+            presenter.searchPeopleList(searchQuery)
+        }
         return true
     }
 


### PR DESCRIPTION
Fix PeopleListFragment accepts few letters (1, 2) as search query.

refs: MBL-16942
affects: Teacher
release note: none

Test plan: Test 

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>
<img src="" maxHeight=500 ![Screenshot_20230728_113213_Canvas Teacher](https://github.com/instructure/canvas-android/assets/92309696/55ecc61d-a901-4106-b952-3acbf2d28b18) />
</td>
<td>
<img src="" maxHeight=500 ![image](https://github.com/instructure/canvas-android/assets/92309696/560ffb31-17d3-454f-9365-448bb1076399)>
</td>
</tr>
</table>

## Checklist

- [ ] Tested in dark mode
- [ ] Tested in light mode
