### PR TITLE
[MBL-16931][Student] K5 Grades LGO

### DIFF
--- a/apps/flutter_parent/lib/models/course_grade.dart
+++ b/apps/flutter_parent/lib/models/course_grade.dart
@@ -83,7 +83,7 @@ class CourseGrade {
 //  double _getFinalScore() =>
 //      _enrollment.grade?.finalScore ?? _enrollment.computedFinalScore;
 
-  String _getCurrentGrade() => _enrollment?.grades?.currentGrade ?? _enrollment?.computedCurrentGrade;
+  String _getCurrentGrade() => _enrollment?.grades?.currentGrade ?? _enrollment?.computedCurrentGrade ?? _enrollment?.computedCurrentLetterGrade;
 
 //  String _getFinalGrade() =>
 //      _enrollment.grade?.finalGrade ?? _enrollment.computedFinalGrade;

--- a/apps/flutter_parent/lib/models/enrollment.dart
+++ b/apps/flutter_parent/lib/models/enrollment.dart
@@ -77,6 +77,10 @@ abstract class Enrollment implements Built<Enrollment, EnrollmentBuilder> {
   @BuiltValueField(wireName: 'computed_final_grade')
   String get computedFinalGrade;
 
+  @nullable
+  @BuiltValueField(wireName: 'computed_current_letter_grade')
+  String get computedCurrentLetterGrade;
+
   @BuiltValueField(wireName: 'multiple_grading_periods_enabled')
   bool get multipleGradingPeriodsEnabled;
 

--- a/apps/flutter_parent/lib/models/enrollment.g.dart
+++ b/apps/flutter_parent/lib/models/enrollment.g.dart
@@ -39,132 +39,119 @@ class _$EnrollmentSerializer implements StructuredSerializer<Enrollment> {
       serializers.serialize(object.limitPrivilegesToCourseSection,
           specifiedType: const FullType(bool)),
     ];
-    result.add('role');
-    if (object.role == null) {
-      result.add(null);
-    } else {
-      result.add(serializers.serialize(object.role,
-          specifiedType: const FullType(String)));
-    }
-    result.add('type');
-    if (object.type == null) {
-      result.add(null);
-    } else {
-      result.add(serializers.serialize(object.type,
-          specifiedType: const FullType(String)));
-    }
-    result.add('course_id');
-    if (object.courseId == null) {
-      result.add(null);
-    } else {
-      result.add(serializers.serialize(object.courseId,
-          specifiedType: const FullType(String)));
-    }
-    result.add('course_section_id');
-    if (object.courseSectionId == null) {
-      result.add(null);
-    } else {
-      result.add(serializers.serialize(object.courseSectionId,
-          specifiedType: const FullType(String)));
-    }
-    result.add('grades');
-    if (object.grades == null) {
-      result.add(null);
-    } else {
-      result.add(serializers.serialize(object.grades,
-          specifiedType: const FullType(Grade)));
-    }
-    result.add('computed_current_score');
-    if (object.computedCurrentScore == null) {
-      result.add(null);
-    } else {
-      result.add(serializers.serialize(object.computedCurrentScore,
-          specifiedType: const FullType(double)));
-    }
-    result.add('computed_final_score');
-    if (object.computedFinalScore == null) {
-      result.add(null);
-    } else {
-      result.add(serializers.serialize(object.computedFinalScore,
-          specifiedType: const FullType(double)));
-    }
-    result.add('computed_current_grade');
-    if (object.computedCurrentGrade == null) {
-      result.add(null);
-    } else {
-      result.add(serializers.serialize(object.computedCurrentGrade,
-          specifiedType: const FullType(String)));
-    }
-    result.add('computed_final_grade');
-    if (object.computedFinalGrade == null) {
-      result.add(null);
-    } else {
-      result.add(serializers.serialize(object.computedFinalGrade,
-          specifiedType: const FullType(String)));
-    }
-    result.add('current_period_computed_current_score');
-    if (object.currentPeriodComputedCurrentScore == null) {
-      result.add(null);
-    } else {
-      result.add(serializers.serialize(object.currentPeriodComputedCurrentScore,
-          specifiedType: const FullType(double)));
-    }
-    result.add('current_period_computed_final_score');
-    if (object.currentPeriodComputedFinalScore == null) {
-      result.add(null);
-    } else {
-      result.add(serializers.serialize(object.currentPeriodComputedFinalScore,
-          specifiedType: const FullType(double)));
-    }
-    result.add('current_period_computed_current_grade');
-    if (object.currentPeriodComputedCurrentGrade == null) {
-      result.add(null);
-    } else {
-      result.add(serializers.serialize(object.currentPeriodComputedCurrentGrade,
-          specifiedType: const FullType(String)));
-    }
-    result.add('current_period_computed_final_grade');
-    if (object.currentPeriodComputedFinalGrade == null) {
-      result.add(null);
-    } else {
-      result.add(serializers.serialize(object.currentPeriodComputedFinalGrade,
-          specifiedType: const FullType(String)));
-    }
-    result.add('current_grading_period_id');
-    if (object.currentGradingPeriodId == null) {
-      result.add(null);
-    } else {
-      result.add(serializers.serialize(object.currentGradingPeriodId,
-          specifiedType: const FullType(String)));
-    }
-    result.add('current_grading_period_title');
-    if (object.currentGradingPeriodTitle == null) {
-      result.add(null);
-    } else {
-      result.add(serializers.serialize(object.currentGradingPeriodTitle,
-          specifiedType: const FullType(String)));
-    }
-    result.add('last_activity_at');
-    if (object.lastActivityAt == null) {
-      result.add(null);
-    } else {
-      result.add(serializers.serialize(object.lastActivityAt,
+    Object value;
+    value = object.role;
+
+    result
+      ..add('role')
+      ..add(
+          serializers.serialize(value, specifiedType: const FullType(String)));
+    value = object.type;
+
+    result
+      ..add('type')
+      ..add(
+          serializers.serialize(value, specifiedType: const FullType(String)));
+    value = object.courseId;
+
+    result
+      ..add('course_id')
+      ..add(
+          serializers.serialize(value, specifiedType: const FullType(String)));
+    value = object.courseSectionId;
+
+    result
+      ..add('course_section_id')
+      ..add(
+          serializers.serialize(value, specifiedType: const FullType(String)));
+    value = object.grades;
+
+    result
+      ..add('grades')
+      ..add(serializers.serialize(value, specifiedType: const FullType(Grade)));
+    value = object.computedCurrentScore;
+
+    result
+      ..add('computed_current_score')
+      ..add(
+          serializers.serialize(value, specifiedType: const FullType(double)));
+    value = object.computedFinalScore;
+
+    result
+      ..add('computed_final_score')
+      ..add(
+          serializers.serialize(value, specifiedType: const FullType(double)));
+    value = object.computedCurrentGrade;
+
+    result
+      ..add('computed_current_grade')
+      ..add(
+          serializers.serialize(value, specifiedType: const FullType(String)));
+    value = object.computedFinalGrade;
+
+    result
+      ..add('computed_final_grade')
+      ..add(
+          serializers.serialize(value, specifiedType: const FullType(String)));
+    value = object.computedCurrentLetterGrade;
+
+    result
+      ..add('computed_current_letter_grade')
+      ..add(
+          serializers.serialize(value, specifiedType: const FullType(String)));
+    value = object.currentPeriodComputedCurrentScore;
+
+    result
+      ..add('current_period_computed_current_score')
+      ..add(
+          serializers.serialize(value, specifiedType: const FullType(double)));
+    value = object.currentPeriodComputedFinalScore;
+
+    result
+      ..add('current_period_computed_final_score')
+      ..add(
+          serializers.serialize(value, specifiedType: const FullType(double)));
+    value = object.currentPeriodComputedCurrentGrade;
+
+    result
+      ..add('current_period_computed_current_grade')
+      ..add(
+          serializers.serialize(value, specifiedType: const FullType(String)));
+    value = object.currentPeriodComputedFinalGrade;
+
+    result
+      ..add('current_period_computed_final_grade')
+      ..add(
+          serializers.serialize(value, specifiedType: const FullType(String)));
+    value = object.currentGradingPeriodId;
+
+    result
+      ..add('current_grading_period_id')
+      ..add(
+          serializers.serialize(value, specifiedType: const FullType(String)));
+    value = object.currentGradingPeriodTitle;
+
+    result
+      ..add('current_grading_period_title')
+      ..add(
+          serializers.serialize(value, specifiedType: const FullType(String)));
+    value = object.lastActivityAt;
+
+    result
+      ..add('last_activity_at')
+      ..add(serializers.serialize(value,
           specifiedType: const FullType(DateTime)));
-    }
-    result.add('observed_user');
-    if (object.observedUser == null) {
-      result.add(null);
-    } else {
-      result.add(serializers.serialize(object.observedUser,
-          specifiedType: const FullType(User)));
-    }
-    result.add('user');
-    if (object.user == null) {
-      result.add(null);
-    } else {
-      result.add(serializers.serialize(object.user,
-          specifiedType: const FullType(User)));
-    }
+    value = object.observedUser;
+
+    result
+      ..add('observed_user')
+      ..add(serializers.serialize(value, specifiedType: const FullType(User)));
+    value = object.user;
+
+    result
+      ..add('user')
+      ..add(serializers.serialize(value, specifiedType: const FullType(User)));
+
     return result;
   }
 
@@ -177,8 +164,7 @@ class _$EnrollmentSerializer implements StructuredSerializer<Enrollment> {
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
-      if (value == null) continue;
+      final Object value = iterator.current;
       switch (key) {
         case 'role':
           result.role = serializers.deserialize(value,
@@ -226,6 +212,10 @@ class _$EnrollmentSerializer implements StructuredSerializer<Enrollment> {
           break;
         case 'computed_final_grade':
           result.computedFinalGrade = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'computed_current_letter_grade':
+          result.computedCurrentLetterGrade = serializers.deserialize(value,
               specifiedType: const FullType(String)) as String;
           break;
         case 'multiple_grading_periods_enabled':
@@ -317,6 +307,8 @@ class _$Enrollment extends Enrollment {
   @override
   final String computedFinalGrade;
   @override
+  final String computedCurrentLetterGrade;
+  @override
   final bool multipleGradingPeriodsEnabled;
   @override
   final bool totalsForAllGradingPeriodsOption;
@@ -359,6 +351,7 @@ class _$Enrollment extends Enrollment {
       this.computedFinalScore,
       this.computedCurrentGrade,
       this.computedFinalGrade,
+      this.computedCurrentLetterGrade,
       this.multipleGradingPeriodsEnabled,
       this.totalsForAllGradingPeriodsOption,
       this.currentPeriodComputedCurrentScore,
@@ -373,30 +366,18 @@ class _$Enrollment extends Enrollment {
       this.observedUser,
       this.user})
       : super._() {
-    if (id == null) {
-      throw new BuiltValueNullFieldError('Enrollment', 'id');
-    }
-    if (enrollmentState == null) {
-      throw new BuiltValueNullFieldError('Enrollment', 'enrollmentState');
-    }
-    if (userId == null) {
-      throw new BuiltValueNullFieldError('Enrollment', 'userId');
-    }
-    if (multipleGradingPeriodsEnabled == null) {
-      throw new BuiltValueNullFieldError(
-          'Enrollment', 'multipleGradingPeriodsEnabled');
-    }
-    if (totalsForAllGradingPeriodsOption == null) {
-      throw new BuiltValueNullFieldError(
-          'Enrollment', 'totalsForAllGradingPeriodsOption');
-    }
-    if (associatedUserId == null) {
-      throw new BuiltValueNullFieldError('Enrollment', 'associatedUserId');
-    }
-    if (limitPrivilegesToCourseSection == null) {
-      throw new BuiltValueNullFieldError(
-          'Enrollment', 'limitPrivilegesToCourseSection');
-    }
+    BuiltValueNullFieldError.checkNotNull(id, 'Enrollment', 'id');
+    BuiltValueNullFieldError.checkNotNull(
+        enrollmentState, 'Enrollment', 'enrollmentState');
+    BuiltValueNullFieldError.checkNotNull(userId, 'Enrollment', 'userId');
+    BuiltValueNullFieldError.checkNotNull(multipleGradingPeriodsEnabled,
+        'Enrollment', 'multipleGradingPeriodsEnabled');
+    BuiltValueNullFieldError.checkNotNull(totalsForAllGradingPeriodsOption,
+        'Enrollment', 'totalsForAllGradingPeriodsOption');
+    BuiltValueNullFieldError.checkNotNull(
+        associatedUserId, 'Enrollment', 'associatedUserId');
+    BuiltValueNullFieldError.checkNotNull(limitPrivilegesToCourseSection,
+        'Enrollment', 'limitPrivilegesToCourseSection');
   }
 
   @override
@@ -422,6 +403,7 @@ class _$Enrollment extends Enrollment {
         computedFinalScore == other.computedFinalScore &&
         computedCurrentGrade == other.computedCurrentGrade &&
         computedFinalGrade == other.computedFinalGrade &&
+        computedCurrentLetterGrade == other.computedCurrentLetterGrade &&
         multipleGradingPeriodsEnabled == other.multipleGradingPeriodsEnabled &&
         totalsForAllGradingPeriodsOption ==
             other.totalsForAllGradingPeriodsOption &&
@@ -463,13 +445,13 @@ class _$Enrollment extends Enrollment {
                                                                 $jc(
                                                                     $jc(
                                                                         $jc(
-                                                                            $jc($jc($jc($jc($jc($jc($jc(0, role.hashCode), type.hashCode), id.hashCode), courseId.hashCode), courseSectionId.hashCode), enrollmentState.hashCode),
-                                                                                userId.hashCode),
-                                                                            grades.hashCode),
-                                                                        computedCurrentScore.hashCode),
-                                                                    computedFinalScore.hashCode),
-                                                                computedCurrentGrade.hashCode),
-                                                            computedFinalGrade.hashCode),
+                                                                            $jc($jc($jc($jc($jc($jc($jc($jc(0, role.hashCode), type.hashCode), id.hashCode), courseId.hashCode), courseSectionId.hashCode), enrollmentState.hashCode), userId.hashCode),
+                                                                                grades.hashCode),
+                                                                            computedCurrentScore.hashCode),
+                                                                        computedFinalScore.hashCode),
+                                                                    computedCurrentGrade.hashCode),
+                                                                computedFinalGrade.hashCode),
+                                                            computedCurrentLetterGrade.hashCode),
                                                         multipleGradingPeriodsEnabled.hashCode),
                                                     totalsForAllGradingPeriodsOption.hashCode),
                                                 currentPeriodComputedCurrentScore.hashCode),
