### PR TITLE
[MBL-17098][Student] - Implement Dashboard Offline E2E Test

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/DashboardE2EOfflineTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/DashboardE2EOfflineTest.kt
@@ -1,0 +1,291 @@
+/*
+ * Copyright (C) 2023 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.instructure.student.ui.e2e.offline
+
+import android.util.Log
+import androidx.test.espresso.Espresso
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiScrollable
+import androidx.test.uiautomator.UiSelector
+import com.instructure.canvas.espresso.E2E
+import com.instructure.dataseeding.api.ConversationsApi
+import com.instructure.dataseeding.api.GroupsApi
+import com.instructure.panda_annotations.FeatureCategory
+import com.instructure.panda_annotations.Priority
+import com.instructure.panda_annotations.TestCategory
+import com.instructure.panda_annotations.TestMetaData
+import com.instructure.student.ui.utils.StudentTest
+import com.instructure.student.ui.utils.seedData
+import com.instructure.student.ui.utils.tokenLogin
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Test
+
+@HiltAndroidTest
+class DashboardE2EOfflineTest : StudentTest() {
+    override fun displaysPageObjects() = Unit
+
+    override fun enableAndConfigureAccessibilityChecks() = Unit
+
+    @E2E
+    @Test
+    @TestMetaData(Priority.MANDATORY, FeatureCategory.DASHBOARD, TestCategory.E2E)
+    fun testDashboardE2E() {
+
+        Log.d(PREPARATION_TAG,"Seeding data.")
+        val data = seedData(students = 1, teachers = 1, courses = 2)
+        val student = data.studentsList[0]
+        val teacher = data.teachersList[0]
+        val course1 = data.coursesList[0]
+        val course2 = data.coursesList[1]
+
+        Log.d(PREPARATION_TAG, "Seed an Inbox conversation via API.")
+        ConversationsApi.createConversation(
+                token = teacher.token,
+                recipients = listOf(student.id.toString())
+        )
+
+        Log.d(PREPARATION_TAG,"Seed some group info.")
+        val groupCategory = GroupsApi.createCourseGroupCategory(data.coursesList[0].id, teacher.token)
+        val groupCategory2 = GroupsApi.createCourseGroupCategory(data.coursesList[0].id, teacher.token)
+        val group = GroupsApi.createGroup(groupCategory.id, teacher.token)
+        val group2 = GroupsApi.createGroup(groupCategory2.id, teacher.token)
+
+        Log.d(PREPARATION_TAG,"Create group membership for ${student.name} student.")
+        GroupsApi.createGroupMembership(group.id, student.id, teacher.token)
+        GroupsApi.createGroupMembership(group2.id, student.id, teacher.token)
+
+        Log.d(STEP_TAG,"Login with user: ${student.name}, login id: ${student.loginId}.")
+        tokenLogin(student)
+        dashboardPage.waitForRender()
+
+        for(course in data.coursesList) {
+            Log.d(STEP_TAG,"Assert that ${course.name} course is displayed.")
+            dashboardPage.assertDisplaysCourse(course)
+        }
+
+        Log.d(STEP_TAG,"Assert that ${group.name} groups is displayed.")
+        dashboardPage.assertDisplaysGroup(group, data.coursesList[0])
+
+        Log.d(STEP_TAG,"Assert that there is an unread e-mail so we have the number '1' on the Inbox bottom-menu icon as a badge.")
+        dashboardPage.assertUnreadEmails(1)
+
+        Log.d(STEP_TAG, "Switch to List View.")
+        dashboardPage.switchCourseView()
+
+        for(course in data.coursesList) {
+            Log.d(STEP_TAG,"Assert that ${course.name} course is displayed.")
+            dashboardPage.assertDisplaysCourse(course)
+        }
+
+        Log.d(STEP_TAG, "Switch to back to Grid View.")
+        dashboardPage.switchCourseView()
+
+        for(course in data.coursesList) {
+            Log.d(STEP_TAG,"Assert that ${course.name} course is displayed.")
+            dashboardPage.assertDisplaysCourse(course)
+        }
+
+        Log.d(STEP_TAG, "Assert that both of the groups '${group.name}' and '${group2.name}' are displayed because they are independent from the courses.")
+        dashboardPage.assertDisplaysGroup(group, course1)
+        dashboardPage.assertDisplaysGroup(group2, course1)
+
+        Log.d(STEP_TAG,"Click on 'All Courses' button. Assert that the All Courses Page is loaded.")
+        dashboardPage.clickEditDashboard()
+        editDashboardPage.assertPageObjects()
+
+        Log.d(STEP_TAG, "Favorite '${course1.name}' course and navigate back to Dashboard Page.")
+        editDashboardPage.favoriteCourse(course1.name)
+        Espresso.pressBack()
+
+        Log.d(STEP_TAG,"Assert that only the favoured course, '${course1.name}' is displayed." +
+                "Assert that the other course, '${course2.name}' is not displayed since it's not favoured.")
+        dashboardPage.assertDisplaysCourse(course1)
+        dashboardPage.assertCourseNotDisplayed(course2)
+
+        Log.d(STEP_TAG, "Assert that both of the groups '${group.name}' and '${group2.name}' are displayed because they are independent from the courses.")
+        dashboardPage.assertDisplaysGroup(group, course1)
+        dashboardPage.assertDisplaysGroup(group2, course1)
+
+        Log.d(STEP_TAG,"Opens ${course1.name} course and assert if Course Details Page has been opened. Navigate back to Dashboard Page.")
+        dashboardPage.selectCourse(course1)
+        courseBrowserPage.assertPageObjects()
+        Espresso.pressBack()
+
+        Log.d(STEP_TAG,"Click on 'All Courses' button. Assert that the All Courses Page is loaded.")
+        dashboardPage.assertPageObjects()
+        dashboardPage.clickEditDashboard()
+        editDashboardPage.assertPageObjects()
+
+        Log.d(STEP_TAG, "Assert that the mass select button's text is 'Unselect All', since one of the courses is selected.")
+        editDashboardPage.assertCourseMassSelectButtonIsDisplayed(true)
+
+        Log.d(STEP_TAG, "Toggle off favourite star icon of '${course1.name}' course." +
+                "Assert that the 'mass' select button's label is 'Select All'.")
+        editDashboardPage.unfavoriteCourse(course1.name)
+        editDashboardPage.assertCourseMassSelectButtonIsDisplayed(false)
+
+        Log.d(STEP_TAG, "Navigate back to Dashboard Page.")
+        Espresso.pressBack()
+
+        Log.d(STEP_TAG,"Assert that both of the courses, '${course1.name}' and '${course2.name}', and their grades are displayed properly.")
+        dashboardPage.assertDisplaysCourse(course1)
+        dashboardPage.assertDisplaysCourse(course2)
+        dashboardPage.assertCourseGrade(course1.name, "N/A")
+        dashboardPage.assertCourseGrade(course2.name, "N/A")
+
+        Log.d(STEP_TAG, "Click on 'Edit nickname' menu of '${course1.name}' course.")
+        dashboardPage.clickCourseOverflowMenu(course1.name, "Edit nickname")
+
+        val newNickname = "New course nickname"
+        Log.d(STEP_TAG, "Change '${course1.name}' course's nickname to: '$newNickname'.")
+        dashboardPage.changeCourseNickname(newNickname)
+
+        Log.d(STEP_TAG, "Wait for Dashboard Page to be reloaded and assert that the course's name has been changed to '$newNickname'.")
+        dashboardPage.assertPageObjects()
+        dashboardPage.assertDisplaysCourse(newNickname)
+
+        Log.d(STEP_TAG,"Assert that ${group.name} groups is displayed and the '$newNickname' is displayed as the corresponding course name of the group.")
+        dashboardPage.assertDisplaysGroup(group, newNickname)
+
+        Log.d(STEP_TAG, "Click on 'Edit nickname' menu of '$newNickname' course.")
+        dashboardPage.clickCourseOverflowMenu(newNickname, "Edit nickname")
+
+        Log.d(STEP_TAG, "Make the course nickname empty and click on 'Ok' on the dialog.")
+        dashboardPage.changeCourseNickname(EMPTY_STRING)
+
+        Log.d(STEP_TAG, "Wait for Dashboard Page to be reloaded. Assert that if there is no nickname for a course, the course's full name, '${course1.name}' will be displayed.")
+        dashboardPage.assertPageObjects()
+        dashboardPage.assertDisplaysCourse(course1.name)
+
+        Log.d(STEP_TAG,"Assert that ${group.name} groups is displayed and the '${data.coursesList[0]}' is displayed as the corresponding course name of the group.")
+        dashboardPage.assertDisplaysGroup(group, data.coursesList[0])
+
+        Log.d(STEP_TAG, "Toggle OFF 'Show Grades' and navigate back to Dashboard Page.")
+        leftSideNavigationDrawerPage.setShowGrades(false)
+
+        Log.d(STEP_TAG, "Assert that the grades does not displayed on both of the courses' cards.")
+        dashboardPage.assertCourseGradeNotDisplayed(course1.name, "N/A")
+        dashboardPage.assertCourseGradeNotDisplayed(course2.name, "N/A")
+
+        Log.d(STEP_TAG, "Toggle ON 'Show Grades' and navigate back to Dashboard Page.")
+        leftSideNavigationDrawerPage.setShowGrades(true)
+
+        Log.d(STEP_TAG, "Assert that the grades are displayed on both of the courses' cards.")
+        dashboardPage.assertCourseGrade(course1.name, "N/A")
+        dashboardPage.assertCourseGrade(course2.name, "N/A")
+
+        Log.d(STEP_TAG,"Click on 'All Courses' button.")
+        dashboardPage.clickEditDashboard()
+        editDashboardPage.assertPageObjects()
+
+        Log.d(STEP_TAG, "Assert that the group 'mass' select button's label is 'Select All'.")
+        editDashboardPage.swipeUp()
+        editDashboardPage.assertGroupMassSelectButtonIsDisplayed(false)
+
+        Log.d(STEP_TAG, "Favorite '${group.name}' course and navigate back to Dashboard Page.")
+        editDashboardPage.favoriteGroup(group.name)
+        Espresso.pressBack()
+
+        Log.d(STEP_TAG,"Assert that only the favoured group, '${group.name}' is displayed." +
+                "Assert that the other group, '${group2.name}' is not displayed since it's not favoured.")
+        dashboardPage.assertDisplaysGroup(group, course1)
+        dashboardPage.assertGroupNotDisplayed(group2)
+
+        Log.d(STEP_TAG,"Click on 'All Courses' button.")
+        dashboardPage.clickEditDashboard()
+        editDashboardPage.assertPageObjects()
+        Thread.sleep(2000) //It can be flaky without this 2 seconds
+        editDashboardPage.swipeUp()
+
+        Log.d(STEP_TAG, "Assert that the group 'mass' select button's label is 'Unselect All'.")
+        editDashboardPage.assertGroupMassSelectButtonIsDisplayed(true)
+
+        Log.d(STEP_TAG, "Toggle off favourite star icon of '${group.name}' group." +
+                "Assert that the 'mass' select button's label is 'Select All'.")
+        editDashboardPage.unfavoriteGroup(group.name)
+        editDashboardPage.assertGroupMassSelectButtonIsDisplayed(false)
+
+        Log.d(STEP_TAG, "Navigate back to Dashboard Page.")
+        Espresso.pressBack()
+
+        Log.d(STEP_TAG,"Assert that both of the groups, '${group.name}' and '${group2.name}' are displayed" +
+                "since if there is no group selected on the All Courses page, we are showing all of them (this is the same logics as with the courses).")
+        dashboardPage.assertDisplaysGroup(group, course1)
+        dashboardPage.assertDisplaysGroup(group2, course1)
+    }
+
+    @E2E
+    @Test
+    @TestMetaData(Priority.NICE_TO_HAVE, FeatureCategory.DASHBOARD, TestCategory.E2E)
+    fun testHelpMenuE2E() {
+        Log.d(PREPARATION_TAG,"Seeding data.")
+        val data = seedData(students = 1, courses = 1)
+        val student = data.studentsList[0]
+
+        Log.d(STEP_TAG,"Login with user: ${student.name}, login id: ${student.loginId}.")
+        tokenLogin(student)
+        dashboardPage.waitForRender()
+
+        Log.d(STEP_TAG, "Open Help Menu.")
+        leftSideNavigationDrawerPage.clickHelpMenu()
+
+        Log.d(STEP_TAG, "Assert Help Menu Dialog is displayed.")
+        helpPage.assertHelpMenuDisplayed()
+
+        Log.d(STEP_TAG, "Assert that all the corresponding Help menu content are displayed.")
+        helpPage.assertHelpMenuContent()
+    }
+
+    @Test
+    fun turnOffWiFi() {
+        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
+        // Open the device's settings
+        device.pressHome()
+
+        // Swipe down to open the app drawer
+        device.swipe(0, device.displayHeight / 2, 0, 0, 10)
+
+        // Wait for a moment to let the app drawer open
+        Thread.sleep(1000)
+
+        val settingsApp = device.findObject(UiSelector().text("Settings"))
+        settingsApp.clickAndWaitForNewWindow()
+
+        // Scroll to find the "Network & Internet" option
+        val scrollable = UiScrollable(UiSelector().scrollable(true))
+        scrollable.scrollTextIntoView("Network & internet")
+
+        // Open "Network & Internet" settings
+        val networkInternet = device.findObject(UiSelector().text("Network & internet"))
+        networkInternet.clickAndWaitForNewWindow()
+
+        // Turn off Wi-Fi
+       /* val wifiSwitch = device.findObject(UiSelector().resourceId("com.android.settings:id/switch_widget"))
+        if (wifiSwitch.isChecked) {
+            wifiSwitch.click()
+        }
+*/
+        val airplaneMode = device.findObject(UiSelector().text("Airplane mode"))
+        airplaneMode.click()
+
+        // Go back to the home screen
+        device.pressHome()
+    }
+
+}

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/DashboardE2EOfflineTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/DashboardE2EOfflineTest.kt
@@ -17,23 +17,23 @@
 package com.instructure.student.ui.e2e.offline
 
 import android.util.Log
