### PR TITLE
[MBL-17648][Teacher] Reload Dashboard on notifications permission

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/activities/InitActivity.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/activities/InitActivity.kt
@@ -37,6 +37,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.lifecycleScope
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.instructure.canvasapi2.managers.CourseNicknameManager
 import com.instructure.canvasapi2.managers.ThemeManager
@@ -152,7 +153,11 @@ class InitActivity : BasePresenterActivity<InitActivityPresenter, InitActivityVi
     private val isDrawerOpen: Boolean
         get() = binding.drawerLayout.isDrawerOpen(GravityCompat.START)
 
-    private val notificationsPermissionContract = registerForActivityResult(ActivityResultContracts.RequestPermission()) {}
+    private val notificationsPermissionContract = registerForActivityResult(ActivityResultContracts.RequestPermission()) {
+        val intent = Intent(Const.COURSE_THING_CHANGED)
+        intent.putExtras(Bundle().apply { putBoolean(Const.COURSE_FAVORITES, true) })
+        LocalBroadcastManager.getInstance(this).sendBroadcast(intent)
+    }
 
     override fun onStart() {
         super.onStart()


### PR DESCRIPTION
Test plan: See ticket.

refs: MBL-17648
affects: Teacher
release note: Fixed a bug, where the Dashboard would not load properly on the first app start.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-android/assets/72087159/75c5ced1-99eb-4221-b6eb-66d1e57dd72e" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-android/assets/72087159/f5750d3e-1f59-45b4-90dd-aa25f4c6a4db" maxHeight=500></td>
</tr>
</table>