### PR TITLE
[MBL-17151][Parent] Manage Student notification dialog new value does not refreshed in list when it's 'Never'

### DIFF
--- a/apps/flutter_parent/lib/screens/alert_thresholds/alert_thresholds_screen.dart
+++ b/apps/flutter_parent/lib/screens/alert_thresholds/alert_thresholds_screen.dart
@@ -270,7 +270,7 @@ class AlertThresholdsState extends State<AlertThresholdsScreen> {
             // Threshold was either deleted or left at 'never'
             if (idx != null && idx != -1) {
               // Threshold exists but was deleted
-              _thresholds?[idx] = null;
+              _thresholds?.removeAt(idx);
             }
           }
         });


### PR DESCRIPTION
Test plan: in the ticket

refs: MBL-17151
affects: Parent
release note: none
