### PR TITLE
[MBL-17441][Student] Inbox filter string can be barely seen after changing from dark to light mode

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/list/InboxFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/list/InboxFragment.kt
@@ -324,6 +324,8 @@ class InboxFragment : Fragment(), NavigationCallbacks, FragmentInteractions {
         ViewStyler.themeToolbarColored(requireActivity(), binding.editToolbar, ThemePrefs.primaryColor, ThemePrefs.primaryTextColor)
         binding.toolbarWrapper.setBackgroundColor(ThemePrefs.primaryColor)
         binding.addMessage.backgroundTintList = ViewStyler.makeColorStateListForButton()
+        binding.scopeFilterText.setTextColor(ThemePrefs.textButtonColor)
+        binding.scopeFilterIcon.setColorFilter(ThemePrefs.textButtonColor)
         inboxRouter.attachNavigationIcon(binding.toolbar)
     }
 

--- a/libs/pandautils/src/main/res/layout/fragment_inbox.xml
+++ b/libs/pandautils/src/main/res/layout/fragment_inbox.xml
@@ -157,6 +157,7 @@
                             tools:text="Inbox" />
 
                         <ImageView
+                            android:id="@+id/scopeFilterIcon"
                             android:layout_width="16dp"
                             android:layout_height="16dp"
                             android:layout_gravity="center_vertical"


### PR DESCRIPTION
Test plan: In the ticket

refs: MBL-17441
affects: Student
release note: none

## Checklist

- [x] Tested in dark mode
- [x] Tested in light mode
