### PR TITLE
[MBL-16923][Student] Dashboard letter grade only

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/holders/CourseViewHolder.kt
+++ b/apps/student/src/main/java/com/instructure/student/holders/CourseViewHolder.kt
@@ -89,20 +89,35 @@ class CourseViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
             } else {
                 gradeTextView.setVisible()
                 lockedGradeImage.setGone()
-                setGradeView(gradeTextView, courseGrade, course.textAndIconColor, root.context)
+                setGradeView(gradeTextView, courseGrade, course.textAndIconColor, root.context, course.settings?.restrictQuantitativeData ?: false)
             }
         } else {
             gradeLayout.setGone()
         }
     }
 
-    private fun setGradeView(textView: TextView, courseGrade: CourseGrade, color: Int, context: Context) {
+    private fun setGradeView(
+        textView: TextView,
+        courseGrade: CourseGrade,
+        color: Int,
+        context: Context,
+        restrictQuantitativeData: Boolean
+    ) {
         if(courseGrade.noCurrentGrade) {
             textView.text = context.getString(R.string.noGradeText)
         } else {
-            val scoreString = NumberHelper.doubleToPercentage(courseGrade.currentScore, 2)
-            textView.text = "${if(courseGrade.hasCurrentGradeString()) courseGrade.currentGrade else ""} $scoreString"
-            textView.contentDescription = getContentDescriptionForMinusGradeString(courseGrade.currentGrade ?: "", context)
+            if (restrictQuantitativeData) {
+                if (courseGrade.currentGrade.isNullOrEmpty()) {
+                    textView.text = context.getString(R.string.noGradeText)
+                } else {
+                    textView.text = "${courseGrade.currentGrade.orEmpty()}"
+                    textView.contentDescription = getContentDescriptionForMinusGradeString(courseGrade.currentGrade.orEmpty(), context)
+                }
+            } else {
+                val scoreString = NumberHelper.doubleToPercentage(courseGrade.currentScore, 2)
+                textView.text = "${if(courseGrade.hasCurrentGradeString()) courseGrade.currentGrade else ""} $scoreString"
+                textView.contentDescription = getContentDescriptionForMinusGradeString(courseGrade.currentGrade ?: "", context)
+            }
         }
         textView.setTextColor(color)
     }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CourseAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CourseAPI.kt
@@ -39,7 +39,7 @@ object CourseAPI {
         @get:GET("dashboard/dashboard_cards")
         val dashboardCourses: Call<List<DashboardCard>>
 
-        @get:GET("courses?include[]=term&include[]=total_scores&include[]=license&include[]=is_public&include[]=needs_grading_count&include[]=permissions&include[]=favorites&include[]=current_grading_period_scores&include[]=course_image&include[]=banner_image&include[]=sections&state[]=completed&state[]=available")
+        @get:GET("courses?include[]=term&include[]=total_scores&include[]=license&include[]=is_public&include[]=needs_grading_count&include[]=permissions&include[]=favorites&include[]=current_grading_period_scores&include[]=course_image&include[]=banner_image&include[]=sections&include[]=settings&state[]=completed&state[]=available")
         val firstPageCourses: Call<List<Course>>
 
         @GET("courses?include[]=term&include[]=total_scores&include[]=license&include[]=is_public&include[]=needs_grading_count&include[]=permissions&include[]=favorites&include[]=current_grading_period_scores&include[]=course_image&include[]=banner_image&include[]=sections&state[]=completed&state[]=available")
@@ -57,7 +57,7 @@ object CourseAPI {
         @get:GET("courses?include[]=term&include[]=syllabus_body&include[]=license&include[]=is_public&include[]=permissions&enrollment_state=active")
         val firstPageCoursesWithSyllabusWithActiveEnrollment: Call<List<Course>>
 
-        @get:GET("courses?include[]=term&include[]=total_scores&include[]=license&include[]=is_public&include[]=needs_grading_count&include[]=permissions&include[]=favorites&include[]=current_grading_period_scores&include[]=course_image&include[]=sections&state[]=completed&state[]=available&state[]=unpublished")
+        @get:GET("courses?include[]=term&include[]=total_scores&include[]=license&include[]=is_public&include[]=needs_grading_count&include[]=permissions&include[]=favorites&include[]=current_grading_period_scores&include[]=course_image&include[]=sections&include[]=settings&state[]=completed&state[]=available&state[]=unpublished")
         val firstPageCoursesTeacher: Call<List<Course>>
 
         @GET("courses/{courseId}?include[]=term&include[]=permissions&include[]=license&include[]=is_public&include[]=needs_grading_count&include[]=course_image")

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Course.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Course.kt
@@ -78,7 +78,9 @@ data class Course(
         @SerializedName("course_color")
         val courseColor: String? = null,
         @SerializedName("grading_periods")
-        val gradingPeriods: List<GradingPeriod>? = null
+        val gradingPeriods: List<GradingPeriod>? = null,
+        @SerializedName("settings")
+        val settings: CourseSettings? = null
 ) : CanvasContext(), Comparable<CanvasContext> {
     override val type: Type get() = Type.COURSE
 

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/CourseSettings.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/CourseSettings.kt
@@ -15,9 +15,14 @@
  */
 package com.instructure.canvasapi2.models
 
+import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 data class CourseSettings(
     @SerializedName("syllabus_course_summary")
-    var courseSummary: Boolean? = null
-)
+    var courseSummary: Boolean? = null,
+    @SerializedName("restrict_quantitative_data")
+    var restrictQuantitativeData: Boolean = false,
+): Parcelable


### PR DESCRIPTION
Test plan: Verify that we don't show any numerical grades on the dashboard if letter grade only is enabled for course. If the setting is disabled grades should be shown the same way as it was before. Compare course grade with the web.

refs: MBL-16923
affects: Student
release note: Implemented letter grade only setting for course

## Checklist

- [ ] Tested in dark mode
- [ ] Tested in light mode
