### PR TITLE
[MBL-17250][Student] - Add Selection to the EditTextDialog

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/dialog/EditTextDialog.kt
+++ b/apps/student/src/main/java/com/instructure/student/dialog/EditTextDialog.kt
@@ -68,8 +68,7 @@ class EditTextDialog : AppCompatDialogFragment() {
         binding.textInput.setText(mDefaultText)
 
         val endIndex = mDefaultText.lastIndexOf(".")
-        if (endIndex != -1) binding.textInput.setSelection(0, endIndex)
-        else binding.textInput.selectAll()
+        if (endIndex != -1) binding.textInput.setSelection(0, endIndex) else binding.textInput.selectAll()
         binding.textInput.requestFocus()
 
         val dialog = AlertDialog.Builder(requireContext())

--- a/apps/student/src/main/java/com/instructure/student/dialog/EditTextDialog.kt
+++ b/apps/student/src/main/java/com/instructure/student/dialog/EditTextDialog.kt
@@ -68,8 +68,8 @@ class EditTextDialog : AppCompatDialogFragment() {
         binding.textInput.setText(mDefaultText)
 
         val endIndex = mDefaultText.lastIndexOf(".")
-        if(endIndex == -1) binding.textInput.selectAll()
-        else binding.textInput.setSelection(0, endIndex)
+        if (endIndex != -1) binding.textInput.setSelection(0, endIndex)
+        else binding.textInput.selectAll()
         binding.textInput.requestFocus()
 
         val dialog = AlertDialog.Builder(requireContext())

--- a/apps/student/src/main/java/com/instructure/student/dialog/EditTextDialog.kt
+++ b/apps/student/src/main/java/com/instructure/student/dialog/EditTextDialog.kt
@@ -66,7 +66,11 @@ class EditTextDialog : AppCompatDialogFragment() {
 
         ViewStyler.themeEditText(requireContext(), binding.textInput, ThemePrefs.brandColor)
         binding.textInput.setText(mDefaultText)
-        binding.textInput.selectAll()
+
+        val endIndex = mDefaultText.lastIndexOf(".")
+        if(endIndex == -1) binding.textInput.selectAll()
+        else binding.textInput.setSelection(0, endIndex)
+        binding.textInput.requestFocus()
 
         val dialog = AlertDialog.Builder(requireContext())
             .setCancelable(true)

--- a/apps/student/src/main/java/com/instructure/student/dialog/EditTextDialog.kt
+++ b/apps/student/src/main/java/com/instructure/student/dialog/EditTextDialog.kt
@@ -68,7 +68,11 @@ class EditTextDialog : AppCompatDialogFragment() {
         binding.textInput.setText(mDefaultText)
 
         val endIndex = mDefaultText.lastIndexOf(".")
-        if (endIndex != -1) binding.textInput.setSelection(0, endIndex) else binding.textInput.selectAll()
+        if (endIndex != -1) {
+            binding.textInput.setSelection(0, endIndex)
+        } else {
+            binding.textInput.selectAll()
+        }
         binding.textInput.requestFocus()
 
         val dialog = AlertDialog.Builder(requireContext())

--- a/apps/student/src/main/java/com/instructure/student/features/files/list/FileListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/files/list/FileListFragment.kt
@@ -404,20 +404,19 @@ class FileListFragment : ParentFragment(), Bookmarkable, FileUploadDialogParent 
 
     private fun renameItem(item: FileFolder) {
         val title = getString(if (item.isFile) R.string.renameFile else R.string.renameFolder)
-        val fileExtension = item.displayName?.let { if ('.' in it) it.substringAfterLast(".") else null }
-        EditTextDialog.show(requireFragmentManager(), title, item.displayName?.substringBeforeLast(".")
-            ?: item.name ?: "") { it ->
+        EditTextDialog.show(parentFragmentManager, title, item.displayName ?: item.name ?: "") {
             if (it.isBlank()) {
                 toast(R.string.blankName)
                 return@show
             }
             tryWeave {
+                val body = UpdateFileFolder(name = it)
                 val updateItem: FileFolder = if (item.isFile) {
-                    val body: UpdateFileFolder = if(fileExtension != null) UpdateFileFolder(name = "${it}.${fileExtension}")
-                    else UpdateFileFolder(name = it)
+                    //val body: UpdateFileFolder = if(fileExtension != null) UpdateFileFolder(name = "${it}.${fileExtension}")
+                    //else UpdateFileFolder(name = it)
                     awaitApi { FileFolderManager.updateFile(item.id, body, it) }
                 } else {
-                    val body = UpdateFileFolder(name = it)
+                   // val body = UpdateFileFolder(name = it)
                     awaitApi { FileFolderManager.updateFolder(item.id, body, it) }
                 }
                 recyclerAdapter?.add(updateItem)

--- a/apps/student/src/main/java/com/instructure/student/features/files/list/FileListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/files/list/FileListFragment.kt
@@ -404,7 +404,7 @@ class FileListFragment : ParentFragment(), Bookmarkable, FileUploadDialogParent 
 
     private fun renameItem(item: FileFolder) {
         val title = getString(if (item.isFile) R.string.renameFile else R.string.renameFolder)
-        EditTextDialog.show(parentFragmentManager, title, item.displayName ?: item.name ?: "") {
+        EditTextDialog.show(requireFragmentManager(), title, item.displayName ?: item.name ?: "") {
             if (it.isBlank()) {
                 toast(R.string.blankName)
                 return@show

--- a/apps/student/src/main/java/com/instructure/student/features/files/list/FileListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/files/list/FileListFragment.kt
@@ -412,11 +412,8 @@ class FileListFragment : ParentFragment(), Bookmarkable, FileUploadDialogParent 
             tryWeave {
                 val body = UpdateFileFolder(name = it)
                 val updateItem: FileFolder = if (item.isFile) {
-                    //val body: UpdateFileFolder = if(fileExtension != null) UpdateFileFolder(name = "${it}.${fileExtension}")
-                    //else UpdateFileFolder(name = it)
                     awaitApi { FileFolderManager.updateFile(item.id, body, it) }
                 } else {
-                   // val body = UpdateFileFolder(name = it)
                     awaitApi { FileFolderManager.updateFolder(item.id, body, it) }
                 }
                 recyclerAdapter?.add(updateItem)


### PR DESCRIPTION
Test plan: Smoke test file renaming and edit username dialogs.

Add Selection to EditTextDialog (it's used in profile settings as well).
Request focus to make the selection visible for users.
Handle that folder names (which does not contain '.' character) should be entirely selected.

refs: MBL-1725
affects: Student
release note: Add selection to file name within the file renaming dialog and profile settings edit username dialog

## Checklist

- [x] Tested in dark mode
- [x] Tested in light mode
