### PR TITLE
[MBL-17593][Student][Teacher] Localize calendar week first day

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/CalendarStateMapper.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/CalendarStateMapper.kt
@@ -20,6 +20,7 @@ import org.threeten.bp.DayOfWeek
 import org.threeten.bp.LocalDate
 import org.threeten.bp.format.TextStyle
 import org.threeten.bp.temporal.ChronoUnit
+import org.threeten.bp.temporal.WeekFields
 import java.util.Locale
 
 class CalendarStateMapper(private val clock: Clock) {
@@ -56,13 +57,14 @@ class CalendarStateMapper(private val clock: Clock) {
     ): CalendarPageUiState {
         val daysInMonth = date.lengthOfMonth()
         val firstDayOfMonth = date.withDayOfMonth(1)
+        val localeFirstDayOfWeek = WeekFields.of(Locale.getDefault()).firstDayOfWeek.value
         val firstDayOfWeekIndex =
-            firstDayOfMonth.dayOfWeek.value % 7 // 0 for Sunday, 6 for Saturday
+            (7 + (firstDayOfMonth.dayOfWeek.value - localeFirstDayOfWeek)) % 7 // We need to add 7 to avoid negative values
 
         val calendarRows = mutableListOf<CalendarRowUiState>()
         val currentWeek = mutableListOf<CalendarDayUiState>()
 
-        // Fill the previous month's days if the first day of the month is not Sunday
+        // Fill the previous month's days if the first day of the month is not the first day of the week
         if (firstDayOfWeekIndex > 0) {
             val previousMonth = date.minusMonths(1).month
             val previousMonthYear = date.minusMonths(1).year

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/composables/Calendar.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/composables/Calendar.kt
@@ -102,6 +102,7 @@ import org.threeten.bp.Clock
 import org.threeten.bp.DayOfWeek
 import org.threeten.bp.LocalDate
 import org.threeten.bp.format.TextStyle
+import org.threeten.bp.temporal.WeekFields
 import java.util.Locale
 
 private const val MIN_SCREEN_HEIGHT_FOR_FULL_CALENDAR = 500
@@ -320,9 +321,11 @@ fun DayHeaders(modifier: Modifier = Modifier) {
     Row(
         modifier = modifier.clearAndSetSemantics { testTag = "dayHeaders" }, horizontalArrangement = Arrangement.SpaceBetween
     ) {
-        val daysOfWeek = DayOfWeek.values()
-        // Shift the starting point to Sunday
-        val shiftedDaysOfWeek = Array(7) { daysOfWeek[(it + 6) % 7] }
+        val daysOfWeek = DayOfWeek.entries.toTypedArray()
+        val localeFirstDayOfWeek = WeekFields.of(Locale.getDefault()).firstDayOfWeek.value
+        // Shift the starting point to the correct day
+        val shiftAmount = localeFirstDayOfWeek - daysOfWeek.first().value
+        val shiftedDaysOfWeek = Array(7) { daysOfWeek[(it + shiftAmount) % 7] }
 
         for (day in shiftedDaysOfWeek) {
             val headerText = day.getDisplayName(TextStyle.SHORT, Locale.getDefault())

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/calendar/CalendarStateMapperTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/calendar/CalendarStateMapperTest.kt
@@ -15,19 +15,34 @@
  */
 package com.instructure.pandautils.features.calendar
 
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.threeten.bp.Clock
 import org.threeten.bp.Instant
 import org.threeten.bp.LocalDate
 import org.threeten.bp.ZoneId
+import java.util.Locale
 
 class CalendarStateMapperTest {
 
     private val clock = Clock.fixed(Instant.parse("2023-04-20T14:00:00.00Z"), ZoneId.systemDefault())
 
     private val calendarStateMapper = CalendarStateMapper(clock)
+
+    private val locale = Locale.getDefault()
+
+    @Before
+    fun setup() {
+        Locale.setDefault(Locale.US)
+    }
+
+    @After
+    fun tearDown() {
+        Locale.setDefault(locale)
+    }
 
     @Test
     fun `Format header UI state for selected date`() {


### PR DESCRIPTION
Test plan: Check if the first day of the calendar is set according to the correct locale. You need to set the locale in the user settings in Canvas, can be done on the web.

refs: MBL-17593
affects: Student, Teacher
release note: none

## Checklist

- [x] Tested in dark mode
- [x] Tested in light mode
