### PR TITLE
[MBL-16877][Student] Keep user logged in while offline

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
@@ -49,7 +49,6 @@ import androidx.lifecycle.lifecycleScope
 import com.airbnb.lottie.LottieAnimationView
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.instructure.canvasapi2.CanvasRestAdapter
-import com.instructure.canvasapi2.managers.CourseManager
 import com.instructure.canvasapi2.managers.GroupManager
 import com.instructure.canvasapi2.managers.UserManager
 import com.instructure.canvasapi2.models.*
@@ -308,6 +307,20 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
 
         networkStateProvider.isOnlineLiveData.observe(this) { isOnline ->
             setOfflineIndicator(!isOnline)
+            handleTokenCheck(isOnline)
+        }
+    }
+
+    private fun handleTokenCheck(online: Boolean?) {
+        val checkToken = ApiPrefs.checkTokenAfterOfflineLogin
+        if (checkToken && online == true) {
+            ApiPrefs.checkTokenAfterOfflineLogin = false
+            lifecycleScope.launch {
+                val isTokenValid = repository.isTokenValid()
+                if (!isTokenValid) {
+                    StudentLogoutTask(LogoutTask.Type.LOGOUT, typefaceBehavior = typefaceBehavior, databaseProvider = databaseProvider).execute()
+                }
+            }
         }
     }
 

--- a/apps/student/src/main/java/com/instructure/student/di/NavigationActivityModule.kt
+++ b/apps/student/src/main/java/com/instructure/student/di/NavigationActivityModule.kt
@@ -21,6 +21,7 @@ import com.instructure.canvasapi2.apis.AssignmentAPI
 import com.instructure.canvasapi2.apis.CourseAPI
 import com.instructure.canvasapi2.apis.EnrollmentAPI
 import com.instructure.canvasapi2.apis.SubmissionAPI
+import com.instructure.canvasapi2.apis.UserAPI
 import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.pandautils.room.offline.facade.AssignmentFacade
 import com.instructure.pandautils.room.offline.facade.CourseFacade
@@ -90,8 +91,9 @@ class NavigationActivityModule {
 
     @Provides
     fun provideNavigationNetworkDataSource(
-        courseApi: CourseAPI.CoursesInterface
+        courseApi: CourseAPI.CoursesInterface,
+        userApi: UserAPI.UsersInterface
     ): NavigationNetworkDataSource {
-        return NavigationNetworkDataSource(courseApi)
+        return NavigationNetworkDataSource(courseApi, userApi)
     }
 }

--- a/apps/student/src/main/java/com/instructure/student/features/navigation/NavigationRepository.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/navigation/NavigationRepository.kt
@@ -22,15 +22,25 @@ import com.instructure.pandautils.utils.FeatureFlagProvider
 import com.instructure.pandautils.utils.NetworkStateProvider
 import com.instructure.student.features.navigation.datasource.NavigationDataSource
 import com.instructure.student.features.navigation.datasource.NavigationLocalDataSource
+import com.instructure.student.features.navigation.datasource.NavigationNetworkDataSource
 
 class NavigationRepository(
     private val localDataSource: NavigationLocalDataSource,
-    private val networkDataSource: NavigationDataSource,
+    private val networkDataSource: NavigationNetworkDataSource,
     private val networkStateProvider: NetworkStateProvider,
     private val featureFlagProvider: FeatureFlagProvider
 ) : Repository<NavigationDataSource>(localDataSource, networkDataSource, networkStateProvider, featureFlagProvider) {
 
     suspend fun getCourse(courseId: Long, forceNetwork: Boolean): Course? {
         return dataSource().getCourse(courseId, forceNetwork)
+    }
+
+    suspend fun isTokenValid(): Boolean {
+        try {
+            val result = networkDataSource.getSelf()
+            return result.isSuccess
+        } catch (e: Exception) {
+            return false
+        }
     }
 }

--- a/apps/student/src/main/java/com/instructure/student/features/navigation/datasource/NavigationNetworkDataSource.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/navigation/datasource/NavigationNetworkDataSource.kt
@@ -17,21 +17,26 @@
 
 package com.instructure.student.features.navigation.datasource
 
-import com.instructure.canvasapi2.apis.AssignmentAPI
 import com.instructure.canvasapi2.apis.CourseAPI
-import com.instructure.canvasapi2.apis.EnrollmentAPI
-import com.instructure.canvasapi2.apis.SubmissionAPI
+import com.instructure.canvasapi2.apis.UserAPI
 import com.instructure.canvasapi2.builders.RestParams
