### PR TITLE
[MBL-17186][Student] Show initials on discussions if offline 

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/features/discussion/details/DiscussionDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/discussion/details/DiscussionDetailsFragment.kt
@@ -612,7 +612,8 @@ class DiscussionDetailsFragment : ParentFragment(), Bookmarkable {
                             canvasContext,
                             discussionTopicHeader,
                             discussionTopic!!.views,
-                            discussionEntryId
+                            discussionEntryId,
+                            repository.isOnline()
                         )
 
                 loadDiscussionTopicViews(html)

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/discussions/DiscussionUtils.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/discussions/DiscussionUtils.kt
@@ -248,7 +248,8 @@ object DiscussionUtils {
             canvasContext: CanvasContext,
             discussionTopicHeader: DiscussionTopicHeader,
             discussionEntries: List<DiscussionEntry>,
-            startEntryId: Long): String {
+            startEntryId: Long,
+            isOnline: Boolean = true): String {
 
         val builder = StringBuilder()
         val brandColor = ThemePrefs.brandColor
@@ -276,7 +277,7 @@ object DiscussionUtils {
         fun buildEntry(discussionEntry: DiscussionEntry, depth: Int) {
             val isViewableEnd = (depth == maxDepth && discussionEntry.totalChildren > 0)
             builder.append(build(context, isTablet, canvasContext, discussionTopicHeader, discussionEntry, converter,
-                    template, makeAvatarForWebView(context, discussionEntry), depth, isViewableEnd, brandColor, likeColor,
+                    template, makeAvatarForWebView(context, discussionEntry, isOnline), depth, isViewableEnd, brandColor, likeColor,
                     likeImage, replyButtonWidth))
             if (depth < maxDepth) discussionEntry.replies?.forEach { buildEntry(it, depth + 1) }
         }
@@ -475,8 +476,8 @@ object DiscussionUtils {
      * If the avatar is valid then returns an empty string. Otherwise...
      * Returns an avatar bitmap converted into a base64 string for webviews.
      */
-    private fun makeAvatarForWebView(context: Context, discussionEntry: DiscussionEntry): String {
-        if (discussionEntry.author != null && ProfileUtils.shouldLoadAltAvatarImage(discussionEntry.author!!.avatarImageUrl)) {
+    private fun makeAvatarForWebView(context: Context, discussionEntry: DiscussionEntry, isOnline: Boolean): String {
+        if (!isOnline || discussionEntry.author != null && ProfileUtils.shouldLoadAltAvatarImage(discussionEntry.author!!.avatarImageUrl)) {
             val avatarBitmap = ProfileUtils.getInitialsAvatarBitMap(
                     context, discussionEntry.author!!.displayName!!,
                     Color.TRANSPARENT,


### PR DESCRIPTION
Test plan: See ticket. If offline initials should load instead of profile picture.

refs: MBL-17186
affects: Student
release note: none

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-android/assets/72087159/12711295-5118-4231-af73-b3e2338bf1b5" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-android/assets/72087159/7bd10ab6-b0b5-4ca8-b1c7-d39bffe8ae1b" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Approve from product
