### PR TITLE
[MBL-17280][Teacher] - Implement Bulk Update Modules E2E Test

### DIFF
--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/ModulesE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/ModulesE2ETest.kt
@@ -387,6 +387,8 @@ class   ModulesE2ETest : TeacherComposeTest() {
         Log.d(STEP_TAG, "Click on 'Publish Module only' and confirm it via the publish dialog.")
         moduleListPage.clickOnText(R.string.publishModuleOnly)
         moduleListPage.clickOnText(R.string.publishDialogPositiveButton)
+        device.waitForWindowUpdate(null, 3000)
+        device.waitForIdle()
 
         Log.d(STEP_TAG, "Assert that only the '${module.name}' module became published, but it's items remaining unpublished.")
         moduleListPage.assertModuleIsPublished(module.name)

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/ModulesE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/ModulesE2ETest.kt
@@ -27,6 +27,7 @@ import org.junit.Test
 
 @HiltAndroidTest
 class   ModulesE2ETest : TeacherComposeTest() {
+
     override fun displaysPageObjects() = Unit
 
     override fun enableAndConfigureAccessibilityChecks() = Unit
@@ -161,7 +162,7 @@ class   ModulesE2ETest : TeacherComposeTest() {
         Log.d(STEP_TAG, "Navigate back to Module List Page.")
         Espresso.pressBack()
 
-        Log.d(PREPARATION_TAG,"Unpublish ${module.name} module via API.")
+        Log.d(PREPARATION_TAG,"Unpublish '${module.name}' module via API.")
         ModulesApi.updateModule(courseId = course.id, moduleId = module.id, published = false, teacherToken = teacher.token)
 
         Log.d(STEP_TAG, "Refresh the Module List Page.")
@@ -205,46 +206,46 @@ class   ModulesE2ETest : TeacherComposeTest() {
         val course = data.coursesList[0]
 
         Log.d(PREPARATION_TAG, "Seeding 'Text Entry' assignment for '${course.name}' course.")
-        val assignment = createAssignment(course, teacher)
+        val assignment = AssignmentsApi.createAssignment(course.id, teacher.token, withDescription = true, submissionTypes = listOf(SubmissionType.ONLINE_TEXT_ENTRY), dueAt = 1.days.fromNow.iso8601)
 
         Log.d(PREPARATION_TAG, "Seeding another 'Text Entry' assignment for '${course.name}' course.")
-        val assignment2 = createAssignment(course, teacher)
+        val assignment2 = AssignmentsApi.createAssignment(course.id, teacher.token, withDescription = true, submissionTypes = listOf(SubmissionType.ONLINE_TEXT_ENTRY), dueAt = 1.days.fromNow.iso8601)
 
         Log.d(PREPARATION_TAG, "Seeding quiz for '${course.name}' course.")
-        val quiz = createQuiz(course, teacher)
+        val quiz =  QuizzesApi.createQuiz(course.id, teacher.token, withDescription = true, dueAt = 3.days.fromNow.iso8601)
 
         Log.d(PREPARATION_TAG, "Create an unpublished page for course: '${course.name}'.")
-        val testPage = createCoursePage(course, teacher, published = false, frontPage = false, body = "<h1 id=\"header1\">Test Page Text</h1>")
+        val testPage = PagesApi.createCoursePage(course.id, teacher.token, published = false, body = "<h1 id=\"header1\">Test Page Text</h1>")
 
         Log.d(PREPARATION_TAG, "Create another unpublished page for course: '${course.name}'.")
-        val testPage2 = createCoursePage(course, teacher, published = true, frontPage = false, body = "<h1 id=\"header1\">This is another test page</h1>")
+        val testPage2 = PagesApi.createCoursePage(course.id, teacher.token, published = true, frontPage = false, body = "<h1 id=\"header1\">This is another test page</h1>")
 
         Log.d(PREPARATION_TAG, "Create a discussion topic for '${course.name}' course.")
-        val discussionTopic = createDiscussion(course, teacher)
+        val discussionTopic = DiscussionTopicsApi.createDiscussion(courseId = course.id, token = teacher.token)
 
         Log.d(PREPARATION_TAG, "Seeding a module for '${course.name}' course. It starts as unpublished.")
-        val module = createModule(course, teacher)
+        val module = ModulesApi.createModule(course.id, teacher.token)
 
         Log.d(PREPARATION_TAG, "Seeding another module for '${course.name}' course. It starts as unpublished.")
-        val module2 = createModule(course, teacher)
+        val module2 = ModulesApi.createModule(course.id, teacher.token)
 
-        Log.d(PREPARATION_TAG, "Associate '${assignment.name}' assignment (and the quiz within it) with module: '${module.id}'.")
-        createModuleItem(course, module, teacher, assignment.name, ModuleItemTypes.ASSIGNMENT.stringVal, assignment.id.toString())
+        Log.d(PREPARATION_TAG,"Associate '${assignment.name}' assignment with module: '${module.id}'.")
+        ModulesApi.createModuleItem(course.id, teacher.token, module.id, moduleItemTitle = assignment.name, moduleItemType = ModuleItemTypes.ASSIGNMENT.stringVal, contentId = assignment.id.toString())
 
-        Log.d(PREPARATION_TAG, "Associate '${quiz.title}' quiz with module: '${module.id}'.")
-        createModuleItem(course, module, teacher, quiz.title, ModuleItemTypes.QUIZ.stringVal, quiz.id.toString())
+        Log.d(PREPARATION_TAG,"Associate '${quiz.title}' quiz with module: '${module.id}'.")
+        ModulesApi.createModuleItem(course.id, teacher.token, module.id, moduleItemTitle = quiz.title, moduleItemType = ModuleItemTypes.QUIZ.stringVal, contentId = quiz.id.toString())
 
-        Log.d(PREPARATION_TAG, "Associate '${testPage.title}' page with module: '${module.id}'.")
-        createModuleItem(course, module, teacher, testPage.title, ModuleItemTypes.PAGE.stringVal, null, pageUrl = testPage.url)
+        Log.d(PREPARATION_TAG,"Associate '${testPage.title}' page with module: '${module.id}'.")
+        ModulesApi.createModuleItem(course.id, teacher.token, module.id, moduleItemTitle = testPage.title, moduleItemType = ModuleItemTypes.PAGE.stringVal, contentId = null, pageUrl = testPage.url)
 
-        Log.d(PREPARATION_TAG, "Associate '${discussionTopic.title}' discussion with module: '${module.id}'.")
-        createModuleItem(course, module, teacher, discussionTopic.title, ModuleItemTypes.DISCUSSION.stringVal, discussionTopic.id.toString())
+        Log.d(PREPARATION_TAG,"Associate '${discussionTopic.title}' discussion with module: '${module.id}'.")
+        ModulesApi.createModuleItem(course.id, teacher.token, module.id, moduleItemTitle = discussionTopic.title, moduleItemType = ModuleItemTypes.DISCUSSION.stringVal, contentId = discussionTopic.id.toString())
 
         Log.d(PREPARATION_TAG, "Associate '${assignment2.name}' assignment with module: '${module2.id}'.")
-        createModuleItem(course, module2, teacher, assignment2.name, ModuleItemTypes.ASSIGNMENT.stringVal, assignment2.id.toString())
+        ModulesApi.createModuleItem(course.id, teacher.token, module2.id , assignment2.name, ModuleItemTypes.ASSIGNMENT.stringVal, assignment2.id.toString())
 
         Log.d(PREPARATION_TAG, "Associate '${testPage2.title}' page with module: '${module2.id}'.")
-        createModuleItem(course, module2, teacher, testPage2.title, ModuleItemTypes.PAGE.stringVal, null, pageUrl = testPage2.url)
+        ModulesApi.createModuleItem(course.id, teacher.token, module2.id, testPage2.title, ModuleItemTypes.PAGE.stringVal, null, pageUrl = testPage2.url)
 
         Log.d(STEP_TAG, "Login with user: '${teacher.name}', login id: '${teacher.loginId}'. Assert that '${course.name}' course is displayed on the Dashboard.")
         tokenLogin(teacher)
@@ -468,90 +469,5 @@ class   ModulesE2ETest : TeacherComposeTest() {
         moduleListPage.assertSnackbarText(R.string.moduleItemUnpublished)
         moduleListPage.assertModuleItemNotPublished(discussionTopic.title)
     }
-
-        private fun createModuleItem(
-        course: CourseApiModel,
-        module: ModuleApiModel,
-        teacher: CanvasUserApiModel,
-        title: String,
-        moduleItemType: String,
-        contentId: String?,
-        pageUrl: String? = null
-    ) {
-        ModulesApi.createModuleItem(
-            courseId = course.id,
-            moduleId = module.id,
-            teacherToken = teacher.token,
-            moduleItemTitle = title,
-            moduleItemType = moduleItemType,
-            contentId = contentId,
-            pageUrl = pageUrl
-        )
-    }
-
-    private fun createModule(
-        course: CourseApiModel,
-        teacher: CanvasUserApiModel
-    ): ModuleApiModel {
-        return ModulesApi.createModule(
-            courseId = course.id,
-            teacherToken = teacher.token,
-            unlockAt = null
-        )
-    }
-
-    private fun createQuiz(
-        course: CourseApiModel,
-        teacher: CanvasUserApiModel
-    ): QuizApiModel {
-        return QuizzesApi.createQuiz(
-            QuizzesApi.CreateQuizRequest(
-                courseId = course.id,
-                withDescription = true,
-                dueAt = 3.days.fromNow.iso8601,
-                token = teacher.token,
-                published = true
-            )
-        )
-    }
-
-    private fun createAssignment(
-        course: CourseApiModel,
-        teacher: CanvasUserApiModel
-    ): AssignmentApiModel {
-        return AssignmentsApi.createAssignment(
-            AssignmentsApi.CreateAssignmentRequest(
-                courseId = course.id,
-                withDescription = true,
-                submissionTypes = listOf(SubmissionType.ONLINE_TEXT_ENTRY),
-                teacherToken = teacher.token,
-                dueAt = 1.days.fromNow.iso8601
-            )
-        )
-    }
-
-    private fun createCoursePage(
-        course: CourseApiModel,
-        teacher: CanvasUserApiModel,
-        published: Boolean = true,
-        frontPage: Boolean = false,
-        body: String = ""
-    ): PageApiModel {
-        return PagesApi.createCoursePage(
-            courseId = course.id,
-            published = published,
-            frontPage = frontPage,
-            token = teacher.token,
-            body = body
-        )
-    }
-
-    private fun createDiscussion(
-        course: CourseApiModel,
-        teacher: CanvasUserApiModel
-    ) = DiscussionTopicsApi.createDiscussion(
-        courseId = course.id,
-        token = teacher.token
-    )
 
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/ModulesE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/ModulesE2ETest.kt
@@ -23,14 +23,16 @@ import com.instructure.dataseeding.model.SubmissionType
 import com.instructure.dataseeding.util.days
 import com.instructure.dataseeding.util.fromNow
 import com.instructure.dataseeding.util.iso8601
-import com.instructure.teacher.ui.utils.TeacherTest
+import com.instructure.teacher.R
+import com.instructure.teacher.ui.utils.TeacherComposeTest
+import com.instructure.teacher.ui.utils.openOverflowMenu
 import com.instructure.teacher.ui.utils.seedData
 import com.instructure.teacher.ui.utils.tokenLogin
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Test
 
 @HiltAndroidTest
-class   ModulesE2ETest : TeacherTest() {
+class   ModulesE2ETest : TeacherComposeTest() {
     override fun displaysPageObjects() = Unit
 
     override fun enableAndConfigureAccessibilityChecks() = Unit
@@ -85,7 +87,7 @@ class   ModulesE2ETest : TeacherTest() {
         Log.d(STEP_TAG,"Refresh the page. Assert that '${module.name}' module is displayed and it is unpublished by default.")
         moduleListPage.refresh()
         moduleListPage.assertModuleIsDisplayed(module.name)
-        moduleListPage.assertModuleNotPublished()
+        moduleListPage.assertModuleNotPublished(module.name)
 
         Log.d(STEP_TAG,"Assert that '${testPage.title}' page is present as a module item, but it's not published.")
         moduleListPage.assertModuleItemIsDisplayed(testPage.title)
@@ -206,7 +208,282 @@ class   ModulesE2ETest : TeacherTest() {
         moduleListPage.assertModuleItemIsPublished(assignment.name)
     }
 
-    private fun createModuleItem(
+    @E2E
+    @Test
+    @TestMetaData(Priority.IMPORTANT, FeatureCategory.MODULES, TestCategory.E2E)
+    fun testBulkUpdateModulesE2E() {
+
+        Log.d(PREPARATION_TAG, "Seeding data.")
+        val data = seedData(students = 1, teachers = 1, courses = 1)
+        val teacher = data.teachersList[0]
+        val course = data.coursesList[0]
+
+        Log.d(PREPARATION_TAG, "Seeding 'Text Entry' assignment for '${course.name}' course.")
+        val assignment = createAssignment(course, teacher)
+
+        Log.d(PREPARATION_TAG, "Seeding another 'Text Entry' assignment for '${course.name}' course.")
+        val assignment2 = createAssignment(course, teacher)
+
+        Log.d(PREPARATION_TAG, "Seeding quiz for '${course.name}' course.")
+        val quiz = createQuiz(course, teacher)
+
+        Log.d(PREPARATION_TAG, "Create an unpublished page for course: '${course.name}'.")
+        val testPage = createCoursePage(course, teacher, published = false, frontPage = false, body = "<h1 id=\"header1\">Test Page Text</h1>")
+
+        Log.d(PREPARATION_TAG, "Create another unpublished page for course: '${course.name}'.")
+        val testPage2 = createCoursePage(course, teacher, published = true, frontPage = false, body = "<h1 id=\"header1\">This is another test page</h1>")
+
+        Log.d(PREPARATION_TAG, "Create a discussion topic for '${course.name}' course.")
+        val discussionTopic = createDiscussion(course, teacher)
+
+        Log.d(PREPARATION_TAG, "Seeding a module for '${course.name}' course. It starts as unpublished.")
+        val module = createModule(course, teacher)
+
+        Log.d(PREPARATION_TAG, "Seeding another module for '${course.name}' course. It starts as unpublished.")
+        val module2 = createModule(course, teacher)
+
+        Log.d(PREPARATION_TAG, "Associate '${assignment.name}' assignment (and the quiz within it) with module: '${module.id}'.")
+        createModuleItem(course, module, teacher, assignment.name, ModuleItemTypes.ASSIGNMENT.stringVal, assignment.id.toString())
+
+        Log.d(PREPARATION_TAG, "Associate '${quiz.title}' quiz with module: '${module.id}'.")
+        createModuleItem(course, module, teacher, quiz.title, ModuleItemTypes.QUIZ.stringVal, quiz.id.toString())
+
+        Log.d(PREPARATION_TAG, "Associate '${testPage.title}' page with module: '${module.id}'.")
+        createModuleItem(course, module, teacher, testPage.title, ModuleItemTypes.PAGE.stringVal, null, pageUrl = testPage.url)
+
+        Log.d(PREPARATION_TAG, "Associate '${discussionTopic.title}' discussion with module: '${module.id}'.")
+        createModuleItem(course, module, teacher, discussionTopic.title, ModuleItemTypes.DISCUSSION.stringVal, discussionTopic.id.toString())
+
+        Log.d(PREPARATION_TAG, "Associate '${assignment2.name}' assignment with module: '${module2.id}'.")
+        createModuleItem(course, module2, teacher, assignment2.name, ModuleItemTypes.ASSIGNMENT.stringVal, assignment2.id.toString())
+
+        Log.d(PREPARATION_TAG, "Associate '${testPage2.title}' page with module: '${module2.id}'.")
+        createModuleItem(course, module2, teacher, testPage2.title, ModuleItemTypes.PAGE.stringVal, null, pageUrl = testPage2.url)
+
+        Log.d(STEP_TAG, "Login with user: '${teacher.name}', login id: '${teacher.loginId}'. Assert that '${course.name}' course is displayed on the Dashboard.")
+        tokenLogin(teacher)
+        dashboardPage.waitForRender()
+
+        Log.d(STEP_TAG, "Open '${course.name}' course and navigate to Modules Page.")
+        dashboardPage.openCourse(course.name)
+        courseBrowserPage.openModulesTab()
+
+        Log.d(STEP_TAG, "Assert that '${module.name}' and '${module2.name}' modules are displayed and they are unpublished by default. Assert that the '${testPage.title}' page module item is not published and the other module items are published in '${module.name}' module.")
+        moduleListPage.assertModuleIsDisplayed(module.name)
+        moduleListPage.assertModuleNotPublished(module.name)
+        moduleListPage.assertModuleIsDisplayed(module2.name)
+        moduleListPage.assertModuleNotPublished(module2.name)
+        moduleListPage.assertModuleItemIsPublished(assignment.name)
+        moduleListPage.assertModuleItemIsPublished(quiz.title)
+        moduleListPage.assertModuleItemIsPublished(discussionTopic.title)
+        moduleListPage.assertModuleItemNotPublished(testPage.title)
+
+        //Upper layer - All Modules and Items
+        Log.d(STEP_TAG, "Open Module List Page overflow menu and assert that the corresponding menu items are displayed.")
+        openOverflowMenu()
+        moduleListPage.assertToolbarMenuItems()
+
+        Log.d(STEP_TAG, "Click on 'Publish all Modules and Items' and confirm it via the publish dialog.")
+        moduleListPage.clickOnText(R.string.publishAllModulesAndItems)
+        moduleListPage.clickOnText(R.string.publishDialogPositiveButton)
+
+        Log.d(STEP_TAG, "Assert that the 'All Modules and Items' is displayed as title and the corresponding note also displayed on the Progress Page. Click on 'Done' on the Progress Page once it finished.")
+        progressPage.assertProgressPageTitle(R.string.allModulesAndItems)
+        progressPage.assertProgressPageNote(R.string.moduleBulkUpdateNote)
+        progressPage.clickDone()
+
+        Log.d(STEP_TAG, "Assert that the proper snack bar text is displayed and the '${module.name}' module and all of it's items became published.")
+        moduleListPage.assertSnackbarText(R.string.allModulesAndAllItemsPublished)
+        moduleListPage.assertModuleIsPublished(module.name)
+        moduleListPage.assertModuleItemIsPublished(assignment.name)
+        moduleListPage.assertModuleItemIsPublished(quiz.title)
+        moduleListPage.assertModuleItemIsPublished(testPage.title)
+        moduleListPage.assertModuleItemIsPublished(discussionTopic.title)
+
+        Log.d(STEP_TAG, "Assert that '${module2.name}' module and all of it's items became published.")
+        moduleListPage.assertModuleIsPublished(module2.name)
+        moduleListPage.assertModuleItemIsPublished(assignment2.name)
+        moduleListPage.assertModuleItemIsPublished(testPage2.title)
+
+        Log.d(STEP_TAG, "Open Module List Page overflow menu")
+        openOverflowMenu()
+
+        Log.d(STEP_TAG, "Click on 'Unpublish all Modules and Items' and confirm it via the unpublish dialog.")
+        moduleListPage.clickOnText(R.string.unpublishAllModulesAndItems)
+        moduleListPage.clickOnText(R.string.unpublishDialogPositiveButton)
+
+        Log.d(STEP_TAG, "Assert that the 'All Modules and Items' is displayed as title on the Progress page. Click on 'Done' on the Progress Page once it finished.")
+        progressPage.assertProgressPageTitle(R.string.allModulesAndItems)
+        progressPage.clickDone()
+
+        Log.d(STEP_TAG, "Assert that the proper snack bar text is displayed and the '${module.name}' module and all of it's items became unpublished.")
+        moduleListPage.assertSnackbarText(R.string.allModulesAndAllItemsUnpublished)
+        moduleListPage.assertModuleNotPublished(module.name)
+        moduleListPage.assertModuleItemNotPublished(assignment.name)
+        moduleListPage.assertModuleItemNotPublished(quiz.title)
+        moduleListPage.assertModuleItemNotPublished(testPage.title)
+        moduleListPage.assertModuleItemNotPublished(discussionTopic.title)
+
+        Log.d(STEP_TAG, "Assert that '${module2.name}' module and all of it's items became unpublished.")
+        moduleListPage.assertModuleNotPublished(module2.name)
+        moduleListPage.assertModuleItemNotPublished(assignment2.name)
+        moduleListPage.assertModuleItemNotPublished(testPage2.title)
+
+        Log.d(STEP_TAG, "Open Module List Page overflow menu")
+        openOverflowMenu()
+
+        Log.d(STEP_TAG, "Click on 'Publish Modules only' and confirm it via the publish dialog.")
+        moduleListPage.clickOnText(R.string.publishModulesOnly)
+        moduleListPage.clickOnText(R.string.publishDialogPositiveButton)
+
+        Log.d(STEP_TAG, "Assert that the 'All Modules' title is displayed on the Progress page. Click on 'Done' on the Progress Page once it finished.")
+        progressPage.assertProgressPageTitle(R.string.allModules)
+        progressPage.clickDone()
+
+        Log.d(STEP_TAG, "Assert that the proper snack bar text is displayed and only the '${module.name}' module became published, but it's items remaining unpublished.")
+        moduleListPage.assertSnackbarText(R.string.onlyModulesPublished)
+        moduleListPage.assertModuleIsPublished(module.name)
+        moduleListPage.assertModuleItemNotPublished(assignment.name)
+        moduleListPage.assertModuleItemNotPublished(quiz.title)
+        moduleListPage.assertModuleItemNotPublished(testPage.title)
+        moduleListPage.assertModuleItemNotPublished(discussionTopic.title)
+
+        Log.d(STEP_TAG, "Assert that '${module2.name}' module became published but all of it's items are remaining unpublished.")
+        moduleListPage.assertModuleIsPublished(module2.name)
+        moduleListPage.assertModuleItemNotPublished(assignment2.name)
+        moduleListPage.assertModuleItemNotPublished(testPage2.title)
+
+        //Middle layer - One Module and Items
+
+        Log.d(STEP_TAG, "Click on '${module.name}' module overflow and assert that the corresponding menu items are displayed.")
+        moduleListPage.clickItemOverflow(module.name)
+        moduleListPage.assertModuleMenuItems()
+
+        Log.d(STEP_TAG, "Click on 'Publish Module and all Items' and confirm it via the publish dialog.")
+        moduleListPage.clickOnText(R.string.publishModuleAndItems)
+        moduleListPage.clickOnText(R.string.publishDialogPositiveButton)
+
+        Log.d(STEP_TAG, "Assert that the 'Selected Modules and Items' is displayed as title on the Progress page. Click on 'Done' on the Progress Page once it finished.")
+        progressPage.assertProgressPageTitle(R.string.selectedModulesAndItems)
+        progressPage.clickDone()
+
+        Log.d(STEP_TAG, "Assert that the proper snack bar text is displayed and the '${module.name}' module and all of it's items became published.")
+        moduleListPage.assertSnackbarText(R.string.moduleAndAllItemsPublished)
+        moduleListPage.assertModuleIsPublished(module.name)
+        moduleListPage.assertModuleItemIsPublished(assignment.name)
+        moduleListPage.assertModuleItemIsPublished(quiz.title)
+        moduleListPage.assertModuleItemIsPublished(testPage.title)
+        moduleListPage.assertModuleItemIsPublished(discussionTopic.title)
+
+        Log.d(STEP_TAG, "Click on '${module.name}' module overflow.")
+        moduleListPage.clickItemOverflow(module.name)
+
+        Log.d(STEP_TAG, "Click on 'Unpublish Module and all Items' and confirm it via the unpublish dialog.")
+        moduleListPage.clickOnText(R.string.unpublishModuleAndItems)
+        moduleListPage.clickOnText(R.string.unpublishDialogPositiveButton)
+
+        Log.d(STEP_TAG, "Assert that the 'Selected Modules and Items' is displayed as title on the Progress page. Click on 'Done' on the Progress Page once it finished.")
+        progressPage.assertProgressPageTitle(R.string.selectedModulesAndItems)
+        progressPage.clickDone()
+
+        Log.d(STEP_TAG, "Assert that the proper snack bar text is displayed and the '${module.name}' module and all of it's items became unpublished.")
+        moduleListPage.assertSnackbarText(R.string.moduleAndAllItemsUnpublished)
+        moduleListPage.assertModuleNotPublished(module.name)
+        moduleListPage.assertModuleItemNotPublished(assignment.name)
+        moduleListPage.assertModuleItemNotPublished(quiz.title)
+        moduleListPage.assertModuleItemNotPublished(testPage.title)
+        moduleListPage.assertModuleItemNotPublished(discussionTopic.title)
+
+        Log.d(STEP_TAG, "Click on '${module.name}' module overflow.")
+        moduleListPage.clickItemOverflow(module.name)
+
+        Log.d(STEP_TAG, "Click on 'Publish Module only' and confirm it via the publish dialog.")
+        moduleListPage.clickOnText(R.string.publishModuleOnly)
+        moduleListPage.clickOnText(R.string.publishDialogPositiveButton)
+
+        Log.d(STEP_TAG, "Assert that only the '${module.name}' module became published, but it's items remaining unpublished.")
+        moduleListPage.assertModuleIsPublished(module.name)
+        moduleListPage.assertModuleItemNotPublished(assignment.name)
+        moduleListPage.assertModuleItemNotPublished(quiz.title)
+        moduleListPage.assertModuleItemNotPublished(testPage.title)
+        moduleListPage.assertModuleItemNotPublished(discussionTopic.title)
+
+        //Bottom layer - One module item
+
+        Log.d(STEP_TAG, "Click on '${assignment.name}' assignment's overflow menu and publish it. Confirm the publish via the publish dialog.")
+        moduleListPage.clickItemOverflow(assignment.name)
+        moduleListPage.clickOnText(R.string.publishModuleItemAction)
+        moduleListPage.clickOnText(R.string.publishDialogPositiveButton)
+
+        Log.d(STEP_TAG, "Assert that the 'Item published' snack bar has displayed and the '${assignment.name}' assignment became published.")
+        moduleListPage.assertSnackbarText(R.string.moduleItemPublished)
+        moduleListPage.assertModuleItemIsPublished(assignment.name)
+
+        Log.d(STEP_TAG, "Click on '${quiz.title}' quiz's overflow menu and publish it. Confirm the publish via the publish dialog.")
+        moduleListPage.clickItemOverflow(quiz.title)
+        moduleListPage.clickOnText(R.string.publishModuleItemAction)
+        moduleListPage.clickOnText(R.string.publishDialogPositiveButton)
+
+        Log.d(STEP_TAG, "Assert that the 'Item published' snack bar has displayed and the '${quiz.title}' quiz became published.")
+        moduleListPage.assertSnackbarText(R.string.moduleItemPublished)
+        moduleListPage.assertModuleItemIsPublished(quiz.title)
+
+        Log.d(STEP_TAG, "Click on '${testPage.title}' page's overflow menu and publish it. Confirm the publish via the publish dialog.")
+        moduleListPage.clickItemOverflow(testPage.title)
+        moduleListPage.clickOnText(R.string.publishModuleItemAction)
+        moduleListPage.clickOnText(R.string.publishDialogPositiveButton)
+
+        Log.d(STEP_TAG, "Assert that the 'Item published' snack bar has displayed and the '${testPage.title}' page module item became published.")
+        moduleListPage.assertSnackbarText(R.string.moduleItemPublished)
+        moduleListPage.assertModuleItemIsPublished(assignment.name)
+
+        Log.d(STEP_TAG, "Click on '${discussionTopic.title}' discussion topic's overflow menu and publish it. Confirm the publish via the publish dialog.")
+        moduleListPage.clickItemOverflow(discussionTopic.title)
+        moduleListPage.clickOnText(R.string.publishModuleItemAction)
+        moduleListPage.clickOnText(R.string.publishDialogPositiveButton)
+
+        Log.d(STEP_TAG, "Assert that the 'Item published' snack bar has displayed and the '${discussionTopic.title}' discussion topic became published.")
+        moduleListPage.assertSnackbarText(R.string.moduleItemPublished)
+        moduleListPage.assertModuleItemIsPublished(discussionTopic.title)
+
+        Log.d(STEP_TAG, "Click on '${assignment.name}' assignment's overflow menu and unpublish it. Confirm the unpublish via the unpublish dialog.")
+        moduleListPage.clickItemOverflow(assignment.name)
+        moduleListPage.clickOnText(R.string.unpublishModuleItemAction)
+        moduleListPage.clickOnText(R.string.unpublishDialogPositiveButton)
+
+        Log.d(STEP_TAG, "Assert that the 'Item unpublished' snack bar has displayed and the '${assignment.name}' assignment became unpublished.")
+        moduleListPage.assertSnackbarText(R.string.moduleItemUnpublished)
+        moduleListPage.assertModuleItemNotPublished(assignment.name)
+
+        Log.d(STEP_TAG, "Click on '${quiz.title}' quiz's overflow menu and unpublish it. Confirm the unpublish via the unpublish dialog.")
+        moduleListPage.clickItemOverflow(quiz.title)
+        moduleListPage.clickOnText(R.string.unpublishModuleItemAction)
+        moduleListPage.clickOnText(R.string.unpublishDialogPositiveButton)
+
+        Log.d(STEP_TAG, "Assert that the 'Item unpublished' snack bar has displayed and the '${quiz.title}' quiz became unpublished.")
+        moduleListPage.assertSnackbarText(R.string.moduleItemUnpublished)
+        moduleListPage.assertModuleItemNotPublished(quiz.title)
+
+        Log.d(STEP_TAG, "Click on '${testPage.title}' page overflow menu and unpublish it. Confirm the unpublish via the unpublish dialog.")
+        moduleListPage.clickItemOverflow(testPage.title)
+        moduleListPage.clickOnText(R.string.unpublishModuleItemAction)
+        moduleListPage.clickOnText(R.string.unpublishDialogPositiveButton)
+
+        Log.d(STEP_TAG, "Assert that the 'Item unpublished' snack bar has displayed and the '${testPage.title}' page module item became unpublished.")
+        moduleListPage.assertSnackbarText(R.string.moduleItemUnpublished)
+        moduleListPage.assertModuleItemNotPublished(testPage.title)
+
+        Log.d(STEP_TAG, "Click on '${discussionTopic.title}' discussion topic's overflow menu and unpublish it. Confirm the unpublish via the unpublish dialog.")
+        moduleListPage.clickItemOverflow(discussionTopic.title)
+        moduleListPage.clickOnText(R.string.unpublishModuleItemAction)
+        moduleListPage.clickOnText(R.string.unpublishDialogPositiveButton)
+
+        Log.d(STEP_TAG, "Assert that the 'Item unpublished' snack bar has displayed and the '${discussionTopic.title}' discussion topic became unpublished.")
+        moduleListPage.assertSnackbarText(R.string.moduleItemUnpublished)
+        moduleListPage.assertModuleItemNotPublished(discussionTopic.title)
+    }
+
+        private fun createModuleItem(
         course: CourseApiModel,
         module: ModuleApiModel,
         teacher: CanvasUserApiModel,
@@ -272,7 +549,7 @@ class   ModulesE2ETest : TeacherTest() {
         teacher: CanvasUserApiModel,
         published: Boolean = true,
         frontPage: Boolean = false,
-        body: String = EMPTY_STRING
+        body: String = ""
     ): PageApiModel {
         return PagesApi.createCoursePage(
             courseId = course.id,

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/ModulesPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/ModulesPage.kt
@@ -38,14 +38,6 @@ class ModulesPage : BasePage() {
         onView(allOf(withId(R.id.moduleListEmptyView), withAncestor(R.id.moduleList))).assertDisplayed()
     }
 
-    /**
-     * Asserts that the module is not published.
-     */
-    fun assertModuleNotPublished() {
-        onView(withId(R.id.unpublishedIcon)).assertDisplayed()
-        onView(withId(R.id.publishedIcon)).assertNotDisplayed()
-    }
-
     fun assertModuleNotPublished(moduleTitle: String) {
         onView(withId(R.id.unpublishedIcon) + hasSibling(withId(R.id.moduleName) + withText(moduleTitle))).assertDisplayed()
         onView(withId(R.id.publishedIcon) + hasSibling(withId(R.id.moduleName) + withText(moduleTitle))).assertNotDisplayed()

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/ProgressPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/ProgressPage.kt
@@ -18,15 +18,32 @@
 
 package com.instructure.teacher.ui.pages
 
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.instructure.espresso.page.BasePage
+import com.instructure.espresso.page.getStringFromResource
 
+@OptIn(ExperimentalTestApi::class)
 class ProgressPage(private val composeTestRule: ComposeTestRule) : BasePage() {
 
     fun clickDone() {
         composeTestRule.waitForIdle()
+        composeTestRule.waitUntilExactlyOneExists(hasText("Done"), 10000)
         composeTestRule.onNodeWithText("Done").performClick()
+    }
+
+   fun assertProgressPageTitle(@StringRes title: Int) {
+        composeTestRule.waitUntilExactlyOneExists(hasText(getStringFromResource(title)), 10000)
+        composeTestRule.onNodeWithText(getStringFromResource(title)).assertIsDisplayed()
+    }
+
+    fun assertProgressPageNote(@StringRes note: Int) {
+        composeTestRule.waitUntilExactlyOneExists(hasText(getStringFromResource(note)), 10000)
+        composeTestRule.onNodeWithText(getStringFromResource(note)).assertIsDisplayed()
     }
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/utils/TeacherTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/utils/TeacherTest.kt
@@ -19,11 +19,12 @@ package com.instructure.teacher.ui.utils
 import android.app.Activity
 import android.util.Log
 import android.view.View
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
 import com.instructure.canvas.espresso.CanvasTest
 import com.instructure.espresso.InstructureActivityTestRule
 import com.instructure.espresso.ModuleItemInteractions
@@ -73,7 +74,6 @@ import com.instructure.teacher.ui.pages.PeopleListPage
 import com.instructure.teacher.ui.pages.PersonContextPage
 import com.instructure.teacher.ui.pages.PostSettingsPage
 import com.instructure.teacher.ui.pages.ProfileSettingsPage
-import com.instructure.teacher.ui.pages.ProgressPage
 import com.instructure.teacher.ui.pages.QuizDetailsPage
 import com.instructure.teacher.ui.pages.QuizListPage
 import com.instructure.teacher.ui.pages.QuizSubmissionListPage
@@ -102,6 +102,8 @@ abstract class TeacherTest : CanvasTest() {
             = TeacherActivityTestRule(LoginActivity::class.java)
 
     override val isTesting = BuildConfig.IS_TESTING
+
+    val device: UiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
     @Inject
     lateinit var workerFactory: HiltWorkerFactory

--- a/automation/espresso/src/main/kotlin/com/instructure/espresso/ScreenshotTestRule.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/espresso/ScreenshotTestRule.kt
@@ -32,7 +32,7 @@ class ScreenshotTestRule : TestRule {
 
     // Run all test methods tryCount times. Take screenshots on failure.
     // A method rule would allow targeting specific (method.getAnnotation(Retry.class))
-    private val tryCount = 1
+    private val tryCount = 5
 
     override fun apply(base: Statement, description: Description): Statement {
         return object : Statement() {

--- a/automation/espresso/src/main/kotlin/com/instructure/espresso/ScreenshotTestRule.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/espresso/ScreenshotTestRule.kt
@@ -32,7 +32,7 @@ class ScreenshotTestRule : TestRule {
 
     // Run all test methods tryCount times. Take screenshots on failure.
     // A method rule would allow targeting specific (method.getAnnotation(Retry.class))
-    private val tryCount = 5
+    private val tryCount = 1
 
     override fun apply(base: Statement, description: Description): Statement {
         return object : Statement() {


### PR DESCRIPTION
Implement Bulk Module Update E2E test.
Add and refactor some methods in (Composable) ProgressPage.

Note: File module item actions will be implemented in a separate test case in a separate ticket.

refs: MBL-17280
affects: Teacher
release note: none

- [x] Run E2E test suite
