### PR TITLE
[MBL-17537][Teacher] Remove select all option from the calendar

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/filter/CalendarFilterScreenUiState.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/filter/CalendarFilterScreenUiState.kt
@@ -23,6 +23,7 @@ data class CalendarFilterScreenUiState(
     val groups: List<CalendarFilterItemUiState> = emptyList(),
     val error: Boolean = false,
     val loading: Boolean = false,
+    val selectAllAvailable: Boolean = false,
     val explanationMessage: String? = null,
     val snackbarMessage: String? = null
 ) {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/filter/CalendarFilterViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/filter/CalendarFilterViewModel.kt
@@ -84,11 +84,12 @@ class CalendarFilterViewModel @Inject constructor(
 
     private fun createNewUiState(error: Boolean = false, loading: Boolean = false, snackbarMessage: String? = null): CalendarFilterScreenUiState {
         val explanationMessage = if (filterLimit != -1) resources.getString(R.string.calendarFilterExplanationLimited, filterLimit) else null
+        val selectAllAvailable = filterLimit == -1 && !loading // We don't want to show the button when the filters are loading.
         return CalendarFilterScreenUiState(
             createFilterItemsUiState(CanvasContext.Type.USER),
             createFilterItemsUiState(CanvasContext.Type.COURSE),
             createFilterItemsUiState(CanvasContext.Type.GROUP),
-            error, loading, explanationMessage, snackbarMessage
+            error, loading, selectAllAvailable, explanationMessage, snackbarMessage
         )
     }
 

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/filter/composables/CalendarFilterScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/filter/composables/CalendarFilterScreen.kt
@@ -93,7 +93,11 @@ fun CalendarFiltersScreen(
                 CanvasAppBar(
                     title = stringResource(id = R.string.calendarFilterTitle),
                     navigationActionClick = navigationActionClick,
-                    actions = { FilterActions(anyFilterSelected = uiState.anyFiltersSelected, actionHandler = actionHandler) }
+                    actions = {
+                        if (uiState.selectAllAvailable || uiState.anyFiltersSelected) {
+                            FilterActions(anyFilterSelected = uiState.anyFiltersSelected, actionHandler = actionHandler)
+                        }
+                    }
                 )
             },
             snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
@@ -213,12 +217,12 @@ private fun FilterActions(
 ) {
     TextButton(
         onClick = {
-            val action = if (anyFilterSelected) CalendarFilterAction.DeselectAll else CalendarFilterAction.SelectAll
+            val action = if (!anyFilterSelected) CalendarFilterAction.SelectAll else CalendarFilterAction.DeselectAll
             actionHandler(action)
         },
         modifier = modifier
     ) {
-        val resourceId = if (anyFilterSelected) R.string.calendarFiltersDeselectAll else R.string.calendarFiltersSelectAll
+        val resourceId = if (!anyFilterSelected) R.string.calendarFiltersSelectAll else R.string.calendarFiltersDeselectAll
         Text(
             text = stringResource(id = resourceId),
             color = Color(color = ThemePrefs.textButtonColor),

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/calendar/filter/CalendarFilterViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/calendar/filter/CalendarFilterViewModelTest.kt
@@ -426,7 +426,7 @@ class CalendarFilterViewModelTest {
     }
 
     @Test
-    fun `Do not show explanation when filter limit is -1`() {
+    fun `Do not show explanation and make select all available when filter limit is -1`() {
         val course = Course(1, name = "Course")
         val group = Group(3, name = "Group")
         coEvery { calendarRepository.getCalendarFilterLimit() } returns -1
@@ -450,6 +450,7 @@ class CalendarFilterViewModelTest {
             listOf(CalendarFilterItemUiState("user_5", "User", false, ThemePrefs.brandColor)),
             listOf(CalendarFilterItemUiState("course_1", "Course", true, course.backgroundColor)),
             listOf(CalendarFilterItemUiState("group_3", "Group", true, group.backgroundColor)),
+            selectAllAvailable = true,
             explanationMessage = null
         )
 


### PR DESCRIPTION
Test plan: Select all button should not be present in the Teacher app when nothing is selected, because of the filter limit. Smoke test the Student filters also.

refs: MBL-17537
affects: Teacher, Student
release note: none

## Checklist

- [x] Tested in light mode
