### PR TITLE
[MBL-17641][Student][Teacher] Delete temp files when removed from file upload

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadDialogViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadDialogViewModel.kt
@@ -178,8 +178,11 @@ class FileUploadDialogViewModel @Inject constructor(
     }
 
     private fun onRemoveFileClicked(fullPath: String) {
-        filesToUpload.removeIf {
+        val removed = filesToUpload.removeIf {
             it.fullPath == fullPath
+        }
+        if (removed) {
+            fileUploadUtils.deleteTempFile(fullPath)
         }
         updateItems()
     }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadUtilsHelper.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/file/upload/FileUploadUtilsHelper.kt
@@ -53,4 +53,8 @@ class FileUploadUtilsHelper(
             }
         }
     }
+
+    fun deleteTempFile(fileName: String) {
+        fileUploadUtils.deleteTempFile(fileName)
+    }
 }


### PR DESCRIPTION
Test plan: See ticket.

refs: MBL-17641
affects: Student, Teacher
release note: Fixed a bug where some temporary files would not be deleted.
