### PR TITLE
[MBL-17384][Student] - Test previous and next arrows in Student Modules E2E Test

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/ModulesE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/ModulesE2ETest.kt
@@ -89,11 +89,11 @@ class ModulesE2ETest: StudentTest() {
         Log.d(PREPARATION_TAG,"Associate '${assignment2.name}' assignment with '${module2.name}' module.")
         ModulesApi.createModuleItem(course.id, teacher.token, module2.id, assignment2.name, ModuleItemTypes.ASSIGNMENT.stringVal, contentId = assignment2.id.toString())
 
-        Log.d(PREPARATION_TAG,"Associate '${page1.title}' page with '${module2.name}' module.")
-        ModulesApi.createModuleItem(course.id, teacher.token, module2.id, page1.title, ModuleItemTypes.PAGE.stringVal, pageUrl = page1.url)
-
         Log.d(PREPARATION_TAG,"Associate '${discussionTopic1.title}' discussion topic with '${module2.name}' module.")
         ModulesApi.createModuleItem(course.id, teacher.token, module2.id, discussionTopic1.title, ModuleItemTypes.DISCUSSION.stringVal, contentId = discussionTopic1.id.toString())
+
+        Log.d(PREPARATION_TAG,"Associate '${quiz1.title}' page with '${module2.name}' module.")
+        ModulesApi.createModuleItem(course.id, teacher.token, module2.id, page1.title, ModuleItemTypes.PAGE.stringVal, pageUrl = page1.url)
 
         Log.d(STEP_TAG, "Login with user: ${teacher.name}, login id: ${teacher.loginId}.")
         tokenLogin(student)
@@ -149,9 +149,61 @@ class ModulesE2ETest: StudentTest() {
         modulesPage.clickOnModuleExpandCollapseIcon(module2.name)
         modulesPage.assertModulesAndItemsCount(7) // 2 modules titles, 2 module items in first module, 3 items in second module
 
-        Log.d(STEP_TAG, "Assert that '${assignment1.name}' module item is displayed and open it. Assert that the Assignment Details page is displayed with the corresponding assignment title.")
+        Log.d(STEP_TAG, "Assert that '${assignment1.name}' module item is displayed and open it. Assert that the Assignment Details page is displayed with the corresponding assignment name: '${assignment1.name}'.")
         modulesPage.assertAndClickModuleItem(module1.name, assignment1.name, true)
         assignmentDetailsPage.assertPageObjects()
         assignmentDetailsPage.assertAssignmentTitle(assignment1.name)
+
+        Log.d(STEP_TAG, "Assert that the module name, '${module1.name}' is displayed at the bottom.")
+        assignmentDetailsPage.moduleItemInteractions.assertModuleNameDisplayed(module1.name)
+
+        Log.d(STEP_TAG, "Assert that the previous arrow button is not displayed because the user is on the first module item's details page, but the next arrow button is displayed.")
+        assignmentDetailsPage.moduleItemInteractions.assertPreviousArrowNotDisplayed()
+        assignmentDetailsPage.moduleItemInteractions.assertNextArrowDisplayed()
+
+        Log.d(STEP_TAG, "Click on the next arrow button and assert that the '${quiz1.title}' quiz module item's 'Go To Quiz' page is displayed.")
+        assignmentDetailsPage.moduleItemInteractions.clickOnNextArrow()
+        goToQuizPage.assertQuizTitle(quiz1.title)
+
+        Log.d(STEP_TAG, "Assert that the module name, '${module1.name}' is displayed at the bottom.")
+        goToQuizPage.moduleItemInteractions.assertModuleNameDisplayed(module1.name)
+
+        Log.d(STEP_TAG, "Assert that both the previous and the next buttons are displayed (since we are not at the first or the last module item details page).")
+        goToQuizPage.moduleItemInteractions.assertPreviousArrowDisplayed()
+        goToQuizPage.moduleItemInteractions.assertNextArrowDisplayed()
+
+        Log.d(STEP_TAG, "Click on the next arrow button and assert that the Assignment Details Page is displayed with the corresponding assignment name: '${assignment2.name}'.")
+        goToQuizPage.moduleItemInteractions.clickOnNextArrow()
+        assignmentDetailsPage.assertPageObjects()
+        assignmentDetailsPage.assertAssignmentTitle(assignment2.name)
+
+        Log.d(STEP_TAG, "Assert that the second module name, '${module2.name}' is displayed at the bottom since we can navigate even between modules with these arrows.")
+        assignmentDetailsPage.moduleItemInteractions.assertModuleNameDisplayed(module2.name)
+
+        Log.d(STEP_TAG, "Assert that both the previous and the next buttons are displayed (since we are not at the first or the last module item details page, even if it's a first item of a module, but of the second module).")
+        assignmentDetailsPage.moduleItemInteractions.assertPreviousArrowDisplayed()
+        assignmentDetailsPage.moduleItemInteractions.assertNextArrowDisplayed()
+
+        Log.d(STEP_TAG, "Click on the next arrow button and assert that the '${discussionTopic1.title}' discussion topic module item's details page is displayed.")
+        assignmentDetailsPage.moduleItemInteractions.clickOnNextArrow()
+        discussionDetailsPage.assertTitleText(discussionTopic1.title)
+
+        Log.d(STEP_TAG, "Assert that the second module name, '${module2.name}' is displayed at the bottom.")
+        discussionDetailsPage.moduleItemInteractions.assertModuleNameDisplayed(module2.name)
+
+        Log.d(STEP_TAG, "Assert that both the previous and the next buttons are displayed.")
+        discussionDetailsPage.moduleItemInteractions.assertPreviousArrowDisplayed()
+        discussionDetailsPage.moduleItemInteractions.assertNextArrowDisplayed()
+
+        Log.d(STEP_TAG, "Click on the next arrow button and assert that the '${page1.url}' page module item's details page is displayed.")
+        discussionDetailsPage.moduleItemInteractions.clickOnNextArrow()
+        pageDetailsPage.webAssertPageUrl(page1.url)
+
+        Log.d(STEP_TAG, "Assert that the second module name, '${module2.name}' is displayed at the bottom.")
+        pageDetailsPage.moduleItemInteractions.assertModuleNameDisplayed(module2.name)
+
+        Log.d(STEP_TAG, "Assert that the previous arrow button is displayed but the next arrow button is not displayed because the user is on the last module item's details page.")
+        pageDetailsPage.moduleItemInteractions.assertPreviousArrowDisplayed()
+        pageDetailsPage.moduleItemInteractions.assertNextArrowNotDisplayed()
     }
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/AssignmentDetailsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/AssignmentDetailsPage.kt
@@ -38,6 +38,7 @@ import com.instructure.canvas.espresso.stringContainsTextCaseInsensitive
 import com.instructure.canvas.espresso.waitForMatcherWithSleeps
 import com.instructure.canvasapi2.models.Assignment
 import com.instructure.dataseeding.model.SubmissionType
+import com.instructure.espresso.ModuleItemInteractions
 import com.instructure.espresso.OnViewWithId
 import com.instructure.espresso.assertContainsText
 import com.instructure.espresso.assertDisplayed
@@ -66,7 +67,7 @@ import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.anything
 import org.hamcrest.Matchers.not
 
-open class AssignmentDetailsPage : BasePage(R.id.assignmentDetailsPage) {
+open class AssignmentDetailsPage(val moduleItemInteractions: ModuleItemInteractions) : BasePage(R.id.assignmentDetailsPage) {
     val toolbar by OnViewWithId(R.id.toolbar)
     val points by OnViewWithId(R.id.points)
     val date by OnViewWithId(R.id.dueDateTextView)

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DiscussionDetailsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DiscussionDetailsPage.kt
@@ -36,6 +36,7 @@ import com.instructure.canvas.espresso.withCustomConstraints
 import com.instructure.canvas.espresso.withElementRepeat
 import com.instructure.canvasapi2.models.DiscussionEntry
 import com.instructure.canvasapi2.models.DiscussionTopicHeader
+import com.instructure.espresso.ModuleItemInteractions
 import com.instructure.espresso.OnViewWithId
 import com.instructure.espresso.assertDisplayed
 import com.instructure.espresso.assertGone
@@ -56,7 +57,7 @@ import org.hamcrest.Matchers.containsString
 import org.junit.Assert.assertTrue
 
 
-class DiscussionDetailsPage : BasePage(R.id.discussionDetailsPage) {
+class DiscussionDetailsPage(val moduleItemInteractions: ModuleItemInteractions) : BasePage(R.id.discussionDetailsPage) {
     private val discussionTopicTitle by OnViewWithId(R.id.discussionTopicTitle)
     private val replyButton by OnViewWithId(R.id.replyToDiscussionTopic)
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/GoToQuizPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/GoToQuizPage.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2024 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.instructure.student.ui.pages
+
+import com.instructure.espresso.ModuleItemInteractions
+import com.instructure.espresso.OnViewWithText
+import com.instructure.espresso.assertDisplayed
+import com.instructure.espresso.click
+import com.instructure.espresso.page.BasePage
+import com.instructure.espresso.page.onView
+import com.instructure.espresso.page.plus
+import com.instructure.espresso.page.withAncestor
+import com.instructure.espresso.page.withId
+import com.instructure.espresso.page.withText
+import com.instructure.student.R
+
+class GoToQuizPage(val moduleItemInteractions: ModuleItemInteractions) : BasePage() {
+
+    private val goToQuizButton by OnViewWithText(R.string.goToQuiz)
+
+    fun clickGoToQuizButton() {
+        goToQuizButton.click()
+    }
+
+    fun assertQuizTitle(expectedTitle: String) {
+        onView(withId(R.id.quizTitle) + withText(expectedTitle) + withAncestor(R.id.quizInfoContainer)).assertDisplayed()
+    }
+}

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/PageDetailsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/PageDetailsPage.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.instructure.student.ui.pages
+
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.web.assertion.WebViewAssertions.webMatches
+import androidx.test.espresso.web.model.Atoms
+import androidx.test.espresso.web.sugar.Web.onWebView
+import com.instructure.espresso.ModuleItemInteractions
+import com.instructure.espresso.page.BasePage
+import com.instructure.student.R
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.containsString
+
+class PageDetailsPage(val moduleItemInteractions: ModuleItemInteractions) : BasePage() {
+
+    fun webAssertPageUrl(pageUrl: String) {
+        onWebView(allOf(withId(R.id.contentWebView), isDisplayed()))
+            .check(webMatches(Atoms.getCurrentUrl(), containsString(pageUrl)))
+    }
+
+}

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTest.kt
@@ -35,6 +35,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.instructure.canvas.espresso.CanvasTest
 import com.instructure.espresso.InstructureActivityTestRule
+import com.instructure.espresso.ModuleItemInteractions
 import com.instructure.espresso.Searchable
 import com.instructure.espresso.swipeRight
 import com.instructure.pandautils.utils.Const
@@ -62,6 +63,7 @@ import com.instructure.student.ui.pages.ElementaryCoursePage
 import com.instructure.student.ui.pages.ElementaryDashboardPage
 import com.instructure.student.ui.pages.FileListPage
 import com.instructure.student.ui.pages.FileUploadPage
+import com.instructure.student.ui.pages.GoToQuizPage
 import com.instructure.student.ui.pages.GradesPage
 import com.instructure.student.ui.pages.GroupBrowserPage
 import com.instructure.student.ui.pages.HelpPage
@@ -78,6 +80,7 @@ import com.instructure.student.ui.pages.ModuleProgressionPage
 import com.instructure.student.ui.pages.ModulesPage
 import com.instructure.student.ui.pages.NewMessagePage
 import com.instructure.student.ui.pages.NotificationPage
+import com.instructure.student.ui.pages.PageDetailsPage
 import com.instructure.student.ui.pages.PageListPage
 import com.instructure.student.ui.pages.PairObserverPage
 import com.instructure.student.ui.pages.PandaAvatarPage
@@ -150,7 +153,7 @@ abstract class StudentTest : CanvasTest() {
      */
     val annotationCommentListPage = AnnotationCommentListPage()
     val announcementListPage = AnnouncementListPage(Searchable(R.id.search, R.id.search_src_text, R.id.search_close_btn))
-    val assignmentDetailsPage = AssignmentDetailsPage()
+    val assignmentDetailsPage = AssignmentDetailsPage(ModuleItemInteractions(R.id.moduleName, R.id.next_item, R.id.prev_item))
     val assignmentListPage = AssignmentListPage(Searchable(R.id.search, R.id.search_src_text))
     val bookmarkPage = BookmarkPage()
     val calendarEventPage = CalendarEventPage()
@@ -163,7 +166,7 @@ abstract class StudentTest : CanvasTest() {
     val courseGradesPage = CourseGradesPage()
     val dashboardPage = DashboardPage()
     val leftSideNavigationDrawerPage = LeftSideNavigationDrawerPage()
-    val discussionDetailsPage = DiscussionDetailsPage()
+    val discussionDetailsPage = DiscussionDetailsPage(ModuleItemInteractions(R.id.moduleName, R.id.next_item, R.id.prev_item))
     val discussionListPage = DiscussionListPage(Searchable(R.id.search, R.id.search_src_text, R.id.search_close_btn))
     val allCoursesPage = AllCoursesPage()
     val fileListPage = FileListPage(Searchable(R.id.search, R.id.queryInput, R.id.clearButton, R.id.backButton))
@@ -181,6 +184,7 @@ abstract class StudentTest : CanvasTest() {
     val newMessagePage = NewMessagePage()
     val notificationPage = NotificationPage()
     val pageListPage = PageListPage(Searchable(R.id.search, R.id.search_src_text, R.id.search_close_btn))
+    val pageDetailsPage = PageDetailsPage(ModuleItemInteractions(R.id.moduleName, R.id.next_item, R.id.prev_item))
     val pairObserverPage = PairObserverPage()
     val pandaAvatarPage = PandaAvatarPage()
     val peopleListPage = PeopleListPage()
@@ -190,6 +194,7 @@ abstract class StudentTest : CanvasTest() {
     val qrLoginPage = QRLoginPage()
     val quizListPage = QuizListPage()
     val quizTakingPage = QuizTakingPage()
+    val goToQuizPage = GoToQuizPage(ModuleItemInteractions(R.id.moduleName, R.id.next_item, R.id.prev_item))
     val remoteConfigSettingsPage = RemoteConfigSettingsPage()
     val settingsPage = SettingsPage()
     val submissionDetailsPage = SubmissionDetailsPage()


### PR DESCRIPTION
Test previous and next arrows in Student ModulesE2ETest.
Add new page objects.
Minor refactor on existing logic.
Implement ModuleItemInteraction to the corresponding Student module item pages.

refs: MBL-17384
affects: Student
release note: none

- [x] Run E2E test suite