### PR TITLE
[MBL-16335][Student] - Extend SyllabusE2E test with Syllabus/Summary tab display logic

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/SyllabusE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/SyllabusE2ETest.kt
@@ -48,7 +48,7 @@ class SyllabusE2ETest: StudentTest() {
     fun testSyllabusE2E() {
 
         Log.d(PREPARATION_TAG, "Seeding data.")
-        val data = seedData(students = 1, teachers = 1, courses = 1)
+        val data = seedData(students = 1, teachers = 1, courses = 1, syllabusBody = "this is the syllabus body")
         val student = data.studentsList[0]
         val teacher = data.teachersList[0]
         val course = data.coursesList[0]
@@ -60,9 +60,10 @@ class SyllabusE2ETest: StudentTest() {
         Log.d(STEP_TAG,"Select ${course.name} course.")
         dashboardPage.selectCourse(course)
 
-        Log.d(STEP_TAG,"Navigate to Syllabus Page. Assert that Empty View is displayed, because there is no syllabus yet.")
+        Log.d(STEP_TAG,"Navigate to Syllabus Page. Assert that the syllabus body string is displayed, and there are no tabs yet.")
         courseBrowserPage.selectSyllabus()
-        syllabusPage.assertEmptyView()
+        syllabusPage.assertNoTabs()
+        syllabusPage.assertSyllabusBody("this is the syllabus body")
 
         Log.d(PREPARATION_TAG,"Seed an assignment for ${course.name} course.")
         val assignment = createAssignment(course, teacher)
@@ -70,10 +71,9 @@ class SyllabusE2ETest: StudentTest() {
         Log.d(PREPARATION_TAG,"Seed a quiz for ${course.name} course.")
         val quiz = createQuiz(course, teacher)
 
-        // TODO: Seed a generic calendar event
-
-        Log.d(STEP_TAG,"Refresh the page. Assert that all of the items, so ${assignment.name} assignment and ${quiz.title} quiz are displayed.")
+        Log.d(STEP_TAG,"Refresh the page. Navigate to 'Summary' tab. Assert that all of the items, so ${assignment.name} assignment and ${quiz.title} quiz are displayed.")
         syllabusPage.refresh()
+        syllabusPage.selectSummaryTab()
         syllabusPage.assertItemDisplayed(assignment.name)
         syllabusPage.assertItemDisplayed(quiz.title)
     }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SyllabusPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SyllabusPage.kt
@@ -17,15 +17,23 @@
 package com.instructure.student.ui.pages
 
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.web.assertion.WebViewAssertions
+import androidx.test.espresso.web.sugar.Web
+import androidx.test.espresso.web.webdriver.DriverAtoms
+import androidx.test.espresso.web.webdriver.Locator
 import com.instructure.canvas.espresso.containsTextCaseInsensitive
 import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.espresso.assertDisplayed
 import com.instructure.espresso.click
 import com.instructure.espresso.page.BasePage
+import com.instructure.espresso.page.plus
 import com.instructure.espresso.page.withAncestor
 import com.instructure.espresso.swipeDown
 import com.instructure.student.R
+import org.hamcrest.Matchers
 import org.hamcrest.Matchers.allOf
 
 open class SyllabusPage : BasePage(R.id.syllabusPage) {
@@ -39,7 +47,11 @@ open class SyllabusPage : BasePage(R.id.syllabusPage) {
     }
 
     fun selectSummaryTab() {
-        onView(containsTextCaseInsensitive("summary")).click()
+        onView(containsTextCaseInsensitive("summary") + withAncestor(R.id.syllabusTabLayout)).click()
+    }
+
+    fun selectSyllabusTab() {
+        onView(containsTextCaseInsensitive("syllabus") + withAncestor(R.id.syllabusTabLayout)).click()
     }
 
     fun selectSummaryEvent(name: String) {
@@ -50,4 +62,18 @@ open class SyllabusPage : BasePage(R.id.syllabusPage) {
         onView(allOf(withId(R.id.swipeRefreshLayout), withAncestor(R.id.syllabusPage))).swipeDown()
     }
 
+    fun assertNoTabs() {
+        onView(withId(R.id.syllabusTabLayout)).check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.GONE)))
+    }
+
+    fun assertSyllabusBody(syllabusBody: String) {
+            Web.onWebView(withId(R.id.contentWebView) + withAncestor(R.id.syllabusPage))
+                .withElement(DriverAtoms.findElement(Locator.ID, "content"))
+                .check(
+                    WebViewAssertions.webMatches(
+                        DriverAtoms.getText(),
+                        Matchers.comparesEqualTo(syllabusBody)
+                    )
+                )
+    }
 }

--- a/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/api/CoursesApi.kt
+++ b/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/api/CoursesApi.kt
@@ -82,7 +82,8 @@ object CoursesApi {
     fun createCourse(
         enrollmentTermId: Long? = null,
         publish: Boolean = true,
-        coursesService: CoursesService = adminCoursesService
+        coursesService: CoursesService = adminCoursesService,
+        syllabusBody: String? = null
     ): CourseApiModel {
         val randomCourseName = Randomizer.randomCourseName()
         val course = CreateCourseWrapper(
@@ -90,7 +91,8 @@ object CoursesApi {
             course = CreateCourse(
                 name = randomCourseName,
                 courseCode = randomCourseName.substring(0, 2),
-                enrollmentTermId = enrollmentTermId
+                enrollmentTermId = enrollmentTermId,
+                syllabusBody = syllabusBody
             )
         )
         return coursesService

--- a/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/api/SeedApi.kt
+++ b/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/api/SeedApi.kt
@@ -16,7 +16,11 @@
 
 package com.instructure.dataseeding.api
 
-import com.instructure.dataseeding.model.*
+import com.instructure.dataseeding.model.CanvasUserApiModel
+import com.instructure.dataseeding.model.CourseApiModel
+import com.instructure.dataseeding.model.DiscussionApiModel
+import com.instructure.dataseeding.model.EnrollmentApiModel
+import com.instructure.dataseeding.model.FavoriteApiModel
 
 // Data-seeding API
 object SeedApi {
@@ -172,7 +176,7 @@ object SeedApi {
         with(seededData) {
             for (c in 0 until maxOf(request.courses + request.pastCourses, request.favoriteCourses)) {
                 // Seed course
-                addCourses(createCourse(request.gradingPeriods, request.publishCourses))
+                addCourses(createCourse(request.gradingPeriods, request.publishCourses, syllabusBody = request.syllabusBody))
 
                 // Seed users
                 for (t in 0 until request.teachers) {
@@ -316,7 +320,7 @@ object SeedApi {
         return if (accountId != null) {
             CoursesApi.createCourseInSubAccount(accountId = accountId, homeroomCourse = isHomeroomCourse, enrollmentTermId = enrollmentTermId, publish = publishCourses, syllabusBody = syllabusBody)
         } else {
-            CoursesApi.createCourse(enrollmentTermId, publishCourses)
+            CoursesApi.createCourse(enrollmentTermId, publishCourses, syllabusBody = syllabusBody)
         }
     }
 }


### PR DESCRIPTION
Extend SyllabusE2E test with Syllabus/Summary tab display logic
Extend API with syllabusBody on non-subaccount seeding.

refs: MBL-16335
affects: Student
release note: none