-import com.instructure.canvasapi2.models.*
-import com.instructure.canvasapi2.utils.depaginate
+import com.instructure.canvasapi2.models.Course
+import com.instructure.canvasapi2.models.User
+import com.instructure.canvasapi2.utils.DataResult
 
 class NavigationNetworkDataSource(
-    private val courseApi: CourseAPI.CoursesInterface
+    private val courseApi: CourseAPI.CoursesInterface,
+    private val userApi: UserAPI.UsersInterface,
 ) : NavigationDataSource {
 
     override suspend fun getCourse(courseId: Long, forceNetwork: Boolean): Course? {
         val params = RestParams(isForceReadFromNetwork = forceNetwork)
 
         return courseApi.getCourse(courseId, params).dataOrNull
+    }
+
+    suspend fun getSelf(): DataResult<User> {
+        val params = RestParams(isForceReadFromNetwork = true)
+        return userApi.getSelf(params)
     }
 }

--- a/apps/student/src/test/java/com/instructure/student/features/navigation/NavigationRepositoryTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/features/navigation/NavigationRepositoryTest.kt
@@ -18,6 +18,8 @@
 package com.instructure.student.features.navigation
 
 import com.instructure.canvasapi2.models.Course
+import com.instructure.canvasapi2.models.User
+import com.instructure.canvasapi2.utils.DataResult
 import com.instructure.pandautils.utils.FEATURE_FLAG_OFFLINE
 import com.instructure.pandautils.utils.FeatureFlagProvider
 import com.instructure.pandautils.utils.NetworkStateProvider
@@ -30,6 +32,8 @@ import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -76,5 +80,23 @@ class NavigationRepositoryTest {
 
         coVerify { localDataSource.getCourse(1, true) }
         assertEquals(offlineExpected, result)
+    }
+
+    @Test
+    fun `Is token valid returns true if network call succeeds`() = runTest {
+        coEvery { networkDataSource.getSelf() } returns DataResult.Success(User())
+
+        val result = repository.isTokenValid()
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `Is token valid returns false if network call fails`() = runTest {
+        coEvery { networkDataSource.getSelf() } returns DataResult.Fail()
+
+        val result = repository.isTokenValid()
+
+        assertFalse(result)
     }
 }

--- a/apps/student/src/test/java/com/instructure/student/features/navigation/datasource/GradesListNetworkDataSourceTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/features/navigation/datasource/GradesListNetworkDataSourceTest.kt
@@ -18,7 +18,9 @@
 package com.instructure.student.features.navigation.datasource
 
 import com.instructure.canvasapi2.apis.CourseAPI
+import com.instructure.canvasapi2.apis.UserAPI
 import com.instructure.canvasapi2.models.Course
+import com.instructure.canvasapi2.models.User
 import com.instructure.canvasapi2.utils.DataResult
 import io.mockk.coEvery
 import io.mockk.mockk
