### PR TITLE
[MBL-17258][Student] Courses with over 100 announcements fail to load

### DIFF
--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/AnnouncementAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/AnnouncementAPI.kt
@@ -44,7 +44,7 @@ object AnnouncementAPI {
         fun getNextPageAnnouncementsList(@Url nextUrl: String): Call<List<DiscussionTopicHeader>>
 
         @GET
-        fun getNextPageAnnouncementsList(@Url nextUrl: String, @Tag params: RestParams): DataResult<List<DiscussionTopicHeader>>
+        suspend fun getNextPageAnnouncementsList(@Url nextUrl: String, @Tag params: RestParams): DataResult<List<DiscussionTopicHeader>>
 
         /**
          * This API call returns the latest announcement. The current implementation is the latest announcement from the last 14 days.


### PR DESCRIPTION
Test plan: In the ticket

refs: MBL-17258
affects: Student
release note: Fixed an issue where announcements wouldn't load when there is more than 100.

## Checklist

- [x] Tested in light mode
