### PR TITLE
[MBL-16890][Student] - Test folder control flow in user groups

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/ShareExtensionE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/ShareExtensionE2ETest.kt
@@ -19,7 +19,6 @@ package com.instructure.student.ui.e2e
 import android.content.Intent
 import android.net.Uri
 import android.util.Log
-import androidx.core.content.FileProvider
 import androidx.test.espresso.Espresso
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
@@ -34,14 +33,12 @@ import com.instructure.dataseeding.model.SubmissionType
 import com.instructure.dataseeding.util.days
 import com.instructure.dataseeding.util.fromNow
 import com.instructure.dataseeding.util.iso8601
-import com.instructure.pandautils.utils.Const
 import com.instructure.student.ui.utils.StudentTest
 import com.instructure.student.ui.utils.ViewUtils
 import com.instructure.student.ui.utils.seedData
 import com.instructure.student.ui.utils.tokenLogin
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Test
-import java.io.File
 
 @HiltAndroidTest
 class ShareExtensionE2ETest: StudentTest() {
@@ -223,20 +220,6 @@ class ShareExtensionE2ETest: StudentTest() {
                 pointsPossible = pointsPossible,
                 dueAt = dueAt
             )
-        )
-    }
-
-    private fun setupFileOnDevice(fileName: String): Uri {
-        copyAssetFileToExternalCache(activityRule.activity, fileName)
-
-        val dir = activityRule.activity.externalCacheDir
-        val file = File(dir?.path, fileName)
-
-        val instrumentationContext = InstrumentationRegistry.getInstrumentation().context
-        return FileProvider.getUriForFile(
-            instrumentationContext,
-            "com.instructure.candroid" + Const.FILE_PROVIDER_AUTHORITY,
-            file
         )
     }
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/usergroups/UserGroupFilesE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/usergroups/UserGroupFilesE2ETest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2019 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.instructure.student.ui.e2e.usergroups
+
+import android.util.Log
+import com.instructure.canvas.espresso.E2E
+import com.instructure.dataseeding.api.GroupsApi
+import com.instructure.panda_annotations.FeatureCategory
+import com.instructure.panda_annotations.Priority
+import com.instructure.panda_annotations.SecondaryFeatureCategory
+import com.instructure.panda_annotations.TestCategory
+import com.instructure.panda_annotations.TestMetaData
+import com.instructure.student.ui.utils.StudentTest
+import com.instructure.student.ui.utils.seedData
+import com.instructure.student.ui.utils.tokenLogin
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Test
+
+@HiltAndroidTest
+class UserGroupFilesE2ETest : StudentTest() {
+    override fun displaysPageObjects() = Unit
+
+    override fun enableAndConfigureAccessibilityChecks() = Unit
+
+    @E2E
+    @Test
+    @TestMetaData(Priority.IMPORTANT, FeatureCategory.DASHBOARD, TestCategory.E2E, secondaryFeature = SecondaryFeatureCategory.GROUPS_FILES)
+    fun testUserGroupFileControlFlow() {
+
+        Log.d(PREPARATION_TAG,"Seeding data.")
+        val data = seedData(students = 1, teachers = 1, courses = 1)
+        val student = data.studentsList[0]
+        val teacher = data.teachersList[0]
+
+        Log.d(PREPARATION_TAG,"Seed some group info.")
+        val groupCategory = GroupsApi.createCourseGroupCategory(data.coursesList[0].id, teacher.token)
+        val groupCategory2 = GroupsApi.createCourseGroupCategory(data.coursesList[0].id, teacher.token)
+        val group = GroupsApi.createGroup(groupCategory.id, teacher.token)
+        val group2 = GroupsApi.createGroup(groupCategory2.id, teacher.token)
+
+        Log.d(PREPARATION_TAG,"Create group membership for ${student.name} student.")
+        GroupsApi.createGroupMembership(group.id, student.id, teacher.token)
+        GroupsApi.createGroupMembership(group2.id, student.id, teacher.token)
+
+        Log.d(STEP_TAG,"Login with user: ${student.name}, login id: ${student.loginId}.")
+        tokenLogin(student)
+        dashboardPage.waitForRender()
+
+        Log.d(STEP_TAG,"Assert that ${group.name} groups is displayed.")
+        dashboardPage.assertDisplaysGroup(group, data.coursesList[0])
+        dashboardPage.assertDisplaysGroup(group2, data.coursesList[0])
+
+        dashboardPage.selectGroup(group)
+
+        groupBrowserPage.assertTitleCorrect(group)
+        groupBrowserPage.selectFiles()
+
+        fileListPage.assertPageObjects()
+        }
+}

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/usergroups/UserGroupFilesE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/usergroups/UserGroupFilesE2ETest.kt
@@ -16,16 +16,9 @@
  */
 package com.instructure.student.ui.e2e.usergroups
 
