### PR TITLE
[MBL-17184][Student] Apply theme to settings fragment onConfigChange

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/activity/SettingsActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/SettingsActivity.kt
@@ -18,9 +18,11 @@ package com.instructure.student.activity
 
 import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import com.instructure.interactions.FragmentInteractions
 import com.instructure.pandautils.analytics.SCREEN_VIEW_SETTINGS
 import com.instructure.pandautils.analytics.ScreenView
 import com.instructure.pandautils.binding.viewBinding
@@ -50,6 +52,17 @@ class SettingsActivity : AppCompatActivity(){
     }
 
     private val currentFragment: Fragment? get() = supportFragmentManager.fragments.last()
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        applyThemeForAllFragments()
+    }
+
+    private fun applyThemeForAllFragments() {
+        supportFragmentManager.fragments.forEach {
+            (it as? FragmentInteractions)?.applyTheme()
+        }
+    }
 
     fun addFragment(fragment: Fragment) {
         val ft = supportFragmentManager.beginTransaction()

--- a/apps/student/src/main/java/com/instructure/student/fragment/ApplicationSettingsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/ApplicationSettingsFragment.kt
@@ -28,7 +28,6 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import com.instructure.canvasapi2.utils.*
 import com.instructure.canvasapi2.utils.pageview.PageView
-import com.instructure.loginapi.login.dialog.NoInternetConnectionDialog
 import com.instructure.pandautils.analytics.SCREEN_VIEW_APPLICATION_SETTINGS
 import com.instructure.pandautils.analytics.ScreenView
 import com.instructure.pandautils.binding.viewBinding


### PR DESCRIPTION
refs: MBL-17184
affects: Student
release note: Fixed a bug where the theme of the settings page would not update.

test plan: See ticket.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-android/assets/72087159/fd3424d0-d9a7-443d-90a8-c29bc47b137b"></td>
<td><img src="https://github.com/instructure/canvas-android/assets/72087159/427fe128-1469-4e26-b47c-3cb8f8cf0413"></td>
</tr>
</table>