### PR TITLE
[MBL-17278][Teacher] Bulk module update snackbars

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ModuleListEffectHandler.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ModuleListEffectHandler.kt
@@ -66,7 +66,8 @@ class ModuleListEffectHandler(
                 effect.canvasContext,
                 effect.moduleIds,
                 effect.action,
-                effect.skipContentTags
+                effect.skipContentTags,
+                allModules = effect.allModules
             )
 
             is ModuleListEffect.UpdateModuleItem -> updateModuleItem(
@@ -75,6 +76,9 @@ class ModuleListEffectHandler(
                 effect.itemId,
                 effect.published
             )
+            is ModuleListEffect.ShowSnackbar -> {
+                view?.showSnackbar(effect.message)
+            }
         }.exhaustive
     }
 
@@ -187,7 +191,8 @@ class ModuleListEffectHandler(
         moduleIds: List<Long>,
         action: BulkModuleUpdateAction,
         skipContentTags: Boolean,
-        async: Boolean = true
+        async: Boolean = true,
+        allModules: Boolean
     ) {
         launch {
             val restParams = RestParams(
@@ -204,13 +209,23 @@ class ModuleListEffectHandler(
                 restParams
             ).dataOrNull?.progress
 
-            progress?.progress?.let {
-                trackUpdateProgress(it)
-            } ?: consumer.accept(ModuleListEvent.BulkUpdateFailed)
+            val bulkUpdateProgress = progress?.progress
+            if (bulkUpdateProgress == null) {
+                consumer.accept(ModuleListEvent.BulkUpdateFailed(skipContentTags))
+                return@launch
+            }
+
+            val success = trackUpdateProgress(bulkUpdateProgress)
+
+            if (success) {
+                consumer.accept(ModuleListEvent.BulkUpdateSuccess(skipContentTags, action, allModules))
+            } else {
+                consumer.accept(ModuleListEvent.BulkUpdateFailed(skipContentTags))
+            }
         }
     }
 
-    private suspend fun trackUpdateProgress(progress: Progress) {
+    private suspend fun trackUpdateProgress(progress: Progress): Boolean {
         val params = RestParams(isForceReadFromNetwork = true)
 
         val result = poll(500, maxAttempts = -1,
@@ -225,11 +240,7 @@ class ModuleListEffectHandler(
                 newProgress
             })
 
-        if (result?.hasRun == true && result.isCompleted) {
-            consumer.accept(ModuleListEvent.BulkUpdateSuccess)
-        } else {
-            consumer.accept(ModuleListEvent.BulkUpdateFailed)
-        }
+        return result?.hasRun == true && result.isCompleted
     }
 
     private fun updateModuleItem(canvasContext: CanvasContext, moduleId: Long, itemId: Long, published: Boolean) {
@@ -248,7 +259,7 @@ class ModuleListEffectHandler(
             ).dataOrNull
 
             moduleItem?.let {
-                consumer.accept(ModuleListEvent.ModuleItemUpdateSuccess(it))
+                consumer.accept(ModuleListEvent.ModuleItemUpdateSuccess(it, published))
             } ?: consumer.accept(ModuleListEvent.ModuleItemUpdateFailed(itemId))
         }
     }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ModuleListModels.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ModuleListModels.kt
@@ -16,6 +16,7 @@
  */
 package com.instructure.teacher.features.modules.list
 
+import androidx.annotation.StringRes
 import com.instructure.canvasapi2.models.CanvasContext
 import com.instructure.canvasapi2.models.ModuleItem
 import com.instructure.canvasapi2.models.ModuleObject
@@ -25,8 +26,6 @@ import com.instructure.canvasapi2.utils.isValid
 sealed class ModuleListEvent {
     object PullToRefresh : ModuleListEvent()
     object NextPageRequested : ModuleListEvent()
-    object BulkUpdateSuccess : ModuleListEvent()
-    object BulkUpdateFailed : ModuleListEvent()
     data class ModuleItemClicked(val moduleItemId: Long) : ModuleListEvent()
     data class ModuleExpanded(val moduleId: Long, val isExpanded: Boolean) : ModuleListEvent()
     data class PageLoaded(val pageData: ModuleListPageData) : ModuleListEvent()
@@ -37,8 +36,10 @@ sealed class ModuleListEvent {
     data class BulkUpdateModule(val moduleId: Long, val action: BulkModuleUpdateAction, val skipContentTags: Boolean) : ModuleListEvent()
     data class BulkUpdateAllModules(val action: BulkModuleUpdateAction, val skipContentTags: Boolean) : ModuleListEvent()
     data class UpdateModuleItem(val itemId: Long, val isPublished: Boolean) : ModuleListEvent()
-    data class ModuleItemUpdateSuccess(val item: ModuleItem): ModuleListEvent()
+    data class ModuleItemUpdateSuccess(val item: ModuleItem, val published: Boolean): ModuleListEvent()
     data class ModuleItemUpdateFailed(val itemId: Long): ModuleListEvent()
+    data class BulkUpdateSuccess(val skipContentTags: Boolean, val action: BulkModuleUpdateAction, val allModules: Boolean) : ModuleListEvent()
+    data class BulkUpdateFailed(val skipContentTags: Boolean) : ModuleListEvent()
 }
 
 sealed class ModuleListEffect {
@@ -65,7 +66,8 @@ sealed class ModuleListEffect {
         val canvasContext: CanvasContext,
         val moduleIds: List<Long>,
         val action: BulkModuleUpdateAction,
-        val skipContentTags: Boolean
+        val skipContentTags: Boolean,
+        val allModules: Boolean
     ) : ModuleListEffect()
 
     data class UpdateModuleItem(
@@ -74,6 +76,8 @@ sealed class ModuleListEffect {
         val itemId: Long,
         val published: Boolean
     ) : ModuleListEffect()
+
+    data class ShowSnackbar(@StringRes val message: Int) : ModuleListEffect()
 }
 
 data class ModuleListModel(

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ui/ModuleListView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ui/ModuleListView.kt
@@ -18,9 +18,11 @@ package com.instructure.teacher.features.modules.list.ui
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.FragmentActivity
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.snackbar.Snackbar
 import com.instructure.canvasapi2.models.CanvasContext
 import com.instructure.canvasapi2.models.ModuleItem
 import com.instructure.pandarecycler.PaginatedScrollListener
@@ -168,5 +170,9 @@ class ModuleListView(
             }
             .setNegativeButton(negativeButton) { _, _ -> }
             .showThemed()
+    }
+
+    fun showSnackbar(@StringRes message: Int) {
+        Snackbar.make(binding.root, message, Snackbar.LENGTH_SHORT).show()
     }
 }

--- a/apps/teacher/src/test/java/com/instructure/teacher/unit/modules/list/ModuleListUpdateTest.kt
+++ b/apps/teacher/src/test/java/com/instructure/teacher/unit/modules/list/ModuleListUpdateTest.kt
@@ -42,6 +42,7 @@ import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import org.junit.Assert
 import org.junit.Test
+import com.instructure.teacher.R
 
 class ModuleListUpdateTest : Assert() {
 
@@ -427,7 +428,8 @@ class ModuleListUpdateTest : Assert() {
             expectedModel.course,
             listOf(1L),
             BulkModuleUpdateAction.PUBLISH,
-            true
+            true,
+            false
         )
 
         updateSpec
@@ -453,6 +455,7 @@ class ModuleListUpdateTest : Assert() {
             expectedModel.course,
             listOf(1L),
             BulkModuleUpdateAction.PUBLISH,
+            false,
             false
         )
 
@@ -487,6 +490,7 @@ class ModuleListUpdateTest : Assert() {
             expectedModel.course,
             listOf(1L, 2L),
             BulkModuleUpdateAction.UNPUBLISH,
+            true,
             true
         )
 
@@ -521,7 +525,8 @@ class ModuleListUpdateTest : Assert() {
             expectedModel.course,
             listOf(1L, 2L),
             BulkModuleUpdateAction.UNPUBLISH,
-            false
+            false,
+            true
         )
 
         updateSpec
@@ -553,13 +558,194 @@ class ModuleListUpdateTest : Assert() {
             expectedModel.pageData,
             expectedModel.scrollToItemId
         )
+        val expectedSnackbarEffect = ModuleListEffect.ShowSnackbar(R.string.onlyModulesPublished)
         updateSpec
             .given(model)
-            .whenEvent(ModuleListEvent.BulkUpdateSuccess)
+            .whenEvent(ModuleListEvent.BulkUpdateSuccess(true, BulkModuleUpdateAction.PUBLISH, true))
             .then(
                 assertThatNext(
                     hasModel(expectedModel),
-                    matchesEffects(expectedEffect)
+                    matchesEffects(expectedEffect, expectedSnackbarEffect)
+                )
+            )
+    }
+
+    @Test
+    fun `BulkUpdateSuccess publish all modules and items displays correct snackbar`() {
+        val model = initModel.copy(
+            isLoading = false,
+            pageData = ModuleListPageData(DataResult.Success(emptyList()), false, "fakeUrl"),
+            modules = listOf(ModuleObject(1L, items = listOf(ModuleItem(100L))), ModuleObject(2L, items = listOf(ModuleItem(200L)))),
+            loadingModuleItemIds = setOf(1L, 100L, 2L, 200L)
+        )
+        val expectedModel = initModel.copy(
+            isLoading = true,
+            pageData = ModuleListPageData(forceNetwork = true),
+            loadingModuleItemIds = emptySet()
+        )
+        val expectedEffect = ModuleListEffect.LoadNextPage(
+            expectedModel.course,
+            expectedModel.pageData,
+            expectedModel.scrollToItemId
+        )
+        val expectedSnackbarEffect = ModuleListEffect.ShowSnackbar(R.string.allModulesAndAllItemsPublished)
+        updateSpec
+            .given(model)
+            .whenEvent(ModuleListEvent.BulkUpdateSuccess(false, BulkModuleUpdateAction.PUBLISH, true))
+            .then(
+                assertThatNext(
+                    hasModel(expectedModel),
+                    matchesEffects(expectedEffect, expectedSnackbarEffect)
+                )
+            )
+    }
+
+    @Test
+    fun `BulkUpdateSuccess unpublish all modules and items displays correct snackbar`() {
+        val model = initModel.copy(
+            isLoading = false,
+            pageData = ModuleListPageData(DataResult.Success(emptyList()), false, "fakeUrl"),
+            modules = listOf(ModuleObject(1L, items = listOf(ModuleItem(100L))), ModuleObject(2L, items = listOf(ModuleItem(200L)))),
+            loadingModuleItemIds = setOf(1L, 100L, 2L, 200L)
+        )
+        val expectedModel = initModel.copy(
+            isLoading = true,
+            pageData = ModuleListPageData(forceNetwork = true),
+            loadingModuleItemIds = emptySet()
+        )
+        val expectedEffect = ModuleListEffect.LoadNextPage(
+            expectedModel.course,
+            expectedModel.pageData,
+            expectedModel.scrollToItemId
+        )
+        val expectedSnackbarEffect = ModuleListEffect.ShowSnackbar(R.string.allModulesAndAllItemsUnpublished)
+        updateSpec
+            .given(model)
+            .whenEvent(ModuleListEvent.BulkUpdateSuccess(false, BulkModuleUpdateAction.UNPUBLISH, true))
+            .then(
+                assertThatNext(
+                    hasModel(expectedModel),
+                    matchesEffects(expectedEffect, expectedSnackbarEffect)
+                )
+            )
+    }
+
+    @Test
+    fun `BulkUpdateSuccess publish all modules displays correct snackbar`() {
+        val model = initModel.copy(
+            isLoading = false,
+            pageData = ModuleListPageData(DataResult.Success(emptyList()), false, "fakeUrl"),
+            modules = listOf(ModuleObject(1L, items = listOf(ModuleItem(100L))), ModuleObject(2L, items = listOf(ModuleItem(200L)))),
+            loadingModuleItemIds = setOf(1L, 2L)
+        )
+        val expectedModel = initModel.copy(
+            isLoading = true,
+            pageData = ModuleListPageData(forceNetwork = true),
+            loadingModuleItemIds = emptySet()
+        )
+        val expectedEffect = ModuleListEffect.LoadNextPage(
+            expectedModel.course,
+            expectedModel.pageData,
+            expectedModel.scrollToItemId
+        )
+        val expectedSnackbarEffect = ModuleListEffect.ShowSnackbar(R.string.onlyModulesPublished)
+        updateSpec
+            .given(model)
+            .whenEvent(ModuleListEvent.BulkUpdateSuccess(true, BulkModuleUpdateAction.PUBLISH, true))
+            .then(
+                assertThatNext(
+                    hasModel(expectedModel),
+                    matchesEffects(expectedEffect, expectedSnackbarEffect)
+                )
+            )
+    }
+
+    @Test
+    fun `BulkUpdateSuccess publish single module with all items displays correct snackbar`() {
+        val model = initModel.copy(
+            isLoading = false,
+            pageData = ModuleListPageData(DataResult.Success(emptyList()), false, "fakeUrl"),
+            modules = listOf(ModuleObject(1L, items = listOf(ModuleItem(100L))), ModuleObject(2L, items = listOf(ModuleItem(200L)))),
+            loadingModuleItemIds = setOf(1L, 100L)
+        )
+        val expectedModel = initModel.copy(
+            isLoading = true,
+            pageData = ModuleListPageData(forceNetwork = true),
+            loadingModuleItemIds = emptySet()
+        )
+        val expectedEffect = ModuleListEffect.LoadNextPage(
+            expectedModel.course,
+            expectedModel.pageData,
+            expectedModel.scrollToItemId
+        )
+        val expectedSnackbarEffect = ModuleListEffect.ShowSnackbar(R.string.moduleAndAllItemsPublished)
+        updateSpec
+            .given(model)
+            .whenEvent(ModuleListEvent.BulkUpdateSuccess(false, BulkModuleUpdateAction.PUBLISH, false))
+            .then(
+                assertThatNext(
+                    hasModel(expectedModel),
+                    matchesEffects(expectedEffect, expectedSnackbarEffect)
+                )
+            )
+    }
+
+    @Test
+    fun `BulkUpdateSuccess unpublish single module with all items displays correct snackbar`() {
+        val model = initModel.copy(
+            isLoading = false,
+            pageData = ModuleListPageData(DataResult.Success(emptyList()), false, "fakeUrl"),
+            modules = listOf(ModuleObject(1L, items = listOf(ModuleItem(100L))), ModuleObject(2L, items = listOf(ModuleItem(200L)))),
+            loadingModuleItemIds = setOf(1L, 100L)
+        )
+        val expectedModel = initModel.copy(
+            isLoading = true,
+            pageData = ModuleListPageData(forceNetwork = true),
+            loadingModuleItemIds = emptySet()
+        )
+        val expectedEffect = ModuleListEffect.LoadNextPage(
+            expectedModel.course,
+            expectedModel.pageData,
+            expectedModel.scrollToItemId
+        )
+        val expectedSnackbarEffect = ModuleListEffect.ShowSnackbar(R.string.moduleAndAllItemsUnpublished)
+        updateSpec
+            .given(model)
+            .whenEvent(ModuleListEvent.BulkUpdateSuccess(false, BulkModuleUpdateAction.UNPUBLISH, false))
+            .then(
+                assertThatNext(
+                    hasModel(expectedModel),
+                    matchesEffects(expectedEffect, expectedSnackbarEffect)
+                )
+            )
+    }
+
+    @Test
+    fun `BulkUpdateSuccess publish single module displays correct snackbar`() {
+        val model = initModel.copy(
+            isLoading = false,
+            pageData = ModuleListPageData(DataResult.Success(emptyList()), false, "fakeUrl"),
+            modules = listOf(ModuleObject(1L, items = listOf(ModuleItem(100L))), ModuleObject(2L, items = listOf(ModuleItem(200L)))),
+            loadingModuleItemIds = setOf(1L)
+        )
+        val expectedModel = initModel.copy(
+            isLoading = true,
+            pageData = ModuleListPageData(forceNetwork = true),
+            loadingModuleItemIds = emptySet()
+        )
+        val expectedEffect = ModuleListEffect.LoadNextPage(
+            expectedModel.course,
+            expectedModel.pageData,
+            expectedModel.scrollToItemId
+        )
+        val expectedSnackbarEffect = ModuleListEffect.ShowSnackbar(R.string.onlyModulePublished)
+        updateSpec
+            .given(model)
+            .whenEvent(ModuleListEvent.BulkUpdateSuccess(true, BulkModuleUpdateAction.PUBLISH, false))
+            .then(
+                assertThatNext(
+                    hasModel(expectedModel),
+                    matchesEffects(expectedEffect, expectedSnackbarEffect)
                 )
             )
     }
@@ -574,13 +760,15 @@ class ModuleListUpdateTest : Assert() {
         val expectedModel = model.copy(
             loadingModuleItemIds = emptySet()
         )
+        val expectedSnackbarEffect = ModuleListEffect.ShowSnackbar(R.string.errorOccurred)
 
         updateSpec
             .given(model)
-            .whenEvent(ModuleListEvent.BulkUpdateFailed)
+            .whenEvent(ModuleListEvent.BulkUpdateFailed(false))
             .then(
                 assertThatNext(
-                    hasModel(expectedModel)
+                    hasModel(expectedModel),
+                    matchesEffects(expectedSnackbarEffect)
                 )
             )
     }
@@ -620,7 +808,7 @@ class ModuleListUpdateTest : Assert() {
             modules = listOf(ModuleObject(1L, items = listOf(ModuleItem(100L, 1L, published = true)))),
             loadingModuleItemIds = emptySet()
         )
-        val event = ModuleListEvent.ModuleItemUpdateSuccess(ModuleItem(100L, 1L, published = true))
+        val event = ModuleListEvent.ModuleItemUpdateSuccess(ModuleItem(100L, 1L, published = true), true)
         updateSpec
             .given(model)
             .whenEvent(event)

--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -1512,6 +1512,14 @@
     <string name="publishModulesAndItemsDialogMessage">This will make all modules and items visible to students.</string>
     <string name="publishModulesDialogMessage">This will make only the modules visible to students.</string>
     <string name="unpublishModulesAndItemsDialogMessage">This will make all modules and items invisible to students.</string>
+    <string name="moduleItemPublished">Item published</string>
+    <string name="moduleItemUnpublished">Item unpublished</string>
+    <string name="onlyModulePublished">Only Module published</string>
+    <string name="moduleAndAllItemsPublished">Module and all Items published</string>
+    <string name="moduleAndAllItemsUnpublished">Module and all Items unpublished</string>
+    <string name="onlyModulesPublished">Only Modules published</string>
+    <string name="allModulesAndAllItemsPublished">All Modules and all Items published</string>
+    <string name="allModulesAndAllItemsUnpublished">All Modules and all Items unpublished</string>
     <plurals name="moduleItemPoints">
         <item quantity="one">%.0f pt</item>
         <item quantity="other">%.0f pts</item>


### PR DESCRIPTION
Test plan: See ticket for design. Test if the correct snackbar shows for every event. The 'Can't publish...' snackbars are blocked by api changes, we'll revisit them when the apis are ready.

refs: MBL-17278
affects: Teacher
release note: none