@@ -500,6 +482,7 @@ class _$Enrollment extends Enrollment {
           ..add('computedFinalScore', computedFinalScore)
           ..add('computedCurrentGrade', computedCurrentGrade)
           ..add('computedFinalGrade', computedFinalGrade)
+          ..add('computedCurrentLetterGrade', computedCurrentLetterGrade)
           ..add('multipleGradingPeriodsEnabled', multipleGradingPeriodsEnabled)
           ..add('totalsForAllGradingPeriodsOption',
               totalsForAllGradingPeriodsOption)
@@ -579,6 +562,11 @@ class EnrollmentBuilder implements Builder<Enrollment, EnrollmentBuilder> {
   String get computedFinalGrade => _$this._computedFinalGrade;
   set computedFinalGrade(String computedFinalGrade) =>
       _$this._computedFinalGrade = computedFinalGrade;
+
+  String _computedCurrentLetterGrade;
+  String get computedCurrentLetterGrade => _$this._computedCurrentLetterGrade;
+  set computedCurrentLetterGrade(String computedCurrentLetterGrade) =>
+      _$this._computedCurrentLetterGrade = computedCurrentLetterGrade;
 
   bool _multipleGradingPeriodsEnabled;
   bool get multipleGradingPeriodsEnabled =>
@@ -661,34 +649,34 @@ class EnrollmentBuilder implements Builder<Enrollment, EnrollmentBuilder> {
   }
 
   EnrollmentBuilder get _$this {
-    if (_$v != null) {
-      _role = _$v.role;
-      _type = _$v.type;
-      _id = _$v.id;
-      _courseId = _$v.courseId;
-      _courseSectionId = _$v.courseSectionId;
-      _enrollmentState = _$v.enrollmentState;
-      _userId = _$v.userId;
-      _grades = _$v.grades?.toBuilder();
-      _computedCurrentScore = _$v.computedCurrentScore;
-      _computedFinalScore = _$v.computedFinalScore;
-      _computedCurrentGrade = _$v.computedCurrentGrade;
-      _computedFinalGrade = _$v.computedFinalGrade;
-      _multipleGradingPeriodsEnabled = _$v.multipleGradingPeriodsEnabled;
-      _totalsForAllGradingPeriodsOption = _$v.totalsForAllGradingPeriodsOption;
-      _currentPeriodComputedCurrentScore =
-          _$v.currentPeriodComputedCurrentScore;
-      _currentPeriodComputedFinalScore = _$v.currentPeriodComputedFinalScore;
-      _currentPeriodComputedCurrentGrade =
-          _$v.currentPeriodComputedCurrentGrade;
-      _currentPeriodComputedFinalGrade = _$v.currentPeriodComputedFinalGrade;
-      _currentGradingPeriodId = _$v.currentGradingPeriodId;
-      _currentGradingPeriodTitle = _$v.currentGradingPeriodTitle;
-      _associatedUserId = _$v.associatedUserId;
-      _lastActivityAt = _$v.lastActivityAt;
-      _limitPrivilegesToCourseSection = _$v.limitPrivilegesToCourseSection;
-      _observedUser = _$v.observedUser?.toBuilder();
-      _user = _$v.user?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      _role = $v.role;
+      _type = $v.type;
+      _id = $v.id;
+      _courseId = $v.courseId;
+      _courseSectionId = $v.courseSectionId;
+      _enrollmentState = $v.enrollmentState;
+      _userId = $v.userId;
+      _grades = $v.grades?.toBuilder();
+      _computedCurrentScore = $v.computedCurrentScore;
+      _computedFinalScore = $v.computedFinalScore;
+      _computedCurrentGrade = $v.computedCurrentGrade;
+      _computedFinalGrade = $v.computedFinalGrade;
+      _computedCurrentLetterGrade = $v.computedCurrentLetterGrade;
+      _multipleGradingPeriodsEnabled = $v.multipleGradingPeriodsEnabled;
+      _totalsForAllGradingPeriodsOption = $v.totalsForAllGradingPeriodsOption;
+      _currentPeriodComputedCurrentScore = $v.currentPeriodComputedCurrentScore;
+      _currentPeriodComputedFinalScore = $v.currentPeriodComputedFinalScore;
+      _currentPeriodComputedCurrentGrade = $v.currentPeriodComputedCurrentGrade;
+      _currentPeriodComputedFinalGrade = $v.currentPeriodComputedFinalGrade;
+      _currentGradingPeriodId = $v.currentGradingPeriodId;
+      _currentGradingPeriodTitle = $v.currentGradingPeriodTitle;
+      _associatedUserId = $v.associatedUserId;
+      _lastActivityAt = $v.lastActivityAt;
+      _limitPrivilegesToCourseSection = $v.limitPrivilegesToCourseSection;
+      _observedUser = $v.observedUser?.toBuilder();
+      _user = $v.user?.toBuilder();
       _$v = null;
     }
     return this;
@@ -696,9 +684,7 @@ class EnrollmentBuilder implements Builder<Enrollment, EnrollmentBuilder> {
 
   @override
   void replace(Enrollment other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$Enrollment;
   }
 
@@ -715,19 +701,25 @@ class EnrollmentBuilder implements Builder<Enrollment, EnrollmentBuilder> {
           new _$Enrollment._(
               role: role,
               type: type,
-              id: id,
+              id: BuiltValueNullFieldError.checkNotNull(id, 'Enrollment', 'id'),
               courseId: courseId,
               courseSectionId: courseSectionId,
-              enrollmentState: enrollmentState,
-              userId: userId,
+              enrollmentState: BuiltValueNullFieldError.checkNotNull(
+                  enrollmentState, 'Enrollment', 'enrollmentState'),
+              userId: BuiltValueNullFieldError.checkNotNull(
+                  userId, 'Enrollment', 'userId'),
               grades: _grades?.build(),
               computedCurrentScore: computedCurrentScore,
               computedFinalScore: computedFinalScore,
               computedCurrentGrade: computedCurrentGrade,
               computedFinalGrade: computedFinalGrade,
-              multipleGradingPeriodsEnabled: multipleGradingPeriodsEnabled,
-              totalsForAllGradingPeriodsOption:
+              computedCurrentLetterGrade: computedCurrentLetterGrade,
+              multipleGradingPeriodsEnabled: BuiltValueNullFieldError.checkNotNull(
+                  multipleGradingPeriodsEnabled, 'Enrollment', 'multipleGradingPeriodsEnabled'),
+              totalsForAllGradingPeriodsOption: BuiltValueNullFieldError.checkNotNull(
                   totalsForAllGradingPeriodsOption,
+                  'Enrollment',
+                  'totalsForAllGradingPeriodsOption'),
               currentPeriodComputedCurrentScore:
                   currentPeriodComputedCurrentScore,
               currentPeriodComputedFinalScore: currentPeriodComputedFinalScore,
@@ -736,9 +728,13 @@ class EnrollmentBuilder implements Builder<Enrollment, EnrollmentBuilder> {
               currentPeriodComputedFinalGrade: currentPeriodComputedFinalGrade,
               currentGradingPeriodId: currentGradingPeriodId,
               currentGradingPeriodTitle: currentGradingPeriodTitle,
-              associatedUserId: associatedUserId,
+              associatedUserId: BuiltValueNullFieldError.checkNotNull(
+                  associatedUserId, 'Enrollment', 'associatedUserId'),
               lastActivityAt: lastActivityAt,
-              limitPrivilegesToCourseSection: limitPrivilegesToCourseSection,
+              limitPrivilegesToCourseSection: BuiltValueNullFieldError.checkNotNull(
+                  limitPrivilegesToCourseSection,
+                  'Enrollment',
+                  'limitPrivilegesToCourseSection'),
               observedUser: _observedUser?.build(),
               user: _user?.build());
     } catch (_) {
@@ -762,4 +758,4 @@ class EnrollmentBuilder implements Builder<Enrollment, EnrollmentBuilder> {
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/ElementaryGradesInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/ElementaryGradesInteractionTest.kt
@@ -20,6 +20,7 @@ import androidx.test.espresso.Espresso
 import com.instructure.canvas.espresso.mockCanvas.MockCanvas
 import com.instructure.canvas.espresso.mockCanvas.addCourseWithEnrollment
 import com.instructure.canvas.espresso.mockCanvas.init
+import com.instructure.canvasapi2.models.CourseSettings
 import com.instructure.canvasapi2.models.Enrollment
 import com.instructure.espresso.page.getStringFromResource
 import com.instructure.panda_annotations.FeatureCategory
@@ -132,6 +133,49 @@ class ElementaryGradesInteractionTest : StudentTest() {
         gradesPage.assertCourseShownWithGrades(scoreGradedCourse.name, "50%")
         gradesPage.assertCourseShownWithGrades(bothGradedCourse.name, "C+")
         gradesPage.assertCourseShownWithGrades(notGradedCourse.name, "0%")
+    }
+
+    @Test
+    @TestMetaData(Priority.COMMON, FeatureCategory.K5_DASHBOARD, TestCategory.INTERACTION)
+    fun testDontShowProgressWhenQuantitativeDataIsRestricted() {
+        val data = createMockData(courseCount = 1)
+        goToGradesTab(data)
+
+        gradesPage.assertPageObjects()
+
+        var course = data.addCourseWithEnrollment(
+            data.students[0],
+            Enrollment.EnrollmentType.Student,
+            50.0,
+            "C+",
+            restrictQuantitativeData = true
+        )
+
+        gradesPage.refresh()
+
+        gradesPage.assertCourseShownWithGrades(course.name, "C+")
+        gradesPage.assertProgressNotDisplayed(course.name)
+    }
+
+    @Test
+    @TestMetaData(Priority.COMMON, FeatureCategory.K5_DASHBOARD, TestCategory.INTERACTION)
+    fun testDontShowGradeWhenQuantitativeDataIsRestrictedAndThereIsOnlyScore() {
+        val data = createMockData(courseCount = 1)
+        goToGradesTab(data)
+
+        gradesPage.assertPageObjects()
+
+        var course = data.addCourseWithEnrollment(
+            data.students[0],
+            Enrollment.EnrollmentType.Student,
+            50.0,
+            "",
+            restrictQuantitativeData = true
+        )
+
+        gradesPage.refresh()
+
+        gradesPage.assertCourseShownWithGrades(course.name, "--")
     }
 
     private fun createMockData(

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/GradesPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/GradesPage.kt
@@ -18,6 +18,7 @@ package com.instructure.student.ui.pages
 
 import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.ViewMatchers.hasSibling
 import com.instructure.espresso.OnViewWithId
 import com.instructure.espresso.assertDisplayed
 import com.instructure.espresso.assertNotDisplayed
@@ -75,6 +76,11 @@ class GradesPage : BasePage(R.id.gradesPage) {
 
     fun assertRecyclerViewNotVisible() {
         gradesRecyclerView.assertNotDisplayed()
+    }
+
+    fun assertProgressNotDisplayed(courseName: String) {
+        val courseNameMatcher = withId(R.id.gradesCourseNameText) + withText(courseName)
+        onView(withId(R.id.progressLayout) + hasSibling(courseNameMatcher)).assertNotDisplayed()
     }
 
     fun clickGradeRow(courseName: String) {

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/MockCanvas.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/MockCanvas.kt
@@ -459,8 +459,15 @@ fun MockCanvas.updateUserEnrollments() {
     }
 }
 
-fun MockCanvas.addCourseWithEnrollment(user: User, enrollmentType: Enrollment.EnrollmentType, score: Double = 0.0, grade: String = "", isHomeroom: Boolean = false): Course {
-    val course = addCourse(isHomeroom = isHomeroom)
+fun MockCanvas.addCourseWithEnrollment(
+    user: User,
+    enrollmentType: Enrollment.EnrollmentType,
+    score: Double = 0.0,
+    grade: String = "",
+    isHomeroom: Boolean = false,
+    restrictQuantitativeData: Boolean = false
+): Course {
+    val course = addCourse(isHomeroom = isHomeroom, restrictQuantitativeData = restrictQuantitativeData)
 
     addEnrollment(
         user = user,
@@ -482,7 +489,8 @@ fun MockCanvas.addCourse(
     section: Section? = null,
     isPublic: Boolean = true,
     withGradingPeriod: Boolean = false,
-    isHomeroom: Boolean = false
+    isHomeroom: Boolean = false,
+    restrictQuantitativeData: Boolean = false
 ): Course {
     val randomCourseName = Randomizer.randomCourseName()
     val endAt = if (concluded) OffsetDateTime.now().minusWeeks(1).toApiString() else null
@@ -508,7 +516,8 @@ fun MockCanvas.addCourse(
         homeroomCourse = isHomeroom,
         gradingPeriods = gradingPeriodList,
         courseColor = "#008EE2",
-        restrictEnrollmentsToCourseDate = concluded
+        restrictEnrollmentsToCourseDate = concluded,
+        settings = CourseSettings(restrictQuantitativeData = restrictQuantitativeData)
     )
     courses += course.id to course
 

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CourseAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CourseAPI.kt
@@ -121,7 +121,7 @@ object CourseAPI {
         @GET("courses/{courseId}/rubrics/{rubricId}")
         fun getRubricSettings(@Path("courseId") courseId: Long, @Path("rubricId") rubricId: Long): Call<RubricSettings>
 
-        @GET("courses?include[]=total_scores&include[]=current_grading_period_scores&include[]=grading_periods&include[]=course_image&enrollment_state=active")
+        @GET("courses?include[]=total_scores&include[]=current_grading_period_scores&include[]=grading_periods&include[]=course_image&include[]=settings&enrollment_state=active")
         fun getFirstPageCoursesWithGrades(): Call<List<Course>>
     }
 

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Enrollment.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Enrollment.kt
@@ -45,6 +45,8 @@ data class Enrollment(
         val computedCurrentGrade: String? = null,
         @SerializedName("computed_final_grade")
         val computedFinalGrade: String? = null,
+        @SerializedName("computed_current_letter_grade")
+        val computedCurrentLetterGrade: String? = null,
         @SerializedName("multiple_grading_periods_enabled")
         val multipleGradingPeriodsEnabled: Boolean = false,
         @SerializedName("totals_for_all_grading_periods_option")
@@ -103,7 +105,7 @@ data class Enrollment(
 
     val currentScore: Double? get() = grades?.currentScore ?: computedCurrentScore
     val finalScore: Double? get() = grades?.finalScore ?: computedFinalScore
-    val currentGrade: String? get() = grades?.currentGrade ?: computedCurrentGrade
+    val currentGrade: String? get() = grades?.currentGrade ?: computedCurrentGrade ?: computedCurrentLetterGrade
     val finalGrade: String? get() = grades?.finalGrade ?: computedFinalGrade
 
     fun currentPeriodComputedCurrentScore(): Double? = grades?.currentScore ?: currentPeriodComputedCurrentScore

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/elementary/grades/GradesViewData.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/elementary/grades/GradesViewData.kt
@@ -31,7 +31,8 @@ data class GradeRowViewData(
     val courseColor: ThemedColor,
     val courseImageUrl: String,
     val score: Double?,
-    val gradeText: String)
+    val gradeText: String,
+    val hideProgress: Boolean = false)
 
 sealed class GradesAction {
     data class OpenCourseGrades(val course: Course) : GradesAction()

--- a/libs/pandautils/src/main/res/layout-sw720dp/item_grade_row.xml
+++ b/libs/pandautils/src/main/res/layout-sw720dp/item_grade_row.xml
@@ -101,6 +101,7 @@
             android:layout_marginTop="6dp"
             android:layout_marginStart="12dp"
             android:layout_marginEnd="8dp"
+            app:visible="@{!itemViewModel.data.hideProgress}"
             app:layout_constraintStart_toEndOf="@id/courseImage"
             app:layout_constraintTop_toBottomOf="@id/gradesCourseNameText"
             app:layout_constraintEnd_toStartOf="@id/chevronIcon">

--- a/libs/pandautils/src/main/res/layout/item_grade_row.xml
+++ b/libs/pandautils/src/main/res/layout/item_grade_row.xml
@@ -73,7 +73,8 @@
             android:src="@drawable/ic_chevron_right"
             android:layout_marginEnd="8dp"
             android:tint="@color/textDark"
-            app:layout_constraintTop_toBottomOf="@id/gradesCourseNameText"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
@@ -83,6 +84,7 @@
             android:layout_marginTop="6dp"
             android:layout_marginStart="16dp"
             android:layout_marginEnd="8dp"
+            app:visible="@{!itemViewModel.data.hideProgress}"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/gradesCourseNameText"
             app:layout_constraintEnd_toStartOf="@id/chevronIcon">

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/elementary/grades/GradesViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/elementary/grades/GradesViewModelTest.kt
@@ -142,7 +142,7 @@ class GradesViewModelTest {
         val expectedGradeRow1 = GradeRowViewData(1, "Course with Grade", ThemedColor(0), "www.1.com", 90.0, "A")
         val expectedGradeRow2 = GradeRowViewData(2, "Course with Score", ThemedColor(0), "www.1.com", 75.6, "76%")
         val expectedGradeRow3 = GradeRowViewData(3, "Course without scores", ThemedColor(0), "www.1.com", null, "--")
-        val expectedGradeRow4 = GradeRowViewData(4, "Hide Final Grades", ThemedColor(0), "www.1.com", 0.0, "--")
+        val expectedGradeRow4 = GradeRowViewData(4, "Hide Final Grades", ThemedColor(0), "www.1.com", 0.0, "--", hideProgress = true)
 
         assertEquals(expectedGradeRow1, gradeRows[0].data)
         assertEquals(expectedGradeRow2, gradeRows[1].data)

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/elementary/grades/GradesViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/elementary/grades/GradesViewModelTest.kt
@@ -23,8 +23,8 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import com.instructure.canvasapi2.managers.CourseManager
 import com.instructure.canvasapi2.managers.EnrollmentManager
-import com.instructure.canvasapi2.models.CanvasContext
 import com.instructure.canvasapi2.models.Course
+import com.instructure.canvasapi2.models.CourseSettings
 import com.instructure.canvasapi2.models.Enrollment
 import com.instructure.canvasapi2.models.GradingPeriod
 import com.instructure.canvasapi2.utils.DataResult
@@ -32,10 +32,8 @@ import com.instructure.pandautils.R
 import com.instructure.pandautils.features.elementary.grades.itemviewmodels.GradeRowItemViewModel
 import com.instructure.pandautils.features.elementary.grades.itemviewmodels.GradingPeriodSelectorItemViewModel
 import com.instructure.pandautils.mvvm.ViewState
-import com.instructure.pandautils.utils.ColorApiHelper
 import com.instructure.pandautils.utils.ColorKeeper
 import com.instructure.pandautils.utils.ThemedColor
-import com.instructure.pandautils.utils.textAndIconColor
 import io.mockk.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -346,6 +344,57 @@ class GradesViewModelTest {
         )
         assertEquals(GradesAction.OpenGradingPeriodsDialog(expectedGradingPeriods, 0), viewModel.events.value!!.getContentIfNotHandled())
     }
+
+    @Test
+    fun `Hide progress when quantitative data is restricted`() {
+        // Given
+        val course = createCourseWithGrades(1, "Course with Grade", "", "www.1.com", 90.0, "A")
+            .copy(settings = CourseSettings(restrictQuantitativeData = true))
+
+        every { courseManager.getCoursesWithGradesAsync(any()) } returns mockk {
+            coEvery { await() } returns DataResult.Success(listOf(course))
+        }
+
+        // When
+        viewModel = createViewModel()
+        viewModel.state.observe(lifecycleOwner, {})
+
+        // Then
+        assertTrue(viewModel.state.value is ViewState.Success)
+        assertEquals(1, viewModel.data.value!!.items.size)
+
+        val gradeRows = viewModel.data.value!!.items.map { it as GradeRowItemViewModel }
+
+        val expectedGradeRow1 = GradeRowViewData(1, "Course with Grade", ThemedColor(0), "www.1.com", 90.0, "A", hideProgress = true)
+
+        assertEquals(expectedGradeRow1, gradeRows[0].data)
+    }
+
+    @Test
+    fun `Do not show score when quantitative data is restricted and there is no grade`() {
+        // Given
+        val course = createCourseWithGrades(1, "Course with Grade", "", "www.1.com", 90.0, null)
+            .copy(settings = CourseSettings(restrictQuantitativeData = true))
+
+        every { courseManager.getCoursesWithGradesAsync(any()) } returns mockk {
+            coEvery { await() } returns DataResult.Success(listOf(course))
+        }
+
+        // When
+        viewModel = createViewModel()
+        viewModel.state.observe(lifecycleOwner, {})
+
+        // Then
+        assertTrue(viewModel.state.value is ViewState.Success)
+        assertEquals(1, viewModel.data.value!!.items.size)
+
+        val gradeRows = viewModel.data.value!!.items.map { it as GradeRowItemViewModel }
+
+        val expectedGradeRow1 = GradeRowViewData(1, "Course with Grade", ThemedColor(0), "www.1.com", 90.0, "--", hideProgress = true)
+
+        assertEquals(expectedGradeRow1, gradeRows[0].data)
+    }
+
 
     private fun createViewModel() = GradesViewModel(courseManager, resources, enrollmentManager, colorKeeper)
 


### PR DESCRIPTION
Test plan: 
- Verify that no quantitative data is shown on K5 grades when quantitative data is restricted.
- The progress should be hidden as well.
- Verify that everything works the same when quantitative data is not restricted.
- There was a slight API change what we also implemented in the Parent app, test that as well.

refs: MBL-16931
affects: Student
release note: none

## Checklist

- [x] Tested in dark mode
- [x] Tested in light mode
