### PR TITLE
[MBL-17356][Student] - Fix front page title bug when navigating to front page from CourseBrowser 'Home'

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/features/coursebrowser/CourseBrowserFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/coursebrowser/CourseBrowserFragment.kt
@@ -213,13 +213,13 @@ class CourseBrowserFragment : Fragment(), FragmentInteractions, AppBarLayout.OnO
                     // Load Pages List
                     if (tabs.any { it.tabId == Tab.PAGES_ID }) {
                         // Do not load the pages list if the tab is hidden or locked.
-                        RouteMatcher.route(requireActivity(), TabHelper.getRouteByTabId(tab, canvasContext))
+                        RouteMatcher.route(requireActivity(), TabHelper.getRouteByTabId(tab, canvasContext, homePageTitle))
                     }
 
                     // If the home tab is a Page and we clicked it lets route directly there.
                     RouteMatcher.route(
                         requireActivity(),
-                        PageDetailsFragment.makeRoute(canvasContext, Page.FRONT_PAGE_NAME)
+                        PageDetailsFragment.makeRoute(canvasContext, homePageTitle ?: Page.FRONT_PAGE_NAME)
                             .apply { ignoreDebounce = true })
                 } else {
                     val route = TabHelper.getRouteByTabId(tab, canvasContext)?.apply { ignoreDebounce = true }

--- a/apps/student/src/main/java/com/instructure/student/features/coursebrowser/CourseBrowserFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/coursebrowser/CourseBrowserFragment.kt
@@ -213,14 +213,20 @@ class CourseBrowserFragment : Fragment(), FragmentInteractions, AppBarLayout.OnO
                     // Load Pages List
                     if (tabs.any { it.tabId == Tab.PAGES_ID }) {
                         // Do not load the pages list if the tab is hidden or locked.
-                        RouteMatcher.route(requireActivity(), TabHelper.getRouteByTabId(tab, canvasContext, homePageTitle))
+                        val route = TabHelper.getRouteByTabId(tab, canvasContext)
+                        route?.arguments = route?.arguments?.apply {
+                            putString(PageDetailsFragment.PAGE_NAME, homePageTitle)
+                        } ?: Bundle()
+                        RouteMatcher.route(requireActivity(), route)
                     }
 
                     // If the home tab is a Page and we clicked it lets route directly there.
-                    RouteMatcher.route(
-                        requireActivity(),
-                        PageDetailsFragment.makeRoute(canvasContext, homePageTitle ?: Page.FRONT_PAGE_NAME)
-                            .apply { ignoreDebounce = true })
+                    val route = PageDetailsFragment.makeFrontPageRoute(canvasContext)
+                        .apply { ignoreDebounce = true }
+                    route.arguments = route.arguments.apply {
+                        putString(PageDetailsFragment.PAGE_NAME, homePageTitle)
+                    }
+                    RouteMatcher.route(requireActivity(), route)
                 } else {
                     val route = TabHelper.getRouteByTabId(tab, canvasContext)?.apply { ignoreDebounce = true }
                     RouteMatcher.route(requireActivity(), route)

--- a/apps/student/src/main/java/com/instructure/student/features/pages/details/PageDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/pages/details/PageDetailsFragment.kt
@@ -51,7 +51,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Job
 import org.greenrobot.eventbus.Subscribe
 import java.util.*
-import java.util.regex.Pattern
+import java.util.regex.*
 import javax.inject.Inject
 
 @ScreenView(SCREEN_VIEW_PAGE_DETAILS)
@@ -67,6 +67,7 @@ class PageDetailsFragment : InternalWebviewFragment(), Bookmarkable {
     private var page: Page by ParcelableArg(default = Page(), key = PAGE)
     private var pageUrl: String? by NullableStringArg(key = PAGE_URL)
     private var navigatedFromModules: Boolean by BooleanArg(key = NAVIGATED_FROM_MODULES)
+    private var frontPage: Boolean by BooleanArg(key = FRONT_PAGE)
 
     // Flag for the webview client to know whether or not we should clear the history
     private var isUpdated = false
@@ -152,11 +153,11 @@ class PageDetailsFragment : InternalWebviewFragment(), Bookmarkable {
             } else {
                 loadFailedPageInfo(null)
             }
-        } else if (pageName == null || pageName == Page.FRONT_PAGE_NAME) fetchFontPage()
+        } else if (frontPage) fetchFrontPage()
         else fetchPageDetails()
     }
 
