### PR TITLE
[MBL-17121][Student] - Create Offline E2E test for Course Files

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/AssignmentsE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/AssignmentsE2ETest.kt
@@ -131,7 +131,7 @@ class AssignmentsE2ETest: StudentTest() {
     fun testLetterGradeTextAssignmentE2E() {
 
         Log.d(PREPARATION_TAG,"Seeding data.")
-        val data = seedData(students = 1, teachers = 1, courses = 1)
+        val data = seedData(teachers = 1, courses = 1, students = 1)
         val student = data.studentsList[0]
         val teacher = data.teachersList[0]
         val course = data.coursesList[0]
@@ -163,7 +163,7 @@ class AssignmentsE2ETest: StudentTest() {
     fun testPercentageFileAssignmentWithCommentE2E() {
 
         Log.d(PREPARATION_TAG,"Seeding data.")
-        val data = seedData(students = 1, teachers = 1, courses = 1)
+        val data = seedData(teachers = 1, courses = 1, students = 1)
         val student = data.studentsList[0]
         val teacher = data.teachersList[0]
         val course = data.coursesList[0]
@@ -186,7 +186,12 @@ class AssignmentsE2ETest: StudentTest() {
         assignmentListPage.clickAssignment(percentageFileAssignment)
 
         Log.d(PREPARATION_TAG, "Seed a text file.")
-        val uploadInfo = uploadTextFile(courseId = course.id, assignmentId = percentageFileAssignment.id, token = student.token, fileUploadType = FileUploadType.ASSIGNMENT_SUBMISSION)
+        val uploadInfo = uploadTextFile(
+            courseId = course.id,
+            assignmentId = percentageFileAssignment.id,
+            token = student.token,
+            fileUploadType = FileUploadType.ASSIGNMENT_SUBMISSION
+        )
 
         Log.d(PREPARATION_TAG,"Submit ${percentageFileAssignment.name} assignment for ${student.name} student.")
         submitCourseAssignment(course, percentageFileAssignment, uploadInfo, student)
@@ -245,7 +250,7 @@ class AssignmentsE2ETest: StudentTest() {
     fun testMultipleAssignmentsE2E() {
 
         Log.d(PREPARATION_TAG,"Seeding data.")
-        val data = seedData(students = 1, teachers = 1, courses = 1)
+        val data = seedData(teachers = 1, courses = 1, students = 1)
         val student = data.studentsList[0]
         val teacher = data.teachersList[0]
         val course = data.coursesList[0]
@@ -288,7 +293,7 @@ class AssignmentsE2ETest: StudentTest() {
     @TestMetaData(Priority.IMPORTANT, FeatureCategory.ASSIGNMENTS, TestCategory.E2E)
     fun testFilterAndSortAssignmentsE2E() {
         Log.d(PREPARATION_TAG,"Seeding data.")
-        val data = seedData(students = 1, teachers = 1, courses = 1)
+        val data = seedData(teachers = 1, courses = 1, students = 1)
         val student = data.studentsList[0]
         val teacher = data.teachersList[0]
         val course = data.coursesList[0]
@@ -420,7 +425,7 @@ class AssignmentsE2ETest: StudentTest() {
     fun testMediaCommentsE2E() {
 
         Log.d(PREPARATION_TAG,"Seeding data.")
-        val data = seedData(students = 1, teachers = 1, courses = 1)
+        val data = seedData(teachers = 1, courses = 1, students = 1)
         val student = data.studentsList[0]
         val teacher = data.teachersList[0]
         val course = data.coursesList[0]
@@ -464,7 +469,7 @@ class AssignmentsE2ETest: StudentTest() {
     fun testAddFileCommentE2E() {
 
         Log.d(PREPARATION_TAG,"Seeding data.")
-        val data = seedData(students = 1, teachers = 1, courses = 1)
+        val data = seedData(teachers = 1, courses = 1, students = 1)
         val student = data.studentsList[0]
         val teacher = data.teachersList[0]
         val course = data.coursesList[0]
@@ -481,8 +486,8 @@ class AssignmentsE2ETest: StudentTest() {
 
         Log.d(STEP_TAG,"Seed a comment attachment upload.")
         val commentUploadInfo = uploadTextFile(
-            assignmentId = assignment.id,
             courseId = course.id,
+            assignmentId = assignment.id,
             token = student.token,
             fileUploadType = FileUploadType.COMMENT_ATTACHMENT
         )
@@ -510,7 +515,7 @@ class AssignmentsE2ETest: StudentTest() {
     fun testSubmissionAttemptSelection() {
 
         Log.d(PREPARATION_TAG, "Seeding data.")
-        val data = seedData(students = 1, teachers = 1, courses = 1)
+        val data = seedData(teachers = 1, courses = 1, students = 1)
         val student = data.studentsList[0]
         val teacher = data.teachersList[0]
         val course = data.coursesList[0]
@@ -572,7 +577,7 @@ class AssignmentsE2ETest: StudentTest() {
     fun testCommentsBelongToSubmissionAttempts() {
 
         Log.d(PREPARATION_TAG,"Seeding data.")
-        val data = seedData(students = 1, teachers = 1, courses = 1)
+        val data = seedData(teachers = 1, courses = 1, students = 1)
         val student = data.studentsList[0]
         val teacher = data.teachersList[0]
         val course = data.coursesList[0]
@@ -665,7 +670,7 @@ class AssignmentsE2ETest: StudentTest() {
     @TestMetaData(Priority.IMPORTANT, FeatureCategory.ASSIGNMENTS, TestCategory.E2E)
     fun showOnlyLetterGradeOnDashboardAndAssignmentListPageE2E() {
         Log.d(PREPARATION_TAG,"Seeding data.")
-        val data = seedData(students = 1, teachers = 1, courses = 1)
+        val data = seedData(teachers = 1, courses = 1, students = 1)
         val student = data.studentsList[0]
         val teacher = data.teachersList[0]
         val course = data.coursesList[0]
@@ -821,7 +826,7 @@ class AssignmentsE2ETest: StudentTest() {
     @TestMetaData(Priority.IMPORTANT, FeatureCategory.GRADES, TestCategory.E2E)
     fun showOnlyLetterGradeOnGradesPageE2E() {
         Log.d(PREPARATION_TAG, "Seeding data.")
-        val data = seedData(students = 1, teachers = 1, courses = 1)
+        val data = seedData(teachers = 1, courses = 1, students = 1)
         val student = data.studentsList[0]
         val teacher = data.teachersList[0]
         val course = data.coursesList[0]

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/ManageOfflineContentE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/ManageOfflineContentE2ETest.kt
@@ -203,6 +203,7 @@ class ManageOfflineContentE2ETest : StudentTest() {
 
         Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
         turnOffConnectionViaADB()
+        device.waitForIdle()
         dashboardPage.waitForRender()
 
         Log.d(STEP_TAG, "Select '${course2.name}' course and open 'Grades' menu to check if it's really synced and can be seen in offline mode.")

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineFilesE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineFilesE2ETest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2024 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.instructure.student.ui.e2e.offline
+
+import android.util.Log
+import androidx.test.espresso.Espresso
+import com.google.android.material.checkbox.MaterialCheckBox
+import com.instructure.canvas.espresso.FeatureCategory
+import com.instructure.canvas.espresso.OfflineE2E
+import com.instructure.canvas.espresso.Priority
+import com.instructure.canvas.espresso.TestCategory
+import com.instructure.canvas.espresso.TestMetaData
+import com.instructure.dataseeding.api.FileFolderApi
+import com.instructure.dataseeding.model.FileUploadType
+import com.instructure.student.ui.utils.StudentTest
+import com.instructure.student.ui.utils.seedData
+import com.instructure.student.ui.utils.tokenLogin
+import com.instructure.student.ui.utils.uploadTextFile
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.After
+import org.junit.Test
+
+@HiltAndroidTest
+class OfflineFilesE2ETest : StudentTest() {
+    override fun displaysPageObjects() = Unit
+
+    override fun enableAndConfigureAccessibilityChecks() = Unit
+
+    @OfflineE2E
+    @Test
+    @TestMetaData(Priority.MANDATORY, FeatureCategory.FILES, TestCategory.E2E)
+    fun testOfflineFilesE2E() {
+
+        Log.d(PREPARATION_TAG,"Seeding data.")
+        val data = seedData(teachers = 1, courses = 1, students = 1)
+        val student = data.studentsList[0]
+        val teacher = data.teachersList[0]
+        val course = data.coursesList[0]
+
+        val testCourseFolderName = "Goodya"
+        Log.d(PREPARATION_TAG, "Create a course folder within the 'Files' tab with the name: '$testCourseFolderName'.")
+        val courseRootFolder = FileFolderApi.getCourseRootFolder(course.id, teacher.token)
+        val courseTestFolder = FileFolderApi.createCourseFolder(courseRootFolder.id, testCourseFolderName, false, teacher.token)
+
+        Log.d(PREPARATION_TAG, "Create a (text) file within the root folder (so the 'Files' tab file list) of the '${course.name}' course.")
+        val rootFolderTestTextFile = uploadTextFile(courseRootFolder.id, token = teacher.token, fileUploadType = FileUploadType.COURSE_FILE)
+
+        Log.d(PREPARATION_TAG, "Create a (text) file within the '${courseTestFolder.name}' folder of the '${course.name}' course.")
+        val courseTestFolderTextFile = uploadTextFile(courseTestFolder.id, token = teacher.token, fileUploadType = FileUploadType.COURSE_FILE)
+
+        Log.d(STEP_TAG,"Login with user: ${student.name}, login id: ${student.loginId}.")
+        tokenLogin(student)
+        dashboardPage.waitForRender()
+
+        Log.d(STEP_TAG, "Open the '${course.name}' course's 'Manage Offline Content' page via the more menu of the Dashboard Page.")
+        dashboardPage.clickCourseOverflowMenu(course.name, "Manage Offline Content")
+
+        Log.d(STEP_TAG, "Assert that the '${course.name}' course's checkbox state is 'Unchecked'.")
+        manageOfflineContentPage.assertCheckedStateOfItem(course.name, MaterialCheckBox.STATE_UNCHECKED)
+
+        Log.d(STEP_TAG, "Expand the course. Select the 'Files' of '${course.name}' course for sync. Click on the 'Sync' button.")
+        manageOfflineContentPage.expandCollapseItem(course.name)
+        manageOfflineContentPage.changeItemSelectionState("Files")
+        manageOfflineContentPage.clickOnSyncButtonAndConfirm()
+
+        Log.d(STEP_TAG, "Wait for the 'Download Started' dashboard notification to be displayed, and the to disappear.")
+        dashboardPage.waitForRender()
+        dashboardPage.waitForSyncProgressDownloadStartedNotification()
+        dashboardPage.waitForSyncProgressDownloadStartedNotificationToDisappear()
+
+        Log.d(STEP_TAG, "Wait for the 'Syncing Offline Content' dashboard notification to be displayed, and the to disappear. (It should be displayed after the 'Download Started' notification immediately.)")
+        dashboardPage.waitForSyncProgressStartingNotification()
+        dashboardPage.waitForSyncProgressStartingNotificationToDisappear()
+
+        Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
+        turnOffConnectionViaADB()
+        Thread.sleep(10000) //Need to wait a bit here because of a UI glitch that when network state change, the dashboard page 'pops' a bit and it can confuse the automation script.
+        device.waitForIdle()
+        device.waitForWindowUpdate(null, 10000)
+
+        Log.d(STEP_TAG, "Wait for the Dashboard Page to be rendered. Refresh the page.")
+        dashboardPage.waitForRender()
+
+        Log.d(STEP_TAG, "Select '${course.name}' course and click on 'Files' tab to navigate to the File List Page.")
+        dashboardPage.selectCourse(course)
+        courseBrowserPage.selectFiles()
+
+        Log.d(STEP_TAG, "Assert that under the 'Files' tab there are 2 items, a folder and a file which has been seeded recently, and there is 1 item within the folder.")
+        fileListPage.assertFileListCount(2)
+        fileListPage.assertFolderSize(courseTestFolder.name, 1)
+
+        Log.d(STEP_TAG, "Assert that the folder's name is '${courseTestFolder.name}' and the file's name is '${rootFolderTestTextFile.fileName}'.")
+        fileListPage.assertItemDisplayed(rootFolderTestTextFile.fileName)
+        fileListPage.assertItemDisplayed(courseTestFolder.name)
+
+        Log.d(STEP_TAG, "Open '${courseTestFolder.name}' folder and assert that the '${courseTestFolderTextFile.fileName}' file is displayed within it. Navigate back to File List Page.")
+        fileListPage.selectItem(courseTestFolder.name)
+        fileListPage.assertItemDisplayed(courseTestFolderTextFile.fileName)
+        Espresso.pressBack()
+
+        Log.d(STEP_TAG, "Click on 'Search' (magnifying glass) icon and type '${rootFolderTestTextFile.fileName}', the file's name to the search input field.")
+        fileListPage.searchable.clickOnSearchButton()
+        fileListPage.searchable.typeToSearchBar(rootFolderTestTextFile.fileName)
+
+        Log.d(STEP_TAG, "Assert that only 1 file matches for the search text, and it is '${rootFolderTestTextFile.fileName}', and no directories has been shown in the result.")
+        fileListPage.assertSearchResultCount(1)
+        fileListPage.assertSearchItemDisplayed(rootFolderTestTextFile.fileName)
+        fileListPage.assertItemNotDisplayed(testCourseFolderName)
+        Espresso.closeSoftKeyboard()
+    }
+
+    @After
+    fun tearDown() {
+        Log.d(PREPARATION_TAG, "Turn back on the Wi-Fi and Mobile Data on the device, so it will come back online.")
+        turnOnConnectionViaADB()
+    }
+
+}

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineLeftSideMenuE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineLeftSideMenuE2ETest.kt
@@ -53,6 +53,8 @@ class OfflineLeftSideMenuE2ETest : StudentTest() {
 
         Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
         turnOffConnectionViaADB()
+        Thread.sleep(10000) //Need to wait a bit here because of a UI glitch that when network state change, the dashboard page 'pops' a bit and it can confuse the automation script.
+
         dashboardPage.waitForRender()
 
         Log.d(STEP_TAG, "Assert that the Offline Indicator (bottom banner) is displayed on the Dashboard Page.")

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineLoginE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineLoginE2ETest.kt
@@ -68,6 +68,7 @@ class OfflineLoginE2ETest : StudentTest() {
 
         Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
         turnOffConnectionViaADB()
+        device.waitForWindowUpdate(null, 10000)
 
         Log.d(STEP_TAG, "Click on 'Change User' button on the left-side menu.")
         leftSideNavigationDrawerPage.clickChangeUserMenu()

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/FileListPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/FileListPage.kt
@@ -20,9 +20,7 @@ import androidx.appcompat.widget.AppCompatButton
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.swipeDown
-import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.*
 import com.instructure.canvas.espresso.containsTextCaseInsensitive
 import com.instructure.canvas.espresso.scrollRecyclerView
@@ -55,6 +53,11 @@ class FileListPage(val searchable: Searchable) : BasePage(R.id.fileListPage) {
 
     fun assertItemDisplayed(itemName: String) {
         val matcher = allOf(withId(R.id.fileName), withText(itemName))
+        waitForView(matcher).scrollTo().assertDisplayed()
+    }
+
+    fun assertSearchItemDisplayed(itemName: String) {
+        val matcher = allOf(withId(R.id.fileName), withAncestor(R.id.fileSearchRecyclerView), withText(itemName))
         waitForView(matcher).scrollTo().assertDisplayed()
     }
 
@@ -127,14 +130,14 @@ class FileListPage(val searchable: Searchable) : BasePage(R.id.fileListPage) {
     fun assertSearchResultCount(expectedCount: Int) {
         Thread.sleep(2000)
         onView(withId(R.id.fileSearchRecyclerView) + withAncestor(R.id.container)).check(
-            ViewAssertions.matches(ViewMatchers.hasChildCount(expectedCount))
+            matches(hasChildCount(expectedCount))
         )
     }
 
     fun assertFileListCount(expectedCount: Int) {
         Thread.sleep(2000)
-        onView(withId(R.id.listView) + withAncestor(R.id.container)).check(
-            ViewAssertions.matches(ViewMatchers.hasChildCount(expectedCount))
+        onView(withId(R.id.listView) + withAncestor(R.id.fileListPage)).check(
+            matches(hasChildCount(expectedCount))
         )
     }
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTest.kt
@@ -32,6 +32,7 @@ import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
 import com.instructure.canvas.espresso.CanvasTest
 import com.instructure.espresso.InstructureActivityTestRule
 import com.instructure.espresso.Searchable
@@ -111,6 +112,8 @@ import java.io.File
 import javax.inject.Inject
 
 abstract class StudentTest : CanvasTest() {
+
+    val device: UiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
     override val activityRule: InstructureActivityTestRule<out Activity> =
         StudentActivityTestRule(LoginActivity::class.java)

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTestExtensions.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTestExtensions.kt
@@ -58,7 +58,7 @@ fun StudentTest.slowLogIn(enrollmentType: String = EnrollmentTypes.STUDENT_ENROL
     return user
 }
 
-fun StudentTest.seedDataForK5(
+fun seedDataForK5(
     teachers: Int = 0,
     tas: Int = 0,
     pastCourses: Int = 0,
@@ -69,7 +69,8 @@ fun StudentTest.seedDataForK5(
     announcements: Int = 0,
     discussions: Int = 0,
     syllabusBody: String? = null,
-    gradingPeriods: Boolean = false): SeedApi.SeededDataApiModel {
+    gradingPeriods: Boolean = false
+): SeedApi.SeededDataApiModel {
 
     val request = SeedApi.SeedDataRequest (
         teachers = teachers,
@@ -88,7 +89,7 @@ fun StudentTest.seedDataForK5(
     return SeedApi.seedDataForSubAccount(request)
 }
 
-fun StudentTest.seedData(
+fun seedData(
     teachers: Int = 0,
     tas: Int = 0,
     pastCourses: Int = 0,
@@ -100,7 +101,8 @@ fun StudentTest.seedData(
     locked: Boolean = false,
     discussions: Int = 0,
     syllabusBody: String? = null,
-    gradingPeriods: Boolean = false): SeedApi.SeededDataApiModel {
+    gradingPeriods: Boolean = false
+): SeedApi.SeededDataApiModel {
 
     val request = SeedApi.SeedDataRequest (
             teachers = teachers,
@@ -119,15 +121,16 @@ fun StudentTest.seedData(
     return SeedApi.seedData(request)
 }
 
-fun StudentTest.seedAssignments(
-        courseId: Long,
-        assignments: Int = 1,
-        withDescription: Boolean = false,
-        lockAt: String = "",
-        unlockAt: String = "",
-        dueAt: String = "",
-        submissionTypes: List<SubmissionType> = emptyList(),
-        teacherToken: String): List<AssignmentApiModel> {
+fun seedAssignments(
+    courseId: Long,
+    assignments: Int = 1,
+    withDescription: Boolean = false,
+    lockAt: String = "",
+    unlockAt: String = "",
+    dueAt: String = "",
+    submissionTypes: List<SubmissionType> = emptyList(),
+    teacherToken: String
+): List<AssignmentApiModel> {
 
     return AssignmentsApi.seedAssignments(AssignmentsApi.CreateAssignmentRequest(
             courseId = courseId,
@@ -203,7 +206,7 @@ fun StudentTest.tokenLoginElementary(user: CanvasUserApiModel) {
     elementaryDashboardPage.assertPageObjects()
 }
 
-fun StudentTest.routeTo(route: String) {
+fun routeTo(route: String) {
     val url = "canvas-student://${CanvasNetworkAdapter.canvasDomain}/$route"
     val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
     val context = InstrumentationRegistry.getInstrumentation().targetContext
@@ -213,7 +216,7 @@ fun StudentTest.routeTo(route: String) {
     context.startActivity(intent)
 }
 
-fun StudentTest.routeTo(route: String, domain: String) {
+fun routeTo(route: String, domain: String) {
     val url = "canvas-student://$domain/$route"
     val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
     val context = InstrumentationRegistry.getInstrumentation().targetContext
@@ -223,39 +226,41 @@ fun StudentTest.routeTo(route: String, domain: String) {
     context.startActivity(intent)
 }
 
-fun StudentTest.routeTo(route: Route, activity: FragmentActivity) {
+fun routeTo(route: Route, activity: FragmentActivity) {
     RouteMatcher.route(activity, route)
 }
 
-fun StudentTest.seedAssignmentSubmission(
-        submissionSeeds: List<SubmissionsApi.SubmissionSeedInfo>,
-        assignmentId: Long,
-        courseId: Long,
-        studentToken: String,
-        commentSeeds: List<SubmissionsApi.CommentSeedInfo> = kotlin.collections.emptyList()
+fun seedAssignmentSubmission(
+    submissionSeeds: List<SubmissionsApi.SubmissionSeedInfo>,
+    assignmentId: Long,
+    courseId: Long,
+    studentToken: String,
+    commentSeeds: List<SubmissionsApi.CommentSeedInfo> = emptyList()
 ): List<SubmissionApiModel> {
 
     // Upload one submission file for each submission seed
     submissionSeeds.forEach {
         it.attachmentsList.add(
                 when (it.submissionType) {
-                    SubmissionType.ONLINE_UPLOAD -> uploadTextFile(courseId, assignmentId, studentToken,
+                    SubmissionType.ONLINE_UPLOAD -> uploadTextFile(
+                        courseId, assignmentId, studentToken,
                         FileUploadType.ASSIGNMENT_SUBMISSION
                     )
                     else -> AttachmentApiModel(displayName="", fileName="", id=0L) // Not handled right now
                 }
-            );
+            )
     }
 
     // Add attachments to comment seeds
     commentSeeds.forEach {
-        val fileAttachments: MutableList<AttachmentApiModel> = kotlin.collections.mutableListOf()
+        val fileAttachments: MutableList<AttachmentApiModel> = mutableListOf()
 
         for (i in 0..it.amount) {
             if (it.fileType != FileType.NONE) {
                 fileAttachments.add(when (it.fileType) {
-                    FileType.PDF -> kotlin.TODO()
-                    FileType.TEXT -> uploadTextFile(courseId, assignmentId, studentToken,
+                    FileType.PDF -> TODO()
+                    FileType.TEXT -> uploadTextFile(
+                        courseId, assignmentId, studentToken,
                         FileUploadType.COMMENT_ATTACHMENT
                     )
                     else -> throw RuntimeException("Unknown file type passed into StudentTest.seedAssignmentSubmission") // Unknown type
@@ -278,7 +283,12 @@ fun StudentTest.seedAssignmentSubmission(
     return SubmissionsApi.seedAssignmentSubmission(submissionRequest)
 }
 
-fun StudentTest.uploadTextFile(courseId: Long, assignmentId: Long, token: String, fileUploadType: FileUploadType): AttachmentApiModel {
+fun uploadTextFile(
+    courseId: Long,
+    assignmentId: Long? = null,
+    token: String,
+    fileUploadType: FileUploadType
+): AttachmentApiModel {
 
     // Create the file
     val file = File(

--- a/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/api/FileFolderApi.kt
+++ b/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/api/FileFolderApi.kt
@@ -1,0 +1,63 @@
+//
+// Copyright (C) 2024-present Instructure, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+package com.instructure.dataseeding.api
+
+import com.instructure.dataseeding.model.CourseFolderUploadApiModel
+import com.instructure.dataseeding.model.CourseFolderUploadApiRequestModel
+import com.instructure.dataseeding.model.CourseRootFolderApiModel
+import com.instructure.dataseeding.util.CanvasNetworkAdapter
+import retrofit2.Call
+import retrofit2.http.*
+
+object FileFolderApi {
+    interface FileFolderService {
+
+        @GET("courses/{courseId}/folders/root")
+        fun getCourseRootFolder(
+            @Path("courseId") courseId: Long): Call<CourseRootFolderApiModel>
+
+        @POST("folders/{folderId}/folders")
+        fun createCourseFolder(
+                @Path("folderId") folderId: Long,
+                @Body courseFolderUploadApiRequestModel: CourseFolderUploadApiRequestModel): Call<CourseFolderUploadApiModel>
+
+    }
+
+    private fun fileFolderService(token: String): FileFolderService
+            = CanvasNetworkAdapter.retrofitWithToken(token).create(FileFolderService::class.java)
+
+    fun getCourseRootFolder(courseId: Long, token: String): CourseRootFolderApiModel {
+        return fileFolderService(token)
+            .getCourseRootFolder(courseId = courseId)
+            .execute()
+            .body()!!
+    }
+
+    fun createCourseFolder(folderId: Long, name: String, locked: Boolean, token: String): CourseFolderUploadApiModel {
+        val courseFolderUploadRequestModel = CourseFolderUploadApiRequestModel(
+            name = name,
+            locked = locked
+        )
+        val createFolderUploadApiModel: CourseFolderUploadApiModel = fileFolderService(token)
+            .createCourseFolder(folderId, courseFolderUploadRequestModel)
+            .execute()
+            .body()!!
+        return createFolderUploadApiModel
+    }
+
+}

--- a/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/api/FileUploadsApi.kt
+++ b/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/api/FileUploadsApi.kt
@@ -44,6 +44,11 @@ object FileUploadsApi {
                 @Path("assignmentId") assignmentId: Long,
                 @Body startFileUpload: StartFileUpload): Call<FileUploadParams>
 
+        @POST("folders/{folderId}/files")
+        fun courseFolderFileUpload(
+            @Path("folderId") folderId: Long?,
+            @Body startFileUpload: StartFileUpload): Call<FileUploadParams>
+
         @Multipart
         @POST
         fun uploadFile(
@@ -66,14 +71,14 @@ object FileUploadsApi {
      * Start here to upload a file!
      */
     fun uploadFile(courseId: Long,
-                   assignmentId: Long,
+                   assignmentId: Long? = null,
                    file: ByteArray,
                    fileName: String,
                    token: String,
                    fileUploadType: FileUploadType): AttachmentApiModel {
 
         // Get file upload params from Canvas, telling us where to upload the file
-        val params = getFileUploadParams(courseId, assignmentId, file, fileName, fileUploadType, token)
+        val params = getFileUploadParams(courseId = courseId, assignmentId= assignmentId, file = file, fileName = fileName, fileUploadType = fileUploadType, token = token)
 
         // Upload the file based on the params we got back; return the resulting attachment
         return uploadFileToCanvas(params, file)
@@ -94,7 +99,7 @@ object FileUploadsApi {
     }
 
     private fun getFileUploadParams(courseId: Long,
-                                    assignmentId: Long,
+                                    assignmentId: Long? = null,
                                     file: ByteArray,
                                     fileName: String,
                                     fileUploadType: FileUploadType,
@@ -103,8 +108,9 @@ object FileUploadsApi {
         val request = StartFileUpload(fileName, file.size.toLong())
 
         return when (fileUploadType) {
-            FileUploadType.ASSIGNMENT_SUBMISSION -> fileUploadsService(token).assignmentSubmissionFileUpload(courseId, assignmentId, request)
-            FileUploadType.COMMENT_ATTACHMENT -> fileUploadsService(token).commentAttachmentFileUpload(courseId, assignmentId, request)
+            FileUploadType.ASSIGNMENT_SUBMISSION -> fileUploadsService(token).assignmentSubmissionFileUpload(courseId, assignmentId!!, request)
+            FileUploadType.COMMENT_ATTACHMENT -> fileUploadsService(token).commentAttachmentFileUpload(courseId, assignmentId!!, request)
+            FileUploadType.COURSE_FILE -> fileUploadsService(token).courseFolderFileUpload(courseId, request)
             else -> TODO()
         }.execute().body()!!
     }

--- a/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/model/CourseFolderUploadApiModel.kt
+++ b/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/model/CourseFolderUploadApiModel.kt
@@ -1,0 +1,39 @@
+//
+// Copyright (C) 2024-present Instructure, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.instructure.dataseeding.model
+
+import com.google.gson.annotations.SerializedName
+
+data class CourseFolderUploadApiRequestModel(
+        @SerializedName("name")
+        val name: String,
+        @SerializedName("locked")
+        val locked: Boolean = false
+)
+
+data class CourseFolderUploadApiModel(
+        @SerializedName("id")
+        val id: Long,
+        @SerializedName("context_type")
+        val contextType: String,
+        @SerializedName("parent_folder_id")
+        val parentFolderId: Long,
+        @SerializedName("name")
+        val name: String,
+        @SerializedName("locked")
+        val locked: Boolean = false
+)

--- a/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/model/CourseRootFolderApiModel.kt
+++ b/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/model/CourseRootFolderApiModel.kt
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2018-present Instructure, Inc.
+// Copyright (C) 2024-present Instructure, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,10 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package com.instructure.dataseeding.model
 
-enum class FileUploadType {
-    ASSIGNMENT_SUBMISSION,
-    COMMENT_ATTACHMENT,
-    COURSE_FILE
-}
+import com.google.gson.annotations.SerializedName
+
+data class CourseRootFolderApiModel(
+        @SerializedName("id")
+        val id: Long,
+        @SerializedName("context_type")
+        val contextType: String,
+        @SerializedName("context_id")
+        val contextId: Long,
+        @SerializedName("name")
+        val name: String
+)


### PR DESCRIPTION
Implement E2E Offline test for student course Files.
Implement API to generate course files.
Move 'device' to StudentTest class. (in later tickets it will be refactored for the existing offline tests to use this same object).
Add COURSE_FILE as new file upload type.
Refactor uploadTextFile method to handle course files as well.

Add different wait types/methods to some flaky tests for further monitoring which is the most
stabile.

refs: MBL-17121
affects: Student
release note: none