### PR TITLE
[MBL-17438][Student] Graded Group Discussions Fail to Launch from To-Do List for Students Outside the First Group

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/ToDoListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/ToDoListFragment.kt
@@ -168,12 +168,10 @@ class ToDoListFragment : ParentFragment() {
         when {
             toDo?.assignment != null -> { // Launch assignment details fragment.
                 if (toDo.assignment!!.discussionTopicHeader != null) {
-                    val groupTopic = toDo.assignment!!.discussionTopicHeader!!.groupTopicChildren.firstOrNull()
-                    if (groupTopic == null) { // Launch discussion details fragment
-                        RouteMatcher.route(requireActivity(), DiscussionRouterFragment.makeRoute(toDo.canvasContext!!, toDo.assignment!!.discussionTopicHeader!!))
-                    } else { // Launch discussion details fragment with the group
-                        RouteMatcher.route(requireActivity(), DiscussionRouterFragment.makeRoute(CanvasContext.emptyGroupContext(groupTopic.groupId), groupTopic.id))
-                    }
+                    RouteMatcher.route(
+                        requireActivity(),
+                        DiscussionRouterFragment.makeRoute(toDo.canvasContext!!, toDo.assignment!!.discussionTopicHeader!!)
+                    )
                 } else {
                     // Launch assignment details fragment.
                     RouteMatcher.route(requireActivity(), AssignmentDetailsFragment.makeRoute(toDo.canvasContext!!, toDo.assignment!!.id))


### PR DESCRIPTION
Test plan: In the ticket

refs: MBL-17438
affects: Student
release note: Fixed a bug where some group discussions wouldn't open from the To Do list.

## Checklist

- [x] Tested in light mode