@@ -32,8 +34,9 @@ import org.junit.Test
 class NavigationNetworkDataSourceTest {
 
     private val courseApi: CourseAPI.CoursesInterface = mockk(relaxed = true)
+    private val userApi: UserAPI.UsersInterface = mockk(relaxed = true)
 
-    private val dataSource = NavigationNetworkDataSource(courseApi)
+    private val dataSource = NavigationNetworkDataSource(courseApi, userApi)
 
     @Test
     fun `Get course successfully returns data`() = runTest {
@@ -45,12 +48,32 @@ class NavigationNetworkDataSourceTest {
 
         assertEquals(expected, result)
     }
-
+    @Test
     fun `Get course failure returns null`() = runTest {
         coEvery { courseApi.getCourse(any(), any()) } returns DataResult.Fail()
 
         val result = dataSource.getCourse(1, true)
 
         assertNull(result)
+    }
+
+    @Test
+    fun `Get self returns success`() = runTest {
+        val expected = User(id = 55)
+
+        coEvery { userApi.getSelf(any()) } returns DataResult.Success(expected)
+
+        val result = dataSource.getSelf()
+
+        assertEquals(expected, result.dataOrThrow)
+    }
+
+    @Test
+    fun `Get self returns failure`() = runTest {
+        coEvery { userApi.getSelf(any()) } returns DataResult.Fail()
+
+        val result = dataSource.getSelf()
+
+        assertEquals(DataResult.Fail(), result)
     }
 }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/UserAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/UserAPI.kt
@@ -41,6 +41,9 @@ object UserAPI {
         @GET("users/self/profile")
         fun getSelf(): Call<User>
 
+        @GET("users/self/profile")
+        suspend fun getSelf(@Tag params: RestParams): DataResult<User>
+
         @GET("users/self/settings")
         fun getSelfSettings(): Call<UserSettings>
 

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/ApiPrefs.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/ApiPrefs.kt
@@ -139,6 +139,8 @@ object ApiPrefs : PrefManager(PREFERENCE_FILE_NAME) {
     // Switch that lets the user manually override and turn off the elementary view in the settings
     var elementaryDashboardEnabledOverride by BooleanPref(true)
 
+    var checkTokenAfterOfflineLogin by BooleanPref()
+
     val showElementaryView
         get() = canvasForElementary && elementaryDashboardEnabledOverride
 

--- a/libs/login-api-2/src/main/java/com/instructure/loginapi/login/viewmodel/LoginViewModel.kt
+++ b/libs/login-api-2/src/main/java/com/instructure/loginapi/login/viewmodel/LoginViewModel.kt
@@ -24,7 +24,9 @@ import com.instructure.canvasapi2.managers.OAuthManager
 import com.instructure.canvasapi2.managers.UserManager
 import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.pandautils.mvvm.Event
+import com.instructure.pandautils.utils.FEATURE_FLAG_OFFLINE
 import com.instructure.pandautils.utils.FeatureFlagProvider
+import com.instructure.pandautils.utils.NetworkStateProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -39,14 +41,17 @@ class LoginViewModel @Inject constructor(
     private val featureFlagProvider: FeatureFlagProvider,
     private val userManager: UserManager,
     private val oauthManager: OAuthManager,
-    private val apiPrefs: ApiPrefs) : ViewModel() {
+    private val apiPrefs: ApiPrefs,
+    private val networkStateProvider: NetworkStateProvider) : ViewModel() {
 
     private val loginResultAction = MutableLiveData<Event<LoginResultAction>>()
 
     fun checkLogin(checkToken: Boolean, checkElementary: Boolean): LiveData<Event<LoginResultAction>> {
         viewModelScope.launch {
             try {
-                if (checkToken) {
+                val offlineEnabled = featureFlagProvider.checkEnvironmentFeatureFlag(FEATURE_FLAG_OFFLINE)
+                val offlineLogin = offlineEnabled && !networkStateProvider.isOnline()
+                if (checkToken && !offlineLogin) {
                     val selfResult = userManager.getSelfAsync(true).await()
                     if (selfResult.isSuccess) {
                         val canvasForElementary = checkCanvasElementary(checkElementary)
@@ -56,7 +61,7 @@ class LoginViewModel @Inject constructor(
                     }
                 } else {
                     val canvasForElementary = checkCanvasElementary(checkElementary)
-                    checkTermsAcceptance(canvasForElementary)
+                    checkTermsAcceptance(canvasForElementary, offlineLogin)
                 }
             } catch (e: Exception) {
                 loginResultAction.value = Event(LoginResultAction.TokenNotValid)
@@ -65,12 +70,13 @@ class LoginViewModel @Inject constructor(
         return loginResultAction
     }
 
-    private suspend fun checkTermsAcceptance(canvasForElementary: Boolean) {
+    private suspend fun checkTermsAcceptance(canvasForElementary: Boolean, offlineLogin: Boolean = false) {
         val authenticatedSession = oauthManager.getAuthenticatedSessionAsync("${apiPrefs.fullDomain}/users/self").await()
         val requiresTermsAcceptance = authenticatedSession.dataOrNull?.requiresTermsAcceptance ?: false
         if (requiresTermsAcceptance) {
             loginResultAction.value = Event(LoginResultAction.ShouldAcceptPolicy(canvasForElementary))
         } else {
+            apiPrefs.checkTokenAfterOfflineLogin = offlineLogin
             loginResultAction.value = Event(LoginResultAction.Login(canvasForElementary))
         }
     }

--- a/libs/login-api-2/src/test/java/com/instructure/loginapi/login/viewmodel/LoginViewModelTest.kt
+++ b/libs/login-api-2/src/test/java/com/instructure/loginapi/login/viewmodel/LoginViewModelTest.kt
@@ -26,7 +26,9 @@ import com.instructure.canvasapi2.models.AuthenticatedSession
 import com.instructure.canvasapi2.models.User
 import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.canvasapi2.utils.DataResult
+import com.instructure.pandautils.utils.FEATURE_FLAG_OFFLINE
 import com.instructure.pandautils.utils.FeatureFlagProvider
+import com.instructure.pandautils.utils.NetworkStateProvider
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -53,6 +55,7 @@ class LoginViewModelTest {
     private val userManager: UserManager = mockk(relaxed = true)
     private val oauthManager: OAuthManager = mockk(relaxed = true)
     private val apiPrefs: ApiPrefs = mockk(relaxed = true)
+    private val networkStateProvider: NetworkStateProvider = mockk(relaxed = true)
     private val lifecycleOwner: LifecycleOwner = mockk(relaxed = true)
     private val lifecycleRegistry = LifecycleRegistry(lifecycleOwner)
 
@@ -183,8 +186,77 @@ class LoginViewModelTest {
         assertEquals(LoginResultAction.ShouldAcceptPolicy(false), loginStatus.value!!.getContentIfNotHandled()!!)
     }
 
+    @Test
+    fun `Set offline login if the user logs in offline and the feature flag is on`() {
+        // Given
+        coEvery { featureFlagProvider.getCanvasForElementaryFlag() } returns true
+        coEvery { featureFlagProvider.checkEnvironmentFeatureFlag(FEATURE_FLAG_OFFLINE) } returns true
+        every { networkStateProvider.isOnline() } returns false
+        every { oauthManager.getAuthenticatedSessionAsync(any()) } returns mockk {
+            coEvery { await() } returns DataResult.Success(AuthenticatedSession("", requiresTermsAcceptance = false))
+        }
+        every { userManager.getSelfAsync(any()) } returns mockk {
+            coEvery { await() } returns DataResult.Success(User())
+        }
+
+        // When
+        viewModel = createViewModel()
+        val loginStatus = viewModel.checkLogin(true, false)
+        loginStatus.observe(lifecycleOwner, {})
+
+        // Then
+        verify { apiPrefs.checkTokenAfterOfflineLogin = true }
+        assertEquals(LoginResultAction.Login(false), loginStatus.value!!.getContentIfNotHandled()!!)
+    }
+
+    @Test
+    fun `Dont Set offline login if the user logs in offline and the feature flag is off`() {
+        // Given
+        coEvery { featureFlagProvider.getCanvasForElementaryFlag() } returns true
+        coEvery { featureFlagProvider.checkEnvironmentFeatureFlag(FEATURE_FLAG_OFFLINE) } returns false
+        every { networkStateProvider.isOnline() } returns false
+        every { oauthManager.getAuthenticatedSessionAsync(any()) } returns mockk {
+            coEvery { await() } returns DataResult.Success(AuthenticatedSession("", requiresTermsAcceptance = false))
+        }
+        every { userManager.getSelfAsync(any()) } returns mockk {
+            coEvery { await() } returns DataResult.Success(User())
+        }
+
+        // When
+        viewModel = createViewModel()
+        val loginStatus = viewModel.checkLogin(true, false)
+        loginStatus.observe(lifecycleOwner, {})
+
+        // Then
+        verify { apiPrefs.checkTokenAfterOfflineLogin = false }
+        assertEquals(LoginResultAction.Login(false), loginStatus.value!!.getContentIfNotHandled()!!)
+    }
+
+    @Test
+    fun `Dont Set offline login if the user logs in online`() {
+        // Given
+        coEvery { featureFlagProvider.getCanvasForElementaryFlag() } returns true
+        coEvery { featureFlagProvider.checkEnvironmentFeatureFlag(FEATURE_FLAG_OFFLINE) } returns true
+        every { networkStateProvider.isOnline() } returns true
+        every { oauthManager.getAuthenticatedSessionAsync(any()) } returns mockk {
+            coEvery { await() } returns DataResult.Success(AuthenticatedSession("", requiresTermsAcceptance = false))
+        }
+        every { userManager.getSelfAsync(any()) } returns mockk {
+            coEvery { await() } returns DataResult.Success(User())
+        }
+
+        // When
+        viewModel = createViewModel()
+        val loginStatus = viewModel.checkLogin(true, false)
+        loginStatus.observe(lifecycleOwner, {})
+
+        // Then
+        verify { apiPrefs.checkTokenAfterOfflineLogin = false }
+        assertEquals(LoginResultAction.Login(false), loginStatus.value!!.getContentIfNotHandled()!!)
+    }
+
     private fun createViewModel(): LoginViewModel {
-        return LoginViewModel(featureFlagProvider, userManager, oauthManager, apiPrefs)
+        return LoginViewModel(featureFlagProvider, userManager, oauthManager, apiPrefs, networkStateProvider)
     }
 
 }


### PR DESCRIPTION
Test plan: 
- Verify that when the user is in offline mode and logged in, we can open the app and the Dashboard will be displayed
- Verify that after an offline login we do a token check the first time the user goes online and if the token is expired we lof out the user.
- This can only be tested by disabling the cache (or waiting 1 hour after login), I have added a patch for this. [no_network_cache.patch](https://github.com/instructure/canvas-android/files/12557932/no_network_cache.patch)

refs: MBL-16877
affects: Student
release note: none

## Checklist

- [x] Tested in light mode
