### PR TITLE
[MBL-17152][Student] - Fix burnt in selectedCount (to 0) to get it from the coursesData

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/offline/offlinecontent/OfflineContentViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/offline/offlinecontent/OfflineContentViewModel.kt
@@ -19,7 +19,11 @@ package com.instructure.pandautils.features.offline.offlinecontent
 
 import android.content.Context
 import android.text.format.Formatter
-import androidx.lifecycle.*
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.models.FileFolder
 import com.instructure.canvasapi2.models.Tab
@@ -40,6 +44,30 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.collections.List
+import kotlin.collections.Map
+import kotlin.collections.MutableSet
+import kotlin.collections.any
+import kotlin.collections.associateBy
+import kotlin.collections.associateWith
+import kotlin.collections.count
+import kotlin.collections.emptyList
+import kotlin.collections.filter
+import kotlin.collections.find
+import kotlin.collections.flatMap
+import kotlin.collections.flatten
+import kotlin.collections.forEach
+import kotlin.collections.listOf
+import kotlin.collections.map
+import kotlin.collections.mapNotNull
+import kotlin.collections.mutableMapOf
+import kotlin.collections.orEmpty
+import kotlin.collections.plus
+import kotlin.collections.putAll
+import kotlin.collections.set
+import kotlin.collections.sumOf
+import kotlin.collections.toList
+import kotlin.collections.toMutableSet
 
 private val ALLOWED_TAB_IDS = CourseSyncSettingsEntity.TABS.plus(Tab.FILES_ID)
 private const val TAB_SIZE = 100000
@@ -98,7 +126,7 @@ class OfflineContentViewModel @Inject constructor(
                 originalSyncSettingsMap.putAll(getCourseSyncSettings(courseMap.values.toList()))
                 courseSelectedFilesMap.putAll(getSelectedFiles(courseMap.values.toList()))
                 val coursesData = createCourseItemViewModels()
-                val data = OfflineContentViewData(storageInfo, coursesData, 0)
+                val data = OfflineContentViewData(storageInfo, coursesData, getSelectedItemCount(coursesData))
                 _data.postValue(data)
                 if (coursesData.isEmpty()) {
                     _state.postValue(


### PR DESCRIPTION
Test plan: Check select/deselect logics (it's in the OfflineContentFragment class, updateMenuText method) that it works well.

refs: MBL-17152
affects: Student
release note: none

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img width="362" src="https://github.com/instructure/canvas-android/assets/92309696/0dabfb39-f1da-4ed5-a77e-44b955e9c03d" height=800></td>
<td>
<img width="362" alt="image" height=800 src="https://github.com/instructure/canvas-android/assets/92309696/2633c830-000f-4f89-bb8b-cc3749a88499"></td>
</tr>
</table>

## Checklist

- [ ] Tested in dark mode
- [ ] Tested in light mode
