### PR TITLE
[MBL-17371][Parent] Grades page displays letter grade with no percentage

### DIFF
--- a/apps/flutter_parent/lib/screens/courses/courses_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/courses_screen.dart
@@ -130,11 +130,14 @@ class _CoursesScreenState extends State<CoursesScreen> {
     // If there is no current grade, return 'No grade'
     // Otherwise, we have a grade, so check if we have the actual grade string
     // or a score
+    var formattedScore = (grade.currentScore() != null && !(course.settings?.restrictQuantitativeData ?? false))
+        ? format.format(grade.currentScore()! / 100)
+        : '';
     var text = grade.noCurrentGrade()
         ? L10n(context).noGrade
         : grade.currentGrade()?.isNotEmpty == true
-            ? grade.currentGrade()!
-            : format.format(grade.currentScore()! / 100);
+            ? "${grade.currentGrade()}${formattedScore.isNotEmpty ? ' $formattedScore' : ''}"
+            : formattedScore;
 
     return Text(
       text,

--- a/apps/flutter_parent/lib/screens/courses/details/course_grades_screen.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_grades_screen.dart
@@ -255,22 +255,25 @@ class _CourseGradeHeader extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: <Widget>[
           Text(L10n(context).courseTotalGradeLabel, style: textTheme.bodyMedium),
-          Text(_courseGrade(context, grade), style: textTheme.bodyMedium, key: Key("total_grade")),
+          Text(_courseGrade(context, grade, model.courseSettings?.restrictQuantitativeData ?? false), style: textTheme.bodyMedium, key: Key("total_grade")),
         ],
       ),
     );
   }
 
-  String _courseGrade(BuildContext context, CourseGrade grade) {
+  String _courseGrade(BuildContext context, CourseGrade grade, bool restrictQuantitativeData) {
     final format = NumberFormat.percentPattern();
     format.maximumFractionDigits = 2;
 
     if (grade.noCurrentGrade()) {
       return L10n(context).noGrade;
     } else {
+      var formattedScore = (grade.currentScore() != null && restrictQuantitativeData == false)
+          ? format.format(grade.currentScore()! / 100)
+          : '';
       return grade.currentGrade()?.isNotEmpty == true
-          ? grade.currentGrade()!
-          : format.format(grade.currentScore()! / 100); // format multiplies by 100 for percentages
+          ? "${grade.currentGrade()}${formattedScore.isNotEmpty ? ' $formattedScore' : ''}"
+          : formattedScore;
     }
   }
 }
@@ -375,7 +378,7 @@ class _AssignmentRow extends StatelessWidget {
 
     final submission = assignment.submission(studentId);
 
-    final restrictQuantitativeData = course?.settings?.restrictQuantitativeData ?? false;
+    final restrictQuantitativeData = course.settings?.restrictQuantitativeData ?? false;
 
     if (submission?.excused ?? false) {
       text = restrictQuantitativeData

--- a/apps/flutter_parent/test/screens/courses/courses_screen_test.dart
+++ b/apps/flutter_parent/test/screens/courses/courses_screen_test.dart
@@ -41,7 +41,6 @@ import 'package:provider/provider.dart';
 import '../../utils/accessibility_utils.dart';
 import '../../utils/platform_config.dart';
 import '../../utils/test_app.dart';
-import '../../utils/test_helpers/mock_helpers.dart';
 import '../../utils/test_helpers/mock_helpers.mocks.dart';
 
 void main() {
@@ -163,6 +162,48 @@ void main() {
             [_mockEnrollment(idx.toString(), userId: student.id, computedCurrentGrade: 'A')],
           ),
         ),
+      );
+
+      _setupLocator(_MockedCoursesInteractor(courses: courses));
+
+      await tester.pumpWidget(_testableMaterialWidget());
+      await tester.pumpAndSettle();
+
+      final gradeWidget = find.text('A');
+      expect(gradeWidget, findsNWidgets(courses.length));
+    });
+
+    testWidgetsWithAccessibilityChecks('shows grade and score if there is a current grade and score', (tester) async {
+      var student = _mockStudent('1');
+      var courses = List.generate(
+        1,
+        (idx) => _mockCourse(
+          idx.toString(),
+          enrollments: ListBuilder<Enrollment>(
+            [_mockEnrollment(idx.toString(), userId: student.id, computedCurrentGrade: 'A', computedCurrentScore: 75)],
+          ),
+        ),
+      );
+
+      _setupLocator(_MockedCoursesInteractor(courses: courses));
+
+      await tester.pumpWidget(_testableMaterialWidget());
+      await tester.pumpAndSettle();
+
+      final gradeWidget = find.text('A 75%');
+      expect(gradeWidget, findsNWidgets(courses.length));
+    });
+
+    testWidgetsWithAccessibilityChecks('shows grade only if there is a current grade and score and restricted', (tester) async {
+      var student = _mockStudent('1');
+      var courses = List.generate(
+        1,
+        (idx) => _mockCourse(
+          idx.toString(),
+          enrollments: ListBuilder<Enrollment>(
+            [_mockEnrollment(idx.toString(), userId: student.id, computedCurrentGrade: 'A', computedCurrentScore: 75)],
+          ),
+        ).rebuild((b) => b..settings = (b.settings..restrictQuantitativeData = true)),
       );
 
       _setupLocator(_MockedCoursesInteractor(courses: courses));


### PR DESCRIPTION
Test plan: in the ticket.

refs: MBL-17371
affects: Parent
release note: Added percentage to course grade.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-android/assets/109959688/90d57beb-cb2a-4176-9deb-90d2538ca9ff" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-android/assets/109959688/4e2c1d98-96d4-4fd5-9a47-52894d9a2991" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/instructure/canvas-android/assets/109959688/d3014180-269e-4ca8-827e-1ac920717a15" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-android/assets/109959688/ee60c646-d975-47c4-a09a-f41de306aa81" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Run E2E test suite
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] A11y checked
