### PR TITLE
[MBL-17268][Student][Teacher] - Implement Calendar To Do E2E test cases in both apps

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/compose/CalendarE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/compose/CalendarE2ETest.kt
@@ -1,18 +1,17 @@
 /*
  * Copyright (C) 2024 - present Instructure, Inc.
  *
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, version 3 of the License.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
  *
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
  */
 package com.instructure.student.ui.e2e.compose
 
@@ -125,11 +124,11 @@ class CalendarE2ETest: StudentComposeTest() {
     fun testCalendarToDoScreenE2E() {
 
         Log.d(PREPARATION_TAG, "Seeding data.")
-        val data = seedData(teachers = 1, courses = 1)
-        val teacher = data.teachersList[0]
+        val data = seedData(students = 1, courses = 1)
+        val student = data.studentsList[0]
 
-        Log.d(STEP_TAG, "Login with user: '${teacher.name}', login id: '${teacher.loginId}'.")
-        tokenLogin(teacher)
+        Log.d(STEP_TAG, "Login with user: '${student.name}', login id: '${student.loginId}'.")
+        tokenLogin(student)
         dashboardPage.waitForRender()
 
         Log.d(STEP_TAG, "Click on the 'Calendar' bottom menu to navigate to the Calendar page. Assert that the page title is 'Calendar'.")

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/compose/CalendarE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/compose/CalendarE2ETest.kt
@@ -68,7 +68,7 @@ class CalendarE2ETest: StudentComposeTest() {
 
         Log.d(STEP_TAG, "Assert that the event is displayed with the corresponding details (title, context name, date, status) on the page.")
         var currentDate = getCurrentDateInCanvasCalendarFormat()
-        calendarScreenPage.assertEventDetails(newEventTitle, student.name, currentDate)
+        calendarScreenPage.assertItemDetails(newEventTitle, student.name, currentDate)
 
         Log.d(STEP_TAG, "Click on the previously created '$newEventTitle' event and assert the event details.")
         calendarScreenPage.clickOnItem(newEventTitle)
@@ -101,7 +101,7 @@ class CalendarE2ETest: StudentComposeTest() {
 
         Log.d(STEP_TAG, "Assert that the event is displayed with the corresponding modified details (title, context name, date) on the page.")
         currentDate = getCurrentDateInCanvasCalendarFormat()
-        calendarScreenPage.assertEventDetails(modifiedEventTitle, student.name, currentDate)
+        calendarScreenPage.assertItemDetails(modifiedEventTitle, student.name, currentDate)
 
         Log.d(STEP_TAG, "Click on the previously created '$modifiedEventTitle' event and assert the event details.")
         calendarScreenPage.clickOnItem(modifiedEventTitle)
@@ -116,6 +116,92 @@ class CalendarE2ETest: StudentComposeTest() {
         calendarEventDetailsPage.confirmDelete()
 
         Log.d(STEP_TAG, "Assert that after the deletion the empty view will be displayed since we don't have any events on the current day.")
-        calendarScreenPage.assertEmptyEventsView()
+        calendarScreenPage.assertEmptyView()
+    }
+
+    @E2E
+    @Test
+    @TestMetaData(Priority.MANDATORY, FeatureCategory.CALENDAR, TestCategory.E2E)
+    fun testCalendarToDoScreenE2E() {
+
+        Log.d(PREPARATION_TAG, "Seeding data.")
+        val data = seedData(teachers = 1, courses = 1)
+        val teacher = data.teachersList[0]
+
+        Log.d(STEP_TAG, "Login with user: '${teacher.name}', login id: '${teacher.loginId}'.")
+        tokenLogin(teacher)
+        dashboardPage.waitForRender()
+
+        Log.d(STEP_TAG, "Click on the 'Calendar' bottom menu to navigate to the Calendar page. Assert that the page title is 'Calendar'.")
+        dashboardPage.clickCalendarTab()
+        calendarScreenPage.assertCalendarPageTitle()
+
+        Log.d(STEP_TAG, "Click on the 'Add' (FAB) button and 'Add To Do' to create a new To Do.")
+        calendarScreenPage.clickOnAddButton()
+        calendarScreenPage.clickAddTodo()
+
+        Log.d(STEP_TAG, "Assert that the page title is 'New To Do' as we are clicked on the 'Add To Do' button to create a new one.")
+        calendarToDoCreateUpdatePage.assertPageTitle("New To Do")
+
+        val testTodoTitle = "Test ToDo Title"
+        val testTodoDescription = "Details of ToDo"
+        Log.d(STEP_TAG, "Fill the title with '$testTodoTitle' and the details/description with '$testTodoDescription' and click on the 'Save' button.")
+        calendarToDoCreateUpdatePage.typeTodoTitle(testTodoTitle)
+        calendarToDoCreateUpdatePage.typeDetails(testTodoDescription)
+        calendarToDoCreateUpdatePage.clickSave()
+
+        Log.d(STEP_TAG, "Assert that the user has been navigated back to the Calendar Screen Page and that the previously created To Do item is displayed with the corresponding title, context and date.")
+        val currentDate = getCurrentDateInCanvasCalendarFormat()
+        calendarScreenPage.assertItemDetails(testTodoTitle, "To Do", "$currentDate at 12:00 PM")
+
+        Log.d(STEP_TAG, "Clicks on the '$testTodoTitle' To Do item.")
+        calendarScreenPage.clickOnItem(testTodoTitle)
+
+        Log.d(STEP_TAG, "Assert that the title is '$testTodoTitle', the context is 'To Do', the date is the current day with 12:00 PM time and the description is '$testTodoDescription'.")
+        calendarToDoDetailsPage.assertTitle(testTodoTitle)
+        calendarToDoDetailsPage.assertPageTitle("To Do")
+        calendarToDoDetailsPage.assertDate("$currentDate at 12:00 PM")
+        calendarToDoDetailsPage.assertDescription(testTodoDescription)
+
+        Log.d(STEP_TAG, "Click on the 'Edit To Do' within the toolbar more menu and confirm the editing.")
+        calendarToDoDetailsPage.clickToolbarMenu()
+        calendarToDoDetailsPage.clickEditMenu()
+
+        Log.d(STEP_TAG, "Assert that the page title is 'Edit To Do' as we are editing an existing To Do item.")
+        calendarToDoCreateUpdatePage.assertPageTitle("Edit To Do")
+
+        Log.d(STEP_TAG, "Assert that the 'original' To Do Title and details has been filled into the input fields as we on the edit screen.")
+        calendarToDoCreateUpdatePage.assertTodoTitle(testTodoTitle)
+        calendarToDoCreateUpdatePage.assertDetails(testTodoDescription)
+
+        val modifiedTestTodoTitle = "Test ToDo Title Mod"
+        val modifiedTestTodoDescription = "Details of ToDo Mod"
+        Log.d(STEP_TAG, "Modify the title with '$modifiedTestTodoTitle' and the details/description with '$modifiedTestTodoDescription' and click on the 'Save' button.")
+        calendarToDoCreateUpdatePage.typeTodoTitle(modifiedTestTodoTitle)
+        calendarToDoCreateUpdatePage.typeDetails(modifiedTestTodoDescription)
+        calendarToDoCreateUpdatePage.clickSave()
+
+        Log.d(STEP_TAG, "Assert that the user has been navigated back to the Calendar Screen Page and that the previously modified To Do item is displayed with the corresponding title, context and with the same date as we haven't changed it.")
+        calendarScreenPage.assertItemDetails(modifiedTestTodoTitle, "To Do", "$currentDate at 12:00 PM")
+
+        Log.d(STEP_TAG, "Clicks on the '$modifiedTestTodoTitle' To Do item.")
+        calendarScreenPage.clickOnItem(modifiedTestTodoTitle)
+
+        Log.d(STEP_TAG, "Assert that the To Do title is '$modifiedTestTodoTitle', the page title is 'To Do', the date remained current day with 12:00 PM time (as we haven't modified it) and the description is '$modifiedTestTodoDescription'.")
+        calendarToDoDetailsPage.assertTitle(modifiedTestTodoTitle)
+        calendarToDoDetailsPage.assertPageTitle("To Do")
+        calendarToDoDetailsPage.assertDate("$currentDate at 12:00 PM")
+        calendarToDoDetailsPage.assertDescription(modifiedTestTodoDescription)
+
+        Log.d(STEP_TAG, "Click on the 'Delete To Do' within the toolbar more menu and confirm the deletion.")
+        calendarToDoDetailsPage.clickToolbarMenu()
+        calendarToDoDetailsPage.clickDeleteMenu()
+        calendarToDoDetailsPage.confirmDeletion()
+
+        Log.d(STEP_TAG, "Assert that the deleted item does not exist anymore on the Calendar Screen Page.")
+        calendarScreenPage.assertItemNotExist(modifiedTestTodoTitle)
+
+        Log.d(STEP_TAG, "Assert that after the deletion the empty view will be displayed since we don't have any To Do items on the current day.")
+        calendarScreenPage.assertEmptyView()
     }
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentComposeTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentComposeTest.kt
@@ -23,6 +23,8 @@ import com.instructure.student.activity.LoginActivity
 import com.instructure.canvas.espresso.common.pages.compose.CalendarEventCreateEditPage
 import com.instructure.canvas.espresso.common.pages.compose.CalendarEventDetailsPage
 import com.instructure.canvas.espresso.common.pages.compose.CalendarScreenPage
+import com.instructure.canvas.espresso.common.pages.compose.CalendarToDoCreateUpdatePage
+import com.instructure.canvas.espresso.common.pages.compose.CalendarToDoDetailsPage
 import org.junit.Rule
 
 abstract class StudentComposeTest : StudentTest() {
@@ -33,4 +35,6 @@ abstract class StudentComposeTest : StudentTest() {
     val calendarEventCreateEditPage = CalendarEventCreateEditPage(composeTestRule)
     val calendarScreenPage = CalendarScreenPage(composeTestRule)
     val calendarEventDetailsPage = CalendarEventDetailsPage(composeTestRule)
+    val calendarToDoCreateUpdatePage = CalendarToDoCreateUpdatePage(composeTestRule)
+    val calendarToDoDetailsPage = CalendarToDoDetailsPage(composeTestRule)
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/TeacherCalendarToDoDetailsPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/TeacherCalendarToDoDetailsPageTest.kt
@@ -30,7 +30,7 @@ import com.instructure.teacher.ui.utils.tokenLogin
 import dagger.hilt.android.testing.HiltAndroidTest
 
 @HiltAndroidTest
-class TeacherToDoDetailsPageTest : ToDoDetailsInteractionTest() {
+class TeacherCalendarToDoDetailsPageTest : ToDoDetailsInteractionTest() {
 
     override val activityRule: InstructureActivityTestRule<out Activity>
             = TeacherActivityTestRule(LoginActivity::class.java)

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/compose/CalendarE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/compose/CalendarE2ETest.kt
@@ -1,18 +1,17 @@
 /*
  * Copyright (C) 2024 - present Instructure, Inc.
  *
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, version 3 of the License.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
  *
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
  */
 package com.instructure.teacher.ui.e2e.compose
 

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/compose/CalendarE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/compose/CalendarE2ETest.kt
@@ -69,7 +69,7 @@ class CalendarE2ETest: TeacherComposeTest() {
 
         Log.d(STEP_TAG, "Assert that the event is displayed with the corresponding details (title, context name, date, status) on the page.")
         var currentDate = getCurrentDateInCanvasCalendarFormat()
-        calendarScreenPage.assertEventDetails(newEventTitle, teacher.name, currentDate)
+        calendarScreenPage.assertItemDetails(newEventTitle, teacher.name, currentDate)
 
         Log.d(STEP_TAG, "Click on the previously created '$newEventTitle' event and assert the event details.")
         calendarScreenPage.clickOnItem(newEventTitle)
@@ -102,7 +102,7 @@ class CalendarE2ETest: TeacherComposeTest() {
 
         Log.d(STEP_TAG, "Assert that the event is displayed with the corresponding modified details (title, context name, date) on the page.")
         currentDate = getCurrentDateInCanvasCalendarFormat()
-        calendarScreenPage.assertEventDetails(modifiedEventTitle, teacher.name, currentDate)
+        calendarScreenPage.assertItemDetails(modifiedEventTitle, teacher.name, currentDate)
 
         Log.d(STEP_TAG, "Click on the previously created '$modifiedEventTitle' event and assert the event details.")
         calendarScreenPage.clickOnItem(modifiedEventTitle)
@@ -116,7 +116,96 @@ class CalendarE2ETest: TeacherComposeTest() {
         calendarEventDetailsPage.clickDeleteMenu()
         calendarEventDetailsPage.confirmDelete()
 
+        Log.d(STEP_TAG, "Assert that the deleted item does not exist anymore on the Calendar Screen Page.")
+        calendarScreenPage.assertItemNotExist(modifiedEventTitle)
+
         Log.d(STEP_TAG, "Assert that after the deletion the empty view will be displayed since we don't have any events on the current day.")
-        calendarScreenPage.assertEmptyEventsView()
+        calendarScreenPage.assertEmptyView()
+    }
+
+    @E2E
+    @Test
+    @TestMetaData(Priority.MANDATORY, FeatureCategory.CALENDAR, TestCategory.E2E)
+    fun testCalendarToDoScreenE2E() {
+
+        Log.d(PREPARATION_TAG, "Seeding data.")
+        val data = seedData(teachers = 1, courses = 1)
+        val teacher = data.teachersList[0]
+
+        Log.d(STEP_TAG, "Login with user: '${teacher.name}', login id: '${teacher.loginId}'.")
+        tokenLogin(teacher)
+        dashboardPage.waitForRender()
+
+        Log.d(STEP_TAG, "Click on the 'Calendar' bottom menu to navigate to the Calendar page. Assert that the page title is 'Calendar'.")
+        dashboardPage.clickCalendarTab()
+        calendarScreenPage.assertCalendarPageTitle()
+
+        Log.d(STEP_TAG, "Click on the 'Add' (FAB) button and 'Add To Do' to create a new To Do.")
+        calendarScreenPage.clickOnAddButton()
+        calendarScreenPage.clickAddTodo()
+
+        Log.d(STEP_TAG, "Assert that the page title is 'New To Do' as we are clicked on the 'Add To Do' button to create a new one.")
+        calendarToDoCreateUpdatePage.assertPageTitle("New To Do")
+
+        val testTodoTitle = "Test ToDo Title"
+        val testTodoDescription = "Details of ToDo"
+        Log.d(STEP_TAG, "Fill the title with '$testTodoTitle' and the details/description with '$testTodoDescription' and click on the 'Save' button.")
+        calendarToDoCreateUpdatePage.typeTodoTitle(testTodoTitle)
+        calendarToDoCreateUpdatePage.typeDetails(testTodoDescription)
+        calendarToDoCreateUpdatePage.clickSave()
+
+        Log.d(STEP_TAG, "Assert that the user has been navigated back to the Calendar Screen Page and that the previously created To Do item is displayed with the corresponding title, context and date.")
+        val currentDate = getCurrentDateInCanvasCalendarFormat()
+        calendarScreenPage.assertItemDetails(testTodoTitle, "To Do", "$currentDate at 12:00 PM")
+
+        Log.d(STEP_TAG, "Clicks on the '$testTodoTitle' To Do item.")
+        calendarScreenPage.clickOnItem(testTodoTitle)
+
+        Log.d(STEP_TAG, "Assert that the title is '$testTodoTitle', the context is 'To Do', the date is the current day with 12:00 PM time and the description is '$testTodoDescription'.")
+        calendarToDoDetailsPage.assertTitle(testTodoTitle)
+        calendarToDoDetailsPage.assertPageTitle("To Do")
+        calendarToDoDetailsPage.assertDate("$currentDate at 12:00 PM")
+        calendarToDoDetailsPage.assertDescription(testTodoDescription)
+
+        Log.d(STEP_TAG, "Click on the 'Edit To Do' within the toolbar more menu and confirm the editing.")
+        calendarToDoDetailsPage.clickToolbarMenu()
+        calendarToDoDetailsPage.clickEditMenu()
+
+        Log.d(STEP_TAG, "Assert that the page title is 'Edit To Do' as we are editing an existing To Do item.")
+        calendarToDoCreateUpdatePage.assertPageTitle("Edit To Do")
+
+        Log.d(STEP_TAG, "Assert that the 'original' To Do Title and details has been filled into the input fields as we on the edit screen.")
+        calendarToDoCreateUpdatePage.assertTodoTitle(testTodoTitle)
+        calendarToDoCreateUpdatePage.assertDetails(testTodoDescription)
+
+        val modifiedTestTodoTitle = "Test ToDo Title Mod"
+        val modifiedTestTodoDescription = "Details of ToDo Mod"
+        Log.d(STEP_TAG, "Modify the title with '$modifiedTestTodoTitle' and the details/description with '$modifiedTestTodoDescription' and click on the 'Save' button.")
+        calendarToDoCreateUpdatePage.typeTodoTitle(modifiedTestTodoTitle)
+        calendarToDoCreateUpdatePage.typeDetails(modifiedTestTodoDescription)
+        calendarToDoCreateUpdatePage.clickSave()
+
+        Log.d(STEP_TAG, "Assert that the user has been navigated back to the Calendar Screen Page and that the previously modified To Do item is displayed with the corresponding title, context and with the same date as we haven't changed it.")
+        calendarScreenPage.assertItemDetails(modifiedTestTodoTitle, "To Do", "$currentDate at 12:00 PM")
+
+        Log.d(STEP_TAG, "Clicks on the '$modifiedTestTodoTitle' To Do item.")
+        calendarScreenPage.clickOnItem(modifiedTestTodoTitle)
+
+        Log.d(STEP_TAG, "Assert that the To Do title is '$modifiedTestTodoTitle', the page title is 'To Do', the date remained current day with 12:00 PM time (as we haven't modified it) and the description is '$modifiedTestTodoDescription'.")
+        calendarToDoDetailsPage.assertTitle(modifiedTestTodoTitle)
+        calendarToDoDetailsPage.assertPageTitle("To Do")
+        calendarToDoDetailsPage.assertDate("$currentDate at 12:00 PM")
+        calendarToDoDetailsPage.assertDescription(modifiedTestTodoDescription)
+
+        Log.d(STEP_TAG, "Click on the 'Delete To Do' within the toolbar more menu and confirm the deletion.")
+        calendarToDoDetailsPage.clickToolbarMenu()
+        calendarToDoDetailsPage.clickDeleteMenu()
+        calendarToDoDetailsPage.confirmDeletion()
+
+        Log.d(STEP_TAG, "Assert that the deleted item does not exist anymore on the Calendar Screen Page.")
+        calendarScreenPage.assertItemNotExist(modifiedTestTodoTitle)
+
+        Log.d(STEP_TAG, "Assert that after the deletion the empty view will be displayed since we don't have any To Do items on the current day.")
+        calendarScreenPage.assertEmptyView()
     }
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/utils/TeacherComposeTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/utils/TeacherComposeTest.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import com.instructure.canvas.espresso.common.pages.compose.CalendarEventCreateEditPage
 import com.instructure.canvas.espresso.common.pages.compose.CalendarEventDetailsPage
 import com.instructure.canvas.espresso.common.pages.compose.CalendarScreenPage
+import com.instructure.canvas.espresso.common.pages.compose.CalendarToDoCreateUpdatePage
+import com.instructure.canvas.espresso.common.pages.compose.CalendarToDoDetailsPage
 import com.instructure.teacher.activities.LoginActivity
 import com.instructure.teacher.ui.pages.ProgressPage
 
@@ -35,5 +37,7 @@ abstract class TeacherComposeTest : TeacherTest() {
     val calendarScreenPage = CalendarScreenPage(composeTestRule)
     val calendarEventCreateEditPage = CalendarEventCreateEditPage(composeTestRule)
     val calendarEventDetailsPage = CalendarEventDetailsPage(composeTestRule)
+    val calendarToDoCreateUpdatePage = CalendarToDoCreateUpdatePage(composeTestRule)
+    val calendarToDoDetailsPage = CalendarToDoDetailsPage(composeTestRule)
     val progressPage = ProgressPage(composeTestRule)
 }

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/interaction/ToDoDetailsInteractionTest.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/interaction/ToDoDetailsInteractionTest.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.instructure.canvas.espresso.CanvasComposeTest
-import com.instructure.canvas.espresso.common.pages.compose.ToDoDetailsPage
+import com.instructure.canvas.espresso.common.pages.compose.CalendarToDoDetailsPage
 import com.instructure.canvas.espresso.mockCanvas.MockCanvas
 import com.instructure.canvas.espresso.mockCanvas.addPlannable
 import com.instructure.canvasapi2.models.PlannableType
@@ -29,7 +29,7 @@ import java.util.Date
 
 abstract class ToDoDetailsInteractionTest : CanvasComposeTest() {
 
-    private val toDoDetailsPage = ToDoDetailsPage(composeTestRule)
+    private val calendarToDoDetailsPage = CalendarToDoDetailsPage(composeTestRule)
 
     @Test
     fun assertTitle() {
@@ -47,7 +47,7 @@ abstract class ToDoDetailsInteractionTest : CanvasComposeTest() {
         goToToDoDetails(data)
 
         composeTestRule.waitForIdle()
-        toDoDetailsPage.assertTitle(data.todos.first().plannable.title)
+        calendarToDoDetailsPage.assertTitle(data.todos.first().plannable.title)
     }
 
     @Test
@@ -66,7 +66,7 @@ abstract class ToDoDetailsInteractionTest : CanvasComposeTest() {
         goToToDoDetails(data)
 
         composeTestRule.waitForIdle()
-        toDoDetailsPage.assertCanvasContext(course.name, course.textAndIconColor)
+        calendarToDoDetailsPage.assertCanvasContext(course.name, course.textAndIconColor)
     }
 
     @Test
@@ -85,7 +85,7 @@ abstract class ToDoDetailsInteractionTest : CanvasComposeTest() {
         goToToDoDetails(data)
 
         composeTestRule.waitForIdle()
-        toDoDetailsPage.assertDate(originalActivity, data.todos.first().plannable.todoDate.toDate()!!)
+        calendarToDoDetailsPage.assertDate(originalActivity, data.todos.first().plannable.todoDate.toDate()!!)
     }
 
     @Test
@@ -105,7 +105,7 @@ abstract class ToDoDetailsInteractionTest : CanvasComposeTest() {
         goToToDoDetails(data)
 
         composeTestRule.waitForIdle()
-        toDoDetailsPage.assertDescription("Test Description")
+        calendarToDoDetailsPage.assertDescription("Test Description")
     }
 
     @Test
@@ -124,8 +124,8 @@ abstract class ToDoDetailsInteractionTest : CanvasComposeTest() {
         goToToDoDetails(data)
 
         composeTestRule.waitForIdle()
-        toDoDetailsPage.clickToolbarMenu()
-        toDoDetailsPage.clickEditMenu()
+        calendarToDoDetailsPage.clickToolbarMenu()
+        calendarToDoDetailsPage.clickEditMenu()
 
         composeTestRule.waitForIdle()
         composeTestRule.onNodeWithText("Edit To Do").assertIsDisplayed()
@@ -147,8 +147,8 @@ abstract class ToDoDetailsInteractionTest : CanvasComposeTest() {
         goToToDoDetails(data)
 
         composeTestRule.waitForIdle()
-        toDoDetailsPage.clickToolbarMenu()
-        toDoDetailsPage.clickDeleteMenu()
+        calendarToDoDetailsPage.clickToolbarMenu()
+        calendarToDoDetailsPage.clickDeleteMenu()
 
         composeTestRule.waitForIdle()
         composeTestRule.onNodeWithText("Delete To Do?").assertIsDisplayed()
@@ -170,8 +170,8 @@ abstract class ToDoDetailsInteractionTest : CanvasComposeTest() {
         goToToDoDetails(data)
 
         composeTestRule.waitForIdle()
-        toDoDetailsPage.clickToolbarMenu()
-        toDoDetailsPage.clickDeleteMenu()
+        calendarToDoDetailsPage.clickToolbarMenu()
+        calendarToDoDetailsPage.clickDeleteMenu()
 
         composeTestRule.waitForIdle()
         composeTestRule.onNodeWithText("Delete To Do?").assertIsDisplayed()

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/interaction/ToDoDetailsInteractionTest.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/interaction/ToDoDetailsInteractionTest.kt
@@ -66,7 +66,8 @@ abstract class ToDoDetailsInteractionTest : CanvasComposeTest() {
         goToToDoDetails(data)
 
         composeTestRule.waitForIdle()
-        calendarToDoDetailsPage.assertCanvasContext(course.name, course.textAndIconColor)
+        calendarToDoDetailsPage.assertCanvasContext(course.name)
+        calendarToDoDetailsPage.assertTextColor(course.name, course.textAndIconColor)
     }
 
     @Test

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/CalendarEventCreateEditPage.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/CalendarEventCreateEditPage.kt
@@ -1,18 +1,17 @@
 /*
  * Copyright (C) 2024 - present Instructure, Inc.
  *
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, version 3 of the License.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
  *
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
  */
 package com.instructure.canvas.espresso.common.pages.compose
 
@@ -34,7 +33,7 @@ import com.instructure.espresso.page.withId
 import com.instructure.pandautils.R
 import org.hamcrest.Matchers
 
-class CalendarEventCreateEditPage(private val composeTestRule: ComposeTestRule) : BasePage() {
+class CalendarEventCreateEditPage(private val composeTestRule: ComposeTestRule) {
 
     fun assertTitle(title: String) {
         composeTestRule.onNodeWithText(title).assertIsDisplayed()

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/CalendarEventDetailsPage.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/CalendarEventDetailsPage.kt
@@ -1,18 +1,17 @@
 /*
  * Copyright (C) 2024 - present Instructure, Inc.
  *
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, version 3 of the License.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
  *
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
  */
 package com.instructure.canvas.espresso.common.pages.compose
 

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/CalendarScreenPage.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/CalendarScreenPage.kt
@@ -44,20 +44,29 @@ class CalendarScreenPage(private val composeTestRule: ComposeTestRule) : BasePag
         composeTestRule.waitForIdle()
     }
 
+    fun clickAddTodo() {
+        composeTestRule.onNodeWithText("Add To Do").performClick()
+        composeTestRule.waitForIdle()
+    }
+
     fun clickOnItem(itemTitle: String) {
         composeTestRule.onNodeWithText(itemTitle).performClick()
         composeTestRule.waitForIdle()
     }
 
-    fun assertEventDetails(eventTitle: String, contextName: String, eventDate: String? = null, eventStatus: String? = null) {
+    fun assertItemDetails(eventTitle: String, contextName: String, eventDate: String? = null, eventStatus: String? = null) {
         composeTestRule.onNodeWithText(eventTitle).assertIsDisplayed()
         composeTestRule.onNodeWithText(contextName).assertIsDisplayed()
         if(eventDate != null) composeTestRule.onNodeWithText(eventDate).assertIsDisplayed()
         if(eventStatus != null) composeTestRule.onNodeWithText(eventStatus).assertIsDisplayed()
     }
 
-    fun assertEmptyEventsView() {
+    fun assertEmptyView() {
         assertTrue(composeTestRule.onAllNodesWithTag("calendarEventsEmpty").fetchSemanticsNodes().isNotEmpty())
+    }
+
+    fun assertItemNotExist(itemTitle: String) {
+        composeTestRule.onNodeWithText(itemTitle).assertDoesNotExist()
     }
 
 }

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/CalendarScreenPage.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/CalendarScreenPage.kt
@@ -1,18 +1,17 @@
 /*
  * Copyright (C) 2024 - present Instructure, Inc.
  *
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, version 3 of the License.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
  *
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
  */
 package com.instructure.canvas.espresso.common.pages.compose
 

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/CalendarToDoCreateUpdatePage.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/CalendarToDoCreateUpdatePage.kt
@@ -1,18 +1,17 @@
 /*
  * Copyright (C) 2024 - present Instructure, Inc.
  *
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, version 3 of the License.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
  *
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
  */
 package com.instructure.canvas.espresso.common.pages.compose
 
@@ -25,7 +24,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextReplacement
 import com.instructure.espresso.page.BasePage
 
-class CalendarToDoCreateUpdatePage(private val composeTestRule: ComposeTestRule) : BasePage() {
+class CalendarToDoCreateUpdatePage(private val composeTestRule: ComposeTestRule) {
 
     fun assertPageTitle(pageTitle: String) {
         composeTestRule.onNodeWithText(pageTitle).assertIsDisplayed()

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/CalendarToDoCreateUpdatePage.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/CalendarToDoCreateUpdatePage.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.canvas.espresso.common.pages.compose
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import com.instructure.espresso.page.BasePage
+
+class CalendarToDoCreateUpdatePage(private val composeTestRule: ComposeTestRule) : BasePage() {
+
+    fun assertPageTitle(pageTitle: String) {
+        composeTestRule.onNodeWithText(pageTitle).assertIsDisplayed()
+    }
+
+    fun typeTodoTitle(todoTitle: String) {
+        composeTestRule.onNodeWithTag("addTitleField").assertExists().performTextReplacement(todoTitle)
+        composeTestRule.waitForIdle()
+    }
+
+    fun assertTodoTitle(todoTitle: String) {
+        composeTestRule.onNodeWithTag("addTitleField").assertTextEquals(todoTitle)
+    }
+
+    fun typeDetails(details: String) {
+        composeTestRule.onNodeWithTag("TodoDetailsTextField").performTextReplacement(details)
+        composeTestRule.waitForIdle()
+    }
+
+    fun assertDetails(details: String) {
+        composeTestRule.onNodeWithTag("TodoDetailsTextField").assertTextEquals(details)
+    }
+
+    fun clickSave() {
+        composeTestRule.onNodeWithText("Save").performClick()
+        composeTestRule.waitForIdle()
+    }
+}

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/CalendarToDoDetailsPage.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/CalendarToDoDetailsPage.kt
@@ -45,10 +45,12 @@ class CalendarToDoDetailsPage(private val composeTestRule: ComposeTestRule) {
             .assertTextEquals(title).isDisplayed()
     }
 
-    fun assertCanvasContext(title: String, color: Int? = null) {
-        composeTestRule.onNodeWithText(title)
-            .assertIsDisplayed()
-            .assertTextColor(Color(color!!))
+    fun assertCanvasContext(title: String) {
+        composeTestRule.onNodeWithText(title).assertIsDisplayed()
+    }
+
+    fun assertTextColor(title: String, color: Int) {
+        composeTestRule.onNodeWithText(title).assertTextColor(Color(color))
     }
 
     fun assertDate(context: Context, date: Date) {

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/CalendarToDoDetailsPage.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/CalendarToDoDetailsPage.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasParent
 import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -31,7 +32,12 @@ import com.instructure.canvasapi2.utils.DateHelper
 import com.instructure.espresso.assertTextColor
 import java.util.Date
 
-class ToDoDetailsPage(private val composeTestRule: ComposeTestRule) {
+class CalendarToDoDetailsPage(private val composeTestRule: ComposeTestRule) {
+
+    fun assertPageTitle(pageTitle: String) {
+        composeTestRule.onNode(hasTestTag("todoDetailsPageTitle") and hasText(pageTitle)).assertIsDisplayed()
+    }
+
 
     fun assertTitle(title: String) {
         composeTestRule.waitForIdle()
@@ -39,10 +45,10 @@ class ToDoDetailsPage(private val composeTestRule: ComposeTestRule) {
             .assertTextEquals(title).isDisplayed()
     }
 
-    fun assertCanvasContext(title: String, color: Int) {
+    fun assertCanvasContext(title: String, color: Int? = null) {
         composeTestRule.onNodeWithText(title)
             .assertIsDisplayed()
-            .assertTextColor(Color(color))
+            .assertTextColor(Color(color!!))
     }
 
     fun assertDate(context: Context, date: Date) {
@@ -54,6 +60,11 @@ class ToDoDetailsPage(private val composeTestRule: ComposeTestRule) {
 
         composeTestRule.onNodeWithTag("date")
             .assertTextEquals(dateTitle).isDisplayed()
+    }
+
+    fun assertDate(dateString: String) {
+        composeTestRule.onNodeWithTag("date")
+            .assertTextEquals(dateString).isDisplayed()
     }
 
     fun assertDescription(description: String) {
@@ -74,6 +85,12 @@ class ToDoDetailsPage(private val composeTestRule: ComposeTestRule) {
     }
 
     fun clickDeleteMenu() {
+        composeTestRule.onNodeWithText("Delete").performClick()
+    }
+
+    fun confirmDeletion() {
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Delete To Do?").assertIsDisplayed()
         composeTestRule.onNodeWithText("Delete").performClick()
     }
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/compose/composables/CanvasThemedAppBar.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/compose/composables/CanvasThemedAppBar.kt
@@ -53,7 +53,7 @@ fun CanvasThemedAppBar(
     TopAppBar(
         title = {
             Column {
-                Text(text = title)
+                Text(text = title, modifier.testTag("todoDetailsPageTitle"))
                 if (subtitle.isNotEmpty()) {
                     Text(
                         text = subtitle,

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendartodo/createupdate/composables/CreateUpdateToDoScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendartodo/createupdate/composables/CreateUpdateToDoScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -288,7 +289,8 @@ private fun CreateUpdateToDoContent(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(48.dp)
-                    .padding(horizontal = 16.dp),
+                    .padding(horizontal = 16.dp)
+                    .testTag("addTitleField"),
                 cursorBrush = SolidColor(colorResource(id = R.color.textDarkest)),
                 textStyle = TextStyle(
                     color = colorResource(id = R.color.textDarkest),
@@ -345,7 +347,8 @@ private fun CreateUpdateToDoContent(
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(horizontal = 16.dp)
-                        .focusRequester(detailsFocusRequester),
+                        .focusRequester(detailsFocusRequester)
+                        .testTag("TodoDetailsTextField"),
                     cursorBrush = SolidColor(colorResource(id = R.color.textDarkest)),
                     textStyle = TextStyle(
                         color = colorResource(id = R.color.textDarkest),


### PR DESCRIPTION
Implement Calendar To Do E2E test cases in both apps.
Add some Page Object classes.
Add some testTags.
Minor refactor (rename some methods and classes to clarify possible future confusion).

refs: MBL-17268
affects: Teacher, Student
release note: none