-    private fun fetchFontPage() {
+    private fun fetchFrontPage() {
         lifecycleScope.tryLaunch {
             val result = repository.getFrontPage(canvasContext, true)
             result.onSuccess {
@@ -331,6 +332,7 @@ class PageDetailsFragment : InternalWebviewFragment(), Bookmarkable {
         const val PAGE = "pageDetails"
         const val PAGE_URL = "pageUrl"
         const val NAVIGATED_FROM_MODULES = "navigated_from_modules"
+        private const val FRONT_PAGE = "frontPage"
 
         fun newInstance(route: Route): PageDetailsFragment? {
             return if (validRoute(route)) PageDetailsFragment().apply {
@@ -349,9 +351,9 @@ class PageDetailsFragment : InternalWebviewFragment(), Bookmarkable {
                             route.paramsHash.containsKey(RouterParams.PAGE_ID))
         }
 
-        fun makeRoute(canvasContext: CanvasContext, pageName: String?): Route {
+        fun makeFrontPageRoute(canvasContext: CanvasContext): Route {
             return Route(null, PageDetailsFragment::class.java, canvasContext, canvasContext.makeBundle(Bundle().apply {
-                if (pageName != null) putString(PAGE_NAME, pageName)
+                putBoolean(FRONT_PAGE, true)
             }))
         }
 

--- a/apps/student/src/main/java/com/instructure/student/features/pages/list/PageListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/pages/list/PageListFragment.kt
@@ -129,9 +129,8 @@ class PageListFragment : ParentFragment(), Bookmarkable {
         super.onActivityCreated(savedInstanceState)
 
         if (isShowFrontPage) {
-            val route = PageDetailsFragment.makeRoute(
-                canvasContext,
-                Page.FRONT_PAGE_NAME
+            val route = PageDetailsFragment.makeFrontPageRoute(
+                canvasContext
             ).apply { ignoreDebounce = true}
             RouteMatcher.route(requireActivity(), route)
         }

--- a/apps/student/src/main/java/com/instructure/student/util/TabHelper.kt
+++ b/apps/student/src/main/java/com/instructure/student/util/TabHelper.kt
@@ -19,7 +19,6 @@ package com.instructure.student.util
 
 import com.instructure.canvasapi2.models.CanvasContext
 import com.instructure.canvasapi2.models.Course
-import com.instructure.canvasapi2.models.Page
 import com.instructure.canvasapi2.models.Tab
 import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.canvasapi2.utils.ContextKeeper
@@ -101,7 +100,7 @@ object TabHelper {
             Tab.ASSIGNMENTS_ID -> AssignmentListFragment.makeRoute(canvasContext)
             Tab.MODULES_ID -> ModuleListFragment.makeRoute(canvasContext)
             Tab.PAGES_ID -> PageListFragment.makeRoute(canvasContext, false)
-            Tab.FRONT_PAGE_ID -> PageDetailsFragment.makeRoute(canvasContext, homePageTitle ?: Page.FRONT_PAGE_NAME)
+            Tab.FRONT_PAGE_ID -> PageDetailsFragment.makeFrontPageRoute(canvasContext)
             Tab.DISCUSSIONS_ID -> DiscussionListFragment.makeRoute(canvasContext)
             Tab.PEOPLE_ID -> PeopleListFragment.makeRoute(canvasContext)
             Tab.FILES_ID -> FileListFragment.makeRoute(canvasContext)

--- a/apps/student/src/main/java/com/instructure/student/util/TabHelper.kt
+++ b/apps/student/src/main/java/com/instructure/student/util/TabHelper.kt
@@ -74,7 +74,7 @@ object TabHelper {
 
     fun isHomeTab(tab: Tab): Boolean = "home".equals(tab.tabId, ignoreCase = true)
 
-    fun getRouteByTabId(tabb: Tab?, canvasContext: CanvasContext, homePageTitle: String? = null): Route? {
+    fun getRouteByTabId(tabb: Tab?, canvasContext: CanvasContext): Route? {
         val tab = tabb ?: Tab(Tab.HOME_ID, "")
 
         // Student view doesn't support groups, collaborations, or external LTIs from the Course Browser

--- a/apps/student/src/main/java/com/instructure/student/util/TabHelper.kt
+++ b/apps/student/src/main/java/com/instructure/student/util/TabHelper.kt
@@ -36,7 +36,11 @@ import com.instructure.student.features.pages.details.PageDetailsFragment
 import com.instructure.student.features.pages.list.PageListFragment
 import com.instructure.student.features.people.list.PeopleListFragment
 import com.instructure.student.features.quiz.list.QuizListFragment
-import com.instructure.student.fragment.*
+import com.instructure.student.fragment.AnnouncementListFragment
+import com.instructure.student.fragment.CourseSettingsFragment
+import com.instructure.student.fragment.LtiLaunchFragment
+import com.instructure.student.fragment.NotificationListFragment
+import com.instructure.student.fragment.UnsupportedTabFragment
 import com.instructure.student.mobius.conferences.conference_list.ui.ConferenceListRepositoryFragment
 import com.instructure.student.mobius.syllabus.ui.SyllabusRepositoryFragment
 import java.util.*
@@ -71,7 +75,7 @@ object TabHelper {
 
     fun isHomeTab(tab: Tab): Boolean = "home".equals(tab.tabId, ignoreCase = true)
 
-    fun getRouteByTabId(tabb: Tab?, canvasContext: CanvasContext): Route? {
+    fun getRouteByTabId(tabb: Tab?, canvasContext: CanvasContext, homePageTitle: String? = null): Route? {
         val tab = tabb ?: Tab(Tab.HOME_ID, "")
 
         // Student view doesn't support groups, collaborations, or external LTIs from the Course Browser
@@ -97,7 +101,7 @@ object TabHelper {
             Tab.ASSIGNMENTS_ID -> AssignmentListFragment.makeRoute(canvasContext)
             Tab.MODULES_ID -> ModuleListFragment.makeRoute(canvasContext)
             Tab.PAGES_ID -> PageListFragment.makeRoute(canvasContext, false)
-            Tab.FRONT_PAGE_ID -> PageDetailsFragment.makeRoute(canvasContext, Page.FRONT_PAGE_NAME)
+            Tab.FRONT_PAGE_ID -> PageDetailsFragment.makeRoute(canvasContext, homePageTitle ?: Page.FRONT_PAGE_NAME)
             Tab.DISCUSSIONS_ID -> DiscussionListFragment.makeRoute(canvasContext)
             Tab.PEOPLE_ID -> PeopleListFragment.makeRoute(canvasContext)
             Tab.FILES_ID -> FileListFragment.makeRoute(canvasContext)


### PR DESCRIPTION
Test plan: Test with a front page as the 'Home' of a course. Smoke test some other 'Home' settings and the Pages tab itself.

Fix front page issue by passing homePageTitle as the parameter for the TabHelper.getRouteByTabId method (null safely).

refs: MBL-17356
affects: Student
release note: Front Page title fixed when navigating from Course Browser by 'Home'.


## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-android/assets/92309696/8c268b44-4f68-4ddc-bee0-d9c2752cfec2" height=800 width=1400></td>
<td><img src="https://github.com/instructure/canvas-android/assets/92309696/dba991c3-8824-4f05-a8e7-5c93b1bd54bd" height=800 width=1400></td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Tested in light mode
