### PR TITLE
[MBL-16954][Student] List the activity stream API shows unassigned assignments

### DIFF
--- a/apps/student/src/main/res/layout/fragment_assignment_details.xml
+++ b/apps/student/src/main/res/layout/fragment_assignment_details.xml
@@ -10,6 +10,8 @@
 
         <import type="com.instructure.pandautils.utils.ThemePrefs" />
 
+        <import type="com.instructure.pandautils.mvvm.ViewState"/>
+
         <variable
             name="viewModel"
             type="com.instructure.student.features.assignments.details.AssignmentDetailsViewModel" />
@@ -52,7 +54,8 @@
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
+                    android:layout_height="wrap_content"
+                    app:visible="@{viewModel.showContent(viewModel.state)}">
 
                     <TextView
                         android:id="@+id/assignmentName"
@@ -554,9 +557,9 @@
         <com.instructure.pandautils.views.EmptyView
             android:id="@+id/emptyView"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="@color/backgroundLightest"
-            android:translationZ="100dp"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toBottomOf="@id/toolbar"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:emptyViewState="@{viewModel.state}"
             tools:visibility="visible" />
 

--- a/apps/student/src/test/java/com/instructure/student/features/offline/assignmentdetails/AssignmentDetailsNetworkDataSourceTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/features/offline/assignmentdetails/AssignmentDetailsNetworkDataSourceTest.kt
@@ -23,6 +23,7 @@ import com.instructure.canvasapi2.apis.QuizAPI
 import com.instructure.canvasapi2.apis.SubmissionAPI
 import com.instructure.canvasapi2.models.*
 import com.instructure.canvasapi2.utils.DataResult
+import com.instructure.canvasapi2.utils.Failure
 import com.instructure.student.features.assignments.details.datasource.AssignmentDetailsNetworkDataSource
 import io.mockk.coEvery
 import io.mockk.mockk
@@ -82,6 +83,13 @@ class AssignmentDetailsNetworkDataSourceTest {
     @Test(expected = IllegalStateException::class)
     fun `Get assignment failure throws exception`() = runTest {
         coEvery { assignmentInterface.getAssignmentWithHistory(any(), any(), any()) } returns DataResult.Fail()
+
+        dataSource.getAssignment(false, 1, 1, true)
+    }
+
+    @Test(expected = IllegalAccessException::class)
+    fun `Get assignment failure throws IllegalAccessException on auth error`() = runTest {
+        coEvery { assignmentInterface.getAssignmentWithHistory(any(), any(), any()) } returns DataResult.Fail(failure = Failure.Authorization())
 
         dataSource.getAssignment(false, 1, 1, true)
     }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/calladapter/DataResultCall.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/calladapter/DataResultCall.kt
@@ -44,7 +44,7 @@ class DataResultCall<T : Any>(private val delegate: Call<T>): Call<DataResult<T>
                     callback.onResponse(this@DataResultCall, Response.success(createSuccessResult(response)))
                 } else {
                     if (error != null) {
-                        val failure = if (code == 401) {
+                        val failure = if (code == 401 || code == 403) {
                             Failure.Authorization(response.message())
                         } else {
                             Failure.Network(response.message(), code)

--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -1461,4 +1461,5 @@
         <item quantity="other">%d items are syncing.</item>
     </plurals>
     <string name="syncProgressAdditionalFiles">Course content images</string>
+    <string name="assignmentNoLongerAvailable">This assignment is no longer available.</string>
 </resources>


### PR DESCRIPTION
Test plan: Repro steps are in the ticket. I made some improvements to the assignment details empty view, and refresh functionality as well. Smoke test the assignment details screen.

refs: MBL-16954
affects: Student
release note: none

## Checklist

- [ ] Tested in light mode
