### PR TITLE
[MBL-17256][All] - Change the Privacy Policy URL

### DIFF
--- a/apps/flutter_parent/lib/screens/account_creation/account_creation_interactor.dart
+++ b/apps/flutter_parent/lib/screens/account_creation/account_creation_interactor.dart
@@ -35,6 +35,6 @@ class AccountCreationInteractor {
   }
 
   launchPrivacyPolicy() {
-    locator<UrlLauncher>().launch('https://www.instructure.com/privacy-security');
+    locator<UrlLauncher>().launch('https://www.instructure.com/policies/product-privacy-policy);
   }
 }

--- a/apps/flutter_parent/lib/screens/account_creation/account_creation_interactor.dart
+++ b/apps/flutter_parent/lib/screens/account_creation/account_creation_interactor.dart
@@ -35,6 +35,6 @@ class AccountCreationInteractor {
   }
 
   launchPrivacyPolicy() {
-    locator<UrlLauncher>().launch('https://www.instructure.com/canvas/privacy');
+    locator<UrlLauncher>().launch('https://www.instructure.com/privacy-security');
   }
 }

--- a/apps/flutter_parent/lib/screens/account_creation/account_creation_interactor.dart
+++ b/apps/flutter_parent/lib/screens/account_creation/account_creation_interactor.dart
@@ -35,6 +35,6 @@ class AccountCreationInteractor {
   }
 
   launchPrivacyPolicy() {
-    locator<UrlLauncher>().launch('https://www.instructure.com/policies/product-privacy-policy);
+    locator<UrlLauncher>().launch('https://www.instructure.com/policies/product-privacy-policy');
   }
 }

