### PR TITLE
[MBL-17375][Student] Investigate why submission is not in SpeedGrader

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/worker/FileUploadWorker.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/worker/FileUploadWorker.kt
@@ -42,6 +42,7 @@ import com.instructure.pandautils.utils.orDefault
 import com.instructure.pandautils.utils.toJson
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import java.lang.IllegalStateException
 import java.util.*
 
 @HiltWorker
@@ -127,7 +128,7 @@ class FileUploadWorker @AssistedInject constructor(
                         updateSubmissionComplete(notificationId)
                         attemptId = it.attempt
                         Result.success()
-                    } ?: Result.retry()
+                    } ?: throw IllegalStateException("Failed to attach file to submission")
                 }
                 ACTION_MESSAGE_ATTACHMENTS -> {
                     updateNotificationComplete(notificationId)


### PR DESCRIPTION
Test plan: To reproduce the issue you need to break the last API request that we make when uploading a file from the share extension (that adds the submission and attaches the file). Also smoke test the share extension.

refs: MBL-17375
affects: Student
release note: none

## Checklist

- [x] Tested in light mode
