### PR TITLE
[MBL-17462][Teacher] All submissions page filter displays twice the Course's name and if uncheck it the 'Clear filter' button remains there and does nothing

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/AssignmentSubmissionListFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/AssignmentSubmissionListFragment.kt
@@ -205,7 +205,9 @@ class AssignmentSubmissionListFragment : BaseSyncFragment<
         when (presenter.getFilter()) {
             SubmissionListFilter.ALL -> {
                 filterTitle.setText(R.string.all_submissions)
-                clearFilterTextView.setGone()
+                if (presenter.getSectionFilterText().isEmpty()) {
+                    clearFilterTextView.setGone()
+                }
             }
             SubmissionListFilter.LATE -> filterTitle.setText(R.string.submitted_late)
             SubmissionListFilter.MISSING -> filterTitle.setText(R.string.havent_submitted_yet)
@@ -236,9 +238,6 @@ class AssignmentSubmissionListFragment : BaseSyncFragment<
             presenter.setSections(canvasContexts)
 
             updateFilterTitle()
-
-            filterTitle.text = filterTitle.text.toString().plus(presenter.getSectionFilterText())
-            clearFilterTextView.setVisible()
             return
         }
 


### PR DESCRIPTION
Test plan: In the ticket

refs: MBL-17462
affects: Teacher
release note: none

## Checklist

- [x] Tested in light mode
