### PR TITLE
[MBL-16818][Teacher] - Extend assignment E2E test with quiz and publish/unpublish

### DIFF
--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/AssignmentE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/AssignmentE2ETest.kt
@@ -86,6 +86,15 @@ class AssignmentE2ETest : TeacherTest() {
                 pointsPossible = 15.0
         )
 
+        Log.d(PREPARATION_TAG,"Seeding 'Quiz' assignment for ${course.name} course.")
+        val quizAssignment = seedAssignments(
+            courseId = course.id,
+            dueAt = 1.days.fromNow.iso8601,
+            submissionTypes = listOf(SubmissionType.ONLINE_QUIZ),
+            teacherToken = teacher.token,
+            pointsPossible = 15.0
+        )
+
         Log.d(STEP_TAG,"Refresh Assignment List Page and assert that the previously seeded ${assignment[0].name} assignment has been displayed." +
                 "Assert that the needs grading count under the corresponding assignment is 1.")
         assignmentListPage.refresh()
@@ -102,15 +111,41 @@ class AssignmentE2ETest : TeacherTest() {
         editAssignmentDetailsPage.clickPublishSwitch()
         editAssignmentDetailsPage.saveAssignment()
 
-        Log.d(STEP_TAG,"Refresh the page. Assert that ${assignment[0].name} assignment has been published.")
-        assignmentDetailsPage.refresh()
+        Log.d(STEP_TAG,"Assert that the '${assignment[0].name}' assignment has been published.")
         assignmentDetailsPage.waitForRender()
         assignmentDetailsPage.assertPublishedStatus(false)
 
-        Log.d(STEP_TAG,"Open Edit Page and re-publish the assignment, then click on Save.")
+        Log.d(STEP_TAG,"Open Edit Page and re-publish the assignment, then click on Save. Assert that the assignment is published automatically, without refresh.")
         assignmentDetailsPage.openEditPage()
         editAssignmentDetailsPage.clickPublishSwitch()
         editAssignmentDetailsPage.saveAssignment()
+        assignmentDetailsPage.assertPublishedStatus(true)
+
+        Log.d(STEP_TAG,"Navigate back to Assignment List page. Open edit quiz page and publish ${quizAssignment[0].name} quiz assignment. Click on Save.")
+        Espresso.pressBack()
+        assignmentListPage.clickAssignment(quizAssignment[0])
+        quizDetailsPage.openEditPage()
+        editAssignmentDetailsPage.clickPublishSwitch()
+        editAssignmentDetailsPage.saveAssignment()
+        quizDetailsPage.assertQuizUnpublished()
+
+        Log.d(STEP_TAG, "Navigate back to Assignment List page. Assert that the '${quizAssignment[0].name}' quiz displays as UNPUBLISHED. Open the quiz assignment again.")
+        Espresso.pressBack()
+        assignmentListPage.assertAssignmentUnPublished(quizAssignment[0].name)
+        assignmentListPage.clickAssignment(quizAssignment[0])
+
+        Log.d(STEP_TAG, "Open Edit Page and re-publish the assignment, then click on Save. Assert that the quiz assignment is published automatically.")
+        quizDetailsPage.openEditPage()
+        editAssignmentDetailsPage.clickPublishSwitch()
+        editAssignmentDetailsPage.saveAssignment()
+        quizDetailsPage.assertQuizPublished()
+
+        Log.d(STEP_TAG, "Navigate back to Assignment List page. Assert that the '${quizAssignment[0].name}' quiz displays as PUBLISHED.")
+        Espresso.pressBack()
+        assignmentListPage.assertAssignmentPublished(quizAssignment[0].name)
+
+        Log.d(STEP_TAG, "Open the '${assignment[0].name}' assignment.")
+        assignmentListPage.clickAssignment(assignment[0])
 
         Log.d(PREPARATION_TAG,"Seed a submission for ${student.name} student.")
         seedAssignmentSubmission(

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/AssignmentListPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/AssignmentListPage.kt
@@ -18,6 +18,8 @@ package com.instructure.teacher.ui.pages
 
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.matcher.ViewMatchers.hasSibling
+import androidx.test.espresso.matcher.ViewMatchers.withChild
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import com.instructure.canvasapi2.models.Assignment
 import com.instructure.dataseeding.model.AssignmentApiModel
 import com.instructure.espresso.OnViewWithId
@@ -30,10 +32,12 @@ import com.instructure.espresso.page.onView
 import com.instructure.espresso.page.plus
 import com.instructure.espresso.page.waitForViewWithText
 import com.instructure.espresso.page.withId
+import com.instructure.espresso.page.withParent
 import com.instructure.espresso.page.withText
 import com.instructure.espresso.swipeDown
 import com.instructure.espresso.waitForCheck
 import com.instructure.teacher.R
+import org.hamcrest.CoreMatchers.allOf
 
 /**
  * AssignmentListPage represents a page that displays a list of assignments.
@@ -144,5 +148,27 @@ class AssignmentListPage : BasePage() {
      */
     fun assertNeedsGradingCountOfAssignment(assignmentName: String, needsGradingCount: Int) {
         onView(withId(R.id.ungradedCount) + withText("$needsGradingCount needs grading") + hasSibling(withId(R.id.assignmentTitle) + withText(assignmentName))).assertDisplayed()
+    }
+
+    /**
+     * Asserts that the given assignment status is published (so the published icon is displayed).
+     *
+     * @param assignmentName The name of the assignment to check.
+     */
+    fun assertAssignmentPublished(assignmentName: String) {
+        onView(allOf(withId(R.id.publishedStatusIcon), withContentDescription(R.string.published),
+            withParent(hasSibling(withChild(withText(assignmentName) + withId(R.id.assignmentTitle))
+            )))).assertDisplayed()
+    }
+
+    /**
+     * Asserts that the given assignment status is unpublished (so the unpublished icon is displayed).
+     *
+     * @param assignmentName The name of the assignment to check.
+     */
+    fun assertAssignmentUnPublished(assignmentName: String) {
+        onView(allOf(withId(R.id.publishedStatusIcon), withContentDescription(R.string.not_published),
+            withParent(hasSibling(withChild(withText(assignmentName) + withId(R.id.assignmentTitle))
+            )))).assertDisplayed()
     }
 }

--- a/automation/espresso/src/main/kotlin/com/instructure/espresso/page/PageExtensions.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/espresso/page/PageExtensions.kt
@@ -42,6 +42,8 @@ fun BasePage.withId(id: Int): Matcher<View> = ViewMatchers.withId(id)
 
 fun BasePage.withParent(id: Int): Matcher<View> = ViewMatchers.withParent(withId(id))
 
+fun BasePage.withParent(matcher: Matcher<View>): Matcher<View> = ViewMatchers.withParent(matcher)
+
 fun BasePage.withAncestor(id: Int): Matcher<View> = ViewMatchers.isDescendantOfA(withId(id))
 
 fun BasePage.withAncestor(matcher: Matcher<View>): Matcher<View> = ViewMatchers.isDescendantOfA(matcher)


### PR DESCRIPTION
Extend assignment E2E test with quiz assignment and with publish/unpublish assertions on the assignment list page.
Add new page extension method.
Add some KDoc.

refs: MBL-16818
affects: Teacher
release note: none