### PR TITLE
[MBL-16327][Teacher] - Use different type of module items in ModulesE2E test in Teacher app

### DIFF
--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/ModulesE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/ModulesE2ETest.kt
@@ -1,15 +1,20 @@
 package com.instructure.teacher.ui.e2e
 
 import android.util.Log
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.web.webdriver.Locator
 import com.instructure.canvas.espresso.E2E
 import com.instructure.dataseeding.api.AssignmentsApi
+import com.instructure.dataseeding.api.DiscussionTopicsApi
 import com.instructure.dataseeding.api.ModulesApi
+import com.instructure.dataseeding.api.PagesApi
 import com.instructure.dataseeding.api.QuizzesApi
 import com.instructure.dataseeding.model.AssignmentApiModel
 import com.instructure.dataseeding.model.CanvasUserApiModel
 import com.instructure.dataseeding.model.CourseApiModel
 import com.instructure.dataseeding.model.ModuleApiModel
 import com.instructure.dataseeding.model.ModuleItemTypes
+import com.instructure.dataseeding.model.PageApiModel
 import com.instructure.dataseeding.model.QuizApiModel
 import com.instructure.dataseeding.model.SubmissionType
 import com.instructure.dataseeding.util.days
@@ -19,6 +24,7 @@ import com.instructure.panda_annotations.FeatureCategory
 import com.instructure.panda_annotations.Priority
 import com.instructure.panda_annotations.TestCategory
 import com.instructure.panda_annotations.TestMetaData
+import com.instructure.teacher.ui.pages.WebViewTextCheck
 import com.instructure.teacher.ui.utils.TeacherTest
 import com.instructure.teacher.ui.utils.seedData
 import com.instructure.teacher.ui.utils.tokenLogin
