### PR TITLE
[MBL-17498][Teacher] Added request for calendar context limit feature.

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/di/CalendarModule.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/di/CalendarModule.kt
@@ -19,6 +19,7 @@ package com.instructure.teacher.di
 import androidx.fragment.app.FragmentActivity
 import com.instructure.canvasapi2.apis.CalendarEventAPI
 import com.instructure.canvasapi2.apis.CourseAPI
+import com.instructure.canvasapi2.apis.FeaturesAPI
 import com.instructure.canvasapi2.apis.PlannerAPI
 import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.pandautils.features.calendar.CalendarRepository
@@ -49,9 +50,10 @@ class CalendarModule {
             plannerApi: PlannerAPI.PlannerInterface,
             coursesApi: CourseAPI.CoursesInterface,
             calendarEventsApi: CalendarEventAPI.CalendarEventInterface,
-            apiPrefs: ApiPrefs
+            apiPrefs: ApiPrefs,
+            featuresApi: FeaturesAPI.FeaturesInterface
         ): CalendarRepository {
-            return TeacherCalendarRepository(plannerApi, coursesApi, calendarEventsApi, apiPrefs)
+            return TeacherCalendarRepository(plannerApi, coursesApi, calendarEventsApi, apiPrefs, featuresApi)
         }
     }
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/calendar/TeacherCalendarRepository.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/calendar/TeacherCalendarRepository.kt
@@ -18,6 +18,7 @@ package com.instructure.teacher.features.calendar
 
 import com.instructure.canvasapi2.apis.CalendarEventAPI
 import com.instructure.canvasapi2.apis.CourseAPI
+import com.instructure.canvasapi2.apis.FeaturesAPI
 import com.instructure.canvasapi2.apis.PlannerAPI
 import com.instructure.canvasapi2.builders.RestParams
 import com.instructure.canvasapi2.models.Assignment
@@ -39,7 +40,8 @@ class TeacherCalendarRepository(
     private val plannerApi: PlannerAPI.PlannerInterface,
     private val coursesApi: CourseAPI.CoursesInterface,
     private val calendarEventApi: CalendarEventAPI.CalendarEventInterface,
-    private val apiPrefs: ApiPrefs
+    private val apiPrefs: ApiPrefs,
+    private val featuresApi: FeaturesAPI.FeaturesInterface
 ) : CalendarRepository {
 
     override suspend fun getPlannerItems(
@@ -105,7 +107,14 @@ class TeacherCalendarRepository(
     }
 
     override suspend fun getCalendarFilterLimit(): Int {
-        return 10
+        val result = featuresApi.getAccountSettingsFeatures(RestParams())
+        return if (result.isSuccess) {
+            val features = result.dataOrThrow
+            val increasedContextLimit = features["calendar_contexts_limit"]
+            if (increasedContextLimit == true) 20 else 10
+        } else {
+            10
+        }
     }
 }
 

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/FeaturesAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/FeaturesAPI.kt
@@ -42,6 +42,9 @@ object FeaturesAPI {
 
         @GET("features/environment")
         suspend fun getEnvironmentFeatureFlags(@Tag restParams: RestParams): DataResult<Map<String, Boolean>>
+
+        @GET("settings/environment")
+        suspend fun getAccountSettingsFeatures(@Tag restParams: RestParams): DataResult<Map<String, Boolean>>
     }
 
     fun getEnabledFeaturesForCourse(adapter: RestBuilder, courseId: Long, callback: StatusCallback<List<String>>, params: RestParams) {


### PR DESCRIPTION
Test plan: Increase the calendar context limit in the account settings and check the filter limit in the Teacher app, it should be 20 now. This only works on beta currently.

refs: MBL-17498
affects: Teacher
release note: none

## Checklist

- [x] Tested in light mode
