### PR TITLE
[MBL-17041][Teacher] - Extend People E2E test with filter by (user) groups

### DIFF
--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/PeopleE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/PeopleE2ETest.kt
@@ -19,6 +19,7 @@ package com.instructure.teacher.ui.e2e
 import android.util.Log
 import androidx.test.espresso.Espresso
 import com.instructure.canvas.espresso.E2E
+import com.instructure.dataseeding.api.GroupsApi
 import com.instructure.dataseeding.api.SubmissionsApi
 import com.instructure.dataseeding.model.AssignmentApiModel
 import com.instructure.dataseeding.model.CanvasUserApiModel
@@ -41,6 +42,7 @@ import com.instructure.teacher.ui.utils.seedData
 import com.instructure.teacher.ui.utils.tokenLogin
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Test
+import java.lang.Thread.sleep
 
 @HiltAndroidTest
 class PeopleE2ETest: TeacherTest() {
@@ -60,6 +62,18 @@ class PeopleE2ETest: TeacherTest() {
         val gradedStudent = data.studentsList[1]
         val course = data.coursesList[0]
         val parent = data.parentsList[0]
+
+        Log.d(PREPARATION_TAG,"Seed some group info.")
+        val groupCategory = GroupsApi.createCourseGroupCategory(data.coursesList[0].id, teacher.token)
+        val groupCategory2 = GroupsApi.createCourseGroupCategory(data.coursesList[0].id, teacher.token)
+        val group = GroupsApi.createGroup(groupCategory.id, teacher.token)
+        val group2 = GroupsApi.createGroup(groupCategory2.id, teacher.token)
+
+        Log.d(PREPARATION_TAG,"Create group membership for ${gradedStudent.name} student to '${group.name}' group.")
+        GroupsApi.createGroupMembership(group.id, gradedStudent.id, teacher.token)
+
+        Log.d(PREPARATION_TAG,"Create group membership for ${notGradedStudent.name} student to '${group2.name}' group.")
+        GroupsApi.createGroupMembership(group2.id, notGradedStudent.id, teacher.token)
 
         Log.d(PREPARATION_TAG,"Seed a 'Text Entry' assignment for course: ${course.name}.")
         val assignments = seedAssignments(
@@ -146,12 +160,52 @@ class PeopleE2ETest: TeacherTest() {
         peopleListPage.assertSearchResultCount(1)
         peopleListPage.assertPersonListed(gradedStudent)
 
-        Log.d(STEP_TAG, "Click on 'Reset' search (X) icon and assert that all the poeple are displayed (5).")
+        Log.d(STEP_TAG, "Click on 'Reset' search (X) icon and assert that all the people are displayed (5).")
         peopleListPage.searchable.clickOnClearSearchButton()
         peopleListPage.assertSearchResultCount(5)
 
+        Log.d(STEP_TAG, "Quit from searching and navigate to People List page.")
+        ViewUtils.pressBackButton(2)
+
+        Log.d(STEP_TAG, "Click on the 'Filter' icon on the top-right corner and select '${group.name}' group as a filter.")
+        peopleListPage.clickOnPeopleFilterMenu()
+        peopleListPage.selectFilter(listOf(group.name))
+
+        Log.d(STEP_TAG, "Assert that the filter title is the previously selected, '${group.name}' group.")
+        peopleListPage.assertFilterTitle(group.name)
+
+        Log.d(STEP_TAG, "Assert that only 1 person matches for the filter, and it is '${gradedStudent.name}', the graded student.")
+        peopleListPage.assertSearchResultCount(1)
+        peopleListPage.assertPersonListed(gradedStudent)
+
+        Log.d(STEP_TAG, "Clear the filter and assert that the list title became 'All People' and all the people are displayed again.")
+        peopleListPage.clickOnClearFilter()
+        sleep(1000) //Allow the clear filter process to propagate.
+        peopleListPage.assertFilterTitle("All People")
+        peopleListPage.assertSearchResultCount(5)
+
+        Log.d(STEP_TAG, "Click on the 'Filter' icon on the top-right corner and select '${group.name}' and '${group2.name}' groups as a filters.")
+        peopleListPage.clickOnPeopleFilterMenu()
+        peopleListPage.selectFilter(listOf(group.name, group2.name))
+
+        Log.d(STEP_TAG, "Assert that the filter title is the previously selected TWO groups: '${group.name}' and '${group2.name}'.")
+        //The order of how the filter title is generated is inconsistent, so we check both way if group1 is the leading and if group2.
+        try { peopleListPage.assertFilterTitle(group.name + ", " + group2.name) }
+        catch(e: AssertionError) { peopleListPage.assertFilterTitle(group2.name + ", " + group.name) }
+
+        Log.d(STEP_TAG, "Assert that only that 2 people matches for the filter, and they are '${gradedStudent.name}' and '${notGradedStudent.name}'.")
+        peopleListPage.assertSearchResultCount(2)
+        peopleListPage.assertPersonListed(gradedStudent)
+        peopleListPage.assertPersonListed(notGradedStudent)
+
+        Log.d(STEP_TAG, "Clear the filter and assert that the list title became 'All People' and all the people are displayed again.")
+        peopleListPage.clickOnClearFilter()
+        sleep(1000) //Allow the clear filter process to propagate.
+        peopleListPage.assertFilterTitle("All People")
+        peopleListPage.assertSearchResultCount(5)
+
         Log.d(STEP_TAG, "Navigate back to Dashboard Page. Click on the Inbox bottom menu. Assert that the 'All' section is empty.")
-        ViewUtils.pressBackButton(4)
+        ViewUtils.pressBackButton(2)
         dashboardPage.openInbox()
         inboxPage.assertInboxEmpty()
 

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/PeopleListPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/PeopleListPage.kt
@@ -17,6 +17,7 @@
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso
+import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers
@@ -25,6 +26,7 @@ import androidx.test.espresso.matcher.ViewMatchers.hasSibling
 import com.instructure.dataseeding.model.CanvasUserApiModel
 import com.instructure.espresso.Searchable
 import com.instructure.espresso.assertDisplayed
+import com.instructure.espresso.assertHasText
 import com.instructure.espresso.click
 import com.instructure.espresso.page.BasePage
 import com.instructure.espresso.page.onView
@@ -33,8 +35,10 @@ import com.instructure.espresso.page.waitForView
 import com.instructure.espresso.page.waitForViewWithText
 import com.instructure.espresso.page.withAncestor
 import com.instructure.espresso.page.withId
+import com.instructure.espresso.page.withParent
 import com.instructure.espresso.page.withText
 import com.instructure.teacher.R
+import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers
 
@@ -128,6 +132,43 @@ class PeopleListPage(val searchable: Searchable) : BasePage(R.id.peopleListPage)
      */
     fun assertPersonRole(personName: String, role: UserRole) {
         onView(withId(R.id.userRole) + withText(role.roleName) + hasSibling(withId(R.id.userName) + withText(personName))).assertDisplayed()
+    }
+
+    /**
+     * Clicks on the People Filter menu item.
+     *
+     */
+    fun clickOnPeopleFilterMenu() {
+        onView(withId(R.id.peopleFilterMenuItem)).click()
+    }
+
+    /**
+     * (De)Select group(s) or section(s) as a filter(s).
+     *
+     * @param filterTextList A String list with the name(s) of the section(s) or group(s) which will be (de)selected for filter.
+     */
+    fun selectFilter(filterTextList: List<String>) {
+        for(filterText in filterTextList) {
+            onView(allOf(withId(R.id.checkbox), hasSibling(withText(filterText)))).perform(click())
+        }
+        onView(withText(android.R.string.ok) + withId(android.R.id.button1)).click()
+    }
+
+    /**
+     * Clicks on the clear filter button.
+     *
+     */
+    fun clickOnClearFilter() {
+        onView(withId(R.id.clearFilterTextView) + withParent(R.id.filterTitleWrapper)).click()
+    }
+
+    /**
+     * Assert filter title
+     *
+     * @param expectedTitle The expected filter title.
+     */
+    fun assertFilterTitle(expectedTitle: String) {
+        onView(withId(R.id.peopleFilter) + withParent(R.id.filterTitleWrapper)).assertHasText(expectedTitle)
     }
 
     /**


### PR DESCRIPTION
Extend PeopleE2ETest with filter by (user) groups.
Seed user groups and assign student to them.
Add some page object methods.

refs: MBL-17041
affects: Teacher
release note: none