### PR TITLE
[MBL-17138][Parent] Manage Students settings dialogs are overlapping

### DIFF
--- a/apps/flutter_parent/lib/screens/alert_thresholds/alert_thresholds_percentage_dialog.dart
+++ b/apps/flutter_parent/lib/screens/alert_thresholds/alert_thresholds_percentage_dialog.dart
@@ -77,6 +77,7 @@ class AlertThresholdsPercentageDialogState extends State<AlertThresholdsPercenta
       builder: (context) => ArrowAwareFocusScope(
         node: _focusScopeNode,
         child: AlertDialog(
+          scrollable: true,
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),
           title: Text(widget._alertType.getTitle(context)),
           content: TextFormField(


### PR DESCRIPTION
Test plan: in the ticket

refs: MBL-17138
affects: Parent
release note: none