### PR TITLE
[MBL-17608][Student][Teacher] Students without permissions can message entire sections by typing section name

### DIFF
--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/GroupManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/GroupManager.kt
@@ -134,8 +134,8 @@ object GroupManager {
 
     fun getPermissionsAsync(
         groupId: Long,
-        forceNetwork: Boolean = false,
-        requestedPermissions: List<String> = emptyList()
+        requestedPermissions: List<String> = emptyList(),
+        forceNetwork: Boolean = false
     ) = apiAsync<CanvasContextPermission> {
         val adapter = RestBuilder()
         val params = RestParams(isForceReadFromNetwork = forceNetwork)


### PR DESCRIPTION
Test plan: In the ticket. Smoke test the same functionality in the Teacher app. This change affects that as well since that part of the Inbox screen is shared.

refs: MBL-17608
affects: Student, Teacher
release note: none

## Checklist

- [x] Tested in light mode