-import androidx.test.espresso.Espresso
+import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
-import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import com.instructure.canvas.espresso.E2E
-import com.instructure.dataseeding.api.ConversationsApi
-import com.instructure.dataseeding.api.GroupsApi
 import com.instructure.panda_annotations.FeatureCategory
 import com.instructure.panda_annotations.Priority
 import com.instructure.panda_annotations.TestCategory
 import com.instructure.panda_annotations.TestMetaData
+import com.instructure.student.ui.e2e.offline.utils.OfflineTestUtils
 import com.instructure.student.ui.utils.StudentTest
 import com.instructure.student.ui.utils.seedData
 import com.instructure.student.ui.utils.tokenLogin
 import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.After
 import org.junit.Test
+import java.lang.Thread.sleep
 
 @HiltAndroidTest
 class DashboardE2EOfflineTest : StudentTest() {
@@ -44,248 +44,68 @@ class DashboardE2EOfflineTest : StudentTest() {
     @E2E
     @Test
     @TestMetaData(Priority.MANDATORY, FeatureCategory.DASHBOARD, TestCategory.E2E)
-    fun testDashboardE2E() {
-
+    fun testOfflineDashboardE2E() {
         Log.d(PREPARATION_TAG,"Seeding data.")
-        val data = seedData(students = 1, teachers = 1, courses = 2)
+        val data = seedData(students = 1, teachers = 1, courses = 2, announcements = 1)
         val student = data.studentsList[0]
-        val teacher = data.teachersList[0]
+        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         val course1 = data.coursesList[0]
         val course2 = data.coursesList[1]
-
-        Log.d(PREPARATION_TAG, "Seed an Inbox conversation via API.")
-        ConversationsApi.createConversation(
-                token = teacher.token,
-                recipients = listOf(student.id.toString())
-        )
-
-        Log.d(PREPARATION_TAG,"Seed some group info.")
-        val groupCategory = GroupsApi.createCourseGroupCategory(data.coursesList[0].id, teacher.token)
-        val groupCategory2 = GroupsApi.createCourseGroupCategory(data.coursesList[0].id, teacher.token)
-        val group = GroupsApi.createGroup(groupCategory.id, teacher.token)
-        val group2 = GroupsApi.createGroup(groupCategory2.id, teacher.token)
-
-        Log.d(PREPARATION_TAG,"Create group membership for ${student.name} student.")
-        GroupsApi.createGroupMembership(group.id, student.id, teacher.token)
-        GroupsApi.createGroupMembership(group2.id, student.id, teacher.token)
+        val testAnnouncement = data.announcementsList[0]
 
         Log.d(STEP_TAG,"Login with user: ${student.name}, login id: ${student.loginId}.")
         tokenLogin(student)
         dashboardPage.waitForRender()
 
-        for(course in data.coursesList) {
-            Log.d(STEP_TAG,"Assert that ${course.name} course is displayed.")
-            dashboardPage.assertDisplaysCourse(course)
-        }
+        Log.d(STEP_TAG, "Open global 'Manage Offline Content' page via the more menu of the Dashboard Page.")
+        dashboardPage.openGlobalManageOfflineContentPage()
 
-        Log.d(STEP_TAG,"Assert that ${group.name} groups is displayed.")
-        dashboardPage.assertDisplaysGroup(group, data.coursesList[0])
+        Log.d(STEP_TAG, "Select the entire '${course1.name}' course for sync. Click on the 'Sync' button.")
+        manageOfflineContentPage.selectEntireCourseForSync(course1.name)
+        manageOfflineContentPage.clickOnSyncButton()
 
-        Log.d(STEP_TAG,"Assert that there is an unread e-mail so we have the number '1' on the Inbox bottom-menu icon as a badge.")
-        dashboardPage.assertUnreadEmails(1)
+        //TODO: Dynamic wait for the sync to be completed.
+        sleep(8000)
 
-        Log.d(STEP_TAG, "Switch to List View.")
-        dashboardPage.switchCourseView()
+        Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
+        OfflineTestUtils.turnOffConnectionViaADB()
 
-        for(course in data.coursesList) {
-            Log.d(STEP_TAG,"Assert that ${course.name} course is displayed.")
-            dashboardPage.assertDisplaysCourse(course)
-        }
+        device.pressHome()
+        Log.d(STEP_TAG, "Click 'Recent Apps' device button and bring Canvas Student into the foreground again." +
+                "Assert that the Dashboard Page is displayed.")
+        device.pressRecentApps()
+        device.findObject(UiSelector().descriptionContains("Canvas")).click()
 
-        Log.d(STEP_TAG, "Switch to back to Grid View.")
-        dashboardPage.switchCourseView()
+        Log.d(STEP_TAG, "Wait for the Dashboard Page to be rendered.")
+        dashboardPage.waitForRender()
 
-        for(course in data.coursesList) {
-            Log.d(STEP_TAG,"Assert that ${course.name} course is displayed.")
-            dashboardPage.assertDisplaysCourse(course)
-        }
+        Log.d(STEP_TAG, "Log out with ${student.name} student.")
+        leftSideNavigationDrawerPage.logout()
 
-        Log.d(STEP_TAG, "Assert that both of the groups '${group.name}' and '${group2.name}' are displayed because they are independent from the courses.")
-        dashboardPage.assertDisplaysGroup(group, course1)
-        dashboardPage.assertDisplaysGroup(group2, course1)
+        Log.d(STEP_TAG,"Login with user: ${student.name}, login id: ${student.loginId}.")
+        tokenLogin(student)
 
-        Log.d(STEP_TAG,"Click on 'All Courses' button. Assert that the All Courses Page is loaded.")
-        dashboardPage.clickEditDashboard()
-        editDashboardPage.assertPageObjects()
+        Log.d(STEP_TAG, "Wait for the Dashboard Page to be rendered. Refresh the page.")
+        dashboardPage.waitForRender()
 
-        Log.d(STEP_TAG, "Favorite '${course1.name}' course and navigate back to Dashboard Page.")
-        editDashboardPage.favoriteCourse(course1.name)
-        Espresso.pressBack()
+        Log.d(STEP_TAG, "Assert that the Offline Indicator (bottom banner) is displayed on the Dashboard Page.")
+        OfflineTestUtils.assertOfflineIndicator()
 
-        Log.d(STEP_TAG,"Assert that only the favoured course, '${course1.name}' is displayed." +
-                "Assert that the other course, '${course2.name}' is not displayed since it's not favoured.")
-        dashboardPage.assertDisplaysCourse(course1)
-        dashboardPage.assertCourseNotDisplayed(course2)
+        Log.d(STEP_TAG, "Assert that the offline sync icon only displayed on the synced course's cours card.")
+        dashboardPage.assertCourseOfflineSyncIcon(course1.name, ViewMatchers.Visibility.VISIBLE)
+        dashboardPage.assertCourseOfflineSyncIcon(course2.name, ViewMatchers.Visibility.GONE)
 
-        Log.d(STEP_TAG, "Assert that both of the groups '${group.name}' and '${group2.name}' are displayed because they are independent from the courses.")
-        dashboardPage.assertDisplaysGroup(group, course1)
-        dashboardPage.assertDisplaysGroup(group2, course1)
-
-        Log.d(STEP_TAG,"Opens ${course1.name} course and assert if Course Details Page has been opened. Navigate back to Dashboard Page.")
+        Log.d(STEP_TAG, "Select '${course1.name}' course and open 'Announcements' menu.")
         dashboardPage.selectCourse(course1)
-        courseBrowserPage.assertPageObjects()
-        Espresso.pressBack()
+        courseBrowserPage.selectAnnouncements()
 
-        Log.d(STEP_TAG,"Click on 'All Courses' button. Assert that the All Courses Page is loaded.")
-        dashboardPage.assertPageObjects()
-        dashboardPage.clickEditDashboard()
-        editDashboardPage.assertPageObjects()
-
-        Log.d(STEP_TAG, "Assert that the mass select button's text is 'Unselect All', since one of the courses is selected.")
-        editDashboardPage.assertCourseMassSelectButtonIsDisplayed(true)
-
-        Log.d(STEP_TAG, "Toggle off favourite star icon of '${course1.name}' course." +
-                "Assert that the 'mass' select button's label is 'Select All'.")
-        editDashboardPage.unfavoriteCourse(course1.name)
-        editDashboardPage.assertCourseMassSelectButtonIsDisplayed(false)
-
-        Log.d(STEP_TAG, "Navigate back to Dashboard Page.")
-        Espresso.pressBack()
-
-        Log.d(STEP_TAG,"Assert that both of the courses, '${course1.name}' and '${course2.name}', and their grades are displayed properly.")
-        dashboardPage.assertDisplaysCourse(course1)
-        dashboardPage.assertDisplaysCourse(course2)
-        dashboardPage.assertCourseGrade(course1.name, "N/A")
-        dashboardPage.assertCourseGrade(course2.name, "N/A")
-
-        Log.d(STEP_TAG, "Click on 'Edit nickname' menu of '${course1.name}' course.")
-        dashboardPage.clickCourseOverflowMenu(course1.name, "Edit nickname")
-
-        val newNickname = "New course nickname"
-        Log.d(STEP_TAG, "Change '${course1.name}' course's nickname to: '$newNickname'.")
-        dashboardPage.changeCourseNickname(newNickname)
-
-        Log.d(STEP_TAG, "Wait for Dashboard Page to be reloaded and assert that the course's name has been changed to '$newNickname'.")
-        dashboardPage.assertPageObjects()
-        dashboardPage.assertDisplaysCourse(newNickname)
-
-        Log.d(STEP_TAG,"Assert that ${group.name} groups is displayed and the '$newNickname' is displayed as the corresponding course name of the group.")
-        dashboardPage.assertDisplaysGroup(group, newNickname)
-
-        Log.d(STEP_TAG, "Click on 'Edit nickname' menu of '$newNickname' course.")
-        dashboardPage.clickCourseOverflowMenu(newNickname, "Edit nickname")
-
-        Log.d(STEP_TAG, "Make the course nickname empty and click on 'Ok' on the dialog.")
-        dashboardPage.changeCourseNickname(EMPTY_STRING)
-
-        Log.d(STEP_TAG, "Wait for Dashboard Page to be reloaded. Assert that if there is no nickname for a course, the course's full name, '${course1.name}' will be displayed.")
-        dashboardPage.assertPageObjects()
-        dashboardPage.assertDisplaysCourse(course1.name)
-
-        Log.d(STEP_TAG,"Assert that ${group.name} groups is displayed and the '${data.coursesList[0]}' is displayed as the corresponding course name of the group.")
-        dashboardPage.assertDisplaysGroup(group, data.coursesList[0])
-
-        Log.d(STEP_TAG, "Toggle OFF 'Show Grades' and navigate back to Dashboard Page.")
-        leftSideNavigationDrawerPage.setShowGrades(false)
-
-        Log.d(STEP_TAG, "Assert that the grades does not displayed on both of the courses' cards.")
-        dashboardPage.assertCourseGradeNotDisplayed(course1.name, "N/A")
-        dashboardPage.assertCourseGradeNotDisplayed(course2.name, "N/A")
-
-        Log.d(STEP_TAG, "Toggle ON 'Show Grades' and navigate back to Dashboard Page.")
-        leftSideNavigationDrawerPage.setShowGrades(true)
-
-        Log.d(STEP_TAG, "Assert that the grades are displayed on both of the courses' cards.")
-        dashboardPage.assertCourseGrade(course1.name, "N/A")
-        dashboardPage.assertCourseGrade(course2.name, "N/A")
-
-        Log.d(STEP_TAG,"Click on 'All Courses' button.")
-        dashboardPage.clickEditDashboard()
-        editDashboardPage.assertPageObjects()
-
-        Log.d(STEP_TAG, "Assert that the group 'mass' select button's label is 'Select All'.")
-        editDashboardPage.swipeUp()
-        editDashboardPage.assertGroupMassSelectButtonIsDisplayed(false)
-
-        Log.d(STEP_TAG, "Favorite '${group.name}' course and navigate back to Dashboard Page.")
-        editDashboardPage.favoriteGroup(group.name)
-        Espresso.pressBack()
-
-        Log.d(STEP_TAG,"Assert that only the favoured group, '${group.name}' is displayed." +
-                "Assert that the other group, '${group2.name}' is not displayed since it's not favoured.")
-        dashboardPage.assertDisplaysGroup(group, course1)
-        dashboardPage.assertGroupNotDisplayed(group2)
-
-        Log.d(STEP_TAG,"Click on 'All Courses' button.")
-        dashboardPage.clickEditDashboard()
-        editDashboardPage.assertPageObjects()
-        Thread.sleep(2000) //It can be flaky without this 2 seconds
-        editDashboardPage.swipeUp()
-
-        Log.d(STEP_TAG, "Assert that the group 'mass' select button's label is 'Unselect All'.")
-        editDashboardPage.assertGroupMassSelectButtonIsDisplayed(true)
-
-        Log.d(STEP_TAG, "Toggle off favourite star icon of '${group.name}' group." +
-                "Assert that the 'mass' select button's label is 'Select All'.")
-        editDashboardPage.unfavoriteGroup(group.name)
-        editDashboardPage.assertGroupMassSelectButtonIsDisplayed(false)
-
-        Log.d(STEP_TAG, "Navigate back to Dashboard Page.")
-        Espresso.pressBack()
-
-        Log.d(STEP_TAG,"Assert that both of the groups, '${group.name}' and '${group2.name}' are displayed" +
-                "since if there is no group selected on the All Courses page, we are showing all of them (this is the same logics as with the courses).")
-        dashboardPage.assertDisplaysGroup(group, course1)
-        dashboardPage.assertDisplaysGroup(group2, course1)
+        Log.d(STEP_TAG,"Assert that the '${testAnnouncement.title}' titled announcement is displayed.")
+        announcementListPage.assertTopicDisplayed(testAnnouncement.title)
     }
 
-    @E2E
-    @Test
-    @TestMetaData(Priority.NICE_TO_HAVE, FeatureCategory.DASHBOARD, TestCategory.E2E)
-    fun testHelpMenuE2E() {
-        Log.d(PREPARATION_TAG,"Seeding data.")
-        val data = seedData(students = 1, courses = 1)
-        val student = data.studentsList[0]
-
-        Log.d(STEP_TAG,"Login with user: ${student.name}, login id: ${student.loginId}.")
-        tokenLogin(student)
-        dashboardPage.waitForRender()
-
-        Log.d(STEP_TAG, "Open Help Menu.")
-        leftSideNavigationDrawerPage.clickHelpMenu()
-
-        Log.d(STEP_TAG, "Assert Help Menu Dialog is displayed.")
-        helpPage.assertHelpMenuDisplayed()
-
-        Log.d(STEP_TAG, "Assert that all the corresponding Help menu content are displayed.")
-        helpPage.assertHelpMenuContent()
-    }
-
-    @Test
-    fun turnOffWiFi() {
-        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-
-        // Open the device's settings
-        device.pressHome()
-
-        // Swipe down to open the app drawer
-        device.swipe(0, device.displayHeight / 2, 0, 0, 10)
-
-        // Wait for a moment to let the app drawer open
-        Thread.sleep(1000)
-
-        val settingsApp = device.findObject(UiSelector().text("Settings"))
-        settingsApp.clickAndWaitForNewWindow()
-
-        // Scroll to find the "Network & Internet" option
-        val scrollable = UiScrollable(UiSelector().scrollable(true))
-        scrollable.scrollTextIntoView("Network & internet")
-
-        // Open "Network & Internet" settings
-        val networkInternet = device.findObject(UiSelector().text("Network & internet"))
-        networkInternet.clickAndWaitForNewWindow()
-
-        // Turn off Wi-Fi
-       /* val wifiSwitch = device.findObject(UiSelector().resourceId("com.android.settings:id/switch_widget"))
-        if (wifiSwitch.isChecked) {
-            wifiSwitch.click()
-        }
-*/
-        val airplaneMode = device.findObject(UiSelector().text("Airplane mode"))
-        airplaneMode.click()
-
-        // Go back to the home screen
-        device.pressHome()
+    @After
+    fun tearDown() {
+        OfflineTestUtils.turnOnConnectionViaADB()
     }
 
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/utils/OfflineTestUtils.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/utils/OfflineTestUtils.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2023 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.instructure.student.ui.e2e.offline.utils
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.matcher.ViewMatchers.withChild
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiScrollable
+import androidx.test.uiautomator.UiSelector
+import com.instructure.espresso.assertDisplayed
+import com.instructure.espresso.page.plus
+import com.instructure.student.R
+import org.hamcrest.CoreMatchers.allOf
+
+object OfflineTestUtils {
+
+    fun turnOffConnectionViaADB() {
+        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
+        device.pressHome()
+
+        device.executeShellCommand("svc wifi disable")
+        device.executeShellCommand("svc data disable")
+    }
+
+    fun turnOnConnectionViaADB() {
+        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
+        device.pressHome()
+
+        device.executeShellCommand("svc wifi enable")
+        device.executeShellCommand("svc data enable")
+    }
+
+    fun turnOffConnectionOnUI() {
+        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
+        device.swipe(0, device.displayHeight / 2, 0, 0, 10)
+
+        Thread.sleep(1000)
+
+        val settingsApp = device.findObject(UiSelector().text("Settings"))
+        settingsApp.clickAndWaitForNewWindow()
+
+        val scrollable = UiScrollable(UiSelector().scrollable(true))
+        scrollable.scrollTextIntoView("Network & internet")
+
+        val networkInternet = device.findObject(UiSelector().text("Network & internet"))
+        networkInternet.clickAndWaitForNewWindow()
+
+        val wifiSwitch =
+            device.findObject(UiSelector().resourceId("com.android.settings:id/switch_widget"))
+        if (wifiSwitch.isChecked) {
+            wifiSwitch.click()
+        }
+
+        val airplaneMode = device.findObject(UiSelector().text("Airplane mode"))
+        airplaneMode.click()
+
+        device.pressHome()
+    }
+
+    fun assertOfflineIndicator() {
+        onView(
+            withId(R.id.offlineIndicator) + allOf(
+                withChild(withId(R.id.divider)),
+                withChild(withId(R.id.offlineIndicatorIcon)),
+                withChild(withId(R.id.offlineIndicatorText) + withText(R.string.offline))
+            )
+        ).assertDisplayed()
+    }
+}

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DashboardPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DashboardPage.kt
@@ -258,6 +258,12 @@ class DashboardPage : BasePage(R.id.dashboardPage) {
             .perform(click());
     }
 
+    fun openGlobalManageOfflineContentPage() {
+        Espresso.openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getInstrumentation().targetContext)
+        onView(withText(containsString("Manage Offline Content")))
+            .perform(click());
+    }
+
     fun clickEditDashboard() {
         onView(withId(R.id.editDashboardTextView)).scrollTo().click()
     }
@@ -332,6 +338,10 @@ class DashboardPage : BasePage(R.id.dashboardPage) {
 
     fun assertOfflineIndicatorNotDisplayed() {
         onView(withId(R.id.offlineIndicator)).check(matches(withEffectiveVisibility(Visibility.GONE)))
+    }
+
+    fun assertCourseOfflineSyncIcon(courseName: String, visibility: Visibility) {
+        onView(withId(R.id.offlineSyncIcon) + hasSibling(withId(R.id.titleTextView) + withText(courseName))).check(matches(withEffectiveVisibility(visibility)))
     }
 }
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/offline/ManageOfflineContentPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/offline/ManageOfflineContentPage.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.instructure.student.ui.pages.offline
+
+import androidx.test.espresso.matcher.ViewMatchers.hasSibling
+import com.instructure.espresso.OnViewWithId
+import com.instructure.espresso.click
+import com.instructure.espresso.page.BasePage
+import com.instructure.espresso.page.onView
+import com.instructure.espresso.page.plus
+import com.instructure.espresso.page.withId
+import com.instructure.espresso.page.withText
+import com.instructure.pandautils.R
+
+class ManageOfflineContentPage : BasePage(R.id.manageOfflineContentPage) {
+
+    private val toolbar by OnViewWithId(R.id.toolbar)
+
+    fun selectEntireCourseForSync(courseName: String) {
+        onView(withId(R.id.checkbox) + hasSibling(withId(R.id.title) + withText(courseName))).click()
+    }
+
+    fun clickOnSyncButton() {
+        onView(withId(R.id.syncButton)).click()
+    }
+}

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTest.kt
@@ -41,7 +41,65 @@ import com.instructure.student.BuildConfig
 import com.instructure.student.R
 import com.instructure.student.activity.LoginActivity
 import com.instructure.student.espresso.StudentHiltTestApplication_Application
-import com.instructure.student.ui.pages.*
+import com.instructure.student.ui.pages.AboutPage
+import com.instructure.student.ui.pages.AnnotationCommentListPage
+import com.instructure.student.ui.pages.AnnouncementListPage
+import com.instructure.student.ui.pages.AssignmentDetailsPage
+import com.instructure.student.ui.pages.AssignmentListPage
+import com.instructure.student.ui.pages.BookmarkPage
+import com.instructure.student.ui.pages.CalendarEventPage
+import com.instructure.student.ui.pages.CanvasWebViewPage
+import com.instructure.student.ui.pages.ConferenceDetailsPage
+import com.instructure.student.ui.pages.ConferenceListPage
+import com.instructure.student.ui.pages.CourseBrowserPage
+import com.instructure.student.ui.pages.CourseGradesPage
+import com.instructure.student.ui.pages.DashboardPage
+import com.instructure.student.ui.pages.DiscussionDetailsPage
+import com.instructure.student.ui.pages.DiscussionListPage
+import com.instructure.student.ui.pages.EditDashboardPage
+import com.instructure.student.ui.pages.ElementaryCoursePage
+import com.instructure.student.ui.pages.ElementaryDashboardPage
+import com.instructure.student.ui.pages.FileListPage
+import com.instructure.student.ui.pages.FileUploadPage
+import com.instructure.student.ui.pages.GradesPage
+import com.instructure.student.ui.pages.GroupBrowserPage
+import com.instructure.student.ui.pages.HelpPage
+import com.instructure.student.ui.pages.HomeroomPage
+import com.instructure.student.ui.pages.ImportantDatesPage
+import com.instructure.student.ui.pages.InboxConversationPage
+import com.instructure.student.ui.pages.InboxPage
+import com.instructure.student.ui.pages.LeftSideNavigationDrawerPage
+import com.instructure.student.ui.pages.LegalPage
+import com.instructure.student.ui.pages.LoginFindSchoolPage
+import com.instructure.student.ui.pages.LoginLandingPage
+import com.instructure.student.ui.pages.LoginSignInPage
+import com.instructure.student.ui.pages.ModuleProgressionPage
+import com.instructure.student.ui.pages.ModulesPage
+import com.instructure.student.ui.pages.NewMessagePage
+import com.instructure.student.ui.pages.NotificationPage
+import com.instructure.student.ui.pages.PageListPage
+import com.instructure.student.ui.pages.PairObserverPage
+import com.instructure.student.ui.pages.PandaAvatarPage
+import com.instructure.student.ui.pages.PeopleListPage
+import com.instructure.student.ui.pages.PersonDetailsPage
+import com.instructure.student.ui.pages.PickerSubmissionUploadPage
+import com.instructure.student.ui.pages.ProfileSettingsPage
+import com.instructure.student.ui.pages.QRLoginPage
+import com.instructure.student.ui.pages.QuizListPage
+import com.instructure.student.ui.pages.QuizTakingPage
+import com.instructure.student.ui.pages.RemoteConfigSettingsPage
+import com.instructure.student.ui.pages.ResourcesPage
+import com.instructure.student.ui.pages.SchedulePage
+import com.instructure.student.ui.pages.SettingsPage
+import com.instructure.student.ui.pages.ShareExtensionStatusPage
+import com.instructure.student.ui.pages.ShareExtensionTargetPage
+import com.instructure.student.ui.pages.SubmissionDetailsPage
+import com.instructure.student.ui.pages.SyllabusPage
+import com.instructure.student.ui.pages.SyncSettingsPage
+import com.instructure.student.ui.pages.TextSubmissionUploadPage
+import com.instructure.student.ui.pages.TodoPage
+import com.instructure.student.ui.pages.UrlSubmissionUploadPage
+import com.instructure.student.ui.pages.offline.ManageOfflineContentPage
 import dagger.hilt.android.testing.HiltAndroidRule
 import instructure.rceditor.RCETextEditor
 import org.hamcrest.Matcher
@@ -144,6 +202,7 @@ abstract class StudentTest : CanvasTest() {
     val shareExtensionTargetPage = ShareExtensionTargetPage()
     val shareExtensionStatusPage = ShareExtensionStatusPage()
     val syncSettingsPage = SyncSettingsPage()
+    val manageOfflineContentPage = ManageOfflineContentPage()
 
     // A no-op interaction to afford us an easy, harmless way to get a11y checking to trigger.
     fun meaninglessSwipe() {

--- a/libs/pandautils/src/main/res/layout/fragment_offline_content.xml
+++ b/libs/pandautils/src/main/res/layout/fragment_offline_content.xml
@@ -13,6 +13,7 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/manageOfflineContentPage"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 


### PR DESCRIPTION
Implement E2E test case for Offline Dashboard.
Add ManageOfflineContentPage page object.
Add an 'OfflineTestUtils' class as a global 'helper' class.
Add view id to fragment_offline_content.xml.
Create offline package structure.

refs: MBL-17098
affects: Student
release note: none