### PR TITLE
[MBL-17099][Student] - Create annotation and flank config for Offline E2E Tests

### DIFF
--- a/apps/student/flank_e2e_offline.yml
+++ b/apps/student/flank_e2e_offline.yml
@@ -12,8 +12,8 @@ gcloud:
   record-video: true
   timeout: 60m
   test-targets:
-  - annotation com.instructure.canvas.espresso.E2E
-  - notAnnotation com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.FlakyE2E, com.instructure.canvas.espresso.KnownBug, com.instructure.canvas.espresso.OfflineTest
+  - annotation com.instructure.canvas.espresso.E2E, com.instructure.canvas.espresso.OfflineTest
+  - notAnnotation com.instructure.canvas.espresso.Stub, com.instructure.canvas.espresso.FlakyE2E, com.instructure.canvas.espresso.KnownBug
   device:
   - model: Pixel2.arm
     version: 29

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/OfflineTest.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/OfflineTest.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2023 - present Instructure, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.instructure.canvas.espresso
+
+// When applied to a test method, denotes that the test is the part of the Offline mode test case suite.
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class OfflineTest(val explanation: String = "")


### PR DESCRIPTION
Create flank file for e2e offline test suite and exclude it from the normal (online) one.

refs: MBL-17098ó9
affects: Student
release note: none