### PR TITLE
[MBL-17327][Student][Teacher] Embedded media content prompts for authentication when logged in via QR login

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/activity/InterwebsToApplication.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/InterwebsToApplication.kt
@@ -76,7 +76,7 @@ class InterwebsToApplication : AppCompatActivity() {
     public override fun onCreate(savedInstanceState: Bundle?) {
         requestWindowFeature(Window.FEATURE_NO_TITLE)
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.interwebs_to_application)
+        setContentView(binding.root)
         loadingBinding = LoadingCanvasViewBinding.bind(binding.root)
         loadingBinding.loadingRoute.visibility = View.VISIBLE
 

--- a/apps/student/src/main/java/com/instructure/student/activity/InterwebsToApplication.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/InterwebsToApplication.kt
@@ -27,11 +27,13 @@ import android.view.View
 import android.view.Window
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import com.instructure.canvasapi2.managers.OAuthManager
 import com.instructure.canvasapi2.models.AccountDomain
 import com.instructure.canvasapi2.utils.Analytics
 import com.instructure.canvasapi2.utils.AnalyticsEventConstants
 import com.instructure.canvasapi2.utils.AnalyticsParamConstants
 import com.instructure.canvasapi2.utils.ApiPrefs
+import com.instructure.canvasapi2.utils.weave.apiAsync
 import com.instructure.canvasapi2.utils.weave.catch
 import com.instructure.canvasapi2.utils.weave.tryWeave
 import com.instructure.loginapi.login.tasks.LogoutTask
@@ -126,6 +128,13 @@ class InterwebsToApplication : AppCompatActivity() {
                     }
 
                     val tokenResponse = performSSOLogin(data, this@InterwebsToApplication)
+
+                    val authResult = apiAsync { OAuthManager.getAuthenticatedSession(ApiPrefs.fullDomain, it) }.await()
+                    if (authResult.isSuccess) {
+                        authResult.dataOrNull?.sessionUrl?.let {
+                            binding.dummyWebView.loadUrl(it)
+                        }
+                    }
 
                     val canvasForElementary = featureFlagProvider.getCanvasForElementaryFlag()
 

--- a/apps/student/src/main/res/layout/interwebs_to_application.xml
+++ b/apps/student/src/main/res/layout/interwebs_to_application.xml
@@ -20,6 +20,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <com.instructure.pandautils.views.CanvasWebView
+        android:id="@+id/dummyWebView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="invisible"/>
+
     <include layout="@layout/loading_canvas_view"/>
 
 </FrameLayout>

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/login/TeacherLoginNavigation.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/login/TeacherLoginNavigation.kt
@@ -17,6 +17,7 @@
 package com.instructure.teacher.features.login
 
 import android.content.Intent
+import android.webkit.CookieManager
 import androidx.fragment.app.FragmentActivity
 import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.loginapi.login.LoginNavigation
@@ -34,6 +35,8 @@ class TeacherLoginNavigation(private val activity: FragmentActivity) : LoginNavi
 
     override fun initMainActivityIntent(): Intent {
         PushNotificationRegistrationWorker.scheduleJob(activity, ApiPrefs.isMasquerading)
+
+        CookieManager.getInstance().flush()
 
         return SplashActivity.createIntent(activity, activity.intent?.extras)
     }

--- a/apps/teacher/src/main/res/layout/activity_route_validator.xml
+++ b/apps/teacher/src/main/res/layout/activity_route_validator.xml
@@ -23,6 +23,12 @@
     android:background="@color/backgroundLightest"
     android:orientation="vertical">
 
+    <com.instructure.pandautils.views.CanvasWebView
+        android:id="@+id/dummyWebView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="invisible"/>
+
     <com.instructure.loginapi.login.view.CanvasLoadingView
         android:id="@+id/canvasLoadingView"
         android:layout_width="120dp"

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/binding/ViewBindingDelegate.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/binding/ViewBindingDelegate.kt
@@ -22,6 +22,7 @@ import android.view.LayoutInflater
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
@@ -80,6 +81,12 @@ fun <T : ViewBinding> Fragment.viewBinding(viewBindingFactory: (View) -> T) =
     FragmentViewBindingDelegate(this, viewBindingFactory)
 
 inline fun <T : ViewBinding> AppCompatActivity.viewBinding(
+    crossinline bindingInflater: (LayoutInflater) -> T) =
+    lazy(LazyThreadSafetyMode.NONE) {
+        bindingInflater.invoke(layoutInflater)
+    }
+
+inline fun <T : ViewBinding> FragmentActivity.viewBinding(
     crossinline bindingInflater: (LayoutInflater) -> T) =
     lazy(LazyThreadSafetyMode.NONE) {
         bindingInflater.invoke(layoutInflater)


### PR DESCRIPTION
Test plan: In the ticket. Test both the Teacher and the Student app. Also smoke test the behavior with normal login and smoke test WebViews that need authentication (for example quizzes)

refs: MBL-17327
affects: Student, Teacher
release note: Fixed a bug where embedded media prompts for authentication after QR login.

## Checklist

- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
