### PR TITLE
Fix scheduleE2ETest

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/k5/ScheduleE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/k5/ScheduleE2ETest.kt
@@ -39,6 +39,7 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.Timeout
+import java.lang.Thread.sleep
 import java.util.*
 
 @HiltAndroidTest
@@ -50,7 +51,7 @@ class ScheduleE2ETest : StudentTest() {
 
     @Rule
     @JvmField
-    var globalTimeout: Timeout = Timeout.millis(600000) // //TODO: workaround for that sometimes this test is running infinite time because of scrollToElement does not find an element.
+    var globalTimeout: Timeout = Timeout.millis(1200000) // //TODO: workaround for that sometimes this test is running infinite time because of scrollToElement does not find an element.
 
     @E2E
     @Test
@@ -88,7 +89,6 @@ class ScheduleE2ETest : StudentTest() {
 
         Log.d(STEP_TAG, "Navigate to K5 Schedule Page and assert it is loaded.")
         elementaryDashboardPage.selectTab(ElementaryDashboardPage.ElementaryTabType.SCHEDULE)
-        schedulePage.assertPageObjects()
 
         //Depends on how we handle Sunday, need to clarify with calendar team
         if(currentDateCalendar.get(Calendar.DAY_OF_WEEK) != 1) {  schedulePage.assertIfCourseHeaderAndScheduleItemDisplayed(homeroomCourse.name, homeroomAnnouncement.title) }
@@ -113,7 +113,7 @@ class ScheduleE2ETest : StudentTest() {
         Log.d(STEP_TAG, "Refresh the Schedule Page. Assert that the items are still displayed correctly.")
         schedulePage.scrollToPosition(0)
         schedulePage.refresh()
-        schedulePage.assertPageObjects()
+        sleep(3000)
 
         Log.d(STEP_TAG, "Assert that the current day of the calendar is titled as 'Today'.")
         schedulePage.assertDayHeaderShownByItemName(concatDayString(currentDateCalendar), schedulePage.getStringFromResource(R.string.today), schedulePage.getStringFromResource(R.string.today))
@@ -158,6 +158,7 @@ class ScheduleE2ETest : StudentTest() {
 
             Log.d(STEP_TAG, "Navigate back to Schedule Page and assert it is loaded.")
             Espresso.pressBack()
+            sleep(3000)
             schedulePage.assertPageObjects()
         }
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/k5/ScheduleE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/k5/ScheduleE2ETest.kt
@@ -108,7 +108,7 @@ class ScheduleE2ETest : StudentTest() {
 
         Log.d(STEP_TAG, "Scroll to 'Missing Items' section  and verify that a missing assignment (${testMissingAssignment.name}) is displayed there with 100 points.")
         schedulePage.scrollToItem(R.id.metaLayout, testMissingAssignment.name)
-        schedulePage.assertMissingItemDisplayed(testMissingAssignment.name, nonHomeroomCourses[2].name, "100 pts")
+        schedulePage.assertMissingItemDisplayedOnPlannerItem(testMissingAssignment.name, nonHomeroomCourses[2].name, "100 pts")
 
         Log.d(STEP_TAG, "Refresh the Schedule Page. Assert that the items are still displayed correctly.")
         schedulePage.scrollToPosition(0)

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/k5/ScheduleE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/k5/ScheduleE2ETest.kt
@@ -107,7 +107,7 @@ class ScheduleE2ETest : StudentTest() {
         schedulePage.assertIfCourseHeaderAndScheduleItemDisplayed(nonHomeroomCourses[2].name, testMissingAssignment.name)
 
         Log.d(STEP_TAG, "Scroll to 'Missing Items' section  and verify that a missing assignment (${testMissingAssignment.name}) is displayed there with 100 points.")
-        schedulePage.scrollToItem(R.id.missingItemLayout, testMissingAssignment.name)
+        schedulePage.scrollToItem(R.id.metaLayout, testMissingAssignment.name)
         schedulePage.assertMissingItemDisplayed(testMissingAssignment.name, nonHomeroomCourses[2].name, "100 pts")
 
         Log.d(STEP_TAG, "Refresh the Schedule Page. Assert that the items are still displayed correctly.")

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/ScheduleInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/ScheduleInteractionTest.kt
@@ -105,7 +105,7 @@ class ScheduleInteractionTest : StudentTest() {
 
         goToScheduleTab(data)
         schedulePage.scrollToPosition(12)
-        schedulePage.assertMissingItemDisplayed(assignment1.name!!, courses[0].name, "10 pts")
+        schedulePage.assertMissingItemDisplayedInMissingItemSummary(assignment1.name!!, courses[0].name, "10 pts")
     }
 
     @Test

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SchedulePage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SchedulePage.kt
@@ -81,13 +81,13 @@ class SchedulePage : BasePage(R.id.schedulePage) {
         var i: Int = 0
         while (true) {
             scrollToPosition(i)
-            Thread.sleep(500)
+            Thread.sleep(300)
             try {
                 if(target == null) onView(withParent(itemId) + withText(itemName)).scrollTo()
                 else onView(target + withText(itemName)).scrollTo()
                 break
             } catch(e: NoMatchingViewException) {
-                i++
+                i+=2
             }
         }
     }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SchedulePage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SchedulePage.kt
@@ -20,6 +20,7 @@ import android.view.View
 import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.ViewMatchers.hasSibling
 import com.instructure.espresso.*
 import com.instructure.espresso.page.*
 import com.instructure.pandautils.binding.BindableViewHolder
@@ -102,14 +103,10 @@ class SchedulePage : BasePage(R.id.schedulePage) {
 
     fun assertMissingItemDisplayed(itemName: String, courseName: String, pointsPossible: String) {
         val titleMatcher = withId(R.id.title) + withText(itemName)
-        val courseNameMatcher = withId(R.id.courseName) + withText(courseName)
+        val courseNameMatcher = withId(R.id.scheduleCourseHeaderText) + withText(courseName)
         val pointsPossibleMatcher = withId(R.id.points) + withText(pointsPossible)
 
-        onView(
-            withId(R.id.missingItemLayout) + withDescendant(titleMatcher) + withDescendant(
-                courseNameMatcher
-            ) + withDescendant(pointsPossibleMatcher)
-        )
+        onView(withId(R.id.plannerItems) + hasSibling(courseNameMatcher) + withDescendant(titleMatcher)  + withDescendant(pointsPossibleMatcher) + withDescendant(withText(R.string.missingAssignment)))
             .scrollTo()
             .assertDisplayed()
     }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SchedulePage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SchedulePage.kt
@@ -101,12 +101,22 @@ class SchedulePage : BasePage(R.id.schedulePage) {
         waitForView(withAncestor(R.id.plannerItems) + withText(scheduleItemName)).assertDisplayed()
     }
 
-    fun assertMissingItemDisplayed(itemName: String, courseName: String, pointsPossible: String) {
+    fun assertMissingItemDisplayedOnPlannerItem(itemName: String, courseName: String, pointsPossible: String) {
         val titleMatcher = withId(R.id.title) + withText(itemName)
         val courseNameMatcher = withId(R.id.scheduleCourseHeaderText) + withText(courseName)
         val pointsPossibleMatcher = withId(R.id.points) + withText(pointsPossible)
 
         onView(withId(R.id.plannerItems) + hasSibling(courseNameMatcher) + withDescendant(titleMatcher)  + withDescendant(pointsPossibleMatcher) + withDescendant(withText(R.string.missingAssignment)))
+            .scrollTo()
+            .assertDisplayed()
+    }
+
+    fun assertMissingItemDisplayedInMissingItemSummary(itemName: String, courseName: String, pointsPossible: String) {
+        val titleMatcher = withId(R.id.title) + withText(itemName)
+        val courseNameMatcher = withId(R.id.courseName) + withText(courseName)
+        val pointsPossibleMatcher = withId(R.id.points) + withText(pointsPossible)
+
+        onView(withId(R.id.missingItemLayout) + withDescendant(courseNameMatcher) + withDescendant(titleMatcher)  + withDescendant(pointsPossibleMatcher))
             .scrollTo()
             .assertDisplayed()
     }


### PR DESCRIPTION
Fix scheduleE2ETest (breaking since Compose UI test dependency was imported. ViewInteraction evaluations became slower)


- [x] Run E2E test suite
