### PR TITLE
[MBL-17440][Student] - Show '(No Subject)' on InboxEntryItem view on the conversation list p…

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/InboxE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/InboxE2ETest.kt
@@ -419,9 +419,10 @@ class InboxE2ETest: StudentTest() {
         tokenLogin(teacher)
         dashboardPage.waitForRender()
 
-        Log.d(STEP_TAG,"Open Inbox Page. Assert that the asked question is displayed in the teacher's inbox with the proper recipients ($recipientList) and message ($questionText).")
+        Log.d(STEP_TAG,"Open Inbox Page. Assert that the asked question is displayed in the teacher's inbox with the proper recipients ($recipientList), subject and message ($questionText).")
         dashboardPage.clickInboxTab()
         inboxPage.assertConversationWithRecipientsDisplayed(recipientList)
+        inboxPage.assertConversationSubject("(No Subject)")
         inboxPage.assertConversationDisplayed(questionText)
 
         Log.d(STEP_TAG, "Open the conversation and assert that there is no subject of the conversation and the message body is equal to which the student typed in the 'Ask Your Instructor' dialog: '$questionText'.")

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxConversationPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxConversationPage.kt
@@ -126,7 +126,7 @@ class InboxConversationPage : BasePage(R.id.inboxConversationPage) {
     }
 
     fun assertNoSubjectDisplayed() {
-        onView(withId(R.id.subjectView) + withText(R.string.noSubject)).assertDisplayed()
+        onView(withId(R.id.subjectView) + withParent(withId(R.id.header)) + withText(R.string.noSubject)).assertDisplayed()
     }
 
     fun refresh() {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxPage.kt
@@ -300,4 +300,8 @@ class InboxPage : BasePage(R.id.inboxPage) {
         editToolbar.assertVisibility(visibility)
     }
 
+    fun assertConversationSubject(expectedSubject: String) {
+        onView(withId(R.id.subjectView) + withText(expectedSubject) + withAncestor(R.id.inboxRecyclerView)).assertDisplayed()
+    }
+
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/list/InboxEntryItemCreator.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/list/InboxEntryItemCreator.kt
@@ -40,7 +40,7 @@ class InboxEntryItemCreator(private val context: Context, private val apiPrefs: 
             conversation.id,
             createAvatarData(conversation),
             createMessageTitle(conversation),
-            conversation.subject ?: "",
+            conversation.subject.takeIf { it?.isNotBlank() == true } ?: context.getString(R.string.noSubject),
             conversation.lastMessagePreview ?: "",
             createDateText(conversation),
             conversation.workflowState == Conversation.WorkflowState.UNREAD,


### PR DESCRIPTION
Show '(No Subject)' on InboxEntryItem view on the conversation list page when there is no subject given.

refs: MBL-17440
affects: Student
release note: Show '(No Subject)' on Inbox conversation list page.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-android/assets/92309696/38b7af78-65d5-4ce5-990b-de4e6759c836" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-android/assets/92309696/093a4356-5eb7-47e3-b9d4-0ce841795327" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Run E2E test suite
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] Approve from product