-import android.app.Activity
-import android.app.Instrumentation
-import android.content.Intent
-import android.net.Uri
 import android.util.Log
-import androidx.core.content.FileProvider
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.intent.matcher.IntentMatchers
-import androidx.test.platform.app.InstrumentationRegistry
 import com.instructure.canvas.espresso.E2E
 import com.instructure.dataseeding.api.GroupsApi
 import com.instructure.panda_annotations.FeatureCategory
@@ -33,14 +26,11 @@ import com.instructure.panda_annotations.Priority
 import com.instructure.panda_annotations.SecondaryFeatureCategory
 import com.instructure.panda_annotations.TestCategory
 import com.instructure.panda_annotations.TestMetaData
-import com.instructure.pandautils.utils.Const
 import com.instructure.student.ui.utils.StudentTest
 import com.instructure.student.ui.utils.seedData
 import com.instructure.student.ui.utils.tokenLogin
 import dagger.hilt.android.testing.HiltAndroidTest
-import org.hamcrest.core.AllOf
 import org.junit.Test
-import java.io.File
 
 @HiltAndroidTest
 class UserGroupFilesE2ETest : StudentTest() {
@@ -132,40 +122,6 @@ class UserGroupFilesE2ETest : StudentTest() {
         Log.d(STEP_TAG, "Select '$testFolderName2' folder and assert that the empty view is displayed.")
         fileListPage.selectItem(testFolderName2)
         fileListPage.assertViewEmpty()
-    }
-
-    private fun setupFileOnDevice(fileName: String): Uri {
-        File(InstrumentationRegistry.getInstrumentation().targetContext.cacheDir, "file_upload").deleteRecursively()
-        copyAssetFileToExternalCache(activityRule.activity, fileName)
-
-        val dir = activityRule.activity.externalCacheDir
-        val file = File(dir?.path, fileName)
-
-        val instrumentationContext = InstrumentationRegistry.getInstrumentation().context
-        return FileProvider.getUriForFile(
-            instrumentationContext,
-            "com.instructure.candroid" + Const.FILE_PROVIDER_AUTHORITY,
-            file
-        )
-    }
-
-    private fun stubFilePickerIntent(fileName: String) {
-        val resultData = Intent()
-        val dir = activityRule.activity.externalCacheDir
-        val file = File(dir?.path, fileName)
-        val newFileUri = FileProvider.getUriForFile(
-            activityRule.activity,
-            "com.instructure.candroid" + Const.FILE_PROVIDER_AUTHORITY,
-            file
-        )
-        resultData.data = newFileUri
-
-        Intents.intending(
-            AllOf.allOf(
-                IntentMatchers.hasAction(Intent.ACTION_GET_CONTENT),
-                IntentMatchers.hasType("*/*"),
-            )
-        ).respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultData))
     }
 
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/GroupLinksInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/GroupLinksInteractionTest.kt
@@ -61,7 +61,7 @@ class GroupLinksInteractionTest : StudentTest() {
     fun testGroupLink_base() {
         setUpGroupAndSignIn()
         dashboardPage.selectGroup(group)
-        courseBrowserPage.assertTitleCorrect(group)
+        groupBrowserPage.assertTitleCorrect(group)
     }
 
     // Link to groups opens dashboard - eg: "/groups"

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/ShareExtensionInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/ShareExtensionInteractionTest.kt
@@ -16,13 +16,9 @@
  */
 package com.instructure.student.ui.interaction
 
-import android.app.Activity
-import android.app.Instrumentation
 import android.content.Intent
 import android.net.Uri
-import androidx.core.content.FileProvider
 import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.UiDevice
@@ -33,11 +29,9 @@ import com.instructure.canvas.espresso.mockCanvas.addAssignment
 import com.instructure.canvas.espresso.mockCanvas.init
 import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.User
-import com.instructure.pandautils.utils.Const
 import com.instructure.student.ui.utils.StudentTest
 import com.instructure.student.ui.utils.tokenLogin
 import dagger.hilt.android.testing.HiltAndroidTest
-import org.hamcrest.core.AllOf
 import org.junit.Test
 import java.io.File
 
@@ -277,20 +271,6 @@ class ShareExtensionInteractionTest : StudentTest() {
         tokenLogin(MockCanvas.data.domain, token!!, student)
     }
 
-    private fun setupFileOnDevice(fileName: String): Uri {
-        copyAssetFileToExternalCache(activityRule.activity, fileName)
-
-        val dir = activityRule.activity.externalCacheDir
-        val file = File(dir?.path, fileName)
-
-        val instrumentationContext = InstrumentationRegistry.getInstrumentation().context
-        return FileProvider.getUriForFile(
-            instrumentationContext,
-            "com.instructure.candroid" + Const.FILE_PROVIDER_AUTHORITY,
-            file
-        )
-    }
-
     private fun shareExternalFile(uri: Uri) {
         val intent = Intent().apply {
             action = Intent.ACTION_SEND
@@ -315,24 +295,5 @@ class ShareExtensionInteractionTest : StudentTest() {
         chooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
 
         InstrumentationRegistry.getInstrumentation().context.startActivity(chooser)
-    }
-
-    private fun stubFilePickerIntent(fileName: String) {
-        val resultData = Intent()
-        val dir = activityRule.activity.externalCacheDir
-        val file = File(dir?.path, fileName)
-        val newFileUri = FileProvider.getUriForFile(
-            activityRule.activity,
-            "com.instructure.candroid" + Const.FILE_PROVIDER_AUTHORITY,
-            file
-        )
-        resultData.data = newFileUri
-
-        Intents.intending(
-            AllOf.allOf(
-                IntentMatchers.hasAction(Intent.ACTION_GET_CONTENT),
-                IntentMatchers.hasType("*/*"),
-            )
-        ).respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultData))
     }
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/CourseBrowserPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/CourseBrowserPage.kt
@@ -27,10 +27,8 @@ import androidx.test.espresso.matcher.ViewMatchers.*
 import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.canvas.espresso.withCustomConstraints
 import com.instructure.canvasapi2.models.Course
-import com.instructure.canvasapi2.models.Group
 import com.instructure.canvasapi2.models.Tab
 import com.instructure.dataseeding.model.CourseApiModel
-import com.instructure.dataseeding.model.GroupApiModel
 import com.instructure.espresso.TextViewColorAssertion
 import com.instructure.espresso.WaitForViewWithId
 import com.instructure.espresso.assertHasText
@@ -122,16 +120,8 @@ open class CourseBrowserPage : BasePage(R.id.courseBrowserPage) {
         onView(allOf(withId(R.id.courseBrowserTitle), isDisplayed())).assertHasText(course.originalName!!)
     }
 
-    fun assertTitleCorrect(group: Group) {
-        onView(allOf(withId(R.id.courseBrowserTitle), isDisplayed())).assertHasText(group.name!!)
-    }
-
     fun assertTitleCorrect(course: CourseApiModel) {
         initialBrowserTitle.assertHasText(course.name)
-    }
-
-    fun assertTitleCorrect(group: GroupApiModel) {
-        onView(allOf(withId(R.id.courseBrowserTitle), isDisplayed())).assertHasText(group.name!!)
     }
 
     fun assertTabDisplayed(tab: Tab) {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/CourseBrowserPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/CourseBrowserPage.kt
@@ -30,14 +30,19 @@ import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.models.Group
 import com.instructure.canvasapi2.models.Tab
 import com.instructure.dataseeding.model.CourseApiModel
-import com.instructure.espresso.*
+import com.instructure.dataseeding.model.GroupApiModel
+import com.instructure.espresso.TextViewColorAssertion
+import com.instructure.espresso.WaitForViewWithId
+import com.instructure.espresso.assertHasText
+import com.instructure.espresso.click
 import com.instructure.espresso.page.BasePage
+import com.instructure.espresso.swipeUp
 import com.instructure.pandautils.views.SwipeRefreshLayoutAppBar
 import com.instructure.student.R
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
 
-class CourseBrowserPage : BasePage(R.id.courseBrowserPage) {
+open class CourseBrowserPage : BasePage(R.id.courseBrowserPage) {
 
     private val initialBrowserTitle by WaitForViewWithId(R.id.courseBrowserTitle)
 
@@ -123,6 +128,10 @@ class CourseBrowserPage : BasePage(R.id.courseBrowserPage) {
 
     fun assertTitleCorrect(course: CourseApiModel) {
         initialBrowserTitle.assertHasText(course.name)
+    }
+
+    fun assertTitleCorrect(group: GroupApiModel) {
+        onView(allOf(withId(R.id.courseBrowserTitle), isDisplayed())).assertHasText(group.name!!)
     }
 
     fun assertTabDisplayed(tab: Tab) {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DashboardPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DashboardPage.kt
@@ -186,6 +186,11 @@ class DashboardPage : BasePage(R.id.dashboardPage) {
         onView(withText(course.name) + withId(R.id.titleTextView)).click()
     }
 
+    fun selectGroup(group: GroupApiModel) {
+        val groupNameMatcher = allOf(withText(group.name), withId(R.id.groupNameView))
+        onView(groupNameMatcher).scrollTo().click()
+    }
+
     fun assertAnnouncementShowing(announcement: AccountNotification) {
         onView(withId(R.id.announcementIcon)).assertDisplayed()
         onView(withId(R.id.announcementTitle) + withText(announcement.subject)).assertDisplayed()

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/FileListPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/FileListPage.kt
@@ -18,6 +18,7 @@ package com.instructure.student.ui.pages
 
 import androidx.appcompat.widget.AppCompatButton
 import androidx.test.espresso.Espresso
+import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.swipeDown
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -54,7 +55,7 @@ class FileListPage : BasePage(R.id.fileListPage) {
 
     fun assertItemDisplayed(itemName: String) {
         val matcher = allOf(withId(R.id.fileName), withText(itemName))
-        onView(matcher).scrollTo().assertDisplayed()
+        waitForView(matcher).scrollTo().assertDisplayed()
     }
 
     fun assertItemNotDisplayed(itemName: String) {
@@ -69,11 +70,11 @@ class FileListPage : BasePage(R.id.fileListPage) {
     }
 
     fun clickAddButton() {
-        addButton.click()
+        onView(allOf(withId(R.id.addFab), isDisplayed())).perform(click())
     }
 
     fun clickUploadFileButton() {
-        uploadFileButton.click()
+        onView(allOf(withId(R.id.addFileFab), isDisplayed())).perform(click())
     }
 
     fun clickCreateNewFolderButton() {
@@ -155,6 +156,6 @@ class FileListPage : BasePage(R.id.fileListPage) {
     }
 
     fun assertFolderSize(folderName: String, expectedSize: Int) {
-        onView(allOf(withId(R.id.fileSize), hasSibling(withId(R.id.fileName) + withText(folderName)))).check(matches(containsTextCaseInsensitive("$expectedSize items")))
+        onView(allOf(withId(R.id.fileSize), hasSibling(withId(R.id.fileName) + withText(folderName)))).check(matches(containsTextCaseInsensitive("$expectedSize ${if (expectedSize == 1) "item" else "items"}")))
     }
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/GroupBrowserPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/GroupBrowserPage.kt
@@ -1,5 +1,30 @@
 package com.instructure.student.ui.pages
 
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.matcher.ViewMatchers
+import com.instructure.canvasapi2.models.Group
+import com.instructure.dataseeding.model.GroupApiModel
+import com.instructure.espresso.assertHasText
+import com.instructure.student.R
+import org.hamcrest.Matchers
+
 class GroupBrowserPage : CourseBrowserPage() {
 
+    fun assertTitleCorrect(group: Group) {
+        Espresso.onView(
+            Matchers.allOf(
+                ViewMatchers.withId(R.id.courseBrowserTitle),
+                ViewMatchers.isDisplayed()
+            )
+        ).assertHasText(group.name!!)
+    }
+
+    fun assertTitleCorrect(group: GroupApiModel) {
+        Espresso.onView(
+            Matchers.allOf(
+                ViewMatchers.withId(R.id.courseBrowserTitle),
+                ViewMatchers.isDisplayed()
+            )
+        ).assertHasText(group.name!!)
+    }
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/GroupBrowserPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/GroupBrowserPage.kt
@@ -1,0 +1,5 @@
+package com.instructure.student.ui.pages
+
+class GroupBrowserPage : CourseBrowserPage() {
+
+}

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTest.kt
@@ -32,7 +32,63 @@ import com.instructure.student.BuildConfig
 import com.instructure.student.R
 import com.instructure.student.activity.LoginActivity
 import com.instructure.student.espresso.StudentHiltTestApplication_Application
-import com.instructure.student.ui.pages.*
+import com.instructure.student.ui.pages.AboutPage
+import com.instructure.student.ui.pages.AnnotationCommentListPage
+import com.instructure.student.ui.pages.AnnouncementListPage
+import com.instructure.student.ui.pages.AssignmentDetailsPage
+import com.instructure.student.ui.pages.AssignmentListPage
+import com.instructure.student.ui.pages.BookmarkPage
+import com.instructure.student.ui.pages.CalendarEventPage
+import com.instructure.student.ui.pages.CanvasWebViewPage
+import com.instructure.student.ui.pages.ConferenceDetailsPage
+import com.instructure.student.ui.pages.ConferenceListPage
+import com.instructure.student.ui.pages.CourseBrowserPage
+import com.instructure.student.ui.pages.CourseGradesPage
+import com.instructure.student.ui.pages.DashboardPage
+import com.instructure.student.ui.pages.DiscussionDetailsPage
+import com.instructure.student.ui.pages.DiscussionListPage
+import com.instructure.student.ui.pages.EditDashboardPage
+import com.instructure.student.ui.pages.ElementaryCoursePage
+import com.instructure.student.ui.pages.ElementaryDashboardPage
+import com.instructure.student.ui.pages.FileListPage
+import com.instructure.student.ui.pages.FileUploadPage
+import com.instructure.student.ui.pages.GradesPage
+import com.instructure.student.ui.pages.GroupBrowserPage
+import com.instructure.student.ui.pages.HelpPage
+import com.instructure.student.ui.pages.HomeroomPage
+import com.instructure.student.ui.pages.ImportantDatesPage
+import com.instructure.student.ui.pages.InboxConversationPage
+import com.instructure.student.ui.pages.InboxPage
+import com.instructure.student.ui.pages.LeftSideNavigationDrawerPage
+import com.instructure.student.ui.pages.LegalPage
+import com.instructure.student.ui.pages.LoginFindSchoolPage
+import com.instructure.student.ui.pages.LoginLandingPage
+import com.instructure.student.ui.pages.LoginSignInPage
+import com.instructure.student.ui.pages.ModuleProgressionPage
+import com.instructure.student.ui.pages.ModulesPage
+import com.instructure.student.ui.pages.NewMessagePage
+import com.instructure.student.ui.pages.NotificationPage
+import com.instructure.student.ui.pages.PageListPage
+import com.instructure.student.ui.pages.PairObserverPage
+import com.instructure.student.ui.pages.PandaAvatarPage
+import com.instructure.student.ui.pages.PeopleListPage
+import com.instructure.student.ui.pages.PersonDetailsPage
+import com.instructure.student.ui.pages.PickerSubmissionUploadPage
+import com.instructure.student.ui.pages.ProfileSettingsPage
+import com.instructure.student.ui.pages.QRLoginPage
+import com.instructure.student.ui.pages.QuizListPage
+import com.instructure.student.ui.pages.QuizTakingPage
+import com.instructure.student.ui.pages.RemoteConfigSettingsPage
+import com.instructure.student.ui.pages.ResourcesPage
+import com.instructure.student.ui.pages.SchedulePage
+import com.instructure.student.ui.pages.SettingsPage
+import com.instructure.student.ui.pages.ShareExtensionStatusPage
+import com.instructure.student.ui.pages.ShareExtensionTargetPage
+import com.instructure.student.ui.pages.SubmissionDetailsPage
+import com.instructure.student.ui.pages.SyllabusPage
+import com.instructure.student.ui.pages.TextSubmissionUploadPage
+import com.instructure.student.ui.pages.TodoPage
+import com.instructure.student.ui.pages.UrlSubmissionUploadPage
 import dagger.hilt.android.testing.HiltAndroidRule
 import instructure.rceditor.RCETextEditor
 import org.hamcrest.Matcher
@@ -84,6 +140,7 @@ abstract class StudentTest : CanvasTest() {
     val calendarEventPage = CalendarEventPage()
     val canvasWebViewPage = CanvasWebViewPage()
     val courseBrowserPage = CourseBrowserPage()
+    val groupBrowserPage = GroupBrowserPage()
     val conferenceListPage = ConferenceListPage()
     val conferenceDetailsPage = ConferenceDetailsPage()
     val elementaryCoursePage = ElementaryCoursePage()


### PR DESCRIPTION
Implement user group folder control flow (create folder, upload file, create subfolder, open folder).
Add some UserGroup related classes.
Add some page object methods.
Initial commit (will be continued with the exact test case)

refs: MBL-16890
affects: Student
release note: none