### PR TITLE
[MBL-17582][Student][Teacher] Show no items when no filter is selected

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/features/calendar/TeacherCalendarRepository.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/calendar/TeacherCalendarRepository.kt
@@ -52,6 +52,8 @@ class TeacherCalendarRepository(
         contextCodes: List<String>,
         forceNetwork: Boolean
     ): List<PlannerItem> {
+        if (contextCodes.isEmpty()) return emptyList()
+
         val restParams = RestParams(usePerPageQueryParam = true, isForceReadFromNetwork = forceNetwork)
 
         val allItems = coroutineScope {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/CalendarViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/CalendarViewModel.kt
@@ -232,7 +232,7 @@ class CalendarViewModel @Inject constructor(
         val eventIndicators = eventsByDay
             .mapValues {
                 min(3, it.value.filter { plannerItem ->
-                    contextIdFilters.isEmpty() || contextIdFilters.contains(plannerItem.canvasContext.contextId)
+                    contextIdFilters.contains(plannerItem.canvasContext.contextId)
                 }.size)
             }
         return CalendarUiState(
@@ -252,7 +252,7 @@ class CalendarViewModel @Inject constructor(
     private fun createEventsPageForDate(date: LocalDate): CalendarEventsPageUiState {
         val eventUiStates = eventsByDay[date]
             ?.filter { plannerItem ->
-                contextIdFilters.isEmpty() || contextIdFilters.contains(plannerItem.canvasContext.contextId)
+                contextIdFilters.contains(plannerItem.canvasContext.contextId)
             }
             ?.map {
             EventUiState(

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendarevent/createupdate/composables/CreateUpdateEventScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendarevent/createupdate/composables/CreateUpdateEventScreen.kt
@@ -85,6 +85,7 @@ import com.instructure.pandautils.features.calendarevent.createupdate.CreateUpda
 import com.instructure.pandautils.utils.ThemePrefs
 import com.jakewharton.threetenabp.AndroidThreeTen
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import org.threeten.bp.LocalDate
 import org.threeten.bp.LocalTime
@@ -342,7 +343,8 @@ private fun CreateUpdateEventContent(
             // Since we cannot track the focus of the RCE correctly we track the focus of all the other text fields.
             // When no text field is focused but the scroll state maxValue is changed that means that the RCE is focused.
             // In this case we just scroll to the bottom.
-            snapshotFlow { scrollState.maxValue }.collect { maxValue ->
+            // We need to drop the first value in case the screen is not tall enough and the initial scroll state is not 0.
+            snapshotFlow { scrollState.maxValue }.drop(1).collect { maxValue ->
                 if (maxValue != 0 && maxValue != Int.MAX_VALUE && focusedTextFields.isEmpty()) {
                     scrollState.scrollTo((maxValue))
                 }

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/calendar/CalendarViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/calendar/CalendarViewModelTest.kt
@@ -126,6 +126,13 @@ class CalendarViewModelTest {
         )
 
         coEvery { calendarRepository.getCalendarFilterLimit() } returns -1
+        coEvery { calendarFilterDao.findByUserIdAndDomain(any(), any()) } returns CalendarFilterEntity(
+            1,
+            "",
+            "1",
+            filters = setOf("course_1", "course_2", "group_3", "group_4", "user_5")
+        )
+
     }
 
     @After
@@ -161,9 +168,9 @@ class CalendarViewModelTest {
         val nextMonthStartDate = LocalDate.of(2023, 5, 1).atStartOfDay().toApiString()
         val nextMonthEndDate = LocalDate.of(2023, 6, 1).atStartOfDay().toApiString()
 
-        coVerify { calendarRepository.getPlannerItems(currentStartDate!!, currentMonthEndDate!!, emptyList(), true) }
-        coVerify { calendarRepository.getPlannerItems(previousMonthStartDate!!, previousMonthEndDate!!, emptyList(), true) }
-        coVerify { calendarRepository.getPlannerItems(nextMonthStartDate!!, nextMonthEndDate!!, emptyList(), true) }
+        coVerify { calendarRepository.getPlannerItems(currentStartDate!!, currentMonthEndDate!!, any(), true) }
+        coVerify { calendarRepository.getPlannerItems(previousMonthStartDate!!, previousMonthEndDate!!, any(), true) }
+        coVerify { calendarRepository.getPlannerItems(nextMonthStartDate!!, nextMonthEndDate!!, any(), true) }
     }
 
     @Test
@@ -285,9 +292,9 @@ class CalendarViewModelTest {
         val nextMonthStartDate = LocalDate.of(2023, 5, 1).atStartOfDay().toApiString()
         val nextMonthEndDate = LocalDate.of(2023, 6, 1).atStartOfDay().toApiString()
 
-        coVerify(exactly = 1) { calendarRepository.getPlannerItems(currentStartDate!!, currentMonthEndDate!!, emptyList(), true) }
-        coVerify(exactly = 1) { calendarRepository.getPlannerItems(previousMonthStartDate!!, previousMonthEndDate!!, emptyList(), true) }
-        coVerify(exactly = 1) { calendarRepository.getPlannerItems(nextMonthStartDate!!, nextMonthEndDate!!, emptyList(), true) }
+        coVerify(exactly = 1) { calendarRepository.getPlannerItems(currentStartDate!!, currentMonthEndDate!!, any(), true) }
+        coVerify(exactly = 1) { calendarRepository.getPlannerItems(previousMonthStartDate!!, previousMonthEndDate!!, any(), true) }
+        coVerify(exactly = 1) { calendarRepository.getPlannerItems(nextMonthStartDate!!, nextMonthEndDate!!, any(), true) }
     }
 
     @Test
@@ -302,9 +309,9 @@ class CalendarViewModelTest {
         val nextMonthStartDate = LocalDate.of(2023, 5, 1).atStartOfDay().toApiString()
         val nextMonthEndDate = LocalDate.of(2023, 6, 1).atStartOfDay().toApiString()
 
-        coVerify(exactly = 1) { calendarRepository.getPlannerItems(currentStartDate!!, currentMonthEndDate!!, emptyList(), true) }
-        coVerify(exactly = 1) { calendarRepository.getPlannerItems(previousMonthStartDate!!, previousMonthEndDate!!, emptyList(), true) }
-        coVerify(exactly = 1) { calendarRepository.getPlannerItems(nextMonthStartDate!!, nextMonthEndDate!!, emptyList(), true) }
+        coVerify(exactly = 1) { calendarRepository.getPlannerItems(currentStartDate!!, currentMonthEndDate!!, any(), true) }
+        coVerify(exactly = 1) { calendarRepository.getPlannerItems(previousMonthStartDate!!, previousMonthEndDate!!, any(), true) }
+        coVerify(exactly = 1) { calendarRepository.getPlannerItems(nextMonthStartDate!!, nextMonthEndDate!!, any(), true) }
 
         viewModel.handleAction(CalendarAction.DaySelected(LocalDate.of(2023, 5, 19)))
         // We also need to call this in the test because day is not selected instantly,
@@ -314,7 +321,7 @@ class CalendarViewModelTest {
         val newMonthStartDate = LocalDate.of(2023, 6, 1).atStartOfDay().toApiString()
         val newMonthEndDate = LocalDate.of(2023, 7, 1).atStartOfDay().toApiString()
 
-        coVerify { calendarRepository.getPlannerItems(newMonthStartDate!!, newMonthEndDate!!, emptyList(), true) }
+        coVerify { calendarRepository.getPlannerItems(newMonthStartDate!!, newMonthEndDate!!, any(), true) }
     }
 
     @Test
@@ -573,7 +580,7 @@ class CalendarViewModelTest {
         val startDate = LocalDate.of(2023, 4, 20).atStartOfDay().toApiString()
         val endDate = LocalDate.of(2023, 4, 21).atStartOfDay().toApiString()
 
-        coVerify(exactly = 1) { calendarRepository.getPlannerItems(startDate!!, endDate!!, emptyList(), true) }
+        coVerify(exactly = 1) { calendarRepository.getPlannerItems(startDate!!, endDate!!, any(), true) }
     }
 
     @Test


### PR DESCRIPTION
Test plan: In the ticket

Note: I also fixed the RCE focus issue here, where you open the create event screen and it scrolls down to the bottom when the screen is scrollable.

refs: MBL-17582
affects: Student, Teacher
release note: none

## Checklist

- [x] Tested in dark mode
- [x] Tested in light mode
