### PR TITLE
Nightly - Offline - Attempt to fix CI UnknownHostException.

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/ManageOfflineContentE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/ManageOfflineContentE2ETest.kt
@@ -24,7 +24,6 @@ import com.instructure.panda_annotations.FeatureCategory
 import com.instructure.panda_annotations.Priority
 import com.instructure.panda_annotations.TestCategory
 import com.instructure.panda_annotations.TestMetaData
-import com.instructure.student.ui.e2e.offline.utils.OfflineTestUtils
 import com.instructure.student.ui.utils.StudentTest
 import com.instructure.student.ui.utils.seedData
 import com.instructure.student.ui.utils.tokenLogin
@@ -197,7 +196,7 @@ class ManageOfflineContentE2ETest : StudentTest() {
         dashboardPage.waitForSyncProgressStartingNotificationToDisappear()
 
         Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
-        OfflineTestUtils.turnOffConnectionViaADB()
+        turnOffConnectionViaADB()
         dashboardPage.waitForRender()
 
         Log.d(STEP_TAG, "Select '${course2.name}' course and open 'Grades' menu to check if it's really synced and can be seen in offline mode.")
@@ -211,7 +210,7 @@ class ManageOfflineContentE2ETest : StudentTest() {
     @After
     fun tearDown() {
         Log.d(PREPARATION_TAG, "Turn back on the Wi-Fi and Mobile Data on the device via ADB, so it will come back online.")
-        OfflineTestUtils.turnOnConnectionViaADB()
+        turnOnConnectionViaADB()
     }
 
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineCourseBrowserE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineCourseBrowserE2ETest.kt
@@ -25,7 +25,6 @@ import com.instructure.panda_annotations.FeatureCategory
 import com.instructure.panda_annotations.Priority
 import com.instructure.panda_annotations.TestCategory
 import com.instructure.panda_annotations.TestMetaData
-import com.instructure.student.ui.e2e.offline.utils.OfflineTestUtils
 import com.instructure.student.ui.pages.CourseBrowserPage
 import com.instructure.student.ui.utils.StudentTest
 import com.instructure.student.ui.utils.seedData
@@ -75,7 +74,7 @@ class OfflineCourseBrowserE2ETest : StudentTest() {
         dashboardPage.waitForSyncProgressStartingNotificationToDisappear()
 
         Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
-        OfflineTestUtils.turnOffConnectionViaADB()
+        turnOffConnectionViaADB()
 
         Log.d(STEP_TAG, "Wait for the Dashboard Page to be rendered. Refresh the page.")
         dashboardPage.waitForRender()
@@ -92,7 +91,7 @@ class OfflineCourseBrowserE2ETest : StudentTest() {
 
         Log.d(STEP_TAG, "Navigate back to Dashboard Page.Turn back on the Wi-Fi and Mobile Data on the device, and wait for it to come online.")
         Espresso.pressBack()
-        OfflineTestUtils.turnOnConnectionViaADB()
+        turnOnConnectionViaADB()
         dashboardPage.waitForNetworkComeBack()
 
         Log.d(STEP_TAG, "Open global 'Manage Offline Content' page via the more menu of the Dashboard Page.")
@@ -112,7 +111,7 @@ class OfflineCourseBrowserE2ETest : StudentTest() {
         dashboardPage.waitForSyncProgressStartingNotificationToDisappear()
 
         Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
-        OfflineTestUtils.turnOffConnectionViaADB()
+        turnOffConnectionViaADB()
 
         Log.d(STEP_TAG, "Select '${course1.name}' course and open 'Announcements' menu.")
         sleep(10000) //Need to wait a bit here because of a UI glitch that when network state change, the dashboard page 'pops' a bit and it can confuse the automation script.
@@ -130,7 +129,7 @@ class OfflineCourseBrowserE2ETest : StudentTest() {
     @After
     fun tearDown() {
         Log.d(PREPARATION_TAG, "Turn back on the Wi-Fi and Mobile Data on the device, so it will come back online.")
-        OfflineTestUtils.turnOnConnectionViaADB()
+        turnOnConnectionViaADB()
     }
 
     private fun assertTabsEnabled(courseBrowserPage: CourseBrowserPage, tabs: Array<String>) {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineDashboardE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineDashboardE2ETest.kt
@@ -75,7 +75,7 @@ class OfflineDashboardE2ETest : StudentTest() {
         dashboardPage.waitForSyncProgressStartingNotificationToDisappear()
 
         Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
-        OfflineTestUtils.turnOffConnectionViaADB()
+        turnOffConnectionViaADB()
         device.waitForIdle()
 
         Log.d(STEP_TAG, "Wait for the Dashboard Page to be rendered. Refresh the page.")
@@ -130,7 +130,7 @@ class OfflineDashboardE2ETest : StudentTest() {
         dashboardPage.waitForSyncProgressStartingNotificationToDisappear()
 
         Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
-        OfflineTestUtils.turnOffConnectionViaADB()
+        turnOffConnectionViaADB()
         device.waitForIdle()
 
         Log.d(STEP_TAG, "Wait for the Dashboard Page to be rendered. Refresh the page.")
@@ -157,7 +157,7 @@ class OfflineDashboardE2ETest : StudentTest() {
     @After
     fun tearDown() {
         Log.d(PREPARATION_TAG, "Turn back on the Wi-Fi and Mobile Data on the device, so it will come back online.")
-        OfflineTestUtils.turnOnConnectionViaADB()
+        turnOnConnectionViaADB()
     }
 
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineSyncProgressE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineSyncProgressE2ETest.kt
@@ -80,7 +80,7 @@ class OfflineSyncProgressE2ETest : StudentTest() {
         Espresso.pressBack()
 
         Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
-        OfflineTestUtils.turnOffConnectionViaADB()
+        turnOffConnectionViaADB()
         dashboardPage.waitForRender()
 
         Log.d(STEP_TAG, "Assert that the Offline Indicator (bottom banner) is displayed on the Dashboard Page.")
@@ -101,7 +101,7 @@ class OfflineSyncProgressE2ETest : StudentTest() {
     @After
     fun tearDown() {
         Log.d(PREPARATION_TAG, "Turn back on the Wi-Fi and Mobile Data on the device via ADB, so it will come back online.")
-        OfflineTestUtils.turnOnConnectionViaADB()
+        turnOnConnectionViaADB()
     }
 
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineSyncSettingsE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineSyncSettingsE2ETest.kt
@@ -23,7 +23,6 @@ import com.instructure.panda_annotations.Priority
 import com.instructure.panda_annotations.TestCategory
 import com.instructure.panda_annotations.TestMetaData
 import com.instructure.pandautils.R
-import com.instructure.student.ui.e2e.offline.utils.OfflineTestUtils
 import com.instructure.student.ui.utils.StudentTest
 import com.instructure.student.ui.utils.ViewUtils
 import com.instructure.student.ui.utils.seedData
@@ -139,7 +138,7 @@ class OfflineSyncSettingsE2ETest : StudentTest() {
     @After
     fun tearDown() {
         Log.d(PREPARATION_TAG, "Turn back on the Wi-Fi and Mobile Data on the device via ADB, so it will come back online.")
-        OfflineTestUtils.turnOnConnectionViaADB()
+        turnOnConnectionViaADB()
     }
 
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/utils/OfflineTestUtils.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/utils/OfflineTestUtils.kt
@@ -31,24 +31,6 @@ import org.hamcrest.CoreMatchers.allOf
 
 object OfflineTestUtils {
 
-    private const val ENABLE_WIFI_COMMAND: String = "svc wifi enable"
-    private const val DISABLE_WIFI_COMMAND: String = "svc wifi disable"
-
-    private const val ENABLE_MOBILE_DATA_COMMAND: String = "svc data enable"
-    private const val DISABLE_MOBILE_DATA_COMMAND: String = "svc data disable"
-
-    fun turnOffConnectionViaADB() {
-        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        device.executeShellCommand(DISABLE_WIFI_COMMAND)
-        device.executeShellCommand(DISABLE_MOBILE_DATA_COMMAND)
-    }
-
-    fun turnOnConnectionViaADB() {
-        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        device.executeShellCommand(ENABLE_WIFI_COMMAND)
-        device.executeShellCommand(ENABLE_MOBILE_DATA_COMMAND)
-    }
-
     fun turnOffConnectionOnUI() {
         val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 

--- a/automation/espresso/build.gradle
+++ b/automation/espresso/build.gradle
@@ -45,7 +45,7 @@ android {
     buildToolsVersion '28.0.3'
 
     defaultConfig {
-        minSdkVersion 17
+        minSdkVersion 24
         targetSdkVersion 28
     }
 

--- a/automation/espresso/src/main/AndroidManifest.xml
+++ b/automation/espresso/src/main/AndroidManifest.xml
@@ -20,6 +20,8 @@
     package="com.instructure.espresso">
 
     <uses-sdk tools:overrideLibrary="android.support.test.uiautomator.v18" />
+
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasTest.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasTest.kt
@@ -21,6 +21,9 @@ import android.app.Activity
 import android.content.Context
 import android.content.res.Configuration
 import android.content.res.Resources
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
 import android.os.Build
 import android.os.Environment
 import android.util.DisplayMetrics
@@ -31,6 +34,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
+import androidx.test.uiautomator.UiDevice
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheckNames
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesViews
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityViewCheckResult
@@ -74,6 +78,8 @@ abstract class CanvasTest : InstructureTestingContract {
 
     var extraAccessibilitySupressions: Matcher<in AccessibilityViewCheckResult>? = Matchers.anyOf()
 
+    val connectivityManager = InstrumentationRegistry.getInstrumentation().context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
     @Rule(order = 1)
     override fun chain(): TestRule {
         return RuleChain
@@ -107,70 +113,20 @@ abstract class CanvasTest : InstructureTestingContract {
             // Only continue if we're on Bitrise
             // (More accurately, if we are on FTL launched from Bitrise.)
             if(splunkToken != null && !splunkToken.isEmpty()) {
-                val bitriseWorkflow = InstrumentationRegistry.getArguments().getString("BITRISE_TRIGGERED_WORKFLOW_ID")
-                val bitriseApp = InstrumentationRegistry.getArguments().getString("BITRISE_APP_TITLE")
-                val bitriseBranch = InstrumentationRegistry.getArguments().getString("BITRISE_GIT_BRANCH")
-                val bitriseBuildNumber = InstrumentationRegistry.getArguments().getString("BITRISE_BUILD_NUMBER")
+                 val networkCapabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+                val hasActiveNetwork = networkCapabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) ?: false
 
-                val eventObject = JSONObject()
-                eventObject.put("workflow", bitriseWorkflow)
-                eventObject.put("branch", bitriseBranch)
-                eventObject.put("bitriseApp", bitriseApp)
-                eventObject.put("status", disposition)
-                eventObject.put("testName", testMethod)
-                eventObject.put("testClass", testClass)
-                eventObject.put("stackTrace", error.stackTrace.take(15).joinToString(", "))
-                eventObject.put("osVersion", Build.VERSION.SDK_INT.toString())
-                // Limit our error message to 4096 chars; they can be unreasonably long (e.g., 137K!) when
-                // they contain a view hierarchy, and there is typically not much useful info after the
-                // first few lines.
-                eventObject.put("message", error.toString().take(4096))
-
-                val payloadObject = JSONObject()
-                payloadObject.put("sourcetype", "mobile-android-qa-testresult")
-                payloadObject.put("event", eventObject)
-
-                val payload = payloadObject.toString()
-                Log.d("CanvasTest", "payload = $payload")
-
-                // Can't run a curl command from FTL, so let's do this the hard way
-                var os : OutputStream? = null
-                var inputStream : InputStream? = null
-                var conn : HttpURLConnection? = null
-
-                try {
-
-                    // Set up our url/connection
-                    val url = URL("https://http-inputs-inst.splunkcloud.com:443/services/collector")
-                    conn = url.openConnection() as HttpURLConnection
-                    conn.requestMethod = "POST"
-                    conn.setRequestProperty("Authorization", "Splunk $splunkToken")
-                    conn.setRequestProperty("Content-Type", "application/json; utf-8")
-                    conn.setRequestProperty("Accept", "application/json")
-                    conn.setDoInput(true)
-                    conn.setDoOutput(true)
-
-                    // Connect
-                    conn.connect()
-
-                    // Send out our post body
-                    os = BufferedOutputStream(conn.outputStream)
-                    os.write(payload.toByteArray())
-                    os.flush()
-
-                    // Report the result summary
-                    Log.d("CanvasTest", "Response code: ${conn.responseCode}, message: ${conn.responseMessage}")
-
-                    // Report the splunk result JSON
-                    inputStream = conn.inputStream
-                    val content = inputStream.bufferedReader().use(BufferedReader::readText)
-                    Log.d("CanvasTest", "Response: $content")
-                }
-                finally {
-                    // Clean up our mess
-                    if(os != null) os.close()
-                    if(inputStream != null) inputStream.close()
-                    if(conn != null) conn.disconnect()
+                if (hasActiveNetwork) {
+                    reportToSplunk(disposition, testMethod, testClass, error, splunkToken)
+                } else {
+                    turnOnConnectionViaADB()
+                    connectivityManager.registerDefaultNetworkCallback(object : ConnectivityManager.NetworkCallback() {
+                        override fun onAvailable(network: Network) {
+                            super.onAvailable(network)
+                            connectivityManager.unregisterNetworkCallback(this)
+                            reportToSplunk(disposition, testMethod, testClass, error, splunkToken)
+                        }
+                    })
                 }
 
             }
@@ -179,6 +135,84 @@ abstract class CanvasTest : InstructureTestingContract {
             }
         })
 
+    }
+
+    private fun reportToSplunk(
+        disposition: String,
+        testMethod: String,
+        testClass: String,
+        error: Throwable,
+        splunkToken: String?
+    ) {
+        val bitriseWorkflow =
+            InstrumentationRegistry.getArguments().getString("BITRISE_TRIGGERED_WORKFLOW_ID")
+        val bitriseApp = InstrumentationRegistry.getArguments().getString("BITRISE_APP_TITLE")
+        val bitriseBranch = InstrumentationRegistry.getArguments().getString("BITRISE_GIT_BRANCH")
+        val bitriseBuildNumber =
+            InstrumentationRegistry.getArguments().getString("BITRISE_BUILD_NUMBER")
+
+        val eventObject = JSONObject()
+        eventObject.put("workflow", bitriseWorkflow)
+        eventObject.put("branch", bitriseBranch)
+        eventObject.put("bitriseApp", bitriseApp)
+        eventObject.put("status", disposition)
+        eventObject.put("testName", testMethod)
+        eventObject.put("testClass", testClass)
+        eventObject.put("stackTrace", error.stackTrace.take(15).joinToString(", "))
+        eventObject.put("osVersion", Build.VERSION.SDK_INT.toString())
+        // Limit our error message to 4096 chars; they can be unreasonably long (e.g., 137K!) when
+        // they contain a view hierarchy, and there is typically not much useful info after the
+        // first few lines.
+        eventObject.put("message", error.toString().take(4096))
+
+        val payloadObject = JSONObject()
+        payloadObject.put("sourcetype", "mobile-android-qa-testresult")
+        payloadObject.put("event", eventObject)
+
+        val payload = payloadObject.toString()
+        Log.d("CanvasTest", "payload = $payload")
+
+        // Can't run a curl command from FTL, so let's do this the hard way
+        var os: OutputStream? = null
+        var inputStream: InputStream? = null
+        var conn: HttpURLConnection? = null
+
+        try {
+
+            // Set up our url/connection
+            val url = URL("https://http-inputs-inst.splunkcloud.com:443/services/collector")
+            conn = url.openConnection() as HttpURLConnection
+            conn.requestMethod = "POST"
+            conn.setRequestProperty("Authorization", "Splunk $splunkToken")
+            conn.setRequestProperty("Content-Type", "application/json; utf-8")
+            conn.setRequestProperty("Accept", "application/json")
+            conn.setDoInput(true)
+            conn.setDoOutput(true)
+
+            // Connect
+            conn.connect()
+
+            // Send out our post body
+            os = BufferedOutputStream(conn.outputStream)
+            os.write(payload.toByteArray())
+            os.flush()
+
+            // Report the result summary
+            Log.d(
+                "CanvasTest",
+                "Response code: ${conn.responseCode}, message: ${conn.responseMessage}"
+            )
+
+            // Report the splunk result JSON
+            inputStream = conn.inputStream
+            val content = inputStream.bufferedReader().use(BufferedReader::readText)
+            Log.d("CanvasTest", "Response: $content")
+        } finally {
+            // Clean up our mess
+            if (os != null) os.close()
+            if (inputStream != null) inputStream.close()
+            if (conn != null) conn.disconnect()
+        }
     }
 
     // Creates an /sdcard/coverage folder if it does not already exist.
@@ -464,6 +498,12 @@ abstract class CanvasTest : InstructureTestingContract {
 
         private var configChecked = false
 
+        val ENABLE_WIFI_COMMAND: String = "svc wifi enable"
+        val DISABLE_WIFI_COMMAND: String = "svc wifi disable"
+
+        val ENABLE_MOBILE_DATA_COMMAND: String = "svc data enable"
+        val DISABLE_MOBILE_DATA_COMMAND: String = "svc data disable"
+
         private fun getDeviceOrientation(context: Context): Int {
             val configuration = context.resources.configuration
             return configuration.orientation
@@ -481,6 +521,19 @@ abstract class CanvasTest : InstructureTestingContract {
         fun isLowResDevice() : Boolean {
             return ApplicationProvider.getApplicationContext<Context?>().resources.displayMetrics.densityDpi < DisplayMetrics.DENSITY_HIGH
         }
+
+        fun turnOffConnectionViaADB() {
+            val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+            device.executeShellCommand(DISABLE_WIFI_COMMAND)
+            device.executeShellCommand(DISABLE_MOBILE_DATA_COMMAND)
+        }
+
+        fun turnOnConnectionViaADB() {
+            val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+            device.executeShellCommand(ENABLE_WIFI_COMMAND)
+            device.executeShellCommand(ENABLE_MOBILE_DATA_COMMAND)
+        }
+
     }
 
 }

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasTest.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/CanvasTest.kt
@@ -498,11 +498,11 @@ abstract class CanvasTest : InstructureTestingContract {
 
         private var configChecked = false
 
-        val ENABLE_WIFI_COMMAND: String = "svc wifi enable"
-        val DISABLE_WIFI_COMMAND: String = "svc wifi disable"
+        private const val ENABLE_WIFI_COMMAND: String = "svc wifi enable"
+        private const val DISABLE_WIFI_COMMAND: String = "svc wifi disable"
 
-        val ENABLE_MOBILE_DATA_COMMAND: String = "svc data enable"
-        val DISABLE_MOBILE_DATA_COMMAND: String = "svc data disable"
+        private const val ENABLE_MOBILE_DATA_COMMAND: String = "svc data enable"
+        private const val DISABLE_MOBILE_DATA_COMMAND: String = "svc data disable"
 
         private fun getDeviceOrientation(context: Context): Int {
             val configuration = context.resources.configuration


### PR DESCRIPTION
java.net.UnknownHostException: Unable to resolve host "http-inputs-inst.splunkcloud.com": No address associated with hostname

Probably the issue was that the device was offline when the test has failed so it cannot open the connection for the Splunk URL.