### PR TITLE
[MBL-17175][Parent] Users are seeing error "Uh oh! We're not sure what happened" when opening app or viewing grades

### DIFF
--- a/apps/flutter_parent/lib/models/course_grade.dart
+++ b/apps/flutter_parent/lib/models/course_grade.dart
@@ -69,7 +69,7 @@ class CourseGrade {
   /// If the course contains no valid current grade or score, this flag will be true. This is usually represented in the
   /// UI with "N/A".
   bool noCurrentGrade() =>
-      _getCurrentScore() == null && (currentGrade() == null || currentGrade()!.contains('N/A') || currentGrade()!.isEmpty);
+      currentScore() == null && (currentGrade() == null || currentGrade()!.contains('N/A') || currentGrade()!.isEmpty);
 
   bool _hasActiveGradingPeriod() =>
       !_forceAllPeriods &&


### PR DESCRIPTION
Test plan: in the ticket

refs: MBL-17175
affects: Parent
release note: none