### PR TITLE
[MBL-17512][Student] Invalid 'Delete' and 'Rename' options on course submission files

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/features/files/list/FileListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/files/list/FileListFragment.kt
@@ -318,7 +318,7 @@ class FileListFragment : ParentFragment(), Bookmarkable, FileUploadDialogParent 
         val isUserFiles = canvasContext.type == CanvasContext.Type.USER
 
         if (recyclerAdapter == null) {
-            recyclerAdapter = FileListRecyclerAdapter(requireContext(), canvasContext, getFileMenuOptions(folder, canvasContext, fileListRepository.isOnline()), folder, adapterCallback, fileListRepository)
+            recyclerAdapter = FileListRecyclerAdapter(requireContext(), canvasContext, getFileMenuOptions(folder, canvasContext, fileListRepository.isOnline(), folder), folder, adapterCallback, fileListRepository)
         }
 
         configureRecyclerView(requireView(), requireContext(), recyclerAdapter!!, R.id.swipeRefreshLayout, R.id.emptyView, R.id.listView)
@@ -362,7 +362,7 @@ class FileListFragment : ParentFragment(), Bookmarkable, FileUploadDialogParent 
         val popup = PopupMenu(requireContext(), anchorView)
         popup.inflate(R.menu.file_folder_options)
         with(popup.menu) {
-            val options = getFileMenuOptions(item, canvasContext, fileListRepository.isOnline())
+            val options = getFileMenuOptions(item, canvasContext, fileListRepository.isOnline(), folder)
             // Only show alternate-open option for PDF files
             findItem(R.id.openAlternate).isVisible = options.contains(FileMenuType.OPEN_IN_ALTERNATE)
             findItem(R.id.download).isVisible = options.contains(FileMenuType.DOWNLOAD)
@@ -609,7 +609,7 @@ class FileListFragment : ParentFragment(), Bookmarkable, FileUploadDialogParent 
         /**
          * @return A list of possible actions the user is able to perform on the file/folder
          */
-        fun getFileMenuOptions(fileFolder: FileFolder?, canvasContext: CanvasContext, isOnline: Boolean): List<FileMenuType> {
+        fun getFileMenuOptions(fileFolder: FileFolder?, canvasContext: CanvasContext, isOnline: Boolean, folder: FileFolder?): List<FileMenuType> {
             if (fileFolder == null) return emptyList()
             val options: MutableList<FileMenuType> = mutableListOf()
 
@@ -617,7 +617,8 @@ class FileListFragment : ParentFragment(), Bookmarkable, FileUploadDialogParent 
                 // We're in the user's files, they should have options in the options menu
                 if (!fileFolder.isLockedForUser) {
                     // File is not locked for this user
-                    if (!fileFolder.forSubmissions) {
+                    val forSubmission = if (!fileFolder.isFile) fileFolder.forSubmissions else folder?.forSubmissions ?: false
+                    if (!forSubmission) {
                         // File/folder is not for a submission, so we can rename/delete
                         with(options) {
                             add(FileMenuType.RENAME)

--- a/apps/student/src/main/java/com/instructure/student/features/files/list/FileListRecyclerAdapter.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/files/list/FileListRecyclerAdapter.kt
@@ -68,7 +68,7 @@ open class FileListRecyclerAdapter(
     }
 
     override fun bindHolder(item: FileFolder, holder: FileViewHolder, position: Int) {
-        holder.bind(item, contextColor, context, FileListFragment.getFileMenuOptions(item, canvasContext, fileListRepository.isOnline()), fileFolderCallback)
+        holder.bind(item, contextColor, context, FileListFragment.getFileMenuOptions(item, canvasContext, fileListRepository.isOnline(), folder), fileFolderCallback)
     }
 
     override fun createViewHolder(v: View, viewType: Int) = FileViewHolder(v)


### PR DESCRIPTION
Test plan: In the ticket. Ticket states that it happens in Teacher as well, but it can happen in rare edge cases, normally teachers won't have submission files, so this fix is only for the student app.

refs: MBL-17512
affects: Student
release note: none

## Checklist

- [ ] Tested in light mode
