### PR TITLE
[MBL-17419][Student] - Fix breaking Offline E2E tests

### DIFF
--- a/apps/student/flank_e2e_offline.yml
+++ b/apps/student/flank_e2e_offline.yml
@@ -21,6 +21,6 @@ gcloud:
     orientation: portrait
 
 flank:
-  testShards: 1
+  testShards: 10
   testRuns: 1
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/ManageOfflineContentE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/ManageOfflineContentE2ETest.kt
@@ -51,7 +51,7 @@ class ManageOfflineContentE2ETest : StudentTest() {
         val course1 = data.coursesList[0]
         val course2 = data.coursesList[1]
 
-        Log.d(STEP_TAG,"Login with user: ${student.name}, login id: ${student.loginId}.")
+        Log.d(STEP_TAG,"Login with user: '${student.name}', login id: '${student.loginId}'.")
         tokenLogin(student)
         dashboardPage.waitForRender()
 
@@ -195,8 +195,9 @@ class ManageOfflineContentE2ETest : StudentTest() {
         Log.d(STEP_TAG, "Click on the 'Sync' button and confirm sync.")
         manageOfflineContentPage.clickOnSyncButtonAndConfirm()
 
-        Log.d(STEP_TAG, "Wait for the 'Download Started' and 'Syncing Offline Content' dashboard notifications to be displayed, and then to disappear.")
-        dashboardPage.waitForOfflineSyncDashboardNotifications()
+        Log.d(STEP_TAG, "Assert that the offline sync icon only displayed on the synced course's course card.")
+        dashboardPage.assertCourseOfflineSyncIconVisible(course2.name)
+        device.waitForIdle()
 
         Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
         turnOffConnectionViaADB()

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineAllCoursesE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineAllCoursesE2ETest.kt
@@ -53,7 +53,7 @@ class OfflineAllCoursesE2ETest : StudentTest() {
         val course2 = data.coursesList[1]
         val course3 = data.coursesList[2]
 
-        Log.d(STEP_TAG, "Login with user: ${student.name}, login id: ${student.loginId}.")
+        Log.d(STEP_TAG, "Login with user: '${student.name}', login id: '${student.loginId}'.")
         tokenLogin(student)
         dashboardPage.waitForRender()
 
@@ -79,8 +79,10 @@ class OfflineAllCoursesE2ETest : StudentTest() {
         manageOfflineContentPage.changeItemSelectionState(course2.name)
         manageOfflineContentPage.clickOnSyncButtonAndConfirm()
 
-        Log.d(STEP_TAG, "Wait for the 'Download Started' and 'Syncing Offline Content' dashboard notifications to be displayed, and then to disappear.")
-        dashboardPage.waitForOfflineSyncDashboardNotifications()
+        Log.d(STEP_TAG, "Assert that the offline sync icon is displayed on the (both of the) synced courses' course card.")
+        dashboardPage.assertCourseOfflineSyncIconVisible(course1.name)
+        dashboardPage.assertCourseOfflineSyncIconVisible(course2.name)
+        device.waitForIdle()
 
         Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
         turnOffConnectionViaADB()

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineAllCoursesE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineAllCoursesE2ETest.kt
@@ -79,9 +79,8 @@ class OfflineAllCoursesE2ETest : StudentTest() {
         manageOfflineContentPage.changeItemSelectionState(course2.name)
         manageOfflineContentPage.clickOnSyncButtonAndConfirm()
 
-        Log.d(STEP_TAG, "Assert that the offline sync icon is displayed on the (both of the) synced courses' course card.")
+        Log.d(STEP_TAG, "Assert that the offline sync icon is displayed on the synced  (and favorited) course's course card.")
         dashboardPage.assertCourseOfflineSyncIconVisible(course1.name)
-        dashboardPage.assertCourseOfflineSyncIconVisible(course2.name)
         device.waitForIdle()
 
         Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
@@ -89,7 +88,6 @@ class OfflineAllCoursesE2ETest : StudentTest() {
         waitForNetworkToGoOffline(device)
 
         Log.d(STEP_TAG, "Wait for the Dashboard Page to be rendered, and assert that '${course1.name}' is the only course which is displayed on the offline mode Dashboard Page.")
-        dashboardPage.waitForRender()
         dashboardPage.assertDisplaysCourse(course1)
         dashboardPage.assertCourseNotDisplayed(course2)
         dashboardPage.assertCourseNotDisplayed(course3)

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineAnnouncementsE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineAnnouncementsE2ETest.kt
@@ -55,20 +55,23 @@ class OfflineAnnouncementsE2ETest : StudentTest() {
 
         val lockedAnnouncement = DiscussionTopicsApi.createAnnouncement(course.id, teacher.token, locked = true)
 
-        Log.d(STEP_TAG,"Login with user: ${student.name}, login id: ${student.loginId}.")
+        Log.d(STEP_TAG,"Login with user: '${student.name}', login id: '${student.loginId}'.")
         tokenLogin(student)
         dashboardPage.waitForRender()
 
         Log.d(STEP_TAG, "Open the '${course.name}' course's 'Manage Offline Content' page via the more menu of the Dashboard Page.")
         dashboardPage.clickCourseOverflowMenu(course.name, "Manage Offline Content")
 
+        Log.d(STEP_TAG, "Expand '${course.name}' course.")
         manageOfflineContentPage.expandCollapseItem(course.name)
+
         Log.d(STEP_TAG, "Select the 'Announcements' of '${course.name}' course for sync. Click on the 'Sync' button.")
         manageOfflineContentPage.changeItemSelectionState("Announcements")
         manageOfflineContentPage.clickOnSyncButtonAndConfirm()
 
-        Log.d(STEP_TAG, "Wait for the 'Download Started' and 'Syncing Offline Content' dashboard notifications to be displayed, and then to disappear.")
-        dashboardPage.waitForOfflineSyncDashboardNotifications()
+        Log.d(STEP_TAG, "Assert that the offline sync icon only displayed on the synced course's course card.")
+        dashboardPage.assertCourseOfflineSyncIconVisible(course.name)
+        device.waitForIdle()
 
         Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
         turnOffConnectionViaADB()
@@ -79,9 +82,6 @@ class OfflineAnnouncementsE2ETest : StudentTest() {
 
         Log.d(STEP_TAG, "Assert that the Offline Indicator (bottom banner) is displayed on the Dashboard Page.")
         OfflineTestUtils.assertOfflineIndicator()
-
-        Log.d(STEP_TAG, "Assert that the offline sync icon only displayed on the synced course's course card.")
-        dashboardPage.assertCourseOfflineSyncIconVisible(course.name)
 
         Log.d(STEP_TAG, "Select '${course.name}' course and open 'Announcements' menu.")
         dashboardPage.selectCourse(course)

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineCourseBrowserE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineCourseBrowserE2ETest.kt
@@ -62,8 +62,9 @@ class OfflineCourseBrowserE2ETest : StudentTest() {
         manageOfflineContentPage.changeItemSelectionState("Announcements")
         manageOfflineContentPage.clickOnSyncButtonAndConfirm()
 
-        Log.d(STEP_TAG, "Wait for the 'Download Started' and 'Syncing Offline Content' dashboard notifications to be displayed, and then to disappear.")
-        dashboardPage.waitForOfflineSyncDashboardNotifications()
+        Log.d(STEP_TAG, "Assert that the offline sync icon only displayed on the synced course's course card.")
+        dashboardPage.assertCourseOfflineSyncIconVisible(course.name)
+        device.waitForIdle()
 
         Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
         turnOffConnectionViaADB()

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineCourseBrowserE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineCourseBrowserE2ETest.kt
@@ -32,7 +32,6 @@ import com.instructure.student.ui.utils.tokenLogin
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.After
 import org.junit.Test
-import java.lang.Thread.sleep
 
 @HiltAndroidTest
 class OfflineCourseBrowserE2ETest : StudentTest() {
@@ -49,18 +48,17 @@ class OfflineCourseBrowserE2ETest : StudentTest() {
         Log.d(PREPARATION_TAG,"Seeding data.")
         val data = seedData(students = 1, teachers = 1, courses = 1, announcements = 1)
         val student = data.studentsList[0]
-        val course1 = data.coursesList[0]
+        val course = data.coursesList[0]
 
-        Log.d(STEP_TAG,"Login with user: ${student.name}, login id: ${student.loginId}.")
+        Log.d(STEP_TAG,"Login with user: '${student.name}', login id: '${student.loginId}'.")
         tokenLogin(student)
         dashboardPage.waitForRender()
 
         Log.d(STEP_TAG, "Open global 'Manage Offline Content' page via the more menu of the Dashboard Page.")
         dashboardPage.openGlobalManageOfflineContentPage()
 
-        Log.d(STEP_TAG, "Select the entire '${course1.name}' course for sync. Click on the 'Sync' button.")
-        Log.d(STEP_TAG, "Expand '${course1.name}' course. Select only the 'Announcements' of the '${course1.name}' course. Click on the 'Sync' button and confirm the sync process.")
-        manageOfflineContentPage.expandCollapseItem(course1.name)
+        Log.d(STEP_TAG, "Expand '${course.name}' course. Select only the 'Announcements' of the '${course.name}' course. Click on the 'Sync' button and confirm the sync process.")
+        manageOfflineContentPage.expandCollapseItem(course.name)
         manageOfflineContentPage.changeItemSelectionState("Announcements")
         manageOfflineContentPage.clickOnSyncButtonAndConfirm()
 
@@ -74,8 +72,8 @@ class OfflineCourseBrowserE2ETest : StudentTest() {
         Log.d(STEP_TAG, "Wait for the Dashboard Page to be rendered. Refresh the page.")
         dashboardPage.waitForRender()
 
-        Log.d(STEP_TAG, "Select '${course1.name}' course and open 'Announcements' menu.")
-        dashboardPage.selectCourse(course1)
+        Log.d(STEP_TAG, "Select '${course.name}' course and open 'Announcements' menu.")
+        dashboardPage.selectCourse(course)
 
         Log.d(STEP_TAG, "Assert that only the 'Announcements' tab is enabled because it is the only one which has been synced, and assert that all the other, previously synced tabs are disabled, because they weren't synced now.")
         var enabledTabs = arrayOf("Announcements")
@@ -91,27 +89,22 @@ class OfflineCourseBrowserE2ETest : StudentTest() {
         Log.d(STEP_TAG, "Open global 'Manage Offline Content' page via the more menu of the Dashboard Page.")
         dashboardPage.openGlobalManageOfflineContentPage()
 
-        Log.d(STEP_TAG, "Deselect the entire '${course1.name}' course for sync.")
-        manageOfflineContentPage.changeItemSelectionState(course1.name)
+        Log.d(STEP_TAG, "Deselect the entire '${course.name}' course for sync.")
+        manageOfflineContentPage.changeItemSelectionState(course.name)
         manageOfflineContentPage.clickOnSyncButtonAndConfirm()
 
-        Log.d(STEP_TAG, "Wait for the 'Download Started' dashboard notification to be displayed, and the to disappear.")
-        dashboardPage.waitForRender()
-        dashboardPage.waitForSyncProgressDownloadStartedNotification()
-        dashboardPage.waitForSyncProgressDownloadStartedNotificationToDisappear()
-
-        Log.d(STEP_TAG, "Wait for the 'Syncing Offline Content' dashboard notification to be displayed, and the to disappear. (It should be displayed after the 'Download Started' notification immediately.)")
-        dashboardPage.waitForSyncProgressStartingNotification()
-        dashboardPage.waitForSyncProgressStartingNotificationToDisappear()
+        Log.d(STEP_TAG, "Assert that the offline sync icon only displayed on the synced course's course card.")
+        dashboardPage.assertCourseOfflineSyncIconVisible(course.name)
+        device.waitForIdle()
 
         Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
         turnOffConnectionViaADB()
 
-        Log.d(STEP_TAG, "Select '${course1.name}' course and open 'Announcements' menu.")
-        sleep(10000) //Need to wait a bit here because of a UI glitch that when network state change, the dashboard page 'pops' a bit and it can confuse the automation script.
-        device.waitForIdle()
-        device.waitForWindowUpdate(null, 10000)
-        dashboardPage.selectCourse(course1)
+        Log.d(STEP_TAG, "Select '${course.name}' course and open 'Announcements' menu.")
+        OfflineTestUtils.waitForNetworkToGoOffline(device)
+
+        Log.d(STEP_TAG, "Select '${course.name}' course.")
+        dashboardPage.selectCourse(course)
 
         Log.d(STEP_TAG, "Assert that the 'Google Drive' and 'Collaborations' tabs are disabled because they aren't supported in offline mode, but the rest of the tabs are enabled because the whole course has been synced.")
         enabledTabs = arrayOf("Announcements", "Discussions", "Grades", "People", "Syllabus", "BigBlueButton")

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineDashboardE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineDashboardE2ETest.kt
@@ -54,7 +54,7 @@ class OfflineDashboardE2ETest : StudentTest() {
         val course2 = data.coursesList[1]
         val testAnnouncement = data.announcementsList[0]
 
-        Log.d(STEP_TAG,"Login with user: ${student.name}, login id: ${student.loginId}.")
+        Log.d(STEP_TAG,"Login with user: '${student.name}', login id: '${student.loginId}'.")
         tokenLogin(student)
         dashboardPage.waitForRender()
 
@@ -117,18 +117,13 @@ class OfflineDashboardE2ETest : StudentTest() {
         manageOfflineContentPage.changeItemSelectionState(course.name)
         manageOfflineContentPage.clickOnSyncButtonAndConfirm()
 
-        Log.d(STEP_TAG, "Wait for the 'Download Started' dashboard notification to be displayed, and the to disappear.")
-        dashboardPage.waitForRender()
-        dashboardPage.waitForSyncProgressDownloadStartedNotification()
-        dashboardPage.waitForSyncProgressDownloadStartedNotificationToDisappear()
-
-        Log.d(STEP_TAG, "Wait for the 'Syncing Offline Content' dashboard notification to be displayed, and the to disappear. (It should be displayed after the 'Download Started' notification immediately.)")
-        dashboardPage.waitForSyncProgressStartingNotification()
-        dashboardPage.waitForSyncProgressStartingNotificationToDisappear()
+        Log.d(STEP_TAG, "Assert that the offline sync icon only displayed on the synced course's course card.")
+        dashboardPage.assertCourseOfflineSyncIconVisible(course.name)
+        device.waitForIdle()
 
         Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
         turnOffConnectionViaADB()
-        device.waitForIdle()
+        waitForNetworkToGoOffline(device)
 
         Log.d(STEP_TAG, "Wait for the Dashboard Page to be rendered. Refresh the page.")
         dashboardPage.waitForRender()

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineDashboardE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineDashboardE2ETest.kt
@@ -68,8 +68,9 @@ class OfflineDashboardE2ETest : StudentTest() {
         manageOfflineContentPage.changeItemSelectionState(course1.name)
         manageOfflineContentPage.clickOnSyncButtonAndConfirm()
 
-        Log.d(STEP_TAG, "Wait for the 'Download Started' and 'Syncing Offline Content' dashboard notifications to be displayed, and then to disappear.")
-        dashboardPage.waitForOfflineSyncDashboardNotifications()
+        Log.d(STEP_TAG, "Assert that the offline sync icon only displayed on the synced course's course card.")
+        dashboardPage.assertCourseOfflineSyncIconVisible(course1.name)
+        device.waitForIdle()
 
         Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
         turnOffConnectionViaADB()

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineFilesE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineFilesE2ETest.kt
@@ -65,7 +65,7 @@ class OfflineFilesE2ETest : StudentTest() {
         Log.d(PREPARATION_TAG, "Create a (text) file within the '${courseTestFolder.name}' folder of the '${course.name}' course.")
         val courseTestFolderTextFile = uploadTextFile(courseTestFolder.id, token = teacher.token, fileUploadType = FileUploadType.COURSE_FILE)
 
-        Log.d(STEP_TAG,"Login with user: ${student.name}, login id: ${student.loginId}.")
+        Log.d(STEP_TAG,"Login with user: '${student.name}', login id: '${student.loginId}'.")
         tokenLogin(student)
         dashboardPage.waitForRender()
 
@@ -80,8 +80,9 @@ class OfflineFilesE2ETest : StudentTest() {
         manageOfflineContentPage.changeItemSelectionState("Files")
         manageOfflineContentPage.clickOnSyncButtonAndConfirm()
 
-        Log.d(STEP_TAG, "Wait for the 'Download Started' and 'Syncing Offline Content' dashboard notifications to be displayed, and then to disappear.")
-        dashboardPage.waitForOfflineSyncDashboardNotifications()
+        Log.d(STEP_TAG, "Assert that the offline sync icon only displayed on the synced course's course card.")
+        dashboardPage.assertCourseOfflineSyncIconVisible(course.name)
+        device.waitForIdle()
 
         Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
         turnOffConnectionViaADB()

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineLeftSideMenuE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineLeftSideMenuE2ETest.kt
@@ -47,10 +47,10 @@ class OfflineLeftSideMenuE2ETest : StudentTest() {
     fun testOfflineLeftSideMenuUnavailableFunctionsE2E() {
 
         Log.d(PREPARATION_TAG,"Seeding data.")
-        val data = seedData(students = 1, teachers = 1, courses = 2, announcements = 1)
+        val data = seedData(students = 1, teachers = 1, courses = 1, announcements = 1)
         val student = data.studentsList[0]
 
-        Log.d(STEP_TAG,"Login with user: ${student.name}, login id: ${student.loginId}.")
+        Log.d(STEP_TAG,"Login with user: '${student.name}', login id: '${student.loginId}'.")
         tokenLogin(student)
         dashboardPage.waitForRender()
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineLoginE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineLoginE2ETest.kt
@@ -51,7 +51,7 @@ class OfflineLoginE2ETest : StudentTest() {
         val student1 = data.studentsList[0]
         val student2 = data.studentsList[1]
 
-        Log.d(STEP_TAG, "Login with user: ${student1.name}, login id: ${student1.loginId}.")
+        Log.d(STEP_TAG, "Login with user: '${student1.name}', login id: '${student1.loginId}'.")
         loginWithUser(student1)
         dashboardPage.waitForRender()
 
@@ -61,7 +61,7 @@ class OfflineLoginE2ETest : StudentTest() {
         Log.d(STEP_TAG, "Click on 'Change User' button on the left-side menu.")
         leftSideNavigationDrawerPage.clickChangeUserMenu()
 
-        Log.d(STEP_TAG, "Login with user: ${student2.name}, login id: ${student2.loginId}.")
+        Log.d(STEP_TAG, "Login with user: '${student2.name}', login id: '${student2.loginId}'.")
         loginWithUser(student2, true)
 
         Log.d(STEP_TAG, "Wait for the Dashboard Page to be rendered. Refresh the page.")

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflinePagesE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflinePagesE2ETest.kt
@@ -68,7 +68,7 @@ class OfflinePagesE2ETest : StudentTest() {
         Log.d(PREPARATION_TAG,"Seed a PUBLISHED, FRONT page for '${course.name}' course.")
         val pagePublishedFront = PagesApi.createCoursePage(course.id, teacher.token, frontPage = true, editingRoles = "public", body = "<h1 id=\"header1\">Front Page Text</h1>")
 
-        Log.d(STEP_TAG,"Login with user: ${student.name}, login id: ${student.loginId}.")
+        Log.d(STEP_TAG,"Login with user: '${student.name}', login id: '${student.loginId}'.")
         tokenLogin(student)
         dashboardPage.waitForRender()
 
@@ -83,8 +83,9 @@ class OfflinePagesE2ETest : StudentTest() {
         manageOfflineContentPage.changeItemSelectionState("Pages")
         manageOfflineContentPage.clickOnSyncButtonAndConfirm()
 
-        Log.d(STEP_TAG, "Wait for the 'Download Started' and 'Syncing Offline Content' dashboard notifications to be displayed, and then to disappear.")
-        dashboardPage.waitForOfflineSyncDashboardNotifications()
+        Log.d(STEP_TAG, "Assert that the offline sync icon only displayed on the synced course's course card.")
+        dashboardPage.assertCourseOfflineSyncIconVisible(course.name)
+        device.waitForIdle()
 
         Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
         turnOffConnectionViaADB()

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflinePeopleE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflinePeopleE2ETest.kt
@@ -50,20 +50,23 @@ class OfflinePeopleE2ETest : StudentTest() {
         val teacher = data.teachersList[0]
         val course = data.coursesList[0]
 
-        Log.d(STEP_TAG,"Login with user: ${student.name}, login id: ${student.loginId}.")
+        Log.d(STEP_TAG,"Login with user: '${student.name}', login id: '${student.loginId}'.")
         tokenLogin(student)
         dashboardPage.waitForRender()
 
         Log.d(STEP_TAG, "Open the '${course.name}' course's 'Manage Offline Content' page via the more menu of the Dashboard Page.")
         dashboardPage.clickCourseOverflowMenu(course.name, "Manage Offline Content")
 
+        Log.d(STEP_TAG, "Expand '${course.name}' course.")
         manageOfflineContentPage.expandCollapseItem(course.name)
+
         Log.d(STEP_TAG, "Select the 'People' of '${course.name}' course for sync. Click on the 'Sync' button.")
         manageOfflineContentPage.changeItemSelectionState("People")
         manageOfflineContentPage.clickOnSyncButtonAndConfirm()
 
-        Log.d(STEP_TAG, "Wait for the 'Download Started' and 'Syncing Offline Content' dashboard notifications to be displayed, and then to disappear.")
-        dashboardPage.waitForOfflineSyncDashboardNotifications()
+        Log.d(STEP_TAG, "Assert that the offline sync icon only displayed on the synced course's course card.")
+        dashboardPage.assertCourseOfflineSyncIconVisible(course.name)
+        device.waitForIdle()
 
         Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
         turnOffConnectionViaADB()
@@ -74,9 +77,6 @@ class OfflinePeopleE2ETest : StudentTest() {
 
         Log.d(STEP_TAG, "Assert that the Offline Indicator (bottom banner) is displayed on the Dashboard Page.")
         OfflineTestUtils.assertOfflineIndicator()
-
-        Log.d(STEP_TAG, "Assert that the offline sync icon only displayed on the synced course's course card.")
-        dashboardPage.assertCourseOfflineSyncIconVisible(course.name)
 
         Log.d(STEP_TAG, "Select '${course.name}' course and open 'People' menu.")
         dashboardPage.selectCourse(course)

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineSyncProgressE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineSyncProgressE2ETest.kt
@@ -52,7 +52,7 @@ class OfflineSyncProgressE2ETest : StudentTest() {
         val course2 = data.coursesList[1]
         val testAnnouncement = data.announcementsList[0]
 
-        Log.d(STEP_TAG,"Login with user: ${student.name}, login id: ${student.loginId}.")
+        Log.d(STEP_TAG,"Login with user: '${student.name}', login id: '${student.loginId}'.")
         tokenLogin(student)
         dashboardPage.waitForRender()
 
@@ -66,17 +66,11 @@ class OfflineSyncProgressE2ETest : StudentTest() {
         manageOfflineContentPage.changeItemSelectionState(course1.name)
         manageOfflineContentPage.clickOnSyncButtonAndConfirm()
 
-        Log.d(STEP_TAG, "Wait for the 'Download Started' dashboard notification to be displayed, and the to disappear.")
+        Log.d(STEP_TAG, "Wait for the Dashboard to be rendered.")
         dashboardPage.waitForRender()
-        dashboardPage.waitForSyncProgressDownloadStartedNotification()
-        dashboardPage.waitForSyncProgressDownloadStartedNotificationToDisappear()
 
-        Log.d(STEP_TAG, "Wait for the 'Syncing Offline Content' dashboard notification to be displayed, and click on it to enter the Sync Progress Page.")
-        dashboardPage.waitForSyncProgressStartingNotification()
+        Log.d(STEP_TAG, "Click on the Dashboard notification to open the Sync Progress Page.")
         dashboardPage.clickOnSyncProgressNotification()
-
-        Log.d(STEP_TAG, "Assert that the Sync Progress has started.")
-        syncProgressPage.waitForDownloadStarting()
 
         Log.d(STEP_TAG, "Assert that the Sync Progress has been successful (so to have the success title and the course success indicator).")
         syncProgressPage.assertDownloadProgressSuccessDetails()
@@ -84,6 +78,7 @@ class OfflineSyncProgressE2ETest : StudentTest() {
 
         Log.d(STEP_TAG, "Navigate back to Dashboard Page and wait for it to be rendered.")
         Espresso.pressBack()
+        device.waitForIdle()
 
         Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
         turnOffConnectionViaADB()

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineSyncProgressE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineSyncProgressE2ETest.kt
@@ -46,7 +46,7 @@ class OfflineSyncProgressE2ETest : StudentTest() {
     fun testOfflineGlobalCourseSyncProgressE2E() {
 
         Log.d(PREPARATION_TAG,"Seeding data.")
-        val data = seedData(students = 1, teachers = 1, courses = 3, announcements = 3)
+        val data = seedData(students = 1, teachers = 1, courses = 3, announcements = 3, discussions = 5, syllabusBody = "Syllabus body")
         val student = data.studentsList[0]
         val course1 = data.coursesList[0]
         val course2 = data.coursesList[1]

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineSyncProgressE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineSyncProgressE2ETest.kt
@@ -46,10 +46,11 @@ class OfflineSyncProgressE2ETest : StudentTest() {
     fun testOfflineGlobalCourseSyncProgressE2E() {
 
         Log.d(PREPARATION_TAG,"Seeding data.")
-        val data = seedData(students = 1, teachers = 1, courses = 2, announcements = 1)
+        val data = seedData(students = 1, teachers = 1, courses = 3, announcements = 3)
         val student = data.studentsList[0]
         val course1 = data.coursesList[0]
         val course2 = data.coursesList[1]
+        val course3 = data.coursesList[2]
         val testAnnouncement = data.announcementsList[0]
 
         Log.d(STEP_TAG,"Login with user: '${student.name}', login id: '${student.loginId}'.")
@@ -64,6 +65,7 @@ class OfflineSyncProgressE2ETest : StudentTest() {
 
         Log.d(STEP_TAG, "Select the entire '${course1.name}' course for sync. Click on the 'Sync' button.")
         manageOfflineContentPage.changeItemSelectionState(course1.name)
+        manageOfflineContentPage.changeItemSelectionState(course2.name)
         manageOfflineContentPage.clickOnSyncButtonAndConfirm()
 
         Log.d(STEP_TAG, "Wait for the Dashboard to be rendered.")
@@ -75,10 +77,25 @@ class OfflineSyncProgressE2ETest : StudentTest() {
         Log.d(STEP_TAG, "Assert that the Sync Progress has been successful (so to have the success title and the course success indicator).")
         syncProgressPage.assertDownloadProgressSuccessDetails()
         syncProgressPage.assertCourseSyncedSuccessfully(course1.name)
+        syncProgressPage.assertCourseSyncedSuccessfully(course2.name)
+
+        Log.d(STEP_TAG, "Get the sum of '${course1.name}' and '${course2.name}' courses' sizes and assert that the sum number is displayed under the progress bar.")
+        val sumOfSyncedCourseSizes = syncProgressPage.getCourseSize(course1.name) + syncProgressPage.getCourseSize(course2.name)
+        syncProgressPage.assertSumOfCourseSizes(sumOfSyncedCourseSizes)
+
+        Log.d(STEP_TAG, "Expand '${course1.name}' course and assert a few tabs (for example) to ensure they synced well and the success indicator is displayed in their rows.")
+        syncProgressPage.expandCollapseCourse(course1.name)
+        syncProgressPage.assertCourseTabSynced("Syllabus")
+        syncProgressPage.assertCourseTabSynced("Announcements")
+        syncProgressPage.assertCourseTabSynced("Grades")
+        device.waitForIdle()
 
         Log.d(STEP_TAG, "Navigate back to Dashboard Page and wait for it to be rendered.")
         Espresso.pressBack()
-        device.waitForIdle()
+
+        Log.d(STEP_TAG, "Assert that the offline sync icon is displayed in online mode on the synced courses' course cards.")
+        dashboardPage.assertCourseOfflineSyncIconVisible(course1.name)
+        dashboardPage.assertCourseOfflineSyncIconVisible(course2.name)
 
         Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
         turnOffConnectionViaADB()
@@ -90,9 +107,10 @@ class OfflineSyncProgressE2ETest : StudentTest() {
         Log.d(STEP_TAG, "Assert that the Offline Indicator (bottom banner) is displayed on the Dashboard Page.")
         OfflineTestUtils.assertOfflineIndicator()
 
-        Log.d(STEP_TAG, "Assert that the offline sync icon only displayed on the synced course's course card.")
+        Log.d(STEP_TAG, "Assert that the offline sync icon only displayed on the synced courses' course card.")
         dashboardPage.assertCourseOfflineSyncIconVisible(course1.name)
-        dashboardPage.assertCourseOfflineSyncIconGone(course2.name)
+        dashboardPage.assertCourseOfflineSyncIconVisible(course2.name)
+        dashboardPage.assertCourseOfflineSyncIconGone(course3.name)
 
         Log.d(STEP_TAG, "Select '${course1.name}' course and open 'Announcements' menu.")
         dashboardPage.selectCourse(course1)

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineSyncProgressE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineSyncProgressE2ETest.kt
@@ -46,11 +46,12 @@ class OfflineSyncProgressE2ETest : StudentTest() {
     fun testOfflineGlobalCourseSyncProgressE2E() {
 
         Log.d(PREPARATION_TAG,"Seeding data.")
-        val data = seedData(students = 1, teachers = 1, courses = 3, announcements = 3, discussions = 5, syllabusBody = "Syllabus body")
+        val data = seedData(students = 1, teachers = 1, courses = 4, announcements = 3, discussions = 5, syllabusBody = "Syllabus body")
         val student = data.studentsList[0]
         val course1 = data.coursesList[0]
         val course2 = data.coursesList[1]
         val course3 = data.coursesList[2]
+        val course4 = data.coursesList[3]
         val testAnnouncement = data.announcementsList[0]
 
         Log.d(STEP_TAG,"Login with user: '${student.name}', login id: '${student.loginId}'.")
@@ -66,6 +67,7 @@ class OfflineSyncProgressE2ETest : StudentTest() {
         Log.d(STEP_TAG, "Select the entire '${course1.name}' course for sync. Click on the 'Sync' button.")
         manageOfflineContentPage.changeItemSelectionState(course1.name)
         manageOfflineContentPage.changeItemSelectionState(course2.name)
+        manageOfflineContentPage.changeItemSelectionState(course3.name)
         manageOfflineContentPage.clickOnSyncButtonAndConfirm()
 
         Log.d(STEP_TAG, "Wait for the Dashboard to be rendered.")
@@ -78,9 +80,10 @@ class OfflineSyncProgressE2ETest : StudentTest() {
         syncProgressPage.assertDownloadProgressSuccessDetails()
         syncProgressPage.assertCourseSyncedSuccessfully(course1.name)
         syncProgressPage.assertCourseSyncedSuccessfully(course2.name)
+        syncProgressPage.assertCourseSyncedSuccessfully(course3.name)
 
-        Log.d(STEP_TAG, "Get the sum of '${course1.name}' and '${course2.name}' courses' sizes and assert that the sum number is displayed under the progress bar.")
-        val sumOfSyncedCourseSizes = syncProgressPage.getCourseSize(course1.name) + syncProgressPage.getCourseSize(course2.name)
+        Log.d(STEP_TAG, "Get the sum of '${course1.name}', '${course2.name}' and '${course3.name}' courses' sizes and assert that the sum number is displayed under the progress bar.")
+        val sumOfSyncedCourseSizes = syncProgressPage.getCourseSize(course1.name) + syncProgressPage.getCourseSize(course2.name) + syncProgressPage.getCourseSize(course3.name)
         syncProgressPage.assertSumOfCourseSizes(sumOfSyncedCourseSizes)
 
         Log.d(STEP_TAG, "Expand '${course1.name}' course and assert a few tabs (for example) to ensure they synced well and the success indicator is displayed in their rows.")
@@ -110,7 +113,8 @@ class OfflineSyncProgressE2ETest : StudentTest() {
         Log.d(STEP_TAG, "Assert that the offline sync icon only displayed on the synced courses' course card.")
         dashboardPage.assertCourseOfflineSyncIconVisible(course1.name)
         dashboardPage.assertCourseOfflineSyncIconVisible(course2.name)
-        dashboardPage.assertCourseOfflineSyncIconGone(course3.name)
+        dashboardPage.assertCourseOfflineSyncIconVisible(course3.name)
+        dashboardPage.assertCourseOfflineSyncIconGone(course4.name)
 
         Log.d(STEP_TAG, "Select '${course1.name}' course and open 'Announcements' menu.")
         dashboardPage.selectCourse(course1)

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineSyncSettingsE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineSyncSettingsE2ETest.kt
@@ -48,7 +48,7 @@ class OfflineSyncSettingsE2ETest : StudentTest() {
         val data = seedData(students = 1, teachers = 1, courses = 2, announcements = 1)
         val student = data.studentsList[0]
 
-        Log.d(STEP_TAG,"Login with user: ${student.name}, login id: ${student.loginId}.")
+        Log.d(STEP_TAG,"Login with user: '${student.name}', login id: '${student.loginId}'.")
         tokenLogin(student)
         dashboardPage.waitForRender()
 
@@ -112,13 +112,13 @@ class OfflineSyncSettingsE2ETest : StudentTest() {
         Log.d(STEP_TAG, "Click 'Find My School' button.")
         loginLandingPage.clickFindMySchoolButton()
 
-        Log.d(STEP_TAG, "Enter domain: ${student.domain}.")
+        Log.d(STEP_TAG, "Enter domain: '${student.domain}'.")
         loginFindSchoolPage.enterDomain(student.domain)
 
         Log.d(STEP_TAG, "Click on 'Next' button on the Toolbar.")
         loginFindSchoolPage.clickToolbarNextMenuItem()
 
-        Log.d(STEP_TAG, "Login with user: ${student.name}, login id: ${student.loginId}.")
+        Log.d(STEP_TAG, "Login with user: '${student.name}', login id: '${student.loginId}'.")
         loginSignInPage.loginAs(student)
         dashboardPage.waitForRender()
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DashboardPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DashboardPage.kt
@@ -27,7 +27,6 @@ import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.platform.app.InstrumentationRegistry
 import com.instructure.canvas.espresso.scrollRecyclerView
@@ -43,6 +42,7 @@ import com.instructure.espresso.page.*
 import com.instructure.student.R
 import com.instructure.student.ui.utils.ViewUtils
 import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.CoreMatchers.anyOf
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers
@@ -395,7 +395,7 @@ class DashboardPage : BasePage(R.id.dashboardPage) {
 
     //OfflineMethod
     fun clickOnSyncProgressNotification() {
-        waitForView(ViewMatchers.withText(com.instructure.pandautils.R.string.syncProgress_syncingOfflineContent)).click()
+        waitForView(anyOf(withText(R.string.syncProgress_syncQueued),withText(R.string.syncProgress_downloadStarting), withText(R.string.syncProgress_syncingOfflineContent))).click()
     }
 
     //OfflineMethod

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DashboardPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DashboardPage.kt
@@ -395,7 +395,8 @@ class DashboardPage : BasePage(R.id.dashboardPage) {
 
     //OfflineMethod
     fun clickOnSyncProgressNotification() {
-        waitForView(anyOf(withText(R.string.syncProgress_syncQueued),withText(R.string.syncProgress_downloadStarting), withText(R.string.syncProgress_syncingOfflineContent))).click()
+        Thread.sleep(2500)
+        onView(anyOf(withText(R.string.syncProgress_syncQueued),withText(R.string.syncProgress_downloadStarting), withText(R.string.syncProgress_syncingOfflineContent))).click()
     }
 
     //OfflineMethod

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/offline/SyncProgressPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/offline/SyncProgressPage.kt
@@ -17,12 +17,15 @@
 
 package com.instructure.student.ui.pages.offline
 
+import android.widget.TextView
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.hasSibling
 import com.instructure.canvas.espresso.containsTextCaseInsensitive
 import com.instructure.espresso.OnViewWithId
+import com.instructure.espresso.assertContainsText
 import com.instructure.espresso.assertDisplayed
 import com.instructure.espresso.assertVisibility
+import com.instructure.espresso.click
 import com.instructure.espresso.page.BasePage
 import com.instructure.espresso.page.onView
 import com.instructure.espresso.page.plus
@@ -32,6 +35,7 @@ import com.instructure.espresso.page.withId
 import com.instructure.espresso.page.withParent
 import com.instructure.espresso.page.withText
 import com.instructure.pandautils.R
+import com.instructure.student.ui.utils.getView
 
 class SyncProgressPage : BasePage(R.id.syncProgressPage) {
 
@@ -54,5 +58,33 @@ class SyncProgressPage : BasePage(R.id.syncProgressPage) {
     fun assertCourseSyncedSuccessfully(courseName: String) {
         onView(withId(R.id.courseName) + withText(courseName) + withAncestor(R.id.syncProgressPage)).assertDisplayed()
         onView(withId(R.id.successIndicator) + withParent(withId(R.id.actionContainer) + hasSibling(withId(R.id.courseName) + withText(courseName)))).assertVisibility(ViewMatchers.Visibility.VISIBLE)
+    }
+
+    fun expandCollapseCourse(courseName: String) {
+        onView(withId(R.id.toggleButton) + hasSibling(withId(R.id.courseName) + withText(courseName))).click()
+    }
+
+    fun assertCourseTabSynced(tabName: String) {
+        onView(withId(R.id.successIndicator) + withParent(withId(R.id.actionContainer) + hasSibling(withId(R.id.tabTitle) + withText(tabName)))).assertVisibility(ViewMatchers.Visibility.VISIBLE)
+    }
+
+    fun getCourseSize(courseName: String): Int {
+        val courseSizeView = onView(withId(R.id.courseSize) + hasSibling(withId(R.id.courseName) + withText(courseName)))
+        val courseSizeText = (courseSizeView.getView() as TextView).text.toString()
+        return courseSizeText.split(" ")[0].toInt()
+    }
+
+    fun assertSumOfCourseSizes(expectedSize: Int) {
+        if(expectedSize > 999) {
+            val convertedSumSize = convertKiloBytesToMegaBytes(expectedSize)
+            onView(withId(R.id.downloadProgressText)).assertContainsText(convertedSumSize.toString())
+        }
+        else {
+            onView(withId(R.id.downloadProgressText)).assertContainsText(expectedSize.toString())
+        }
+    }
+
+    private fun convertKiloBytesToMegaBytes(kilobytes: Int): Double {
+        return kilobytes / 1000.0
     }
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTest.kt
@@ -23,7 +23,6 @@ import android.net.Uri
 import android.os.Environment
 import android.util.Log
 import android.view.View
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.core.content.FileProvider
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.test.espresso.Espresso


### PR DESCRIPTION
Fix breaking Offline E2E tests.

4 Offline E2E successful runs in a row:

https://app.bitrise.io/build/79201f49-dc2e-4b45-a745-d730105a0caa

https://app.bitrise.io/build/a1b9ba9d-9647-4541-983a-500cd57f7722

https://app.bitrise.io/build/7b33d1b9-b520-4d74-949f-3708c09b1dc7

https://app.bitrise.io/build/61035303-3d8d-4cfa-8c44-cede07dd9e26


refs: MBL-17419
affects: Student
release note: none