### PR TITLE
[MBL-17032][Student] Student receives an error trying to view their current calendar

### DIFF
--- a/libs/flutter_student_embed/lib/screens/calendar/planner_fetcher.dart
+++ b/libs/flutter_student_embed/lib/screens/calendar/planner_fetcher.dart
@@ -131,7 +131,7 @@ class PlannerFetcher extends ChangeNotifier {
     items.forEach((item) {
       if (item.plannableDate != null) {
         String dayKey = dayKeyForDate(item.plannableDate.toLocal());
-        dayItems[dayKey].add(item);
+        dayItems[dayKey]?.add(item);
       }
     });
 


### PR DESCRIPTION
Test plan: in the ticket

refs: MBL-17032
affects: Student
release note: none

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-android/assets/109959688/bdf73686-175f-4f3e-a28a-be3ef0282253" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-android/assets/109959688/196e873f-c914-43c3-8936-23276803b8b6" maxHeight=500></td>
</tr>
</table>
