### PR TITLE
[MBL-17173][Student] Make Announcement/Discussion attachments available offline

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/features/discussion/details/DiscussionDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/discussion/details/DiscussionDetailsFragment.kt
@@ -194,33 +194,29 @@ class DiscussionDetailsFragment : ParentFragment(), Bookmarkable {
     //region Discussion Actions
 
     private fun viewAttachments(remoteFiles: List<RemoteFile>) {
-        if (repository.isOnline()) {
-            // Only one file can be attached to a discussion
-            val remoteFile = remoteFiles.firstOrNull() ?: return
+        // Only one file can be attached to a discussion
+        val remoteFile = remoteFiles.firstOrNull() ?: return
 
-            // Show lock message if file is locked
-            if (remoteFile.lockedForUser) {
-                if (remoteFile.lockExplanation.isValid()) {
-                    Snackbar.make(
-                        requireView(),
-                        remoteFile.lockExplanation!!,
-                        Snackbar.LENGTH_SHORT
-                    ).show()
-                } else {
-                    Snackbar.make(
-                        requireView(),
-                        R.string.fileCurrentlyLocked,
-                        Snackbar.LENGTH_SHORT
-                    ).show()
-                }
+        // Show lock message if file is locked
+        if (remoteFile.lockedForUser) {
+            if (remoteFile.lockExplanation.isValid()) {
+                Snackbar.make(
+                    requireView(),
+                    remoteFile.lockExplanation!!,
+                    Snackbar.LENGTH_SHORT
+                ).show()
+            } else {
+                Snackbar.make(
+                    requireView(),
+                    R.string.fileCurrentlyLocked,
+                    Snackbar.LENGTH_SHORT
+                ).show()
             }
-
-            // Show attachment
-            val attachment = remoteFile.mapToAttachment()
-            openMedia(attachment.contentType, attachment.url, attachment.filename, canvasContext)
-        } else {
-            NoInternetConnectionDialog.show(requireFragmentManager())
         }
+
+        // Show attachment
+        val attachment = remoteFile.mapToAttachment()
+        openMedia(attachment.contentType, attachment.url, attachment.filename, canvasContext, localFile = attachment.isLocalFile)
     }
 
     private fun showReplyView(discussionEntryId: Long) {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Attachment.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Attachment.kt
@@ -17,7 +17,10 @@
 
 package com.instructure.canvasapi2.models
 
+import android.webkit.URLUtil
 import com.google.gson.annotations.SerializedName
+import com.instructure.canvasapi2.utils.isValid
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import java.util.*
 
@@ -40,4 +43,7 @@ data class Attachment(
 ) : CanvasModel<Attachment>() {
     override val comparisonDate get() = createdAt
     override val comparisonString get() = displayName
+
+    @IgnoredOnParcel
+    val isLocalFile = url.isValid() && !URLUtil.isNetworkUrl(url)
 }

--- a/libs/pandautils/src/androidTest/java/com/instructure/pandautils/room/offline/daos/DiscussionTopicRemoteFileDaoTest.kt
+++ b/libs/pandautils/src/androidTest/java/com/instructure/pandautils/room/offline/daos/DiscussionTopicRemoteFileDaoTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2024 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */package com.instructure.pandautils.room.offline.daos
+
+import android.content.Context
+import android.database.sqlite.SQLiteConstraintException
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.instructure.canvasapi2.models.Course
+import com.instructure.canvasapi2.models.DiscussionParticipant
+import com.instructure.canvasapi2.models.DiscussionTopicHeader
+import com.instructure.canvasapi2.models.RemoteFile
+import com.instructure.pandautils.room.offline.OfflineDatabase
+import com.instructure.pandautils.room.offline.entities.CourseEntity
+import com.instructure.pandautils.room.offline.entities.DiscussionParticipantEntity
+import com.instructure.pandautils.room.offline.entities.DiscussionTopicHeaderEntity
+import com.instructure.pandautils.room.offline.entities.DiscussionTopicPermissionEntity
+import com.instructure.pandautils.room.offline.entities.DiscussionTopicRemoteFileEntity
+import com.instructure.pandautils.room.offline.entities.RemoteFileEntity
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
+class DiscussionTopicRemoteFileDaoTest {
+
+    private lateinit var db: OfflineDatabase
+    private lateinit var remoteFileDao: RemoteFileDao
+    private lateinit var discussionTopicHeaderDao: DiscussionTopicHeaderDao
+    private lateinit var discussionTopicRemoteFileDao: DiscussionTopicRemoteFileDao
+
+    @Before
+    fun setUp() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, OfflineDatabase::class.java).build()
+        remoteFileDao = db.remoteFileDao()
+        discussionTopicRemoteFileDao = db.discussionTopicRemoteFileDao()
+        discussionTopicHeaderDao = db.discussionTopicHeaderDao()
+
+        db.courseDao().insert(CourseEntity(Course(1L)))
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun testFindByDiscussionId() = runTest {
+        val remoteFileEntity = RemoteFileEntity(RemoteFile(1L))
+        val discussionTopicEntity = DiscussionTopicHeaderEntity(DiscussionTopicHeader(2L), 1L)
+        discussionTopicHeaderDao.insert(discussionTopicEntity)
+        remoteFileDao.insert(remoteFileEntity)
+
+        val discussionTopicRemoteFileEntity = DiscussionTopicRemoteFileEntity(discussionTopicEntity.id, remoteFileEntity.id)
+        discussionTopicRemoteFileDao.insert(discussionTopicRemoteFileEntity)
+        val result = discussionTopicRemoteFileDao.findByDiscussionId(discussionTopicEntity.id)
+        assertEquals(listOf(discussionTopicRemoteFileEntity), result)
+    }
+
+    @Test(expected = SQLiteConstraintException::class)
+    fun testInsertDiscussionForeignKey() = runTest {
+        val remoteFileEntity = RemoteFileEntity(RemoteFile(1L))
+        remoteFileDao.insert(remoteFileEntity)
+
+        val discussionTopicRemoteFileEntity = DiscussionTopicRemoteFileEntity(1L, remoteFileEntity.id)
+        discussionTopicRemoteFileDao.insert(discussionTopicRemoteFileEntity)
+    }
+
+    @Test(expected = SQLiteConstraintException::class)
+    fun testInsertRemoteFileForeignKey() = runTest {
+        val discussionTopicEntity = DiscussionTopicHeaderEntity(DiscussionTopicHeader(1L), 1L)
+        discussionTopicHeaderDao.insert(discussionTopicEntity)
+
+        val discussionTopicRemoteFileEntity = DiscussionTopicRemoteFileEntity(discussionTopicEntity.id, 1L)
+        discussionTopicRemoteFileDao.insert(discussionTopicRemoteFileEntity)
+    }
+
+    @Test
+    fun testRemoteFileCascade() = runTest {
+        val remoteFileEntity = RemoteFileEntity(RemoteFile(1L))
+        remoteFileDao.insert(remoteFileEntity)
+
+        val discussionTopicEntity = DiscussionTopicHeaderEntity(DiscussionTopicHeader(2L), 1L)
+        discussionTopicHeaderDao.insert(discussionTopicEntity)
+
+        val discussionTopicRemoteFileEntity = DiscussionTopicRemoteFileEntity(discussionTopicEntity.id, remoteFileEntity.id)
+        discussionTopicRemoteFileDao.insert(discussionTopicRemoteFileEntity)
+
+        remoteFileDao.delete(remoteFileEntity)
+        val result = discussionTopicRemoteFileDao.findByDiscussionId(discussionTopicEntity.id)
+        assertEquals(emptyList<DiscussionTopicRemoteFileEntity>(), result)
+    }
+
+    @Test
+    fun testDiscussionTopicCascade() = runTest {
+        val remoteFileEntity = RemoteFileEntity(RemoteFile(1L))
+        remoteFileDao.insert(remoteFileEntity)
+
+        val discussionTopicEntity = DiscussionTopicHeaderEntity(DiscussionTopicHeader(2L), 1L)
+        discussionTopicHeaderDao.insert(discussionTopicEntity)
+
+        val discussionTopicRemoteFileEntity = DiscussionTopicRemoteFileEntity(discussionTopicEntity.id, remoteFileEntity.id)
+        discussionTopicRemoteFileDao.insert(discussionTopicRemoteFileEntity)
+
+        discussionTopicHeaderDao.delete(discussionTopicEntity)
+        val result = discussionTopicRemoteFileDao.findByDiscussionId(discussionTopicEntity.id)
+        assertEquals(emptyList<DiscussionTopicRemoteFileEntity>(), result)
+    }
+
+}

--- a/libs/pandautils/src/androidTest/java/com/instructure/pandautils/room/offline/daos/RemoteFileDaoTest.kt
+++ b/libs/pandautils/src/androidTest/java/com/instructure/pandautils/room/offline/daos/RemoteFileDaoTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2024 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */package com.instructure.pandautils.room.offline.daos
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.instructure.canvasapi2.models.RemoteFile
+import com.instructure.pandautils.room.offline.OfflineDatabase
+import com.instructure.pandautils.room.offline.entities.RemoteFileEntity
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
+class RemoteFileDaoTest {
+
+    private lateinit var db: OfflineDatabase
+    private lateinit var remoteFileDao: RemoteFileDao
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, OfflineDatabase::class.java).build()
+        remoteFileDao = db.remoteFileDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun testInsertReplace() = runTest {
+        val remoteFileEntity = RemoteFileEntity(RemoteFile(1L))
+        val updated = remoteFileEntity.copy(displayName = "new name")
+        remoteFileDao.insert(remoteFileEntity)
+        remoteFileDao.insert(updated)
+        val result = remoteFileDao.findById(1)
+        assertEquals(updated, result)
+    }
+
+    @Test
+    fun testInsertAllReplace() = runTest {
+        val remoteFileEntity1 = RemoteFileEntity(RemoteFile(1L))
+        val remoteFileEntity2 = RemoteFileEntity(RemoteFile(2L))
+        val updated = remoteFileEntity1.copy(displayName = "new name")
+        remoteFileDao.insertAll(listOf(remoteFileEntity1, remoteFileEntity2))
+        remoteFileDao.insertAll(listOf(updated))
+        val result1 = remoteFileDao.findById(1)
+        val result2 = remoteFileDao.findById(2)
+        assertEquals(updated, result1)
+        assertEquals(remoteFileEntity2, result2)
+    }
+
+    @Test
+    fun testFindById() = runTest {
+        val remoteFileEntity = RemoteFileEntity(RemoteFile(1L))
+        val remoteFileEntity2 = RemoteFileEntity(RemoteFile(2L))
+        remoteFileDao.insertAll(listOf(remoteFileEntity, remoteFileEntity2))
+        val result = remoteFileDao.findById(1)
+        assertEquals(remoteFileEntity, result)
+    }
+
+}

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/di/OfflineModule.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/di/OfflineModule.kt
@@ -282,9 +282,20 @@ class OfflineModule {
         discussionTopicHeaderDao: DiscussionTopicHeaderDao,
         discussionParticipantDao: DiscussionParticipantDao,
         discussionTopicPermissionDao: DiscussionTopicPermissionDao,
+        remoteFileDao: RemoteFileDao,
+        localFileDao: LocalFileDao,
+        discussionTopicRemoteFileDao: DiscussionTopicRemoteFileDao,
         offlineDatabase: OfflineDatabase,
     ): DiscussionTopicHeaderFacade {
-        return DiscussionTopicHeaderFacade(discussionTopicHeaderDao, discussionParticipantDao, discussionTopicPermissionDao, offlineDatabase)
+        return DiscussionTopicHeaderFacade(
+            discussionTopicHeaderDao,
+            discussionParticipantDao,
+            discussionTopicPermissionDao,
+            remoteFileDao,
+            localFileDao,
+            discussionTopicRemoteFileDao,
+            offlineDatabase
+        )
     }
 
     @Provides
@@ -531,5 +542,17 @@ class OfflineModule {
         apiPrefs: ApiPrefs
     ): OfflineSyncHelper {
         return OfflineSyncHelper(workManager, syncSettingsFacade, apiPrefs)
+    }
+
+    @Provides
+    fun provideRemoteFileDao(
+        appDatabase: OfflineDatabase
+    ): RemoteFileDao {
+        return appDatabase.remoteFileDao()
+    }
+
+    @Provides
+    fun provideDiscussionTopicRemoteFileDao(appDatabase: OfflineDatabase): DiscussionTopicRemoteFileDao {
+        return appDatabase.discussionTopicRemoteFileDao()
     }
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/offline/sync/CourseSync.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/offline/sync/CourseSync.kt
@@ -59,6 +59,7 @@ import com.instructure.pandautils.room.offline.entities.CourseSyncProgressEntity
 import com.instructure.pandautils.room.offline.entities.CourseSyncSettingsEntity
 import com.instructure.pandautils.room.offline.entities.FileFolderEntity
 import com.instructure.pandautils.room.offline.entities.QuizEntity
+import com.instructure.pandautils.room.offline.entities.RemoteFileEntity
 import com.instructure.pandautils.room.offline.facade.AssignmentFacade
 import com.instructure.pandautils.room.offline.facade.ConferenceFacade
 import com.instructure.pandautils.room.offline.facade.CourseFacade
@@ -150,7 +151,11 @@ class CourseSync(
             listOf(contentDeferred, filesDeferred).awaitAll()
         }
 
-        fileSync.syncAdditionalFiles(courseSettings, additionalFileIdsToSync[courseId].orEmpty(), externalFilesToSync[courseId].orEmpty())
+        fileSync.syncAdditionalFiles(
+            courseSettings,
+            additionalFileIdsToSync[courseId].orEmpty(),
+            externalFilesToSync[courseId].orEmpty(),
+        )
 
         val progress = courseSyncProgressDao.findByCourseId(courseId)
         progress
@@ -411,6 +416,9 @@ class CourseSync(
 
             discussions.forEach {
                 it.message = parseHtmlContent(it.message, courseId)
+                it.attachments.forEach {
+                    additionalFileIdsToSync[courseId] = additionalFileIdsToSync[courseId].orEmpty() + it.id
+                }
             }
 
             discussionTopicHeaderFacade.insertDiscussions(discussions, courseId, false)
@@ -433,6 +441,9 @@ class CourseSync(
 
             announcements.forEach {
                 it.message = parseHtmlContent(it.message, courseId)
+                it.attachments.forEach {
+                    additionalFileIdsToSync[courseId] = additionalFileIdsToSync[courseId].orEmpty() + it.id
+                }
             }
 
             discussionTopicHeaderFacade.insertDiscussions(announcements, courseId, true)

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/room/offline/OfflineDatabase.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/room/offline/OfflineDatabase.kt
@@ -43,6 +43,7 @@ import com.instructure.pandautils.room.offline.daos.DiscussionParticipantDao
 import com.instructure.pandautils.room.offline.daos.DiscussionTopicDao
 import com.instructure.pandautils.room.offline.daos.DiscussionTopicHeaderDao
 import com.instructure.pandautils.room.offline.daos.DiscussionTopicPermissionDao
+import com.instructure.pandautils.room.offline.daos.DiscussionTopicRemoteFileDao
 import com.instructure.pandautils.room.offline.daos.EditDashboardItemDao
 import com.instructure.pandautils.room.offline.daos.EnrollmentDao
 import com.instructure.pandautils.room.offline.daos.FileFolderDao
@@ -66,6 +67,7 @@ import com.instructure.pandautils.room.offline.daos.ModuleObjectDao
 import com.instructure.pandautils.room.offline.daos.PageDao
 import com.instructure.pandautils.room.offline.daos.PlannerOverrideDao
 import com.instructure.pandautils.room.offline.daos.QuizDao
+import com.instructure.pandautils.room.offline.daos.RemoteFileDao
 import com.instructure.pandautils.room.offline.daos.RubricCriterionAssessmentDao
 import com.instructure.pandautils.room.offline.daos.RubricCriterionDao
 import com.instructure.pandautils.room.offline.daos.RubricCriterionRatingDao
@@ -341,4 +343,8 @@ abstract class OfflineDatabase : RoomDatabase() {
     abstract fun discussionEntryDao(): DiscussionEntryDao
 
     abstract fun discussionTopicPermissionDao(): DiscussionTopicPermissionDao
+
+    abstract fun remoteFileDao(): RemoteFileDao
+
+    abstract fun discussionTopicRemoteFileDao(): DiscussionTopicRemoteFileDao
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/room/offline/daos/DiscussionTopicRemoteFileDao.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/room/offline/daos/DiscussionTopicRemoteFileDao.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */package com.instructure.pandautils.room.offline.daos
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.instructure.pandautils.room.offline.entities.DiscussionTopicRemoteFileEntity
+
+@Dao
+interface DiscussionTopicRemoteFileDao {
+
+    @Insert
+    suspend fun insert(entity: DiscussionTopicRemoteFileEntity)
+
+    @Insert
+    suspend fun insertAll(entities: List<DiscussionTopicRemoteFileEntity>)
+
+    @Query("SELECT * FROM DiscussionTopicRemoteFileEntity WHERE discussionId = :discussionId")
+    suspend fun findByDiscussionId(discussionId: Long): List<DiscussionTopicRemoteFileEntity>
+}

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/room/offline/daos/RemoteFileDao.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/room/offline/daos/RemoteFileDao.kt
@@ -15,6 +15,7 @@
  */package com.instructure.pandautils.room.offline.daos
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
@@ -28,6 +29,9 @@ interface RemoteFileDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(entities: List<RemoteFileEntity>)
+
+    @Delete
+    suspend fun delete(entity: RemoteFileEntity)
 
     @Query("SELECT * FROM RemoteFileEntity WHERE id = :id")
     suspend fun findById(id: Long): RemoteFileEntity?

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/room/offline/daos/RemoteFileDao.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/room/offline/daos/RemoteFileDao.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2024 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */package com.instructure.pandautils.room.offline.daos
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.instructure.pandautils.room.offline.entities.RemoteFileEntity
+
+@Dao
+interface RemoteFileDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(entity: RemoteFileEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(entities: List<RemoteFileEntity>)
+
+    @Query("SELECT * FROM RemoteFileEntity WHERE id = :id")
+    suspend fun findById(id: Long): RemoteFileEntity?
+}

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/room/offline/entities/DiscussionTopicHeaderEntity.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/room/offline/entities/DiscussionTopicHeaderEntity.kt
@@ -24,6 +24,7 @@ import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.DiscussionParticipant
 import com.instructure.canvasapi2.models.DiscussionTopicHeader
 import com.instructure.canvasapi2.models.DiscussionTopicPermission
+import com.instructure.canvasapi2.models.RemoteFile
 import com.instructure.pandautils.utils.orDefault
 import java.util.Date
 
@@ -126,7 +127,8 @@ data class DiscussionTopicHeaderEntity(
     fun toApiModel(
         author: DiscussionParticipant? = null,
         assignment: Assignment? = null,
-        permissions: DiscussionTopicPermission? = null
+        permissions: DiscussionTopicPermission? = null,
+        attachments: List<RemoteFile>
     ) = DiscussionTopicHeader(
         id = id,
         discussionType = discussionType,
@@ -151,8 +153,7 @@ data class DiscussionTopicHeaderEntity(
         groupCategoryId = groupCategoryId,
         announcement = announcement,
         groupTopicChildren = emptyList(),
-        //TODO
-        attachments = mutableListOf(),
+        attachments = attachments.toMutableList(),
         //TODO
         permissions = permissions,
         assignment = assignment,

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/room/offline/entities/RemoteFileEntity.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/room/offline/entities/RemoteFileEntity.kt
@@ -19,6 +19,7 @@ package com.instructure.pandautils.room.offline.entities
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.instructure.canvasapi2.models.RemoteFile
 
 @Entity
 data class RemoteFileEntity(
@@ -42,4 +43,48 @@ data class RemoteFileEntity(
     val lockedForUser: Boolean,
     val previewUrl: String?,
     val lockExplanation: String?
-)
+) {
+    constructor(remoteFile: RemoteFile) : this(
+        id = remoteFile.id,
+        folderId = remoteFile.folderId,
+        displayName = remoteFile.displayName,
+        fileName = remoteFile.fileName,
+        contentType = remoteFile.contentType,
+        url = remoteFile.url,
+        size = remoteFile.size,
+        createdAt = remoteFile.createdAt,
+        updatedAt = remoteFile.updatedAt,
+        unlockAt = remoteFile.unlockAt,
+        locked = remoteFile.locked,
+        hidden = remoteFile.hidden,
+        lockAt = remoteFile.lockAt,
+        hiddenForUser = remoteFile.hiddenForUser,
+        thumbnailUrl = remoteFile.thumbnailUrl,
+        modifiedAt = remoteFile.modifiedAt,
+        lockedForUser = remoteFile.lockedForUser,
+        previewUrl = remoteFile.previewUrl,
+        lockExplanation = remoteFile.lockExplanation
+    )
+
+    fun toApiModel() = RemoteFile(
+        id = id,
+        folderId = folderId,
+        displayName = displayName,
+        fileName = fileName,
+        contentType = contentType,
+        url = url,
+        size = size,
+        createdAt = createdAt,
+        updatedAt = updatedAt,
+        unlockAt = unlockAt,
+        locked = locked,
+        hidden = hidden,
+        lockAt = lockAt,
+        hiddenForUser = hiddenForUser,
+        thumbnailUrl = thumbnailUrl,
+        modifiedAt = modifiedAt,
+        lockedForUser = lockedForUser,
+        previewUrl = previewUrl,
+        lockExplanation = lockExplanation
+    )
+}

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/room/offline/facade/DiscussionTopicHeaderFacade.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/room/offline/facade/DiscussionTopicHeaderFacade.kt
@@ -23,14 +23,22 @@ import com.instructure.pandautils.room.offline.OfflineDatabase
 import com.instructure.pandautils.room.offline.daos.DiscussionParticipantDao
 import com.instructure.pandautils.room.offline.daos.DiscussionTopicHeaderDao
 import com.instructure.pandautils.room.offline.daos.DiscussionTopicPermissionDao
+import com.instructure.pandautils.room.offline.daos.DiscussionTopicRemoteFileDao
+import com.instructure.pandautils.room.offline.daos.LocalFileDao
+import com.instructure.pandautils.room.offline.daos.RemoteFileDao
 import com.instructure.pandautils.room.offline.entities.DiscussionParticipantEntity
 import com.instructure.pandautils.room.offline.entities.DiscussionTopicHeaderEntity
 import com.instructure.pandautils.room.offline.entities.DiscussionTopicPermissionEntity
+import com.instructure.pandautils.room.offline.entities.DiscussionTopicRemoteFileEntity
+import com.instructure.pandautils.room.offline.entities.RemoteFileEntity
 
 class DiscussionTopicHeaderFacade(
     private val discussionTopicHeaderDao: DiscussionTopicHeaderDao,
     private val discussionParticipantDao: DiscussionParticipantDao,
     private val discussionTopicPermissionDao: DiscussionTopicPermissionDao,
+    private val remoteFileDao: RemoteFileDao,
+    private val localFileDao: LocalFileDao,
+    private val discussionTopicRemoteFileDao: DiscussionTopicRemoteFileDao,
     private val offlineDatabase: OfflineDatabase
 ) {
     suspend fun insertDiscussion(discussionTopicHeader: DiscussionTopicHeader, courseId: Long): Long {
@@ -51,15 +59,23 @@ class DiscussionTopicHeaderFacade(
 
             discussionParticipantDao.upsertAll(authors)
 
-            val discussionEntities =
-                discussionTopicHeaders.mapIndexed { index, discussionTopicHeader ->
-                    DiscussionTopicHeaderEntity(
-                        discussionTopicHeader,
-                        courseId,
-                        null
-                    )
-                }
+            val discussionEntities = mutableListOf<DiscussionTopicHeaderEntity>()
+            val attachmentEntities = mutableListOf<RemoteFileEntity>()
+            val discussionRemoteFileEntities = mutableListOf<DiscussionTopicRemoteFileEntity>()
+
+            discussionTopicHeaders.forEach { discussion ->
+                val entity = DiscussionTopicHeaderEntity(discussion, courseId, null)
+                val attachments = discussion.attachments.map { RemoteFileEntity(it) }
+                val connectionEntites = attachments.map { DiscussionTopicRemoteFileEntity(entity.id, it.id) }
+
+                discussionEntities.add(entity)
+                attachmentEntities.addAll(attachments)
+                discussionRemoteFileEntities.addAll(connectionEntites)
+            }
+
             discussionTopicHeaderDao.insertAll(discussionEntities)
+            remoteFileDao.insertAll(attachmentEntities)
+            discussionTopicRemoteFileDao.insertAll(discussionRemoteFileEntities)
 
             val permissionIds = discussionTopicHeaders.mapIndexed { index, discussionTopicHeader ->
                 discussionTopicHeader.permissions?.let {
@@ -76,9 +92,7 @@ class DiscussionTopicHeaderFacade(
     suspend fun getDiscussionsForCourse(courseId: Long): List<DiscussionTopicHeader> {
         return discussionTopicHeaderDao.findAllDiscussionsForCourse(courseId)
             .map { discussionTopic ->
-                val authorEntity = discussionTopic.authorId?.let { discussionParticipantDao.findById(it) }
-                val permission = discussionTopicPermissionDao.findByDiscussionTopicHeaderId(discussionTopic.id)
-                discussionTopic.toApiModel(author = authorEntity?.toApiModel(), permissions = permission?.toApiModel())
+                createDiscussionApiModel(discussionTopic)
             }
     }
 
@@ -97,8 +111,18 @@ class DiscussionTopicHeaderFacade(
     }
 
     private suspend fun createDiscussionApiModel(discussionTopicHeaderEntity: DiscussionTopicHeaderEntity): DiscussionTopicHeader {
-        val authorEntity = discussionTopicHeaderEntity.authorId?.let { discussionParticipantDao.findById(it) }
-        val permission = discussionTopicPermissionDao.findByDiscussionTopicHeaderId(discussionTopicHeaderEntity.id)
-        return discussionTopicHeaderEntity.toApiModel(authorEntity?.toApiModel(), permissions = permission?.toApiModel())
+        val authorEntity =
+            discussionTopicHeaderEntity.authorId?.let { discussionParticipantDao.findById(it) }
+        val permission =
+            discussionTopicPermissionDao.findByDiscussionTopicHeaderId(discussionTopicHeaderEntity.id)
+        val attachments = discussionTopicRemoteFileDao.findByDiscussionId(
+            discussionTopicHeaderEntity.id
+        ).mapNotNull { remoteFileDao.findById(it.remoteFileId) }
+            .map {
+                val path = localFileDao.findById(it.id)?.path
+                it.copy(url = path)
+            }
+            .map { it.toApiModel() }
+        return discussionTopicHeaderEntity.toApiModel(authorEntity?.toApiModel(), permissions = permission?.toApiModel(), attachments = attachments)
     }
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/room/offline/facade/DiscussionTopicHeaderFacade.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/room/offline/facade/DiscussionTopicHeaderFacade.kt
@@ -45,6 +45,10 @@ class DiscussionTopicHeaderFacade(
         discussionTopicHeader.author?.let { discussionParticipantDao.insert(DiscussionParticipantEntity(it)) }
         val discussionTopicHeaderId = discussionTopicHeaderDao.insert(DiscussionTopicHeaderEntity(discussionTopicHeader, courseId, null))
         val permissionId = discussionTopicHeader.permissions?.let { discussionTopicPermissionDao.insert(DiscussionTopicPermissionEntity(it, discussionTopicHeaderId)) }
+        val attachments = discussionTopicHeader.attachments.map { RemoteFileEntity(it) }
+        val connectionEntities = attachments.map { DiscussionTopicRemoteFileEntity(discussionTopicHeaderId, it.id) }
+        remoteFileDao.insertAll(attachments)
+        discussionTopicRemoteFileDao.insertAll(connectionEntities)
         discussionTopicHeaderDao.update(DiscussionTopicHeaderEntity(discussionTopicHeader.copy(id = discussionTopicHeaderId), courseId, permissionId))
         return discussionTopicHeaderId
     }

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/room/offline/facade/DiscussionTopicHeaderFacadeTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/room/offline/facade/DiscussionTopicHeaderFacadeTest.kt
@@ -21,13 +21,20 @@ import androidx.room.withTransaction
 import com.instructure.canvasapi2.models.DiscussionParticipant
 import com.instructure.canvasapi2.models.DiscussionTopicHeader
 import com.instructure.canvasapi2.models.DiscussionTopicPermission
+import com.instructure.canvasapi2.models.RemoteFile
 import com.instructure.pandautils.room.offline.OfflineDatabase
 import com.instructure.pandautils.room.offline.daos.DiscussionParticipantDao
 import com.instructure.pandautils.room.offline.daos.DiscussionTopicHeaderDao
 import com.instructure.pandautils.room.offline.daos.DiscussionTopicPermissionDao
+import com.instructure.pandautils.room.offline.daos.DiscussionTopicRemoteFileDao
+import com.instructure.pandautils.room.offline.daos.LocalFileDao
+import com.instructure.pandautils.room.offline.daos.RemoteFileDao
 import com.instructure.pandautils.room.offline.entities.DiscussionParticipantEntity
 import com.instructure.pandautils.room.offline.entities.DiscussionTopicHeaderEntity
 import com.instructure.pandautils.room.offline.entities.DiscussionTopicPermissionEntity
+import com.instructure.pandautils.room.offline.entities.DiscussionTopicRemoteFileEntity
+import com.instructure.pandautils.room.offline.entities.LocalFileEntity
+import com.instructure.pandautils.room.offline.entities.RemoteFileEntity
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -41,6 +48,7 @@ import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import java.util.Date
 
 @ExperimentalCoroutinesApi
 class DiscussionTopicHeaderFacadeTest {
@@ -48,9 +56,12 @@ class DiscussionTopicHeaderFacadeTest {
     private val discussionTopicHeaderDao: DiscussionTopicHeaderDao = mockk(relaxed = true)
     private val discussionParticipantDao: DiscussionParticipantDao = mockk(relaxed = true)
     private val discussionTopicPermissionDao: DiscussionTopicPermissionDao = mockk(relaxed = true)
+    private val remoteFileDao: RemoteFileDao = mockk(relaxed = true)
+    private val localFileDao: LocalFileDao = mockk(relaxed = true)
+    private val discussionTopicRemoteFileDao: DiscussionTopicRemoteFileDao = mockk(relaxed = true)
     private val offlineDatabase: OfflineDatabase = mockk(relaxed = true)
 
-    private val facade = DiscussionTopicHeaderFacade(discussionTopicHeaderDao, discussionParticipantDao, discussionTopicPermissionDao, offlineDatabase)
+    private val facade = DiscussionTopicHeaderFacade(discussionTopicHeaderDao, discussionParticipantDao, discussionTopicPermissionDao, remoteFileDao, localFileDao, discussionTopicRemoteFileDao, offlineDatabase)
 
     @Before
     fun setup() {
@@ -75,7 +86,7 @@ class DiscussionTopicHeaderFacadeTest {
     fun `Calling insertDiscussion should insert discussion topic header and related entities`() = runTest {
         val discussionParticipant = DiscussionParticipant(id = 1L)
         val discussionTopicPermission = DiscussionTopicPermission()
-        val discussionTopicHeader = DiscussionTopicHeader(author = discussionParticipant, permissions = discussionTopicPermission)
+        val discussionTopicHeader = DiscussionTopicHeader(author = discussionParticipant, permissions = discussionTopicPermission, attachments = mutableListOf(RemoteFile(1L)))
 
         coEvery { discussionParticipantDao.insert(any()) } returns 1L
         coEvery { discussionTopicHeaderDao.insert(any()) } returns 1L
@@ -87,14 +98,16 @@ class DiscussionTopicHeaderFacadeTest {
         coVerify { discussionTopicHeaderDao.insert(DiscussionTopicHeaderEntity(discussionTopicHeader, 1L, null)) }
         coVerify { discussionTopicPermissionDao.insert(DiscussionTopicPermissionEntity(discussionTopicPermission.copy(), 1L)) }
         coVerify { discussionTopicHeaderDao.update(DiscussionTopicHeaderEntity(discussionTopicHeader.copy(id = 1), 1L, 1L)) }
+        coVerify { remoteFileDao.insertAll(listOf(RemoteFileEntity(discussionTopicHeader.attachments[0]))) }
+        coVerify { discussionTopicRemoteFileDao.insertAll(listOf(DiscussionTopicRemoteFileEntity(1, 1)))}
     }
 
     @Test
     fun `insertDiscussions should insert discussion topic headers and related entities`() = runTest {
         val discussionParticipant = DiscussionParticipant(id = 1L)
         val discussionParticipant2 = DiscussionParticipant(id = 2L)
-        val discussionTopicHeader = DiscussionTopicHeader(author = discussionParticipant)
-        val discussionTopicHeader2 = DiscussionTopicHeader(author = discussionParticipant2)
+        val discussionTopicHeader = DiscussionTopicHeader(id = 1, author = discussionParticipant, attachments = mutableListOf(RemoteFile(1L)))
+        val discussionTopicHeader2 = DiscussionTopicHeader(id = 2, author = discussionParticipant2, attachments = mutableListOf(RemoteFile(2L)))
 
         facade.insertDiscussions(listOf(discussionTopicHeader, discussionTopicHeader2), 1, false)
 
@@ -114,6 +127,23 @@ class DiscussionTopicHeaderFacadeTest {
                 )
             )
         }
+
+        coVerify {
+            remoteFileDao.insertAll(
+                listOf(
+                    RemoteFileEntity(discussionTopicHeader.attachments[0]),
+                    RemoteFileEntity(discussionTopicHeader2.attachments[0])
+                )
+            )
+        }
+        coVerify {
+            discussionTopicRemoteFileDao.insertAll(
+                listOf(
+                    DiscussionTopicRemoteFileEntity(1, 1),
+                    DiscussionTopicRemoteFileEntity(2, 2)
+                )
+            )
+        }
     }
 
     @Test
@@ -121,11 +151,14 @@ class DiscussionTopicHeaderFacadeTest {
         val discussionTopicHeaderId = 1L
         val discussionParticipant = DiscussionParticipant(id = 1L, displayName = "displayName")
         val discussionPermission = DiscussionTopicPermission()
-        val discussionTopicHeader = DiscussionTopicHeader(id = discussionTopicHeaderId, author = discussionParticipant, permissions = discussionPermission, title = "Title")
+        val discussionTopicHeader = DiscussionTopicHeader(id = discussionTopicHeaderId, author = discussionParticipant, permissions = discussionPermission, title = "Title", attachments = mutableListOf(RemoteFile(1L, url = "path")))
 
         coEvery { discussionParticipantDao.findById(any()) } returns DiscussionParticipantEntity(discussionParticipant)
         coEvery { discussionTopicHeaderDao.findById(any()) } returns DiscussionTopicHeaderEntity(discussionTopicHeader, 1)
         coEvery { discussionTopicPermissionDao.findByDiscussionTopicHeaderId(any()) } returns DiscussionTopicPermissionEntity(discussionPermission, discussionTopicHeaderId)
+        coEvery { remoteFileDao.findById(any()) } returns RemoteFileEntity(discussionTopicHeader.attachments[0])
+        coEvery { discussionTopicRemoteFileDao.findByDiscussionId(any()) } returns listOf(DiscussionTopicRemoteFileEntity(discussionTopicHeaderId, 1))
+        coEvery { localFileDao.findById(any()) } returns LocalFileEntity(id = 1, path = "path", courseId = 1L, createdDate = Date())
 
         val result = facade.getDiscussionTopicHeaderById(discussionTopicHeaderId)!!
 


### PR DESCRIPTION
Test plan: Check if the attachments are available offline. Only works for the topic header, not for the replies. Supposedly no db scheme change, but check a migration to be sure.

refs: MBL-17173
affects: Student
release note: Announcement and Discussion attachments are now available offline.

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [ ] Run E2E test suite
