### PR TITLE
[MBL-17353][Teacher] - Remove unused TestRail annotation

### DIFF
--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/AssignmentDetailsPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/AssignmentDetailsPageTest.kt
@@ -32,7 +32,6 @@ import com.instructure.dataseeding.util.ago
 import com.instructure.dataseeding.util.days
 import com.instructure.dataseeding.util.fromNow
 import com.instructure.dataseeding.util.iso8601
-import com.instructure.espresso.TestRail
 import com.instructure.teacher.ui.utils.TeacherTest
 import com.instructure.teacher.ui.utils.tokenLogin
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -42,7 +41,6 @@ import org.junit.Test
 class AssignmentDetailsPageTest : TeacherTest() {
 
     @Test
-    @TestRail(ID = "C3109579")
     override fun displaysPageObjects() {
         getToAssignmentDetailsPage(
                 submissionTypes = listOf(ONLINE_TEXT_ENTRY),
@@ -52,35 +50,30 @@ class AssignmentDetailsPageTest : TeacherTest() {
     }
 
     @Test
-    @TestRail(ID = "C3109579")
     fun displaysCorrectDetails() {
         val assignment = getToAssignmentDetailsPage()
         assignmentDetailsPage.assertAssignmentDetails(assignment)
     }
 
     @Test
-    @TestRail(ID = "C3109579")
     fun displaysInstructions() {
         getToAssignmentDetailsPage(withDescription = true)
         assignmentDetailsPage.assertDisplaysInstructions()
     }
 
     @Test
-    @TestRail(ID = "C3134480")
     fun displaysNoInstructionsMessage() {
         getToAssignmentDetailsPage()
         assignmentDetailsPage.assertDisplaysNoInstructionsView()
     }
 
     @Test
-    @TestRail(ID = "C3134481")
     fun displaysClosedAvailability() {
         getToAssignmentDetailsPage(lockAt = 7.days.ago.iso8601)
         assignmentDetailsPage.assertAssignmentClosed()
     }
 
     @Test
-    @TestRail(ID = "C313448 2")
     fun displaysNoFromDate() {
         val lockAt = 7.days.fromNow.iso8601
         getToAssignmentDetailsPage(lockAt = lockAt)
@@ -88,7 +81,6 @@ class AssignmentDetailsPageTest : TeacherTest() {
     }
 
     @Test
-    @TestRail(ID = "C3134483")
     fun displaysNoToDate() {
         getToAssignmentDetailsPage(unlockAt = 7.days.ago.iso8601)
         assignmentDetailsPage.assertFromFilledAndToEmpty()

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/AssignmentDueDatesPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/AssignmentDueDatesPageTest.kt
@@ -25,7 +25,6 @@ import com.instructure.dataseeding.util.ago
 import com.instructure.dataseeding.util.days
 import com.instructure.dataseeding.util.fromNow
 import com.instructure.dataseeding.util.iso8601
-import com.instructure.espresso.TestRail
 import com.instructure.teacher.ui.utils.TeacherTest
 import com.instructure.teacher.ui.utils.tokenLogin
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -35,28 +34,24 @@ import org.junit.Test
 class AssignmentDueDatesPageTest : TeacherTest() {
 
     @Test
-    @TestRail(ID = "C3134131")
     override fun displaysPageObjects() {
         getToDueDatesPage()
         assignmentDueDatesPage.assertPageObjects()
     }
 
     @Test
-    @TestRail(ID = "C3134484")
     fun displaysNoDueDate() {
         getToDueDatesPage()
         assignmentDueDatesPage.assertDisplaysNoDueDate()
     }
 
     @Test
-    @TestRail(ID = "C3134485")
     fun displaysSingleDueDate() {
         getToDueDatesPage(dueAt = 7.days.fromNow.iso8601)
         assignmentDueDatesPage.assertDisplaysSingleDueDate()
     }
 
     @Test
-    @TestRail(ID = "C3134486")
     fun displaysAvailabilityDates() {
         getToDueDatesPage(lockAt = 7.days.fromNow.iso8601, unlockAt = 7.days.ago.iso8601)
         assignmentDueDatesPage.assertDisplaysAvailabilityDates()

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/AssignmentListPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/AssignmentListPageTest.kt
@@ -22,7 +22,6 @@ import com.instructure.canvas.espresso.mockCanvas.init
 import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.AssignmentGroup
 import com.instructure.canvasapi2.models.CanvasContextPermission
-import com.instructure.espresso.TestRail
 import com.instructure.teacher.ui.utils.TeacherTest
 import com.instructure.teacher.ui.utils.tokenLogin
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -32,28 +31,24 @@ import org.junit.Test
 class AssignmentListPageTest : TeacherTest() {
 
     @Test
-    @TestRail(ID = "C3109578")
     override fun displaysPageObjects() {
         getToAssignmentsPage()
         assignmentListPage.assertPageObjects()
     }
 
     @Test
-    @TestRail(ID = "C3134487")
     fun displaysNoAssignmentsView() {
         getToAssignmentsPage(0)
         assignmentListPage.assertDisplaysNoAssignmentsView()
     }
 
     @Test
-    @TestRail(ID = "C3109578")
     fun displaysAssignment() {
         val assignment = getToAssignmentsPage().assignments.values.first()
         assignmentListPage.assertHasAssignment(assignment)
     }
 
     @Test
-    @TestRail(ID = "C3134488")
     fun displaysGradingPeriods() {
         getToAssignmentsPage(gradingPeriods = true)
         assignmentListPage.assertHasGradingPeriods()

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/CourseBrowserPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/CourseBrowserPageTest.kt
@@ -17,7 +17,6 @@ package com.instructure.teacher.ui
 
 import com.instructure.canvas.espresso.mockCanvas.MockCanvas
 import com.instructure.canvas.espresso.mockCanvas.init
-import com.instructure.espresso.TestRail
 import com.instructure.teacher.ui.utils.TeacherTest
 import com.instructure.teacher.ui.utils.tokenLogin
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -27,7 +26,6 @@ import org.junit.Test
 class CourseBrowserPageTest : TeacherTest() {
 
     @Test
-    @TestRail(ID = "C3108909")
     override fun displaysPageObjects() {
         val data = MockCanvas.init(teacherCount = 1, courseCount = 3, favoriteCourseCount = 3)
         val teacher = data.teachers[0]

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/CourseSettingsPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/CourseSettingsPageTest.kt
@@ -17,7 +17,6 @@ package com.instructure.teacher.ui
 
 import com.instructure.canvas.espresso.mockCanvas.MockCanvas
 import com.instructure.canvas.espresso.mockCanvas.init
-import com.instructure.espresso.TestRail
 import com.instructure.espresso.randomString
 import com.instructure.teacher.ui.utils.TeacherTest
 import com.instructure.teacher.ui.utils.tokenLogin
@@ -28,14 +27,12 @@ import org.junit.Test
 class CourseSettingsPageTest : TeacherTest() {
 
     @Test
-    @TestRail(ID = "C3108914")
     override fun displaysPageObjects() {
         navigateToCourseSettings()
         courseSettingsPage.assertPageObjects()
     }
 
     @Test
-    @TestRail(ID = "C3108915")
     fun editCourseName() {
         navigateToCourseSettings()
         courseSettingsPage.clickCourseName()
@@ -45,7 +42,6 @@ class CourseSettingsPageTest : TeacherTest() {
     }
 
     @Test
-    @TestRail(ID = "C3108916")
     fun editCourseHomePage() {
         navigateToCourseSettings()
         courseSettingsPage.clickSetHomePage()

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/DashboardPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/DashboardPageTest.kt
@@ -19,7 +19,6 @@ package com.instructure.teacher.ui
 
 import com.instructure.canvas.espresso.mockCanvas.MockCanvas
 import com.instructure.canvas.espresso.mockCanvas.init
-import com.instructure.espresso.TestRail
 import com.instructure.teacher.ui.utils.TeacherTest
 import com.instructure.teacher.ui.utils.tokenLogin
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -29,7 +28,6 @@ import org.junit.Test
 class DashboardPageTest : TeacherTest() {
 
     @Test
-    @TestRail(ID = "C3108898")
     override fun displaysPageObjects() {
         val data = MockCanvas.init(teacherCount = 1, courseCount = 1, favoriteCourseCount = 1)
         val teacher = data.teachers[0]
@@ -39,7 +37,6 @@ class DashboardPageTest : TeacherTest() {
     }
 
     @Test
-    @TestRail(ID = "C3109494")
     fun displaysNoCoursesView() {
         val data = MockCanvas.init(teacherCount = 1, pastCourseCount = 1)
         val teacher = data.teachers[0]
@@ -49,7 +46,6 @@ class DashboardPageTest : TeacherTest() {
     }
 
     @Test
-    @TestRail(ID = "C3108898")
     fun displaysCourseList() {
         val data = MockCanvas.init(teacherCount = 1, favoriteCourseCount = 3, courseCount = 3)
         val teacher = data.teachers[0]

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/EditAssignmentDetailsPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/EditAssignmentDetailsPageTest.kt
@@ -25,7 +25,6 @@ import com.instructure.canvas.espresso.mockCanvas.init
 import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.CanvasContextPermission
 import com.instructure.canvasapi2.utils.NumberHelper
-import com.instructure.espresso.TestRail
 import com.instructure.espresso.randomDouble
 import com.instructure.espresso.randomString
 import com.instructure.teacher.R
@@ -39,7 +38,6 @@ import org.junit.Test
 class EditAssignmentDetailsPageTest : TeacherTest() {
 
     @Test
-    @TestRail(ID = "C3109580")
     override fun displaysPageObjects() {
         getToEditAssignmentDetailsPage()
         editAssignmentDetailsPage.assertPageObjects()
@@ -55,7 +53,6 @@ class EditAssignmentDetailsPageTest : TeacherTest() {
     }
 
     @Test
-    @TestRail(ID = "C3134126")
     fun editAssignmentName() {
         getToEditAssignmentDetailsPage()
         editAssignmentDetailsPage.clickAssignmentNameEditText()
@@ -66,7 +63,6 @@ class EditAssignmentDetailsPageTest : TeacherTest() {
     }
 
     @Test
-    @TestRail(ID = "C3134126")
     fun editAssignmentPoints() {
         getToEditAssignmentDetailsPage()
         editAssignmentDetailsPage.clickPointsPossibleEditText()

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/EditDashboardPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/EditDashboardPageTest.kt
@@ -19,7 +19,6 @@ package com.instructure.teacher.ui
 
 import com.instructure.canvas.espresso.mockCanvas.MockCanvas
 import com.instructure.canvas.espresso.mockCanvas.init
-import com.instructure.espresso.TestRail
 import com.instructure.teacher.ui.utils.TeacherTest
 import com.instructure.teacher.ui.utils.tokenLogin
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -29,7 +28,6 @@ import org.junit.Test
 class EditDashboardPageTest : TeacherTest() {
 
     @Test
-    @TestRail(ID = "C3109572")
     override fun displaysPageObjects() {
         setUpAndSignIn(numCourses = 1, numFavoriteCourses = 0)
         dashboardPage.clickEditDashboard()
@@ -37,7 +35,6 @@ class EditDashboardPageTest : TeacherTest() {
     }
 
     @Test
-    @TestRail(ID = "C3109572")
     fun displaysCourseList() {
         val data = setUpAndSignIn(numCourses = 1, numFavoriteCourses = 0)
         val course = data.courses.values.toList()[0]
@@ -46,7 +43,6 @@ class EditDashboardPageTest : TeacherTest() {
     }
 
     @Test
-    @TestRail(ID = "C3109574")
     fun addCourseToFavourites() {
         val data = setUpAndSignIn(numCourses = 1, numFavoriteCourses = 0)
         val courses = data.courses.values.toList()
@@ -57,7 +53,6 @@ class EditDashboardPageTest : TeacherTest() {
     }
 
     @Test
-    @TestRail(ID = "C3109575")
     fun removeCourseFromFavourites() {
         val data = setUpAndSignIn(numCourses = 1, numFavoriteCourses = 1)
         val courses = data.courses.values.toList()

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/LoginFindSchoolPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/LoginFindSchoolPageTest.kt
@@ -1,6 +1,5 @@
 package com.instructure.teacher.ui
 
-import com.instructure.espresso.TestRail
 import com.instructure.teacher.ui.utils.TeacherTest
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Test
@@ -9,7 +8,6 @@ import org.junit.Test
 class LoginFindSchoolPageTest: TeacherTest() {
 
     @Test
-    @TestRail(ID = "C3108892")
     override fun displaysPageObjects() {
         loginLandingPage.clickFindMySchoolButton()
         loginFindSchoolPage.assertPageObjects()

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/LoginLandingPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/LoginLandingPageTest.kt
@@ -1,6 +1,5 @@
 package com.instructure.teacher.ui
 
-import com.instructure.espresso.TestRail
 import com.instructure.espresso.filters.P1
 import com.instructure.teacher.ui.utils.TeacherTest
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -11,7 +10,6 @@ class LoginLandingPageTest: TeacherTest() {
 
     // Runs live; no MockCanvas
     @Test
-    @TestRail(ID = "C3108891")
     @P1
     override fun displaysPageObjects() {
         loginLandingPage.assertPageObjects()
@@ -19,7 +17,6 @@ class LoginLandingPageTest: TeacherTest() {
 
     // Runs live; no MockCanvas
     @Test
-    @TestRail(ID = "C3108893")
     fun opensCanvasNetworksSignInPage() {
         loginLandingPage.clickCanvasNetworkButton()
         loginSignInPage.assertPageObjects()

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/LoginSignInPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/LoginSignInPageTest.kt
@@ -17,7 +17,6 @@
 
 package com.instructure.teacher.ui
 
-import com.instructure.espresso.TestRail
 import com.instructure.teacher.ui.utils.TeacherTest
 import com.instructure.teacher.ui.utils.enterDomain
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -28,7 +27,6 @@ class LoginSignInPageTest: TeacherTest() {
 
     // Runs live; no MockCanvas
     @Test
-    @TestRail(ID = "C3108896")
     override fun displaysPageObjects() {
         loginLandingPage.clickFindMySchoolButton()
         enterDomain()

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/QuizDetailsPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/QuizDetailsPageTest.kt
@@ -15,14 +15,17 @@
  */
 package com.instructure.teacher.ui
 
-import com.instructure.canvas.espresso.mockCanvas.*
+import com.instructure.canvas.espresso.mockCanvas.MockCanvas
+import com.instructure.canvas.espresso.mockCanvas.addCoursePermissions
+import com.instructure.canvas.espresso.mockCanvas.addQuizSubmission
+import com.instructure.canvas.espresso.mockCanvas.addQuizToCourse
+import com.instructure.canvas.espresso.mockCanvas.init
 import com.instructure.canvasapi2.models.CanvasContextPermission
 import com.instructure.canvasapi2.models.Quiz
 import com.instructure.dataseeding.util.ago
 import com.instructure.dataseeding.util.days
 import com.instructure.dataseeding.util.fromNow
 import com.instructure.dataseeding.util.iso8601
-import com.instructure.espresso.TestRail
 import com.instructure.teacher.ui.utils.TeacherTest
 import com.instructure.teacher.ui.utils.tokenLogin
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -32,42 +35,36 @@ import org.junit.Test
 class QuizDetailsPageTest: TeacherTest() {
 
     @Test
-    @TestRail(ID = "C3109579")
     override fun displaysPageObjects() {
         getToQuizDetailsPage()
         quizDetailsPage.assertPageObjects()
     }
 
     @Test
-    @TestRail(ID = "C3109579")
     fun displaysCorrectDetails() {
         val quiz = getToQuizDetailsPage()
         quizDetailsPage.assertQuizDetails(quiz)
     }
 
     @Test
-    @TestRail(ID = "C3109579")
     fun displaysInstructions() {
         getToQuizDetailsPage(withDescription = true)
         quizDetailsPage.assertDisplaysInstructions()
     }
 
     @Test
-    @TestRail(ID = "C3134480")
     fun displaysNoInstructionsMessage() {
         getToQuizDetailsPage()
         quizDetailsPage.assertDisplaysNoInstructionsView()
     }
 
     @Test
-    @TestRail(ID = "C3134481")
     fun displaysClosedAvailability() {
         getToQuizDetailsPage(lockAt = 1.days.ago.iso8601)
         quizDetailsPage.assertQuizClosed()
     }
 
     @Test
-    @TestRail(ID = "C3134482")
     fun displaysNoFromDate() {
         val lockAt = 2.days.fromNow.iso8601
         getToQuizDetailsPage(lockAt = lockAt)
@@ -75,7 +72,6 @@ class QuizDetailsPageTest: TeacherTest() {
     }
 
     @Test
-    @TestRail(ID = "C3134483")
     fun displaysNoToDate() {
         getToQuizDetailsPage(unlockAt = 2.days.ago.iso8601)
         quizDetailsPage.assertFromFilledAndToEmpty()

--- a/automation/espresso/src/main/kotlin/com/instructure/espresso/TestRail.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/espresso/TestRail.kt
@@ -1,8 +1,0 @@
-package com.instructure.espresso
-
-import java.lang.annotation.Retention
-import java.lang.annotation.RetentionPolicy
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
-annotation class TestRail(val ID: String = "unknown")


### PR DESCRIPTION
Remove unused TestRail annotation from teacher page tests.

refs: MBL-17353
affects: Student
release note: none