@@ -59,18 +65,33 @@ class   ModulesE2ETest : TeacherTest() {
         Log.d(PREPARATION_TAG,"Seeding quiz for ${course.name} course.")
         val quiz = createQuiz(course, teacher)
 
+        Log.d(PREPARATION_TAG,"Create an unpublished page for course: ${course.name}.")
+        val testPage = createCoursePage(course, teacher, published = false, frontPage = false, body = "<h1 id=\"header1\">Test Page Text</h1>")
+
+        Log.d(PREPARATION_TAG,"Create a discussion topic for ${course.name} course.")
+        val discussionTopic = createDiscussion(course, teacher)
+
         Log.d(PREPARATION_TAG,"Seeding a module for ${course.name} course. It starts as unpublished.")
         val module = createModule(course, teacher)
 
         Log.d(PREPARATION_TAG,"Associate ${assignment.name} assignment (and the quiz within it) with module: ${module.id}.")
-        createModuleAssignmentItem(course, module, teacher, assignment)
+        createModuleItem(course, module, teacher, assignment.name, ModuleItemTypes.ASSIGNMENT.stringVal, assignment.id.toString())
+        createModuleItem(course, module, teacher, quiz.title, ModuleItemTypes.QUIZ.stringVal, quiz.id.toString())
 
-        createModuleQuizItem(course, module, teacher, quiz)
+        Log.d(PREPARATION_TAG,"Associate ${testPage.title} page with module: ${module.id}.")
+        createModuleItem(course, module, teacher, testPage.title, ModuleItemTypes.PAGE.stringVal, null, pageUrl = testPage.url)
+
+        Log.d(PREPARATION_TAG,"Associate ${discussionTopic.title} discussion with module: ${module.id}.")
+        createModuleItem(course, module, teacher, discussionTopic.title, ModuleItemTypes.DISCUSSION.stringVal, discussionTopic.id.toString())
 
         Log.d(STEP_TAG,"Refresh the page. Assert that ${module.name} module is displayed and it is unpublished by default.")
         modulesPage.refresh()
         modulesPage.assertModuleIsDisplayed(module.name)
         modulesPage.assertModuleNotPublished()
+
+        Log.d(STEP_TAG,"Assert that ${testPage.title} page is present as a module item, but it's not published.")
+        modulesPage.assertModuleItemIsDisplayed(testPage.title)
+        modulesPage.assertModuleItemNotPublished(module.name, testPage.title)
 
         Log.d(PREPARATION_TAG,"Publish ${module.name} module via API.")
         ModulesApi.updateModule(
@@ -91,42 +112,74 @@ class   ModulesE2ETest : TeacherTest() {
         modulesPage.assertModuleItemIsDisplayed(quiz.title)
         modulesPage.assertModuleItemIsPublished(quiz.title)
 
+        Log.d(STEP_TAG,"Assert that ${testPage.title} page is present as a module item, but it's not published.")
+        modulesPage.assertModuleItemIsDisplayed(testPage.title)
+        modulesPage.assertModuleItemIsPublished(testPage.title)
+
+        Log.d(STEP_TAG, "Collapse the ${module.name} and assert that the module items has not displayed.")
         modulesPage.clickOnCollapseExpandIcon()
         modulesPage.assertItemCountInModule(module.name, 0)
 
+        Log.d(STEP_TAG, "Expand the ${module.name} and assert that the module items are displayed.")
         modulesPage.clickOnCollapseExpandIcon()
-        modulesPage.assertItemCountInModule(module.name, 2)
-    }
+        modulesPage.assertItemCountInModule(module.name, 4)
 
-    private fun createModuleQuizItem(
-        course: CourseApiModel,
-        module: ModuleApiModel,
-        teacher: CanvasUserApiModel,
-        quiz: QuizApiModel
-    ) {
-        ModulesApi.createModuleItem(
+        Log.d(PREPARATION_TAG,"Unpublish ${module.name} module via API.")
+        ModulesApi.updateModule(
             courseId = course.id,
-            moduleId = module.id,
-            teacherToken = teacher.token,
-            title = quiz.title,
-            type = ModuleItemTypes.QUIZ.stringVal,
-            contentId = quiz.id.toString()
+            id = module.id,
+            published = false,
+            teacherToken = teacher.token
         )
+
+        Log.d(STEP_TAG, "Refresh the Modules Page.")
+        modulesPage.refresh()
+
+        Log.d(STEP_TAG,"Assert that ${assignment.name} assignment and ${quiz.title} quiz and ${testPage.title} page are present as module items, and they are NOT published since their module is unpublished.")
+        modulesPage.assertModuleItemIsDisplayed(assignment.name)
+        modulesPage.assertModuleItemNotPublished(module.name, assignment.name)
+        modulesPage.assertModuleItemIsDisplayed(quiz.title)
+        modulesPage.assertModuleItemNotPublished(module.name, quiz.title)
+        modulesPage.assertModuleItemIsDisplayed(testPage.title)
+        modulesPage.assertModuleItemNotPublished(module.name, testPage.title)
+
+        Log.d(STEP_TAG, "Open the ${assignment.name} assignment module item and assert that the Assignment Details Page is displayed. Navigate back to Modules Page.")
+        modulesPage.clickOnModuleItem(assignment.name)
+        assignmentDetailsPage.assertPageObjects()
+        Espresso.pressBack()
+
+        Log.d(STEP_TAG, "Open the ${quiz.title} quiz module item and assert that the Quiz Details Page is displayed. Navigate back to Modules Page.")
+        modulesPage.clickOnModuleItem(quiz.title)
+        quizDetailsPage.assertPageObjects()
+        Espresso.pressBack()
+
+        Log.d(STEP_TAG, "Open the ${testPage.title} page module item and assert that the Page Details Page is displayed. Navigate back to Modules Page.")
+        modulesPage.clickOnModuleItem(testPage.title)
+        editPageDetailsPage.runTextChecks(WebViewTextCheck(Locator.ID, "header1", "Test Page Text"))
+        Espresso.pressBack()
+
+        Log.d(STEP_TAG, "Open the ${discussionTopic.title} discussion module item and assert that the Discussion Details Page is displayed.")
+        modulesPage.clickOnModuleItem(discussionTopic.title)
+        discussionsDetailsPage.assertPageObjects()
     }
 
-    private fun createModuleAssignmentItem(
+    private fun createModuleItem(
         course: CourseApiModel,
         module: ModuleApiModel,
         teacher: CanvasUserApiModel,
-        assignment: AssignmentApiModel
+        title: String,
+        moduleItemType: String,
+        contentId: String?,
+        pageUrl: String? = null
     ) {
         ModulesApi.createModuleItem(
             courseId = course.id,
             moduleId = module.id,
             teacherToken = teacher.token,
-            title = assignment.name,
-            type = ModuleItemTypes.ASSIGNMENT.stringVal,
-            contentId = assignment.id.toString()
+            title = title,
+            type = moduleItemType,
+            contentId = contentId,
+            pageUrl = pageUrl
         )
     }
 
@@ -170,5 +223,29 @@ class   ModulesE2ETest : TeacherTest() {
             )
         )
     }
+
+    private fun createCoursePage(
+        course: CourseApiModel,
+        teacher: CanvasUserApiModel,
+        published: Boolean = true,
+        frontPage: Boolean = false,
+        body: String = EMPTY_STRING
+    ): PageApiModel {
+        return PagesApi.createCoursePage(
+            courseId = course.id,
+            published = published,
+            frontPage = frontPage,
+            token = teacher.token,
+            body = body
+        )
+    }
+
+    private fun createDiscussion(
+        course: CourseApiModel,
+        teacher: CanvasUserApiModel
+    ) = DiscussionTopicsApi.createDiscussion(
+        courseId = course.id,
+        token = teacher.token
+    )
 
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/ModulesPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/ModulesPage.kt
@@ -76,6 +76,15 @@ class ModulesPage : BasePage() {
     }
 
     /**
+     * Click on the module item with the given title to open it's detailer.
+     *
+     * @param itemTitle The title of the module item.
+     */
+    fun clickOnModuleItem(itemTitle: String) {
+        onView(allOf(withId(R.id.moduleItemTitle), withText(itemTitle))).click()
+    }
+
+    /**
      * Asserts that the module item with the specified name is published.
      *
      * @param moduleItemName The name of the module item.


### PR DESCRIPTION
Use different type of module items in ModulesE2E test in Teacher app.
Add some page object methods.
Extend test with publish/unpublish module and assert how the module items behave, and extend the test with open the module items and assert that their corresponding detailer page is displayed and loaded.

refs: MBL-16327
affects: Teacher
release note: none