--- a/apps/flutter_parent/lib/screens/settings/legal_screen.dart
+++ b/apps/flutter_parent/lib/screens/settings/legal_screen.dart
@@ -34,7 +34,7 @@ class LegalScreen extends StatelessWidget {
           children: <Widget>[
             _LegalRow(
               label: l10n.privacyPolicy,
-              onTap: () => locator<UrlLauncher>().launch('https://www.instructure.com/privacy-security'),
+              onTap: () => locator<UrlLauncher>().launch('https://www.instructure.com/policies/product-privacy-policy'),
               icon: CanvasIcons.admin,
             ),
             _LegalRow(

--- a/apps/flutter_parent/lib/screens/settings/legal_screen.dart
+++ b/apps/flutter_parent/lib/screens/settings/legal_screen.dart
@@ -34,7 +34,7 @@ class LegalScreen extends StatelessWidget {
           children: <Widget>[
             _LegalRow(
               label: l10n.privacyPolicy,
-              onTap: () => locator<UrlLauncher>().launch('https://www.instructure.com/canvas/privacy'),
+              onTap: () => locator<UrlLauncher>().launch('https://www.instructure.com/privacy-security'),
               icon: CanvasIcons.admin,
             ),
             _LegalRow(

--- a/apps/flutter_parent/test/screens/account_creation/account_creation_interactor_test.dart
+++ b/apps/flutter_parent/test/screens/account_creation/account_creation_interactor_test.dart
@@ -57,7 +57,7 @@ void main() {
   test('launchPrivacyPolicy calls the url launcher', () {
     AccountCreationInteractor().launchPrivacyPolicy();
     verify(
-      launcher.launch('https://www.instructure.com/privacy-security'),
+      launcher.launch('https://www.instructure.com/policies/product-privacy-policy'),
     ).called(1);
   });
 }

--- a/apps/flutter_parent/test/screens/account_creation/account_creation_interactor_test.dart
+++ b/apps/flutter_parent/test/screens/account_creation/account_creation_interactor_test.dart
@@ -57,7 +57,7 @@ void main() {
   test('launchPrivacyPolicy calls the url launcher', () {
     AccountCreationInteractor().launchPrivacyPolicy();
     verify(
-      launcher.launch('https://www.instructure.com/canvas/privacy'),
+      launcher.launch('https://www.instructure.com/privacy-security'),
     ).called(1);
   });
 }

--- a/apps/flutter_parent/test/screens/settings/legal_screen_test.dart
+++ b/apps/flutter_parent/test/screens/settings/legal_screen_test.dart
@@ -47,7 +47,7 @@ void main() {
     await tester.tap(find.text(l10n.privacyPolicy));
     await tester.pumpAndSettle();
 
-    verify(mockLauncher.launch('https://www.instructure.com/canvas/privacy')).called(1);
+    verify(mockLauncher.launch('https://www.instructure.com/privacy-security')).called(1);
   });
 
   testWidgetsWithAccessibilityChecks('tapping github launches url', (tester) async {

--- a/apps/flutter_parent/test/screens/settings/legal_screen_test.dart
+++ b/apps/flutter_parent/test/screens/settings/legal_screen_test.dart
@@ -47,7 +47,7 @@ void main() {
     await tester.tap(find.text(l10n.privacyPolicy));
     await tester.pumpAndSettle();
 
-    verify(mockLauncher.launch('https://www.instructure.com/privacy-security')).called(1);
+    verify(mockLauncher.launch('https://www.instructure.com/policies/product-privacy-policy')).called(1);
   });
 
   testWidgetsWithAccessibilityChecks('tapping github launches url', (tester) async {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/SettingsInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/SettingsInteractionTest.kt
@@ -96,7 +96,7 @@ class SettingsInteractionTest : StudentTest() {
         settingsPage.openLegalPage()
         legalPage.openPrivacyPolicy()
         canvasWebViewPage.acceptCookiePolicyIfNecessary()
-        canvasWebViewPage.checkWebViewURL("https://www.instructure.com/privacy-security")
+        canvasWebViewPage.checkWebViewURL("https://www.instructure.com/policies/product-privacy-policy")
 
     }
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/SettingsInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/SettingsInteractionTest.kt
@@ -96,7 +96,7 @@ class SettingsInteractionTest : StudentTest() {
         settingsPage.openLegalPage()
         legalPage.openPrivacyPolicy()
         canvasWebViewPage.acceptCookiePolicyIfNecessary()
-        canvasWebViewPage.checkWebViewURL("https://www.instructure.com/canvas/privacy")
+        canvasWebViewPage.checkWebViewURL("https://www.instructure.com/privacy-security")
 
     }
 

--- a/apps/student/src/main/java/com/instructure/student/dialog/LegalDialogStyled.kt
+++ b/apps/student/src/main/java/com/instructure/student/dialog/LegalDialogStyled.kt
@@ -87,7 +87,7 @@ class LegalDialogStyled : AppCompatDialogFragment() {
         }
 
         binding.privacyPolicy.onClick {
-            val intent = InternalWebViewActivity.createIntent(activity, "https://www.instructure.com/canvas/privacy", getString(R.string.privacyPolicy), false)
+            val intent = InternalWebViewActivity.createIntent(activity, "https://www.instructure.com/privacy-security", getString(R.string.privacyPolicy), false)
             requireContext().startActivity(intent)
             dialog?.dismiss()
         }

--- a/apps/student/src/main/java/com/instructure/student/dialog/LegalDialogStyled.kt
+++ b/apps/student/src/main/java/com/instructure/student/dialog/LegalDialogStyled.kt
@@ -87,7 +87,7 @@ class LegalDialogStyled : AppCompatDialogFragment() {
         }
 
         binding.privacyPolicy.onClick {
-            val intent = InternalWebViewActivity.createIntent(activity, "https://www.instructure.com/privacy-security", getString(R.string.privacyPolicy), false)
+            val intent = InternalWebViewActivity.createIntent(activity, "https://www.instructure.com/policies/product-privacy-policy", getString(R.string.privacyPolicy), false)
             requireContext().startActivity(intent)
             dialog?.dismiss()
         }

--- a/apps/teacher/src/main/java/com/instructure/teacher/dialog/LegalDialog.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/dialog/LegalDialog.kt
@@ -85,7 +85,7 @@ class LegalDialog : AppCompatDialogFragment() {
         }
 
         binding.privacyPolicy.setOnClickListener {
-            val intent = InternalWebViewActivity.createIntent(requireActivity(), "https://www.instructure.com/canvas/privacy", getString(R.string.privacyPolicy), false)
+            val intent = InternalWebViewActivity.createIntent(requireActivity(), "https://www.instructure.com/privacy-security", getString(R.string.privacyPolicy), false)
             requireActivity().startActivity(intent)
             dialog.dismiss()
         }

--- a/apps/teacher/src/main/java/com/instructure/teacher/dialog/LegalDialog.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/dialog/LegalDialog.kt
@@ -85,7 +85,7 @@ class LegalDialog : AppCompatDialogFragment() {
         }
 
         binding.privacyPolicy.setOnClickListener {
-            val intent = InternalWebViewActivity.createIntent(requireActivity(), "https://www.instructure.com/privacy-security", getString(R.string.privacyPolicy), false)
+            val intent = InternalWebViewActivity.createIntent(requireActivity(), "https://www.instructure.com/policies/product-privacy-policy", getString(R.string.privacyPolicy), false)
             requireActivity().startActivity(intent)
             dialog.dismiss()
         }


### PR DESCRIPTION
Change the Privacy Policy URL from "https://www.instructure.com/canvas/privacy" to "https://www.instructure.com/privacy-security", since it seems like it has changed on the web and the old one only has alias on it.

Test plan: Check if the changed URL works in all the apps.

refs: MBL-17256
affects: Student, Teacher, Parent
release note: Change Privacy Policy URL in all apps.

- [x] Tested in dark mode
- [x] Tested in light mode
