### PR TITLE
[MBL-17391][Student] Calendar swipe animation

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/CalendarScreenUiState.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/CalendarScreenUiState.kt
@@ -85,7 +85,7 @@ data class EventUiState(
 )
 
 sealed class CalendarAction {
-    data object ExpandChanged : CalendarAction()
+    data class ExpandChanged(val isExpanded: Boolean) : CalendarAction()
     data object ExpandDisabled : CalendarAction()
     data object ExpandEnabled : CalendarAction()
     data class DaySelected(val selectedDay: LocalDate) : CalendarAction()

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/CalendarViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/CalendarViewModel.kt
@@ -259,7 +259,7 @@ class CalendarViewModel @Inject constructor(
     fun handleAction(calendarAction: CalendarAction) {
         when (calendarAction) {
             is CalendarAction.DaySelected -> selectedDayChangedWithPageAnimation(calendarAction.selectedDay)
-            CalendarAction.ExpandChanged -> expandChangedWithAnimation(!expanded)
+            is CalendarAction.ExpandChanged -> expandChangedWithAnimation(calendarAction.isExpanded)
             CalendarAction.ExpandDisabled -> {
                 expandAllowed = false
                 expandChanged(false, save = false)

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/composables/Calendar.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/composables/Calendar.kt
@@ -20,6 +20,7 @@ import androidx.compose.animation.core.animateIntAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -38,11 +39,16 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.FractionalThreshold
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
+import androidx.compose.material.rememberSwipeableState
+import androidx.compose.material.swipeable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -79,7 +85,7 @@ private const val MIN_SCREEN_HEIGHT_FOR_FULL_CALENDAR = 500
 private const val HEADER_HEIGHT = 20
 private const val CALENDAR_ROW_HEIGHT = 46
 
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterialApi::class)
 @Composable
 fun Calendar(calendarUiState: CalendarUiState, actionHandler: (CalendarAction) -> Unit, modifier: Modifier = Modifier) {
     Column(modifier = modifier) {
@@ -90,6 +96,9 @@ fun Calendar(calendarUiState: CalendarUiState, actionHandler: (CalendarAction) -
         ) {
             Int.MAX_VALUE
         }
+
+        val calendarBodyUiState = calendarUiState.bodyUiState
+        val maxHeight = CALENDAR_ROW_HEIGHT + CALENDAR_ROW_HEIGHT * calendarBodyUiState.currentPage.calendarRows.size - 1
 
         LaunchedEffect(pagerState) {
             snapshotFlow { pagerState.settledPage }.collect { page ->
@@ -114,6 +123,15 @@ fun Calendar(calendarUiState: CalendarUiState, actionHandler: (CalendarAction) -
         )
         Spacer(modifier = Modifier.height(10.dp))
         HorizontalPager(
+            modifier = Modifier.swipeable(
+                state = rememberSwipeableState(initialValue = if (calendarUiState.expanded) 1f else 0f, confirmStateChange = {
+                    actionHandler(CalendarAction.ExpandChanged(it == 1f))
+                    true
+                }),
+                orientation = Orientation.Vertical,
+                anchors = mapOf(0f to 0f, maxHeight.toFloat() to 1f),
+                thresholds = { _, _ -> FractionalThreshold(0.5f) },
+            ),
             state = pagerState,
             beyondBoundsPageCount = 2,
             reverseLayout = false,
@@ -122,7 +140,6 @@ fun Calendar(calendarUiState: CalendarUiState, actionHandler: (CalendarAction) -
                 val settledPage = pagerState.settledPage
 
                 val monthOffset = page - centerIndex
-                val calendarBodyUiState = calendarUiState.bodyUiState
                 val calendarPageUiState = when (monthOffset) {
                     -1 -> calendarBodyUiState.previousPage
                     1 -> calendarBodyUiState.nextPage
@@ -181,7 +198,7 @@ fun CalendarHeader(
     var monthRowModifier = Modifier.semantics(mergeDescendants = true) {}
     if (screenHeightDp > MIN_SCREEN_HEIGHT_FOR_FULL_CALENDAR) {
         monthRowModifier = monthRowModifier.clickable(
-            onClick = { actionHandler(CalendarAction.ExpandChanged) },
+            onClick = { actionHandler(CalendarAction.ExpandChanged(!calendarOpen)) },
             onClickLabel = stringResource(id = if (calendarOpen) R.string.a11y_calendarSwitchToWeekView else R.string.a11y_calendarSwitchToMonthView)
         )
     }

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/calendar/CalendarViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/calendar/CalendarViewModelTest.kt
@@ -317,10 +317,10 @@ class CalendarViewModelTest {
 
         assertEquals(expectedState, viewModel.uiState.value)
 
-        viewModel.handleAction(CalendarAction.ExpandChanged)
+        viewModel.handleAction(CalendarAction.ExpandChanged(true))
         assertEquals(expectedState.calendarUiState.copy(expanded = true), viewModel.uiState.value.calendarUiState)
 
-        viewModel.handleAction(CalendarAction.ExpandChanged)
+        viewModel.handleAction(CalendarAction.ExpandChanged(false))
         assertEquals(expectedState.calendarUiState.copy(expanded = false), viewModel.uiState.value.calendarUiState)
     }
 
@@ -339,7 +339,7 @@ class CalendarViewModelTest {
 
         assertEquals(expectedState, viewModel.uiState.value)
 
-        viewModel.handleAction(CalendarAction.ExpandChanged)
+        viewModel.handleAction(CalendarAction.ExpandChanged(true))
         assertEquals(expectedState.calendarUiState.copy(expanded = true), viewModel.uiState.value.calendarUiState)
 
         viewModel.handleAction(CalendarAction.ExpandDisabled)
@@ -395,7 +395,7 @@ class CalendarViewModelTest {
     fun `Today tapped on the same page selects today`() = runTest {
         coEvery { calendarRepository.getPlannerItems(any(), any(), any(), any()) } returns emptyList()
         initViewModel()
-        viewModel.handleAction(CalendarAction.ExpandChanged) // Switch to month view
+        viewModel.handleAction(CalendarAction.ExpandChanged(true)) // Switch to month view
 
         val expectedState = CalendarScreenUiState(
             baseCalendarUiState.copy(expanded = true), CalendarEventsUiState(
@@ -439,7 +439,7 @@ class CalendarViewModelTest {
 
         assertEquals(expectedState, viewModel.uiState.value)
 
-        viewModel.handleAction(CalendarAction.ExpandChanged)
+        viewModel.handleAction(CalendarAction.ExpandChanged(true))
         viewModel.handleAction(CalendarAction.PageChanged(1))
 
         val newExpectedState = CalendarScreenUiState(
@@ -769,7 +769,7 @@ class CalendarViewModelTest {
 
         assertEquals(expectedState, viewModel.uiState.value)
 
-        viewModel.handleAction(CalendarAction.ExpandChanged)
+        viewModel.handleAction(CalendarAction.ExpandChanged(false))
         viewModel.handleAction(CalendarAction.HeightAnimationFinished) // We also need to call this to fully collapse the calendar and save the state
 
         assertEquals(expectedState.calendarUiState.copy(expanded = false), viewModel.uiState.value.calendarUiState)


### PR DESCRIPTION
Test plan: Expand/collapse animation should trigger when swiping on the calendar. When the expand is disabled the swipe should have no effect either.

refs: MBL-17391
affects: Student
release note: none
