### PR TITLE
[MBL-17668][Student][Teacher] -  Refactor E2E tests to handle new discussion redesign as default

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/AnnouncementsE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/AnnouncementsE2ETest.kt
@@ -87,7 +87,7 @@ class AnnouncementsE2ETest : StudentTest() {
 
         Log.d(STEP_TAG, "Assert that the '${announcement.title}' announcement's title is displayed on the toolbar and the 'Reply' button is displayed as this announcement is not locked.")
         discussionDetailsPage.assertToolbarDiscussionTitle(announcement.title)
-        discussionDetailsPage.waitForReplyButtonDisplayed()
+        discussionDetailsPage.waitForReplyButton()
         discussionDetailsPage.assertReplyButtonDisplayed()
 
         Log.d(STEP_TAG,"Assert the the previously seeded reply, '$replyMessage', is displayed on the (online) details page.")

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/AnnouncementsE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/AnnouncementsE2ETest.kt
@@ -24,7 +24,6 @@ import com.instructure.canvas.espresso.Priority
 import com.instructure.canvas.espresso.TestCategory
 import com.instructure.canvas.espresso.TestMetaData
 import com.instructure.canvas.espresso.refresh
-import com.instructure.canvasapi2.models.DiscussionEntry
 import com.instructure.dataseeding.api.DiscussionTopicsApi
 import com.instructure.student.ui.utils.StudentTest
 import com.instructure.student.ui.utils.seedData
@@ -49,48 +48,52 @@ class AnnouncementsE2ETest : StudentTest() {
         val student = data.studentsList[0]
         val teacher = data.teachersList[0]
         val course = data.coursesList[0]
-        val announcement = data.announcementsList[0]
+        val replyMessage = "Reply text"
 
+        Log.d(PREPARATION_TAG, "Seed an announcement for '${course.name}' course and a (message) entry for this announcement with the '$replyMessage' as a student.")
+        val announcement = data.announcementsList[0]
+        DiscussionTopicsApi.createEntryToDiscussionTopic(student.token, course.id, announcement.id, replyMessage)
+
+        Log.d(PREPARATION_TAG, "Seed another announcement for '${course.name}' which is locked so replies not allowed for it.")
         val lockedAnnouncement = DiscussionTopicsApi.createAnnouncement(course.id, teacher.token, locked = true)
 
-        Log.d(STEP_TAG,"Login with user: ${student.name}, login id: ${student.loginId}.")
+        Log.d(STEP_TAG,"Login with user: '${student.name}', login id: '${student.loginId}'.")
         tokenLogin(student)
         dashboardPage.waitForRender()
 
-        Log.d(STEP_TAG,"Navigate to ${course.name} course's announcements page.")
+        Log.d(STEP_TAG,"Navigate to '${course.name}' course's announcements page.")
         dashboardPage.assertDisplaysCourse(course)
         dashboardPage.selectCourse(course)
         courseBrowserPage.selectAnnouncements()
 
-        Log.d(STEP_TAG,"Assert that ${announcement.title} announcement is displayed.")
+        Log.d(STEP_TAG,"Assert that '${announcement.title}' announcement is displayed.")
         announcementListPage.assertTopicDisplayed(announcement.title)
 
-        Log.d(STEP_TAG, "Assert that ${lockedAnnouncement.title} announcement is really locked so that the 'locked' icon is displayed.")
+        Log.d(STEP_TAG, "Assert that '${lockedAnnouncement.title}' announcement is really locked so that the 'locked' icon is displayed.")
         announcementListPage.assertAnnouncementLocked(lockedAnnouncement.title)
 
-        Log.d(STEP_TAG, "Select ${lockedAnnouncement.title} announcement and assert if we are landing on the Discussion Details Page.")
+        Log.d(STEP_TAG, "Select '${lockedAnnouncement.title}' announcement.")
         announcementListPage.selectTopic(lockedAnnouncement.title)
-        discussionDetailsPage.assertTitleText(lockedAnnouncement.title)
+
+        Log.d(STEP_TAG, "Assert that the '${lockedAnnouncement.title}' announcement's title is displayed on the toolbar.")
+        discussionDetailsPage.assertToolbarDiscussionTitle(lockedAnnouncement.title)
 
         Log.d(STEP_TAG, "Assert that the 'Reply' button is not available on a locked announcement. Navigate back to Announcement List Page.")
         discussionDetailsPage.assertReplyButtonNotDisplayed()
         Espresso.pressBack()
 
-        Log.d(STEP_TAG,"Select ${announcement.title} announcement and assert if we are landing on the Discussion Details Page.")
+        Log.d(STEP_TAG,"Select '${announcement.title}' announcement.")
         announcementListPage.selectTopic(announcement.title)
-        discussionDetailsPage.assertTitleText(announcement.title)
 
-        val replyMessage = "Reply text"
-        Log.d(STEP_TAG,"Send a reply to the selected announcement with message: $replyMessage.")
-        discussionDetailsPage.sendReply(replyMessage)
-        discussionDetailsPage.assertPageObjects()
+        Log.d(STEP_TAG, "Assert that the '${announcement.title}' announcement's title is displayed on the toolbar and the 'Reply' button is displayed as this announcement is not locked.")
+        discussionDetailsPage.assertToolbarDiscussionTitle(announcement.title)
+        discussionDetailsPage.waitForReplyButtonDisplayed()
+        discussionDetailsPage.assertReplyButtonDisplayed()
 
-        Log.d(STEP_TAG,"Assert that the previously sent reply has been displayed.")
-        val announcementReply  = DiscussionEntry(message = replyMessage)
-        discussionDetailsPage.assertIfThereIsAReply()
-        discussionDetailsPage.assertReplyDisplayed(announcementReply)
+        Log.d(STEP_TAG,"Assert the the previously seeded reply, '$replyMessage', is displayed on the (online) details page.")
+        discussionDetailsPage.assertEntryDisplayed(replyMessage)
 
-        Log.d(STEP_TAG,"Click on Search button and type ${announcement.title} to the search input field.")
+        Log.d(STEP_TAG,"Click on Search button and type '${announcement.title}' to the search input field.")
         Espresso.pressBack()
         announcementListPage.searchable.clickOnSearchButton()
         announcementListPage.searchable.typeToSearchBar(announcement.title)

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/DiscussionsE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/DiscussionsE2ETest.kt
@@ -80,7 +80,7 @@ class DiscussionsE2ETest: StudentTest() {
 
         Log.d(STEP_TAG,"Select '${announcement.title}' announcement and assert if the Discussion Details Page is displayed.")
         discussionListPage.selectTopic(announcement.title)
-        discussionDetailsPage.assertTitleText(announcement.title)
+        discussionDetailsPage.assertToolbarDiscussionTitle(announcement.title)
 
         Log.d(STEP_TAG,"Navigate back to the Discussion List Page.")
         Espresso.pressBack()
@@ -108,8 +108,7 @@ class DiscussionsE2ETest: StudentTest() {
         Log.d(STEP_TAG,"Select '${topic1.title}' discussion and assert if the details page is displayed and there is no reply for the discussion yet.")
         discussionListPage.assertTopicDisplayed(topic1.title)
         discussionListPage.selectTopic(topic1.title)
-        discussionDetailsPage.assertTitleText(topic1.title)
-        discussionDetailsPage.assertNoRepliesDisplayed()
+        discussionDetailsPage.assertToolbarDiscussionTitle(topic1.title)
 
         Log.d(STEP_TAG,"Navigate back to Discussion List Page.")
         Espresso.pressBack()
@@ -117,8 +116,7 @@ class DiscussionsE2ETest: StudentTest() {
         Log.d(STEP_TAG,"Select '${topic1.title}' discussion and assert if the details page is displayed and there is no reply for the discussion yet.")
         discussionListPage.assertTopicDisplayed(topic2.title)
         discussionListPage.selectTopic(topic2.title)
-        discussionDetailsPage.assertTitleText(topic2.title)
-        discussionDetailsPage.assertNoRepliesDisplayed()
+        discussionDetailsPage.assertToolbarDiscussionTitle(topic2.title)
 
         Log.d(STEP_TAG,"Navigate back to Discussion List Page.")
         Espresso.pressBack()
@@ -133,29 +131,29 @@ class DiscussionsE2ETest: StudentTest() {
         discussionListPage.assertTopicDisplayed(newTopicName)
         discussionListPage.assertReplyCount(newTopicName, 0)
 
-        Log.d(STEP_TAG,"Select '$newTopicName' topic and assert that there is no reply on the details page as well.")
-        discussionListPage.selectTopic(newTopicName)
-        discussionDetailsPage.assertNoRepliesDisplayed()
-
         val replyMessage = "My reply"
-        Log.d(STEP_TAG,"Send a reply with text: '$replyMessage'.")
-        discussionDetailsPage.sendReply(replyMessage)
-        sleep(2000) // Allow some time for reply to propagate
+        Log.d(PREPARATION_TAG, "Seed a discussion topic (message) entry for the '${topic1.title}' discussion with the '$replyMessage' message as a student.")
+        DiscussionTopicsApi.createEntryToDiscussionTopic(student.token, course.id, topic1.id, replyMessage)
+        sleep(2000) // Allow some time for entry creation to propagate
 
-        Log.d(STEP_TAG,"Assert the the previously sent reply ($replyMessage) is displayed on the details page.")
-        discussionDetailsPage.assertRepliesDisplayed()
+        Log.d(STEP_TAG,"Select '${topic1.title}' topic.")
+        discussionListPage.selectTopic(topic1.title)
+
+        Log.d(STEP_TAG,"Assert the the previously sent entry message, '$replyMessage')' is displayed on the details (web view) page.")
+        discussionDetailsPage.waitForEntryDisplayed(replyMessage)
+        discussionDetailsPage.assertEntryDisplayed(replyMessage)
 
         Log.d(STEP_TAG,"Navigate back to Discussion List Page.")
         Espresso.pressBack()
 
         Log.d(STEP_TAG,"Refresh the page. Assert that the previously sent reply has been counted, and there are no unread replies.")
         discussionListPage.pullToUpdate()
-        discussionListPage.assertReplyCount(newTopicName, 1)
-        discussionListPage.assertUnreadReplyCount(newTopicName, 0)
+        discussionListPage.assertReplyCount(topic1.title, 1)
+        discussionListPage.assertUnreadReplyCount(topic1.title, 0)
 
         Log.d(STEP_TAG, "Assert that the due date is the current date (in the expected format).")
         val currentDate = getDateInCanvasFormat()
-        discussionListPage.assertDueDate(newTopicName, currentDate)
+        discussionListPage.assertDueDate(topic1.title, currentDate)
     }
 
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/ModulesE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/ModulesE2ETest.kt
@@ -186,7 +186,7 @@ class ModulesE2ETest: StudentTest() {
 
         Log.d(STEP_TAG, "Click on the next arrow button and assert that the '${discussionTopic1.title}' discussion topic module item's details page is displayed.")
         assignmentDetailsPage.moduleItemInteractions.clickOnNextArrow()
-        discussionDetailsPage.assertTitleText(discussionTopic1.title)
+        discussionDetailsPage.assertModulesToolbarDiscussionTitle(discussionTopic1.title)
 
         Log.d(STEP_TAG, "Assert that the second module name, '${module2.name}' is displayed at the bottom.")
         discussionDetailsPage.moduleItemInteractions.assertModuleNameDisplayed(module2.name)

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/k5/HomeroomE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/k5/HomeroomE2ETest.kt
@@ -126,8 +126,8 @@ class HomeroomE2ETest : StudentTest() {
         homeroomPage.assertPageObjects()
         homeroomPage.openCourseAnnouncement(data.announcementsList[1].title)
 
-        Log.d(STEP_TAG, "Assert that the '${data.announcementsList[1].title}' announcement's details page is displayed.")
-        discussionDetailsPage.assertTitleText(data.announcementsList[1].title)
+        Log.d(STEP_TAG, "Assert that the '${data.announcementsList[1].title}' discussion's details page is displayed.")
+        discussionDetailsPage.assertHomeroomToolbarDiscussionTitle(data.announcementsList[1].title)
 
         Log.d(STEP_TAG, "Navigate back to Homeroom Page. Open the Assignment List Page of '${nonHomeroomCourses[2].name}' course.")
         Espresso.pressBack()

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineAnnouncementsE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineAnnouncementsE2ETest.kt
@@ -95,18 +95,18 @@ class OfflineAnnouncementsE2ETest : StudentTest() {
 
         Log.d(STEP_TAG, "Select '${lockedAnnouncement.title}' announcement and assert if we are landing on the Discussion Details Page.")
         announcementListPage.selectTopic(lockedAnnouncement.title)
-        discussionDetailsPage.assertTitleText(lockedAnnouncement.title)
+        nativeDiscussionDetailsPage.assertTitleText(lockedAnnouncement.title)
 
         Log.d(STEP_TAG, "Assert that the 'Reply' button is not available on a locked announcement. Navigate back to Announcement List Page.")
-        discussionDetailsPage.assertReplyButtonNotDisplayed()
+        nativeDiscussionDetailsPage.assertReplyButtonNotDisplayed()
         Espresso.pressBack()
 
         Log.d(STEP_TAG,"Select '${announcement.title}' announcement and assert if we are landing on the Discussion Details Page.")
         announcementListPage.selectTopic(announcement.title)
-        discussionDetailsPage.assertTitleText(announcement.title)
+        nativeDiscussionDetailsPage.assertTitleText(announcement.title)
 
         Log.d(STEP_TAG, "Click on the 'Reply' button and assert that the 'No Internet Connection' dialog has displayed. Dismiss the dialog.")
-        discussionDetailsPage.clickReply()
+        nativeDiscussionDetailsPage.clickReply()
         OfflineTestUtils.assertNoInternetConnectionDialog()
         OfflineTestUtils.dismissNoInternetConnectionDialog()
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineDiscussionsE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineDiscussionsE2ETest.kt
@@ -79,6 +79,7 @@ class OfflineDiscussionsE2ETest : StudentTest() {
         discussionListPage.selectTopic(discussion1.title)
 
         Log.d(STEP_TAG, "Assert that the 'Reply' button is displayed on the Discussion Details (Web view) Page.")
+        discussionDetailsPage.waitForReplyButton()
         discussionDetailsPage.assertReplyButtonDisplayed()
 
         Log.d(STEP_TAG,"Assert the the previously sent reply 'My reply', is displayed on the (online) details page.")

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineDiscussionsE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineDiscussionsE2ETest.kt
@@ -37,7 +37,6 @@ import com.instructure.student.ui.utils.tokenLogin
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.After
 import org.junit.Test
-import java.lang.Thread.sleep
 
 @HiltAndroidTest
 class OfflineDiscussionsE2ETest : StudentTest() {
@@ -63,6 +62,9 @@ class OfflineDiscussionsE2ETest : StudentTest() {
         Log.d(PREPARATION_TAG,"Seed another discussion topic for '${course.name}' course.")
         val discussion2 = DiscussionTopicsApi.createDiscussion(course.id, teacher.token)
 
+        Log.d(PREPARATION_TAG,"Seed an entry ('main reply') for the '${course.name}' course's '${discussion1.title}' discussion topic.")
+        DiscussionTopicsApi.createEntryToDiscussionTopic(student.token, course.id, discussion1.id, "My reply")
+
         Log.d(STEP_TAG,"Login with user: '${student.name}', login id: '${student.loginId}'.")
         tokenLogin(student)
 
@@ -75,15 +77,12 @@ class OfflineDiscussionsE2ETest : StudentTest() {
 
         Log.d(STEP_TAG,"Select '$discussion1' discussion topic and assert that there is no reply on the details page as well.")
         discussionListPage.selectTopic(discussion1.title)
-        discussionDetailsPage.assertNoRepliesDisplayed()
 
-        val replyMessage = "My reply"
-        Log.d(STEP_TAG,"Send a reply with text: '$replyMessage'.")
-        discussionDetailsPage.sendReply(replyMessage)
-        sleep(2000) // Allow some time for reply to propagate
+        Log.d(STEP_TAG, "Assert that the 'Reply' button is displayed on the Discussion Details (Web view) Page.")
+        discussionDetailsPage.assertReplyButtonDisplayed()
 
-        Log.d(STEP_TAG,"Assert the the previously sent reply '$replyMessage', is displayed on the details page.")
-        discussionDetailsPage.assertRepliesDisplayed()
+        Log.d(STEP_TAG,"Assert the the previously sent reply 'My reply', is displayed on the (online) details page.")
+        discussionDetailsPage.assertEntryDisplayed("My reply")
 
         Log.d(STEP_TAG, "Navigate back to the Dashboard page.")
         ViewUtils.pressBackButton(3)
@@ -145,15 +144,15 @@ class OfflineDiscussionsE2ETest : StudentTest() {
 
         Log.d(STEP_TAG,"Select '${discussion1.title}' discussion and assert if the corresponding discussion title is displayed.")
         discussionListPage.selectTopic(discussion1.title)
-        discussionDetailsPage.assertTitleText(discussion1.title)
+        nativeDiscussionDetailsPage.assertTitleText(discussion1.title)
 
         Log.d(STEP_TAG, "Try to click on the (main) 'Reply' button and assert that the 'No Internet Connection' dialog has displayed. Dismiss the dialog.")
-        discussionDetailsPage.clickReply()
+        nativeDiscussionDetailsPage.clickReply()
         OfflineTestUtils.assertNoInternetConnectionDialog()
         OfflineTestUtils.dismissNoInternetConnectionDialog()
 
         Log.d(STEP_TAG, "Try to click on the (inner) 'Reply' button (so try to 'reply to a reply') and assert that the 'No Internet Connection' dialog has displayed. Dismiss the dialog.")
-        discussionDetailsPage.clickOnInnerReply()
+        nativeDiscussionDetailsPage.clickOnInnerReply()
         OfflineTestUtils.assertNoInternetConnectionDialog()
         OfflineTestUtils.dismissNoInternetConnectionDialog()
 
@@ -162,12 +161,12 @@ class OfflineDiscussionsE2ETest : StudentTest() {
 
         Log.d(STEP_TAG,"Select '${discussion2.title}' discussion and assert if the Discussion Details page is displayed and there is no reply for the discussion yet.")
         discussionListPage.selectTopic(discussion2.title)
-        discussionDetailsPage.assertTitleText(discussion2.title)
-        discussionDetailsPage.assertNoRepliesDisplayed()
+        nativeDiscussionDetailsPage.assertTitleText(discussion2.title)
+        nativeDiscussionDetailsPage.assertNoRepliesDisplayed()
 
         Log.d(STEP_TAG, "Try to click on 'Add Bookmark' overflow menu and assert that the 'Functionality unavailable while offline' toast message is displayed.")
         openOverflowMenu()
-        discussionDetailsPage.clickOnAddBookmarkMenu()
+        nativeDiscussionDetailsPage.clickOnAddBookmarkMenu()
         checkToastText(R.string.notAvailableOffline, activityRule.activity)
     }
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/AnnouncementInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/AnnouncementInteractionTest.kt
@@ -70,11 +70,11 @@ class AnnouncementInteractionTest : StudentTest() {
         // the discussion list page / discussion details page
         discussionListPage.assertTopicDisplayed(announcement.title!!)
         discussionListPage.selectTopic(announcement.title!!)
-        discussionDetailsPage.assertTopicInfoShowing(announcement)
-        discussionDetailsPage.sendReply("Will do!")
+        nativeDiscussionDetailsPage.assertTopicInfoShowing(announcement)
+        nativeDiscussionDetailsPage.sendReply("Will do!")
         //Find our DiscussionReply
         val reply = data.discussionTopics[announcement.id]?.views?.find {it.message == "Will do!"} !!
-        discussionDetailsPage.assertReplyDisplayed(reply)
+        nativeDiscussionDetailsPage.assertReplyDisplayed(reply)
 
         // Just for fun, let's change the user to be enrolled in a section of the course to which
         // the announcement does not apply, and make sure that the user no longer sees the announcement.
@@ -123,8 +123,8 @@ class AnnouncementInteractionTest : StudentTest() {
         // Now let's test
         courseBrowserPage.selectAnnouncements()
         discussionListPage.selectTopic(announcement.title!!)
-        discussionDetailsPage.assertMainAttachmentDisplayed()
-        discussionDetailsPage.previewAndCheckMainAttachment(
+        nativeDiscussionDetailsPage.assertMainAttachmentDisplayed()
+        nativeDiscussionDetailsPage.previewAndCheckMainAttachment(
                 WebViewTextCheck(Locator.ID, "p1", "Et tu, Brute?")
         )
 
@@ -147,11 +147,11 @@ class AnnouncementInteractionTest : StudentTest() {
         courseBrowserPage.selectAnnouncements()
         discussionListPage.assertTopicDisplayed(announcement.title!!)
         discussionListPage.selectTopic(announcement.title!!)
-        discussionDetailsPage.assertTopicInfoShowing(announcement)
-        discussionDetailsPage.sendReply("Roger!")
+        nativeDiscussionDetailsPage.assertTopicInfoShowing(announcement)
+        nativeDiscussionDetailsPage.sendReply("Roger!")
         //Find our DiscussionReply
         val reply = data.discussionTopics[announcement.id]?.views?.find {it.message == "Roger!"} !!
-        discussionDetailsPage.assertReplyDisplayed(reply)
+        nativeDiscussionDetailsPage.assertReplyDisplayed(reply)
     }
 
     // Tests that we can create an announcement (as teacher).

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/DiscussionsInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/DiscussionsInteractionTest.kt
@@ -61,8 +61,8 @@ class DiscussionsInteractionTest : StudentTest() {
         discussionListPage.pullToUpdate()
         discussionListPage.assertTopicDisplayed(topicName)
         discussionListPage.selectTopic(topicName)
-        discussionDetailsPage.assertTitleText(topicName)
-        discussionDetailsPage.assertDescriptionText(topicDescription)
+        nativeDiscussionDetailsPage.assertTitleText(topicName)
+        nativeDiscussionDetailsPage.assertDescriptionText(topicDescription)
     }
 
     // Tests the creation of a discussion with an attachment.
@@ -101,10 +101,10 @@ class DiscussionsInteractionTest : StudentTest() {
         discussionListPage.pullToUpdate()
         discussionListPage.assertTopicDisplayed(topicName)
         discussionListPage.selectTopic(topicName)
-        discussionDetailsPage.assertTitleText(topicName)
-        discussionDetailsPage.assertDescriptionText(topicDescription)
-        discussionDetailsPage.assertMainAttachmentDisplayed()
-        discussionDetailsPage.previewAndCheckMainAttachment(
+        nativeDiscussionDetailsPage.assertTitleText(topicName)
+        nativeDiscussionDetailsPage.assertDescriptionText(topicDescription)
+        nativeDiscussionDetailsPage.assertMainAttachmentDisplayed()
+        nativeDiscussionDetailsPage.previewAndCheckMainAttachment(
             WebViewTextCheck(Locator.ID, "header1", "Famous Quote"),
             WebViewTextCheck(Locator.ID, "p1", "-- Socrates")
         )
@@ -145,7 +145,7 @@ class DiscussionsInteractionTest : StudentTest() {
         courseBrowserPage.selectDiscussions()
         discussionListPage.pullToUpdate()
         discussionListPage.selectTopic(topicName)
-        discussionDetailsPage.clickLinkInDescription(course2LinkElementId) // Should navigate to course2
+        nativeDiscussionDetailsPage.clickLinkInDescription(course2LinkElementId) // Should navigate to course2
 
         courseBrowserPage.assertTitleCorrect(course2)
     }
@@ -180,8 +180,8 @@ class DiscussionsInteractionTest : StudentTest() {
         discussionListPage.assertUnreadCount(topicHeader.title!!, 1)
         discussionListPage.selectTopic(topicHeader.title!!)
         sleep(3000) // let's allow time for the webview to become populated/visible before we scroll to it
-        discussionDetailsPage.scrollToRepliesWebview() // may be necessary on shorter screens / landscape
-        discussionDetailsPage.waitForUnreadIndicatorToDisappear(discussionEntry)
+        nativeDiscussionDetailsPage.scrollToRepliesWebview() // may be necessary on shorter screens / landscape
+        nativeDiscussionDetailsPage.waitForUnreadIndicatorToDisappear(discussionEntry)
         Espresso.pressBack() // Back to discussionListPage
         discussionListPage.pullToUpdate()
         discussionListPage.assertUnreadCount(topicHeader.title!!, 0)
@@ -222,9 +222,9 @@ class DiscussionsInteractionTest : StudentTest() {
 
         courseBrowserPage.selectDiscussions()
         discussionListPage.selectTopic(topicHeader.title!!)
-        discussionDetailsPage.assertTopicInfoShowing(topicHeader)
-        discussionDetailsPage.assertMainAttachmentDisplayed()
-        discussionDetailsPage.previewAndCheckMainAttachment(
+        nativeDiscussionDetailsPage.assertTopicInfoShowing(topicHeader)
+        nativeDiscussionDetailsPage.assertMainAttachmentDisplayed()
+        nativeDiscussionDetailsPage.previewAndCheckMainAttachment(
             WebViewTextCheck(Locator.ID, "header1", "Famous Quote"),
             WebViewTextCheck(Locator.ID, "p1", "No matter where you go")
         )
@@ -262,14 +262,14 @@ class DiscussionsInteractionTest : StudentTest() {
         discussionListPage.selectTopic(topicName)
 
         // Check that favoriting works as expected
-        discussionDetailsPage.assertFavoritingEnabled(discussionEntry)
-        discussionDetailsPage.assertLikeCount(discussionEntry, 0)
-        discussionDetailsPage.clickLikeOnEntry(discussionEntry)
+        nativeDiscussionDetailsPage.assertFavoritingEnabled(discussionEntry)
+        nativeDiscussionDetailsPage.assertLikeCount(discussionEntry, 0)
+        nativeDiscussionDetailsPage.clickLikeOnEntry(discussionEntry)
         sleep(1000) // Small wait to allow "like" to propagate
-        discussionDetailsPage.assertLikeCount(discussionEntry, 1, refreshesAllowed = 2)
-        discussionDetailsPage.clickLikeOnEntry(discussionEntry)
+        nativeDiscussionDetailsPage.assertLikeCount(discussionEntry, 1, refreshesAllowed = 2)
+        nativeDiscussionDetailsPage.clickLikeOnEntry(discussionEntry)
         sleep(1000) // Small wait to allow "unlike" to propagate
-        discussionDetailsPage.assertLikeCount(discussionEntry, 0)
+        nativeDiscussionDetailsPage.assertLikeCount(discussionEntry, 0)
     }
 
     // Tests that like count is shown if only graders can like
@@ -305,8 +305,8 @@ class DiscussionsInteractionTest : StudentTest() {
         discussionListPage.selectTopic(topicName)
 
         // Check that ratings show
-        discussionDetailsPage.assertFavoritingDisabled(discussionEntry)
-        discussionDetailsPage.assertLikeCount(discussionEntry, 1)
+        nativeDiscussionDetailsPage.assertFavoritingDisabled(discussionEntry)
+        nativeDiscussionDetailsPage.assertLikeCount(discussionEntry, 1)
     }
 
     // Tests that discussion entry liking is not available when disabled
@@ -335,7 +335,7 @@ class DiscussionsInteractionTest : StudentTest() {
         discussionListPage.assertTopicDisplayed(topicHeader.title!!)
         discussionListPage.selectTopic(topicHeader.title!!)
 
-        discussionDetailsPage.assertFavoritingDisabled(discussionEntry)
+        nativeDiscussionDetailsPage.assertFavoritingDisabled(discussionEntry)
     }
 
     // Test basic discussion view
@@ -355,7 +355,7 @@ class DiscussionsInteractionTest : StudentTest() {
         discussionListPage.pullToUpdate()
         discussionListPage.assertTopicDisplayed(topicHeader.title!!)
         discussionListPage.selectTopic(topicHeader.title!!)
-        discussionDetailsPage.assertTopicInfoShowing(topicHeader)
+        nativeDiscussionDetailsPage.assertTopicInfoShowing(topicHeader)
     }
 
     // Test that you can reply to a discussion (if enabled)
@@ -380,9 +380,9 @@ class DiscussionsInteractionTest : StudentTest() {
         courseBrowserPage.selectDiscussions()
         discussionListPage.pullToUpdate()
         discussionListPage.selectTopic(topicHeader.title!!)
-        discussionDetailsPage.assertRepliesDisplayed()
+        nativeDiscussionDetailsPage.assertRepliesDisplayed()
 
-        discussionDetailsPage.assertReplyDisplayed(discussionEntry)
+        nativeDiscussionDetailsPage.assertReplyDisplayed(discussionEntry)
     }
 
     // Test that replies are not possible when they are not enabled
@@ -403,7 +403,7 @@ class DiscussionsInteractionTest : StudentTest() {
         courseBrowserPage.selectDiscussions()
         discussionListPage.pullToUpdate()
         discussionListPage.selectTopic(topicHeader.title!!)
-        discussionDetailsPage.assertRepliesDisabled()
+        nativeDiscussionDetailsPage.assertRepliesDisabled()
     }
 
     // Test that a reply is displayed properly
@@ -422,14 +422,14 @@ class DiscussionsInteractionTest : StudentTest() {
         courseBrowserPage.selectDiscussions()
         discussionListPage.pullToUpdate()
         discussionListPage.selectTopic(topicHeader.title!!)
-        discussionDetailsPage.assertTopicInfoShowing(topicHeader)
-        discussionDetailsPage.assertRepliesEnabled()
+        nativeDiscussionDetailsPage.assertTopicInfoShowing(topicHeader)
+        nativeDiscussionDetailsPage.assertRepliesEnabled()
 
         // Let's reply via the app
         val replyText = "I'm a reply"
-        discussionDetailsPage.sendReply(replyText)
+        nativeDiscussionDetailsPage.sendReply(replyText)
         val discussionEntry = findDiscussionEntry(data, topicHeader.title!!, replyText)
-        discussionDetailsPage.assertReplyDisplayed(discussionEntry, refreshesAllowed = 2)
+        nativeDiscussionDetailsPage.assertReplyDisplayed(discussionEntry, refreshesAllowed = 2)
     }
 
     // Tests replying with an attachment.
@@ -454,7 +454,7 @@ class DiscussionsInteractionTest : StudentTest() {
 
         // Let's reply via the app
         val replyText = "I'm a reply"
-        discussionDetailsPage.sendReply(replyText)
+        nativeDiscussionDetailsPage.sendReply(replyText)
 
         // Now let's append the attachment after-the-fact, since it is very hard
         // to manually attach anything via Espresso, since it would require manipulating
@@ -480,9 +480,9 @@ class DiscussionsInteractionTest : StudentTest() {
         Espresso.pressBack()
         discussionListPage.selectTopic(topicHeader.title!!)
 
-        discussionDetailsPage.assertReplyDisplayed(discussionEntry)
-        discussionDetailsPage.assertReplyAttachment(discussionEntry)
-        discussionDetailsPage.previewAndCheckReplyAttachment(
+        nativeDiscussionDetailsPage.assertReplyDisplayed(discussionEntry)
+        nativeDiscussionDetailsPage.assertReplyAttachment(discussionEntry)
+        nativeDiscussionDetailsPage.previewAndCheckReplyAttachment(
             discussionEntry,
             WebViewTextCheck(Locator.ID, "header1", "Famous Quote"),
             WebViewTextCheck(Locator.ID, "p1", "That's one small step")
@@ -509,19 +509,19 @@ class DiscussionsInteractionTest : StudentTest() {
 
         // Let's reply via the app
         val replyText = "I'm a reply"
-        discussionDetailsPage.sendReply(replyText)
+        nativeDiscussionDetailsPage.sendReply(replyText)
 
         // Verify that our reply has made it to the screen
         val replyEntry = findDiscussionEntry(data, topicHeader.title!!, replyText)
-        discussionDetailsPage.assertReplyDisplayed(replyEntry, refreshesAllowed = 2)
+        nativeDiscussionDetailsPage.assertReplyDisplayed(replyEntry, refreshesAllowed = 2)
 
         // Now let's reply to the reply (i.e., threaded reply)
         val replyReplyText = "Threaded Reply"
-        discussionDetailsPage.replyToReply(replyEntry, replyReplyText)
+        nativeDiscussionDetailsPage.replyToReply(replyEntry, replyReplyText)
 
         // And verify that our reply-to-reply is showing
         val replyReplyEntry = findDiscussionEntry(data, topicHeader.title!!, replyReplyText)
-        discussionDetailsPage.assertReplyDisplayed(replyReplyEntry, refreshesAllowed = 2)
+        nativeDiscussionDetailsPage.assertReplyDisplayed(replyReplyEntry, refreshesAllowed = 2)
     }
 
     // Tests that we can make a threaded reply with an attachment
@@ -546,15 +546,15 @@ class DiscussionsInteractionTest : StudentTest() {
 
         // Let's reply via the app
         val replyText = "I'm a reply"
-        discussionDetailsPage.sendReply(replyText)
+        nativeDiscussionDetailsPage.sendReply(replyText)
 
         // Make sure that the reply is displayed, so that we can reply to it
         val replyEntry = findDiscussionEntry(data, topicHeader.title!!, replyText)
-        discussionDetailsPage.assertReplyDisplayed(replyEntry, refreshesAllowed = 2)
+        nativeDiscussionDetailsPage.assertReplyDisplayed(replyEntry, refreshesAllowed = 2)
 
         // Now let's reply to the reply (i.e., threaded reply)
         val replyReplyText = "Threaded Reply"
-        discussionDetailsPage.replyToReply(replyEntry, replyReplyText)
+        nativeDiscussionDetailsPage.replyToReply(replyEntry, replyReplyText)
 
         // And verify that our reply-to-reply is showing
         val replyReplyEntry = findDiscussionEntry(data, topicHeader.title!!, replyReplyText)
@@ -580,9 +580,9 @@ class DiscussionsInteractionTest : StudentTest() {
         Espresso.pressBack()
         discussionListPage.selectTopic(topicHeader.title!!)
 
-        discussionDetailsPage.assertReplyDisplayed(replyReplyEntry)
-        discussionDetailsPage.assertReplyAttachment(replyReplyEntry)
-        discussionDetailsPage.previewAndCheckReplyAttachment(
+        nativeDiscussionDetailsPage.assertReplyDisplayed(replyReplyEntry)
+        nativeDiscussionDetailsPage.assertReplyAttachment(replyReplyEntry)
+        nativeDiscussionDetailsPage.previewAndCheckReplyAttachment(
             replyReplyEntry,
             WebViewTextCheck(Locator.ID, "header1", "Famous Quote"),
             WebViewTextCheck(Locator.ID, "p1", "The only thing we have to fear")
@@ -628,7 +628,7 @@ class DiscussionsInteractionTest : StudentTest() {
         dashboardPage.selectCourse(course)
         courseBrowserPage.selectDiscussions()
         discussionListPage.selectTopic(discussion.title!!)
-        discussionDetailsPage.assertPointsPossibleDisplayed(assignment.pointsPossible.toInt().toString())
+        nativeDiscussionDetailsPage.assertPointsPossibleDisplayed(assignment.pointsPossible.toInt().toString())
     }
 
     // Tests a discussion with a linked assignment, show possible points if not restricted
@@ -672,7 +672,7 @@ class DiscussionsInteractionTest : StudentTest() {
         dashboardPage.selectCourse(course)
         courseBrowserPage.selectDiscussions()
         discussionListPage.selectTopic(discussion.title!!)
-        discussionDetailsPage.assertPointsPossibleDisplayed(assignment.pointsPossible.toInt().toString())
+        nativeDiscussionDetailsPage.assertPointsPossibleDisplayed(assignment.pointsPossible.toInt().toString())
     }
 
 
@@ -717,7 +717,7 @@ class DiscussionsInteractionTest : StudentTest() {
         dashboardPage.selectCourse(course)
         courseBrowserPage.selectDiscussions()
         discussionListPage.selectTopic(discussion.title!!)
-        discussionDetailsPage.assertPointsPossibleNotDisplayed()
+        nativeDiscussionDetailsPage.assertPointsPossibleNotDisplayed()
     }
 
     //

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/GroupLinksInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/GroupLinksInteractionTest.kt
@@ -134,7 +134,7 @@ class GroupLinksInteractionTest : StudentTest() {
         dashboardPage.selectGroup(group)
         courseBrowserPage.selectAnnouncements()
         discussionListPage.selectTopic(announcement.title!!)
-        discussionDetailsPage.assertTopicInfoShowing(announcement)
+        nativeDiscussionDetailsPage.assertTopicInfoShowing(announcement)
 
     }
 
@@ -156,7 +156,7 @@ class GroupLinksInteractionTest : StudentTest() {
         dashboardPage.selectGroup(group)
         courseBrowserPage.selectDiscussions()
         discussionListPage.selectTopic(discussion.title!!)
-        discussionDetailsPage.assertTopicInfoShowing(discussion)
+        nativeDiscussionDetailsPage.assertTopicInfoShowing(discussion)
     }
 
     // Link to group discussion list opens list - eg: "/groups/:id/discussion_topics"

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/HomeroomInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/HomeroomInteractionTest.kt
@@ -198,8 +198,8 @@ class HomeroomInteractionTest : StudentTest() {
 
         homeroomPage.openCourseAnnouncement(courseAnnouncement.title!!)
 
-        discussionDetailsPage.assertPageObjects()
-        discussionDetailsPage.assertTitleText(courseAnnouncement.title!!)
+        nativeDiscussionDetailsPage.assertPageObjects()
+        nativeDiscussionDetailsPage.assertTitleText(courseAnnouncement.title!!)
     }
 
     @Test

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/ModuleInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/ModuleInteractionTest.kt
@@ -126,7 +126,7 @@ class ModuleInteractionTest : StudentTest() {
         modulesPage.assertModuleDisplayed(module)
         modulesPage.assertModuleItemDisplayed(module, topicHeader!!.title!!)
         modulesPage.clickModuleItem(module, topicHeader!!.title!!)
-        discussionDetailsPage.assertTopicInfoShowing(topicHeader!!)
+        nativeDiscussionDetailsPage.assertTopicInfoShowing(topicHeader!!)
     }
 
     @Test

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/StudentCalendarInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/StudentCalendarInteractionTest.kt
@@ -24,7 +24,7 @@ import com.instructure.student.BuildConfig
 import com.instructure.student.activity.LoginActivity
 import com.instructure.student.ui.pages.AssignmentDetailsPage
 import com.instructure.student.ui.pages.DashboardPage
-import com.instructure.student.ui.pages.DiscussionDetailsPage
+import com.instructure.student.ui.pages.offline.NativeDiscussionDetailsPage
 import com.instructure.student.ui.utils.StudentActivityTestRule
 import com.instructure.student.ui.utils.tokenLogin
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -38,7 +38,7 @@ class StudentCalendarInteractionTest : CalendarInteractionTest() {
 
     private val dashboardPage = DashboardPage()
     private val assignmentDetailsPage = AssignmentDetailsPage(ModuleItemInteractions())
-    private val discussionDetailsPage = DiscussionDetailsPage(ModuleItemInteractions())
+    private val nativeDiscussionDetailsPage = NativeDiscussionDetailsPage(ModuleItemInteractions())
 
     override fun goToCalendar(data: MockCanvas) {
         val student = data.students[0]
@@ -68,6 +68,6 @@ class StudentCalendarInteractionTest : CalendarInteractionTest() {
     }
 
     override fun assertDiscussionDetailsTitle(title: String) {
-        discussionDetailsPage.assertTitleText(title)
+        nativeDiscussionDetailsPage.assertTitleText(title)
     }
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DiscussionDetailsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DiscussionDetailsPage.kt
@@ -70,7 +70,7 @@ class DiscussionDetailsPage(val moduleItemInteractions: ModuleItemInteractions) 
         onView(withText(discussionTitle) + withAncestor(withId(R.id.toolbar) + hasSibling(withId(R.id.discussionWebView)))).assertDisplayed()
     }
 
-    fun waitForReplyButtonDisplayed() {
+    fun waitForReplyButton() {
         waitForWebElement(
             webViewMatcher = withId(R.id.discussionWebView),
             locator = Locator.XPATH,

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DiscussionDetailsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DiscussionDetailsPage.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 - present Instructure, Inc.
+ * Copyright (C) 2024 - present Instructure, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -16,333 +16,77 @@
  */
 package com.instructure.student.ui.pages
 
-import android.os.SystemClock.sleep
-import androidx.test.espresso.Espresso
-import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions.swipeDown
-import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast
-import androidx.test.espresso.web.assertion.WebViewAssertions.webMatches
+import androidx.test.espresso.matcher.ViewMatchers.hasSibling
+import androidx.test.espresso.web.assertion.WebViewAssertions.webContent
+import androidx.test.espresso.web.matcher.DomMatchers.hasElementWithXpath
 import androidx.test.espresso.web.sugar.Web.onWebView
-import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
-import androidx.test.espresso.web.webdriver.DriverAtoms.getText
-import androidx.test.espresso.web.webdriver.DriverAtoms.webClick
 import androidx.test.espresso.web.webdriver.Locator
-import com.instructure.canvas.espresso.containsTextCaseInsensitive
-import com.instructure.canvas.espresso.isElementDisplayed
-import com.instructure.canvas.espresso.waitForMatcherWithSleeps
-import com.instructure.canvas.espresso.withCustomConstraints
-import com.instructure.canvas.espresso.withElementRepeat
-import com.instructure.canvasapi2.models.DiscussionEntry
-import com.instructure.canvasapi2.models.DiscussionTopicHeader
 import com.instructure.espresso.ModuleItemInteractions
-import com.instructure.espresso.OnViewWithId
 import com.instructure.espresso.assertDisplayed
-import com.instructure.espresso.assertGone
-import com.instructure.espresso.assertHasText
-import com.instructure.espresso.assertNotDisplayed
-import com.instructure.espresso.click
 import com.instructure.espresso.page.BasePage
+import com.instructure.espresso.page.onView
 import com.instructure.espresso.page.plus
-import com.instructure.espresso.page.waitForViewWithId
 import com.instructure.espresso.page.withAncestor
 import com.instructure.espresso.page.withId
 import com.instructure.espresso.page.withText
-import com.instructure.espresso.scrollTo
+import com.instructure.espresso.waitForWebElement
 import com.instructure.student.R
-import com.instructure.student.ui.utils.TypeInRCETextEditor
-import org.hamcrest.Matchers.allOf
-import org.hamcrest.Matchers.containsString
-import org.junit.Assert.assertTrue
+import org.junit.Assert
 
 
 class DiscussionDetailsPage(val moduleItemInteractions: ModuleItemInteractions) : BasePage(R.id.discussionDetailsPage) {
-    private val discussionTopicTitle by OnViewWithId(R.id.discussionTopicTitle)
-    private val replyButton by OnViewWithId(R.id.replyToDiscussionTopic)
 
-    fun assertTitleText(titleText: String) {
-        discussionTopicTitle.assertHasText(titleText)
+    fun assertReplyButtonDisplayed() {
+        onWebView().check(webContent(hasElementWithXpath("//button[@data-testid='discussion-topic-reply']")))
     }
 
-    fun assertDescriptionText(descriptionText: String) {
-        onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionTopicHeaderWebViewWrapper))
-            .withElement(findElement(Locator.ID, "content"))
-            .check(webMatches(getText(), containsString(descriptionText)))
-    }
-
-    fun assertTopicInfoShowing(topicHeader: DiscussionTopicHeader) {
-        assertTitleText(topicHeader.title!!)
-        assertDescriptionText(topicHeader.message!!)
-    }
-
-    fun clickLinkInDescription(linkElementId: String) {
-        onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionTopicHeaderWebViewWrapper))
-            .withElement(findElement(Locator.ID, linkElementId))
-            .perform(webClick())
-    }
-
-    fun refresh() {
-        scrollToTop()
-        onView(allOf(withId(R.id.swipeRefreshLayout), isDisplayingAtLeast(10)))
-            .perform(withCustomConstraints(swipeDown(), isDisplayingAtLeast(10)))
-    }
-
-    fun scrollToRepliesWebview() {
-        waitForMatcherWithSleeps(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper), timeout = 20000)
-        onView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper)).scrollTo()
-    }
-
-    fun clickReply() {
-        replyButton.click()
+    private fun replyButtonNotDisplayed(): Boolean {
+        return try {
+            onWebView().check(webContent(hasElementWithXpath("//button[@data-testid='discussion-topic-reply']")))
+            false
+        }
+        catch (e: AssertionError) {
+            true
+        }
     }
 
     fun assertReplyButtonNotDisplayed() {
-        replyButton.check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.GONE)))
+        Assert.assertTrue("Reply button has displayed but it should not.",replyButtonNotDisplayed())
     }
 
-    fun assertRepliesEnabled() {
-        replyButton.assertDisplayed()
+    fun assertEntryDisplayed(entryMessage: String) {
+        onWebView().check(webContent(hasElementWithXpath("//span[text()='$entryMessage']")))
     }
 
-    fun assertRepliesDisabled() {
-        replyButton.assertGone()
+    fun assertModulesToolbarDiscussionTitle(discussionTitle: String) {
+        onView(withText(discussionTitle) + withAncestor(R.id.moduleProgressionPage)).assertDisplayed()
     }
 
-    fun assertRepliesDisplayed() {
-        onView(withId(R.id.discussionTopicRepliesTitle)).scrollTo().assertDisplayed()
+    fun assertHomeroomToolbarDiscussionTitle(discussionTitle: String) {
+        onView(withText(discussionTitle) + withAncestor(R.id.toolbar) + withAncestor(R.id.fullScreenCoordinatorLayout)).assertDisplayed()
     }
 
-    fun assertNoRepliesDisplayed() {
-        onView(withId(R.id.discussionTopicRepliesTitle)).assertNotDisplayed()
+    fun assertToolbarDiscussionTitle(discussionTitle: String) {
+        onView(withText(discussionTitle) + withAncestor(withId(R.id.toolbar) + hasSibling(withId(R.id.discussionWebView)))).assertDisplayed()
     }
 
-    fun sendReply(replyMessage: String) {
-        clickReply()
-        waitForViewWithId(R.id.rce_webView).perform(TypeInRCETextEditor(replyMessage))
-        clickOnSendReplyButton()
-
-        sleep(3000) // wait out the toast message
+    fun waitForReplyButtonDisplayed() {
+        waitForWebElement(
+            webViewMatcher = withId(R.id.discussionWebView),
+            locator = Locator.XPATH,
+            value = "//button[@data-testid='discussion-topic-reply']",
+            timeoutMillis = 10000,
+            intervalMillis = 500
+        )
     }
 
-    private fun clickOnSendReplyButton() {
-        onView(withId(R.id.menu_send)).click()
-    }
-
-    fun assertReplyDisplayed(reply: DiscussionEntry, refreshesAllowed: Int = 0) {
-
-        // Allow up to refreshesAllowed attempt/refresh cycles
-        for (i in 0 until refreshesAllowed) {
-            try {
-                onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
-                    .withElement(findElement(Locator.ID, "message_content_${reply.id}"))
-                    .check(webMatches(getText(), containsString(reply.message)))
-                return
-            } catch (t: Throwable) {
-                refresh()
-            }
-        }
-
-        // If we have not yet seen the desired reply, try one more time, allowing up to
-        // 3 retries for the page to render and the reply to appear.  (Each attempt
-        // waits ~10 secs before failing.)
-        // (It can take a *long* time for the reply to get rendered to the webview on
-        // tablets (in FTL, anyway).)
-        onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
-            .withElementRepeat(findElement(Locator.ID, "message_content_${reply.id}"), 3)
-            .check(webMatches(getText(), containsString(reply.message)))
-    }
-
-    fun assertReplyDisplayed(reply: DiscussionEntry) {
-        onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
-            .withElement(findElement(Locator.TAG_NAME, "html"))
-            .check(webMatches(getText(), containsString(reply.message)))
-    }
-
-    fun assertIfThereIsAReply() {
-        onView(withId(R.id.discussionTopicRepliesTitle)).assertDisplayed()
-        onView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper)).assertDisplayed()
-    }
-
-    fun assertFavoritingEnabled(reply: DiscussionEntry) {
-        try {
-            onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
-                .withElement(findElement(Locator.CLASS_NAME, "likes_icon_wrapper_${reply.id}"))
-        } catch (t: Throwable) {
-            assertTrue("Favoriting icon is disabled", false)
-        }
-    }
-
-    fun assertFavoritingDisabled(reply: DiscussionEntry) {
-        try {
-            onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
-                .withElement(findElement(Locator.CLASS_NAME, "likes_icon_wrapper_${reply.id}"))
-            // We shouldn't reach this point if the favoriting icon is disabled -- we should throw
-            assertTrue("Favoriting icon is enabled", false)
-        } catch (_: Throwable) {}
-    }
-
-    fun clickLikeOnEntry(reply: DiscussionEntry) {
-        onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
-            .withElement(findElement(Locator.CLASS_NAME, "likes_icon_wrapper_${reply.id}"))
-            .perform(webClick())
-    }
-
-    fun assertLikeCount(reply: DiscussionEntry, count: Int, refreshesAllowed: Int = 0) {
-        if (count > 0) {
-
-            for (i in 0 until refreshesAllowed) {
-                try {
-                    onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
-                        .withElement(findElement(Locator.CLASS_NAME, "likes_count_${reply.id}"))
-                        .check(webMatches(getText(), containsString(count.toString())))
-                    return
-                } catch (t: Throwable) {
-                    refresh()
-                }
-            }
-
-            // If we haven't verified our info by now, let's make one last call to either
-            // (1) succeed or (2) throw a sensible error.
-            onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
-                .withElement(findElement(Locator.CLASS_NAME, "likes_count_${reply.id}"))
-                .check(webMatches(getText(), containsString(count.toString())))
-        } else {
-            try {
-                onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
-                    .withElement(findElement(Locator.CLASS_NAME, "likes_count_${reply.id}"))
-                assertTrue("Didn't expect to see like count with 0 count", false)
-            } catch (_: Throwable) {}
-        }
-    }
-
-    fun assertReplyAttachment(reply: DiscussionEntry) {
-        try {
-            onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
-                .withElement(findElement(Locator.CLASS_NAME, "attachments_${reply.id}"))
-        } catch (t: Throwable) {
-            assertTrue("Discussion entry did not have an attachment", false)
-        }
-    }
-
-    fun previewAndCheckReplyAttachment(reply: DiscussionEntry, vararg checks: WebViewTextCheck) {
-
-        // Sometimes clicking the attachment logo fails to do anything.
-        // We'll give it 3 chances.
-        var triesRemaining = 3;
-        while (!isElementDisplayed(R.id.canvasWebViewWrapper) && triesRemaining > 0) {
-            if (triesRemaining < 3) {
-                refresh() // Maybe web content was incorrectly rendered?  Try again
-                sleep(1500) // Allow webview some time to render
-            }
-            onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
-                .withElementRepeat(findElement(Locator.CLASS_NAME, "attachments_${reply.id}"), 20)
-                .perform(webClick())
-            triesRemaining -= 1
-        }
-
-        assertTrue("FAILED to bring up reply attachment", isElementDisplayed(R.id.canvasWebViewWrapper));
-
-        for (check in checks) {
-            onWebView(withId(R.id.contentWebView) + withAncestor(R.id.canvasWebViewWrapper))
-                .withElement(findElement(check.locatorType, check.locatorValue))
-                .check(webMatches(getText(), containsString(check.textValue)))
-        }
-        Espresso.pressBack()
-
-    }
-
-    fun replyToReply(reply: DiscussionEntry, replyMessage: String) {
-
-        // It appears that sometimes the click to reply doesn't work.
-        // Let's give it 3 chances.
-        var triesRemaining = 3
-        while (!isElementDisplayed(R.id.rce_webView) && triesRemaining > 0) {
-            if (triesRemaining < 3) {
-                refresh() // maybe the html was rendered badly and needs refreshing?
-                sleep(2000) // A little time for the webview to render
-            }
-            onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
-                .withElementRepeat(findElement(Locator.ID, "reply_${reply.id}"), 20)
-                .perform(webClick())
-            triesRemaining -= 1
-        }
-
-        assertTrue("FAILED to bring up rce / reply editor", isElementDisplayed(R.id.rce_webView));
-
-        onView(withId(R.id.rce_webView)).perform(TypeInRCETextEditor(replyMessage))
-        onView(withId(R.id.menu_send)).click()
-
-        sleep(3000) // wait out the toast message
-    }
-
-    fun assertMainAttachmentDisplayed() {
-        onView(withId(R.id.attachmentIcon)).assertDisplayed()
-    }
-
-    /**
-     * Assumes that the attachment is html
-     */
-    fun previewAndCheckMainAttachment(vararg checks: WebViewTextCheck) {
-        onView(withId(R.id.attachmentIcon)).click()
-        for (check in checks) {
-            onWebView(withId(R.id.contentWebView) + withAncestor(R.id.canvasWebViewWrapper))
-                .withElement(findElement(check.locatorType, check.locatorValue))
-                .check(webMatches(getText(), containsString(check.textValue)))
-        }
-        Espresso.pressBack()
-    }
-
-    /**
-     * It can take a *long* time (much longer than the advertised 2.5 seconds) for
-     * the unread indicator to disappear when running tests on FTL.  Rather than
-     * use an ever-increasing timeout, I figured I would just programmatically
-     * wait until the unread indicator disappeared, for up to 10 seconds.
-     *
-     * The downside is that we are relying on webview elements to not change.
-     * If that is something that happens often (or maybe even once), we will
-     * need to go back to using a timeout.
-     */
-    fun waitForUnreadIndicatorToDisappear(reply: DiscussionEntry) {
-        repeat(10) {
-            if (!isUnreadIndicatorVisible(reply)) return
-            sleep(1000)
-        }
-
-        assertTrue("Timed out waiting for unread indicator to disappear", false)
-    }
-
-    fun assertPointsPossibleDisplayed(points: String) {
-        onView(withId(R.id.pointsTextView)).check(matches(containsTextCaseInsensitive(points)))
-    }
-
-    fun assertPointsPossibleNotDisplayed() {
-        onView(withId(R.id.pointsTextView)).assertNotDisplayed()
-    }
-
-    fun clickOnInnerReply() {
-        onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
-            .withElement(findElement(Locator.XPATH, "//div[@class='reply_wrapper' and contains(@id, 'reply')]"))
-            .perform(webClick())
-    }
-
-    fun clickOnAddBookmarkMenu() {
-        onView(withText("Add Bookmark")).click()
-    }
-
-    private fun isUnreadIndicatorVisible(reply: DiscussionEntry): Boolean {
-        return try {
-            onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
-                .withElement(findElement(Locator.ID, "unread_indicator_${reply.id}"))
-                .withElement(findElement(Locator.CLASS_NAME, "unread"))
-            true
-        } catch (t: Throwable) {
-            false
-        }
-    }
-
-    private fun scrollToTop() {
-        onView(allOf(withId(R.id.swipeRefreshLayout), isDisplayingAtLeast(10)))
-            .perform(withCustomConstraints(swipeDown(), isDisplayingAtLeast(10)))
+    fun waitForEntryDisplayed(entryMessage: String) {
+        waitForWebElement(
+            webViewMatcher = withId(R.id.discussionWebView),
+            locator = Locator.XPATH,
+            value = "//span[text()='$entryMessage']",
+            timeoutMillis = 10000,
+            intervalMillis = 500
+        )
     }
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/offline/NativeDiscussionDetailsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/offline/NativeDiscussionDetailsPage.kt
@@ -1,0 +1,349 @@
+/*
+ * Copyright (C) 2019 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.instructure.student.ui.pages.offline
+
+import android.os.SystemClock.sleep
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.swipeDown
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast
+import androidx.test.espresso.web.assertion.WebViewAssertions.webMatches
+import androidx.test.espresso.web.sugar.Web.onWebView
+import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
+import androidx.test.espresso.web.webdriver.DriverAtoms.getText
+import androidx.test.espresso.web.webdriver.DriverAtoms.webClick
+import androidx.test.espresso.web.webdriver.Locator
+import com.instructure.canvas.espresso.containsTextCaseInsensitive
+import com.instructure.canvas.espresso.isElementDisplayed
+import com.instructure.canvas.espresso.waitForMatcherWithSleeps
+import com.instructure.canvas.espresso.withCustomConstraints
+import com.instructure.canvas.espresso.withElementRepeat
+import com.instructure.canvasapi2.models.DiscussionEntry
+import com.instructure.canvasapi2.models.DiscussionTopicHeader
+import com.instructure.espresso.ModuleItemInteractions
+import com.instructure.espresso.OnViewWithId
+import com.instructure.espresso.assertDisplayed
+import com.instructure.espresso.assertGone
+import com.instructure.espresso.assertHasText
+import com.instructure.espresso.assertNotDisplayed
+import com.instructure.espresso.click
+import com.instructure.espresso.page.BasePage
+import com.instructure.espresso.page.plus
+import com.instructure.espresso.page.waitForViewWithId
+import com.instructure.espresso.page.withAncestor
+import com.instructure.espresso.page.withId
+import com.instructure.espresso.page.withText
+import com.instructure.espresso.scrollTo
+import com.instructure.student.R
+import com.instructure.student.ui.pages.WebViewTextCheck
+import com.instructure.student.ui.utils.TypeInRCETextEditor
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.containsString
+import org.junit.Assert.assertTrue
+
+
+class NativeDiscussionDetailsPage(val moduleItemInteractions: ModuleItemInteractions) : BasePage(R.id.discussionDetailsPage) {
+    private val discussionTopicTitle by OnViewWithId(R.id.discussionTopicTitle)
+    private val replyButton by OnViewWithId(R.id.replyToDiscussionTopic)
+
+    fun assertTitleText(titleText: String) {
+        discussionTopicTitle.assertHasText(titleText)
+    }
+
+    fun assertDescriptionText(descriptionText: String) {
+        onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionTopicHeaderWebViewWrapper))
+            .withElement(findElement(Locator.ID, "content"))
+            .check(webMatches(getText(), containsString(descriptionText)))
+    }
+
+    fun assertTopicInfoShowing(topicHeader: DiscussionTopicHeader) {
+        assertTitleText(topicHeader.title!!)
+        assertDescriptionText(topicHeader.message!!)
+    }
+
+    fun clickLinkInDescription(linkElementId: String) {
+        onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionTopicHeaderWebViewWrapper))
+            .withElement(findElement(Locator.ID, linkElementId))
+            .perform(webClick())
+    }
+
+    fun refresh() {
+        scrollToTop()
+        onView(allOf(withId(R.id.swipeRefreshLayout), isDisplayingAtLeast(10)))
+            .perform(withCustomConstraints(swipeDown(), isDisplayingAtLeast(10)))
+    }
+
+    fun scrollToRepliesWebview() {
+        waitForMatcherWithSleeps(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper), timeout = 20000)
+        onView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper)).scrollTo()
+    }
+
+    fun clickReply() {
+        replyButton.click()
+    }
+
+    fun assertReplyButtonNotDisplayed() {
+        replyButton.check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.GONE)))
+    }
+
+    fun assertRepliesEnabled() {
+        replyButton.assertDisplayed()
+    }
+
+    fun assertRepliesDisabled() {
+        replyButton.assertGone()
+    }
+
+    fun assertRepliesDisplayed() {
+        onView(withId(R.id.discussionTopicRepliesTitle)).scrollTo().assertDisplayed()
+    }
+
+    fun assertNoRepliesDisplayed() {
+        onView(withId(R.id.discussionTopicRepliesTitle)).assertNotDisplayed()
+    }
+
+    fun sendReply(replyMessage: String) {
+        clickReply()
+        waitForViewWithId(R.id.rce_webView).perform(TypeInRCETextEditor(replyMessage))
+        clickOnSendReplyButton()
+
+        sleep(3000) // wait out the toast message
+    }
+
+    private fun clickOnSendReplyButton() {
+        onView(withId(R.id.menu_send)).click()
+    }
+
+    fun assertReplyDisplayed(reply: DiscussionEntry, refreshesAllowed: Int = 0) {
+
+        // Allow up to refreshesAllowed attempt/refresh cycles
+        for (i in 0 until refreshesAllowed) {
+            try {
+                onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
+                    .withElement(findElement(Locator.ID, "message_content_${reply.id}"))
+                    .check(webMatches(getText(), containsString(reply.message)))
+                return
+            } catch (t: Throwable) {
+                refresh()
+            }
+        }
+
+        // If we have not yet seen the desired reply, try one more time, allowing up to
+        // 3 retries for the page to render and the reply to appear.  (Each attempt
+        // waits ~10 secs before failing.)
+        // (It can take a *long* time for the reply to get rendered to the webview on
+        // tablets (in FTL, anyway).)
+        onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
+            .withElementRepeat(findElement(Locator.ID, "message_content_${reply.id}"), 3)
+            .check(webMatches(getText(), containsString(reply.message)))
+    }
+
+    fun assertReplyDisplayed(reply: DiscussionEntry) {
+        onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
+            .withElement(findElement(Locator.TAG_NAME, "html"))
+            .check(webMatches(getText(), containsString(reply.message)))
+    }
+
+    fun assertIfThereIsAReply() {
+        onView(withId(R.id.discussionTopicRepliesTitle)).assertDisplayed()
+        onView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper)).assertDisplayed()
+    }
+
+    fun assertFavoritingEnabled(reply: DiscussionEntry) {
+        try {
+            onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
+                .withElement(findElement(Locator.CLASS_NAME, "likes_icon_wrapper_${reply.id}"))
+        } catch (t: Throwable) {
+            assertTrue("Favoriting icon is disabled", false)
+        }
+    }
+
+    fun assertFavoritingDisabled(reply: DiscussionEntry) {
+        try {
+            onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
+                .withElement(findElement(Locator.CLASS_NAME, "likes_icon_wrapper_${reply.id}"))
+            // We shouldn't reach this point if the favoriting icon is disabled -- we should throw
+            assertTrue("Favoriting icon is enabled", false)
+        } catch (_: Throwable) {}
+    }
+
+    fun clickLikeOnEntry(reply: DiscussionEntry) {
+        onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
+            .withElement(findElement(Locator.CLASS_NAME, "likes_icon_wrapper_${reply.id}"))
+            .perform(webClick())
+    }
+
+    fun assertLikeCount(reply: DiscussionEntry, count: Int, refreshesAllowed: Int = 0) {
+        if (count > 0) {
+
+            for (i in 0 until refreshesAllowed) {
+                try {
+                    onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
+                        .withElement(findElement(Locator.CLASS_NAME, "likes_count_${reply.id}"))
+                        .check(webMatches(getText(), containsString(count.toString())))
+                    return
+                } catch (t: Throwable) {
+                    refresh()
+                }
+            }
+
+            // If we haven't verified our info by now, let's make one last call to either
+            // (1) succeed or (2) throw a sensible error.
+            onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
+                .withElement(findElement(Locator.CLASS_NAME, "likes_count_${reply.id}"))
+                .check(webMatches(getText(), containsString(count.toString())))
+        } else {
+            try {
+                onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
+                    .withElement(findElement(Locator.CLASS_NAME, "likes_count_${reply.id}"))
+                assertTrue("Didn't expect to see like count with 0 count", false)
+            } catch (_: Throwable) {}
+        }
+    }
+
+    fun assertReplyAttachment(reply: DiscussionEntry) {
+        try {
+            onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
+                .withElement(findElement(Locator.CLASS_NAME, "attachments_${reply.id}"))
+        } catch (t: Throwable) {
+            assertTrue("Discussion entry did not have an attachment", false)
+        }
+    }
+
+    fun previewAndCheckReplyAttachment(reply: DiscussionEntry, vararg checks: WebViewTextCheck) {
+
+        // Sometimes clicking the attachment logo fails to do anything.
+        // We'll give it 3 chances.
+        var triesRemaining = 3;
+        while (!isElementDisplayed(R.id.canvasWebViewWrapper) && triesRemaining > 0) {
+            if (triesRemaining < 3) {
+                refresh() // Maybe web content was incorrectly rendered?  Try again
+                sleep(1500) // Allow webview some time to render
+            }
+            onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
+                .withElementRepeat(findElement(Locator.CLASS_NAME, "attachments_${reply.id}"), 20)
+                .perform(webClick())
+            triesRemaining -= 1
+        }
+
+        assertTrue("FAILED to bring up reply attachment", isElementDisplayed(R.id.canvasWebViewWrapper));
+
+        for (check in checks) {
+            onWebView(withId(R.id.contentWebView) + withAncestor(R.id.canvasWebViewWrapper))
+                .withElement(findElement(check.locatorType, check.locatorValue))
+                .check(webMatches(getText(), containsString(check.textValue)))
+        }
+        Espresso.pressBack()
+
+    }
+
+    fun replyToReply(reply: DiscussionEntry, replyMessage: String) {
+
+        // It appears that sometimes the click to reply doesn't work.
+        // Let's give it 3 chances.
+        var triesRemaining = 3
+        while (!isElementDisplayed(R.id.rce_webView) && triesRemaining > 0) {
+            if (triesRemaining < 3) {
+                refresh() // maybe the html was rendered badly and needs refreshing?
+                sleep(2000) // A little time for the webview to render
+            }
+            onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
+                .withElementRepeat(findElement(Locator.ID, "reply_${reply.id}"), 20)
+                .perform(webClick())
+            triesRemaining -= 1
+        }
+
+        assertTrue("FAILED to bring up rce / reply editor", isElementDisplayed(R.id.rce_webView));
+
+        onView(withId(R.id.rce_webView)).perform(TypeInRCETextEditor(replyMessage))
+        onView(withId(R.id.menu_send)).click()
+
+        sleep(3000) // wait out the toast message
+    }
+
+    fun assertMainAttachmentDisplayed() {
+        onView(withId(R.id.attachmentIcon)).assertDisplayed()
+    }
+
+    /**
+     * Assumes that the attachment is html
+     */
+    fun previewAndCheckMainAttachment(vararg checks: WebViewTextCheck) {
+        onView(withId(R.id.attachmentIcon)).click()
+        for (check in checks) {
+            onWebView(withId(R.id.contentWebView) + withAncestor(R.id.canvasWebViewWrapper))
+                .withElement(findElement(check.locatorType, check.locatorValue))
+                .check(webMatches(getText(), containsString(check.textValue)))
+        }
+        Espresso.pressBack()
+    }
+
+    /**
+     * It can take a *long* time (much longer than the advertised 2.5 seconds) for
+     * the unread indicator to disappear when running tests on FTL.  Rather than
+     * use an ever-increasing timeout, I figured I would just programmatically
+     * wait until the unread indicator disappeared, for up to 10 seconds.
+     *
+     * The downside is that we are relying on webview elements to not change.
+     * If that is something that happens often (or maybe even once), we will
+     * need to go back to using a timeout.
+     */
+    fun waitForUnreadIndicatorToDisappear(reply: DiscussionEntry) {
+        repeat(10) {
+            if (!isUnreadIndicatorVisible(reply)) return
+            sleep(1000)
+        }
+
+        assertTrue("Timed out waiting for unread indicator to disappear", false)
+    }
+
+    fun assertPointsPossibleDisplayed(points: String) {
+        onView(withId(R.id.pointsTextView)).check(matches(containsTextCaseInsensitive(points)))
+    }
+
+    fun assertPointsPossibleNotDisplayed() {
+        onView(withId(R.id.pointsTextView)).assertNotDisplayed()
+    }
+
+    fun clickOnInnerReply() {
+        onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
+            .withElement(findElement(Locator.XPATH, "//div[@class='reply_wrapper' and contains(@id, 'reply')]"))
+            .perform(webClick())
+    }
+
+    fun clickOnAddBookmarkMenu() {
+        onView(withText("Add Bookmark")).click()
+    }
+
+    private fun isUnreadIndicatorVisible(reply: DiscussionEntry): Boolean {
+        return try {
+            onWebView(withId(R.id.contentWebView) + withAncestor(R.id.discussionRepliesWebViewWrapper))
+                .withElement(findElement(Locator.ID, "unread_indicator_${reply.id}"))
+                .withElement(findElement(Locator.CLASS_NAME, "unread"))
+            true
+        } catch (t: Throwable) {
+            false
+        }
+    }
+
+    private fun scrollToTop() {
+        onView(allOf(withId(R.id.swipeRefreshLayout), isDisplayingAtLeast(10)))
+            .perform(withCustomConstraints(swipeDown(), isDisplayingAtLeast(10)))
+    }
+}

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTest.kt
@@ -53,7 +53,6 @@ import com.instructure.student.ui.pages.ConferenceListPage
 import com.instructure.student.ui.pages.CourseBrowserPage
 import com.instructure.student.ui.pages.CourseGradesPage
 import com.instructure.student.ui.pages.DashboardPage
-import com.instructure.student.ui.pages.DiscussionDetailsPage
 import com.instructure.student.ui.pages.DiscussionListPage
 import com.instructure.student.ui.pages.ElementaryCoursePage
 import com.instructure.student.ui.pages.ElementaryDashboardPage
@@ -99,6 +98,7 @@ import com.instructure.student.ui.pages.TextSubmissionUploadPage
 import com.instructure.student.ui.pages.TodoPage
 import com.instructure.student.ui.pages.UrlSubmissionUploadPage
 import com.instructure.student.ui.pages.offline.ManageOfflineContentPage
+import com.instructure.student.ui.pages.offline.NativeDiscussionDetailsPage
 import com.instructure.student.ui.pages.offline.OfflineSyncSettingsPage
 import com.instructure.student.ui.pages.offline.SyncProgressPage
 import instructure.rceditor.RCETextEditor
@@ -132,7 +132,8 @@ abstract class StudentTest : CanvasTest() {
     val courseGradesPage = CourseGradesPage()
     val dashboardPage = DashboardPage()
     val leftSideNavigationDrawerPage = LeftSideNavigationDrawerPage()
-    val discussionDetailsPage = DiscussionDetailsPage(ModuleItemInteractions(R.id.moduleName, R.id.next_item, R.id.prev_item))
+    val discussionDetailsPage = com.instructure.student.ui.pages.DiscussionDetailsPage(ModuleItemInteractions(R.id.moduleName, R.id.next_item, R.id.prev_item))
+    val nativeDiscussionDetailsPage = NativeDiscussionDetailsPage(ModuleItemInteractions(R.id.moduleName, R.id.next_item, R.id.prev_item))
     val discussionListPage = DiscussionListPage(Searchable(R.id.search, R.id.search_src_text, R.id.search_close_btn))
     val allCoursesPage = AllCoursesPage()
     val fileListPage = FileListPage(Searchable(R.id.search, R.id.queryInput, R.id.clearButton, R.id.backButton))

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/TeacherCalendarPageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/TeacherCalendarPageTest.kt
@@ -24,7 +24,7 @@ import com.instructure.teacher.BuildConfig
 import com.instructure.teacher.activities.LoginActivity
 import com.instructure.teacher.ui.pages.AssignmentDetailsPage
 import com.instructure.teacher.ui.pages.DashboardPage
-import com.instructure.teacher.ui.pages.DiscussionsDetailsPage
+import com.instructure.teacher.ui.pages.NativeDiscussionsDetailsPage
 import com.instructure.teacher.ui.utils.TeacherActivityTestRule
 import com.instructure.teacher.ui.utils.tokenLogin
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -38,7 +38,7 @@ class TeacherCalendarPageTest : CalendarInteractionTest() {
 
     private val dashboardPage = DashboardPage()
     private val assignmentDetailsPage = AssignmentDetailsPage(ModuleItemInteractions())
-    private val discussionDetailsPage = DiscussionsDetailsPage(ModuleItemInteractions())
+    private val discussionDetailsPage = NativeDiscussionsDetailsPage(ModuleItemInteractions())
 
     override fun goToCalendar(data: MockCanvas) {
         val teacher = data.teachers[0]

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/AnnouncementsE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/AnnouncementsE2ETest.kt
@@ -38,7 +38,7 @@ class AnnouncementsE2ETest : TeacherTest() {
     override fun enableAndConfigureAccessibilityChecks() = Unit
 
     //Because of naming conventions, we are using 'announcementDetailsPage' naming in this class to make the code more readable and straightforward.
-    private val announcementDetailsPage = nativeDiscussionsDetailsPage
+    private val announcementDetailsPage = discussionDetailsPage
 
     @E2E
     @Test
@@ -56,10 +56,10 @@ class AnnouncementsE2ETest : TeacherTest() {
         tokenLogin(teacher)
         dashboardPage.waitForRender()
 
-        Log.d(STEP_TAG,"Assert ${course.name} course is displayed.")
+        Log.d(STEP_TAG, "Assert ${course.name} course is displayed.")
         dashboardPage.assertDisplaysCourse(course)
 
-        Log.d(STEP_TAG,"Open ${course.name} course and navigate to it's Announcements Page. Assert that the ${announcement.title} announcement has been displayed.")
+        Log.d(STEP_TAG, "Open ${course.name} course and navigate to it's Announcements Page. Assert that the ${announcement.title} announcement has been displayed.")
         dashboardPage.openCourse(course.name)
         courseBrowserPage.openAnnouncementsTab()
         announcementsListPage.assertHasAnnouncement(announcement)
@@ -76,40 +76,31 @@ class AnnouncementsE2ETest : TeacherTest() {
         announcementsListPage.searchable.clickOnClearSearchButton()
         announcementsListPage.assertSearchResultCount(2)
 
-        Log.d(STEP_TAG,"Open the '${announcement.title}' announcement. Assert that it's title is displayed on the (web view) page's toolbar title and the 'Reply' button is also displayed.")
+        Log.d(STEP_TAG, "Open the '${announcement.title}' announcement. Assert that it's title is displayed on the (web view) page's toolbar title and the 'Reply' button is also displayed.")
         announcementsListPage.clickAnnouncement(announcement)
-        discussionDetailsPage.assertToolbarDiscussionTitle(announcement.title)
-        discussionDetailsPage.waitForReplyButtonDisplayed()
-        discussionDetailsPage.assertReplyButtonDisplayed()
+        announcementDetailsPage.assertToolbarDiscussionTitle(announcement.title)
+        announcementDetailsPage.waitForReplyButtonDisplayed()
+        announcementDetailsPage.assertReplyButtonDisplayed()
 
-        discussionDetailsPage.clickOnDiscussionMoreMenu()
-        discussionDetailsPage.editDiscussion("Haha")
+        Log.d(STEP_TAG, "Click on the more menu of the announcement and assert if the more menu items are all displayed.")
+        announcementDetailsPage.clickOnDiscussionMoreMenu()
+        announcementDetailsPage.assertMoreMenuButtonDisplayed("Mark All as Read")
+        announcementDetailsPage.assertMoreMenuButtonDisplayed("Mark All as Unread")
+        announcementDetailsPage.assertMoreMenuButtonDisplayed("Edit")
+        announcementDetailsPage.assertMoreMenuButtonDisplayed("Delete")
+        announcementDetailsPage.assertMoreMenuButtonDisplayed("Send To...")
+        announcementDetailsPage.assertMoreMenuButtonDisplayed("Copy To...")
+        announcementDetailsPage.assertMoreMenuButtonDisplayed("Share to Commons")
 
-        Log.d(STEP_TAG,"Navigate back to the Announcements Page. Refresh the page and assert that the announcement name has been changed to 'Haha'.")
+        Log.d(STEP_TAG, "Navigate back to the Announcement List Page.")
         Espresso.pressBack()
-        announcementsListPage.refresh()
-        announcementsListPage.assertHasAnnouncement("Haha")
 
-        Log.d(STEP_TAG,"Delete the 'Haha' titled announcement.")
-        announcementsListPage.clickAnnouncement("Haha")
-        announcementDetailsPage.openEdit()
-        editAnnouncementDetailsPage.deleteAnnouncement()
-
-        Log.d(STEP_TAG, "Click on ${announcement2.title} announcement and delete it.")
-        announcementsListPage.clickAnnouncement(announcement2.title)
-        announcementDetailsPage.openEdit()
-        editAnnouncementDetailsPage.deleteAnnouncement()
-
-        Log.d(STEP_TAG,"Refresh the Announcements List Page and assert that there is no announcement displayed. Assert that only 1 announcement left because we just deleted the other one.")
-        announcementsListPage.refresh()
-        announcementsListPage.assertAnnouncementCount(1)
-
-        Log.d(STEP_TAG,"Create a new valid announcement.")
+        Log.d(STEP_TAG, "Create a new valid announcement.")
         announcementsListPage.createAnnouncement(announcementName = "I am an announcement", announcementDetails = "I am the detail")
 
-        Log.d(STEP_TAG,"Refresh the Announcements Page and assert that the previously created announcement is displayed. Assert that there are 2 announcements displayed on the Announcement List Page.")
+        Log.d(STEP_TAG, "Refresh the Announcements Page and assert that the previously created announcement is displayed. Assert that there are 3 announcements displayed on the Announcement List Page.")
         announcementsListPage.refresh()
         announcementsListPage.assertHasAnnouncement("I am an announcement")
-        announcementsListPage.assertAnnouncementCount(1)
+        announcementsListPage.assertSearchResultCount(3)
     }
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/AnnouncementsE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/AnnouncementsE2ETest.kt
@@ -38,7 +38,7 @@ class AnnouncementsE2ETest : TeacherTest() {
     override fun enableAndConfigureAccessibilityChecks() = Unit
 
     //Because of naming conventions, we are using 'announcementDetailsPage' naming in this class to make the code more readable and straightforward.
-    private val announcementDetailsPage = discussionsDetailsPage
+    private val announcementDetailsPage = nativeDiscussionsDetailsPage
 
     @E2E
     @Test
@@ -76,11 +76,14 @@ class AnnouncementsE2ETest : TeacherTest() {
         announcementsListPage.searchable.clickOnClearSearchButton()
         announcementsListPage.assertSearchResultCount(2)
 
-        Log.d(STEP_TAG,"Edit ${announcement.title} announcement's name to 'Haha'. Save the modifications.")
+        Log.d(STEP_TAG,"Open the '${announcement.title}' announcement. Assert that it's title is displayed on the (web view) page's toolbar title and the 'Reply' button is also displayed.")
         announcementsListPage.clickAnnouncement(announcement)
-        announcementDetailsPage.openEdit()
-        editAnnouncementDetailsPage.editAnnouncementTitle("Haha")
-        editAnnouncementDetailsPage.saveAnnouncement()
+        discussionDetailsPage.assertToolbarDiscussionTitle(announcement.title)
+        discussionDetailsPage.waitForReplyButtonDisplayed()
+        discussionDetailsPage.assertReplyButtonDisplayed()
+
+        discussionDetailsPage.clickOnDiscussionMoreMenu()
+        discussionDetailsPage.editDiscussion("Haha")
 
         Log.d(STEP_TAG,"Navigate back to the Announcements Page. Refresh the page and assert that the announcement name has been changed to 'Haha'.")
         Espresso.pressBack()
@@ -92,20 +95,21 @@ class AnnouncementsE2ETest : TeacherTest() {
         announcementDetailsPage.openEdit()
         editAnnouncementDetailsPage.deleteAnnouncement()
 
-        Log.d(STEP_TAG, "")
+        Log.d(STEP_TAG, "Click on ${announcement2.title} announcement and delete it.")
         announcementsListPage.clickAnnouncement(announcement2.title)
         announcementDetailsPage.openEdit()
         editAnnouncementDetailsPage.deleteAnnouncement()
 
-        Log.d(STEP_TAG,"Refresh the Announcements Page and assert that there is no announcement displayed. Assert that empty view is displayed.")
+        Log.d(STEP_TAG,"Refresh the Announcements List Page and assert that there is no announcement displayed. Assert that only 1 announcement left because we just deleted the other one.")
         announcementsListPage.refresh()
-        announcementsListPage.assertEmpty()
+        announcementsListPage.assertAnnouncementCount(1)
 
         Log.d(STEP_TAG,"Create a new valid announcement.")
         announcementsListPage.createAnnouncement(announcementName = "I am an announcement", announcementDetails = "I am the detail")
 
-        Log.d(STEP_TAG,"Refresh the Announcements Page and assert that the previously created announcement is displayed.")
+        Log.d(STEP_TAG,"Refresh the Announcements Page and assert that the previously created announcement is displayed. Assert that there are 2 announcements displayed on the Announcement List Page.")
         announcementsListPage.refresh()
         announcementsListPage.assertHasAnnouncement("I am an announcement")
+        announcementsListPage.assertAnnouncementCount(1)
     }
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/DiscussionsE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/DiscussionsE2ETest.kt
@@ -63,7 +63,7 @@ class DiscussionsE2ETest : TeacherTest() {
 
         Log.d(STEP_TAG,"Click on '${discussion.title}' discussion and navigate to Discussions Details Page by clicking on 'Edit'.")
         discussionsListPage.clickDiscussion(discussion)
-        discussionsDetailsPage.openEdit()
+        nativeDiscussionsDetailsPage.openEdit()
 
         val newTitle = "New Discussion"
         Log.d(STEP_TAG,"Edit the discussion's title to: '$newTitle'. Click on 'Save'.")
@@ -71,18 +71,18 @@ class DiscussionsE2ETest : TeacherTest() {
         editDiscussionsDetailsPage.saveDiscussion()
 
         Log.d(STEP_TAG,"Refresh the page. Assert that the discussion's name has been changed to '$newTitle' and it is published.")
-        discussionsDetailsPage.refresh()
-        discussionsDetailsPage.assertDiscussionTitle(newTitle)
-        discussionsDetailsPage.assertDiscussionPublished()
+        nativeDiscussionsDetailsPage.refresh()
+        nativeDiscussionsDetailsPage.assertDiscussionTitle(newTitle)
+        nativeDiscussionsDetailsPage.assertDiscussionPublished()
 
         Log.d(STEP_TAG,"Navigate to Discussions Details Page by clicking on 'Edit'. Unpublish the '$newTitle' discussion and click on 'Save'.")
-        discussionsDetailsPage.openEdit()
+        nativeDiscussionsDetailsPage.openEdit()
         editDiscussionsDetailsPage.togglePublished()
         editDiscussionsDetailsPage.saveDiscussion()
 
         Log.d(STEP_TAG,"Refresh the page. Assert that the '$newTitle' discussion has been unpublished.")
-        discussionsDetailsPage.refresh()
-        discussionsDetailsPage.assertDiscussionUnpublished()
+        nativeDiscussionsDetailsPage.refresh()
+        nativeDiscussionsDetailsPage.assertDiscussionUnpublished()
 
         Log.d(STEP_TAG, "Navigate back to Discussion List Page. Select 'Pin' overflow menu of '${discussion2.title}' discussion and assert that it has became Pinned.")
         Espresso.pressBack()
@@ -97,7 +97,7 @@ class DiscussionsE2ETest : TeacherTest() {
 
         Log.d(STEP_TAG,"Navigate to Discussions Details Page by clicking on 'Edit'. Delete the '$newTitle' discussion.")
         discussionsListPage.clickDiscussion(newTitle)
-        discussionsDetailsPage.openEdit()
+        nativeDiscussionsDetailsPage.openEdit()
         editDiscussionsDetailsPage.deleteDiscussion()
 
         Log.d(STEP_TAG,"Navigate to Discussions Details Page by clicking on 'Edit'. Delete the '${discussion2.title}' discussion via the overflow menu.")
@@ -122,7 +122,7 @@ class DiscussionsE2ETest : TeacherTest() {
         Log.d(STEP_TAG,"Assert that '$newDiscussionTitle' discussion is displayed and published.")
         discussionsListPage.assertHasDiscussion(newDiscussionTitle)
         discussionsListPage.clickDiscussion(newDiscussionTitle)
-        discussionsDetailsPage.assertDiscussionPublished()
+        nativeDiscussionsDetailsPage.assertDiscussionPublished()
         Espresso.pressBack()
 
         Log.d(STEP_TAG,"Click on the Search icon and type some search query string which matches only with the previously created discussion's title.")

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/ModulesE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/ModulesE2ETest.kt
@@ -149,15 +149,14 @@ class   ModulesE2ETest : TeacherComposeTest() {
         editPageDetailsPage.moduleItemInteractions.assertPreviousArrowDisplayed()
         editPageDetailsPage.moduleItemInteractions.assertNextArrowDisplayed()
 
-        Log.d(STEP_TAG, "Click on the next arrow button and assert that the '${discussionTopic.title}' discussion module item's details page is displayed. Assert that the module name is displayed at the bottom.")
+        Log.d(STEP_TAG, "Click on the next arrow button and assert that the '${discussionTopic.title}' discussion module item's details (web view) page is displayed. Assert that the module name is displayed at the bottom.")
         editPageDetailsPage.moduleItemInteractions.clickOnNextArrow()
-        discussionsDetailsPage.assertDiscussionTitle(discussionTopic.title)
-        discussionsDetailsPage.assertDiscussionPublished()
-        discussionsDetailsPage.moduleItemInteractions.assertModuleNameDisplayed(module.name)
+        discussionDetailsPage.assertToolbarDiscussionTitle(discussionTopic.title)
+        discussionDetailsPage.moduleItemInteractions.assertModuleNameDisplayed(module.name)
 
         Log.d(STEP_TAG, "Assert that the next arrow button is not displayed because the user is on the last assignment's details page, but the previous arrow button is displayed.")
-        discussionsDetailsPage.moduleItemInteractions.assertPreviousArrowDisplayed()
-        discussionsDetailsPage.moduleItemInteractions.assertNextArrowNotDisplayed()
+        discussionDetailsPage.moduleItemInteractions.assertPreviousArrowDisplayed()
+        discussionDetailsPage.moduleItemInteractions.assertNextArrowNotDisplayed()
 
         Log.d(STEP_TAG, "Click on the previous arrow button and assert that the '${testPage.title}' page module item's details page is displayed. Assert that the module name is displayed at the bottom.")
         quizDetailsPage.moduleItemInteractions.clickOnPreviousArrow()

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/DiscussionsDetailsPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/DiscussionsDetailsPage.kt
@@ -19,7 +19,6 @@ package com.instructure.teacher.ui.pages
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.web.assertion.WebViewAssertions
 import androidx.test.espresso.web.matcher.DomMatchers
-import androidx.test.espresso.web.model.Atoms
 import androidx.test.espresso.web.sugar.Web
 import androidx.test.espresso.web.webdriver.DriverAtoms
 import androidx.test.espresso.web.webdriver.DriverAtoms.webClick
@@ -34,7 +33,6 @@ import com.instructure.espresso.page.withId
 import com.instructure.espresso.page.withText
 import com.instructure.espresso.waitForWebElement
 import com.instructure.teacher.R
-import org.junit.Assert
 
 class DiscussionsDetailsPage(val moduleItemInteractions: ModuleItemInteractions) : BasePage() {
 
@@ -49,104 +47,9 @@ class DiscussionsDetailsPage(val moduleItemInteractions: ModuleItemInteractions)
             .perform(webClick())
     }
 
-    fun editDiscussion(newTitle: String) {
+    fun assertMoreMenuButtonDisplayed(menuText: String) {
         Web.onWebView()
-            .withElement(DriverAtoms.findElement(Locator.XPATH, "//ul[@role='menu']//span[text()='Edit']"))
-            .perform(webClick())
-
-        waitForWebElement(
-            webViewMatcher = withId(R.id.canvasWebView),
-            locator = Locator.XPATH,
-            value = "//input[@placeholder='Topic Title']",
-            timeoutMillis = 10000,
-            intervalMillis = 500
-        )
-
-        /*Web.onWebView()
-            .withElement(DriverAtoms.findElement(Locator.XPATH, "//input[@placeholder='Topic Title']"))
-            .perform(Atoms.script("arguments[1].focus();"))  // Focus on the input field using JavaScript
-          //  .perform(webKeys(CharArray(100) { '\b' }.joinToString("")))
-            .perform(Atoms.script("arguments[1].value = '$newTitle'"))
-        //  .perform(Atoms.script("arguments[0].value = ''")) //This clears the previous value so that's why we need it.*/
-
-    /*    Web.onWebView()
-            .withElement(DriverAtoms.findElement(Locator.XPATH, "//input[@placeholder='Topic Title']"))
-            .perform(Atoms.script("""
-        const input = arguments[0];
-        input.value = '';
-        input.dispatchEvent(new Event('input', { bubbles: true }));
-        input.dispatchEvent(new Event('change', { bubbles: true }));
-        input.blur();
-        arguments[0].focus();
-        input.value = '$newTitle';  // Directly inject the new title
-        input.dispatchEvent(new Event('input', { bubbles: true }));
-        input.dispatchEvent(new Event('change', { bubbles: true }));
-        input.blur();
-    """))*/
-
-
-        Web.onWebView()
-            .withElement(DriverAtoms.findElement(Locator.XPATH, "//input[@placeholder='Topic Title']"))
-            .perform(Atoms.script("""
-        function updateInputValue(input, newValue) {
-            input.focus();
-            input.value = '';
-            input.dispatchEvent(new Event('input', { bubbles: true }));
-
-            function typeCharacter(index) {
-                if (index < newValue.length) {
-                    input.value += newValue[index];
-                    input.dispatchEvent(new Event('input', { bubbles: true }));
-                    setTimeout(() => typeCharacter(index + 1), 500);
-                } else {
-                    input.dispatchEvent(new Event('change', { bubbles: true }));
-                    input.blur();
-                }
-            }
-
-            typeCharacter(0);
-        }
-        updateInputValue(arguments[0], "$newTitle");
-    """))
-
-
-        /*  Web.onWebView()
-              .withElement(DriverAtoms.findElement(Locator.XPATH, "//input[@placeholder='Topic Title']"))
-              .perform(Atoms.script("arguments[0].focus()"))  // Focus the input
-
-          Web.onWebView()
-              .withElement(DriverAtoms.findElement(Locator.XPATH, "//input[@placeholder='Topic Title']"))
-              .perform(webKeys(CharArray(100) { '\b' }.joinToString("")))  // Clear input field with backspaces
-
-          Web.onWebView()
-              .withElement(DriverAtoms.findElement(Locator.XPATH, "//input[@placeholder='Topic Title']"))
-              .perform(webKeys(newTitle))  // Type the new title
-  */
-        Web.onWebView()
-            .withElement(DriverAtoms.findElement(Locator.XPATH, "//button[@data-testid='announcement-submit-button']"))
-            .perform(webClick())
-
-        print("asd")
-    }
-
-    private fun replyButtonNotDisplayed(): Boolean {
-        return try {
-            Web.onWebView()
-                .check(WebViewAssertions.webContent(DomMatchers.hasElementWithXpath("//button[@data-testid='discussion-topic-reply']")))
-            false
-        }
-        catch (e: AssertionError) {
-            true
-        }
-    }
-
-    fun assertReplyButtonNotDisplayed() {
-        Assert.assertTrue("Reply button has displayed but it should not.",replyButtonNotDisplayed())
-    }
-
-    fun assertEntryDisplayed(entryMessage: String) {
-        Web.onWebView()
-            .check(WebViewAssertions.webContent(DomMatchers.hasElementWithXpath("//span[text()='$entryMessage']")))
+            .check(WebViewAssertions.webContent(DomMatchers.hasElementWithXpath("//ul[@role='menu']//span[text()='$menuText']")))
     }
 
     fun assertToolbarDiscussionTitle(discussionTitle: String) {
@@ -161,16 +64,6 @@ class DiscussionsDetailsPage(val moduleItemInteractions: ModuleItemInteractions)
             webViewMatcher = withId(R.id.discussionWebView),
             locator = Locator.XPATH,
             value = "//button[@data-testid='discussion-topic-reply']",
-            timeoutMillis = 10000,
-            intervalMillis = 500
-        )
-    }
-
-    fun waitForEntryDisplayed(entryMessage: String) {
-        waitForWebElement(
-            webViewMatcher = withId(R.id.discussionWebView),
-            locator = Locator.XPATH,
-            value = "//span[text()='$entryMessage']",
             timeoutMillis = 10000,
             intervalMillis = 500
         )

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/NativeDiscussionsDetailsPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/NativeDiscussionsDetailsPage.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2021 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.instructure.teacher.ui.pages
+
+import com.instructure.espresso.ModuleItemInteractions
+import com.instructure.espresso.assertDisplayed
+import com.instructure.espresso.assertHasText
+import com.instructure.espresso.assertNotDisplayed
+import com.instructure.espresso.click
+import com.instructure.espresso.page.BasePage
+import com.instructure.espresso.page.onView
+import com.instructure.espresso.page.withId
+import com.instructure.espresso.scrollTo
+import com.instructure.espresso.swipeDown
+import com.instructure.teacher.R
+import com.instructure.teacher.ui.utils.TypeInRCETextEditor
+
+class NativeDiscussionsDetailsPage(val moduleItemInteractions: ModuleItemInteractions) : BasePage() {
+
+    /**
+     * Asserts that the discussion has the specified [title].
+     *
+     * @param title The title of the discussion to be asserted.
+     */
+    fun assertDiscussionTitle(title: String) {
+        onView(withId(R.id.discussionTopicTitle)).assertHasText(title)
+    }
+
+    /**
+     * Asserts that the discussion is published.
+     */
+    fun assertDiscussionPublished() {
+        checkPublishedTextView("Published")
+    }
+
+    /**
+     * Asserts that the discussion is unpublished.
+     */
+    fun assertDiscussionUnpublished() {
+        checkPublishedTextView("Unpublished")
+    }
+
+    /**
+     * Asserts that there are no replies in the discussion.
+     */
+    fun assertNoReplies() {
+        onView(withId(R.id.discussionTopicReplies)).assertNotDisplayed()
+    }
+
+    /**
+     * Asserts that the discussion has at least one reply.
+     */
+    fun assertHasReply() {
+        val repliesHeader = onView(withId(R.id.discussionTopicReplies))
+        repliesHeader.scrollTo()
+        repliesHeader.assertDisplayed()
+    }
+
+    /**
+     * Opens the edit menu of the discussion.
+     */
+    fun openEdit() {
+        onView(withId(R.id.menu_edit)).click()
+    }
+
+    /**
+     * Refreshes the discussion page.
+     */
+    fun refresh() {
+        onView(withId(R.id.swipeRefreshLayout)).swipeDown()
+    }
+
+    /**
+     * Adds a reply with the specified [content] to the discussion.
+     *
+     * @param content The content of the reply.
+     */
+    fun addReply(content: String) {
+        onView(withId(R.id.replyToDiscussionTopic)).click()
+        onView(withId(R.id.rce_webView)).perform(TypeInRCETextEditor(content))
+        onView(withId(R.id.menu_send)).click()
+    }
+
+    private fun checkPublishedTextView(status: String) {
+        onView(withId(R.id.publishStatusTextView)).assertHasText(status)
+    }
+}

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/utils/TeacherTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/utils/TeacherTest.kt
@@ -63,6 +63,7 @@ import com.instructure.teacher.ui.pages.LoginFindSchoolPage
 import com.instructure.teacher.ui.pages.LoginLandingPage
 import com.instructure.teacher.ui.pages.LoginSignInPage
 import com.instructure.teacher.ui.pages.ModulesPage
+import com.instructure.teacher.ui.pages.NativeDiscussionsDetailsPage
 import com.instructure.teacher.ui.pages.NavDrawerPage
 import com.instructure.teacher.ui.pages.NotATeacherPage
 import com.instructure.teacher.ui.pages.PageListPage
@@ -122,7 +123,8 @@ abstract class TeacherTest : CanvasTest() {
     val remoteConfigSettingsPage = RemoteConfigSettingsPage()
     val profileSettingsPage = ProfileSettingsPage()
     val editProfileSettingsPage = EditProfileSettingsPage()
-    val discussionsDetailsPage = DiscussionsDetailsPage(ModuleItemInteractions(R.id.moduleName, R.id.next, R.id.previous))
+    val nativeDiscussionsDetailsPage = NativeDiscussionsDetailsPage(ModuleItemInteractions(R.id.moduleName, R.id.next, R.id.previous))
+    val discussionDetailsPage = DiscussionsDetailsPage(ModuleItemInteractions(R.id.moduleName, R.id.next, R.id.previous))
     val discussionsListPage = DiscussionsListPage(Searchable(R.id.search, R.id.search_src_text, R.id.search_close_btn))
     val editAnnouncementDetailsPage = EditAnnouncementDetailsPage()
     val editAssignmentDetailsPage = EditAssignmentDetailsPage()

--- a/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/api/DiscussionTopicsApi.kt
+++ b/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/api/DiscussionTopicsApi.kt
@@ -19,6 +19,8 @@ package com.instructure.dataseeding.api
 
 import com.instructure.dataseeding.model.CreateDiscussionTopic
 import com.instructure.dataseeding.model.DiscussionApiModel
+import com.instructure.dataseeding.model.DiscussionTopicEntryRequest
+import com.instructure.dataseeding.model.DiscussionTopicEntryResponse
 import com.instructure.dataseeding.util.CanvasNetworkAdapter
 import com.instructure.dataseeding.util.Randomizer
 import retrofit2.Call
@@ -30,10 +32,22 @@ object DiscussionTopicsApi {
     interface DiscussionTopicsService {
         @POST("courses/{courseId}/discussion_topics")
         fun createDiscussionTopic(@Path("courseId") courseId: Long, @Body createDiscussionTopic: CreateDiscussionTopic): Call<DiscussionApiModel>
+
+        @POST("courses/{courseId}/discussion_topics/{discussionId}/entries")
+        fun createEntryToDiscussionTopic(@Path("courseId") courseId: Long, @Path("discussionId") discussionId: Long, @Body discussionTopicEntry: DiscussionTopicEntryRequest): Call<DiscussionTopicEntryResponse>
+
     }
 
     private fun discussionTopicsService(token: String): DiscussionTopicsService
             = CanvasNetworkAdapter.retrofitWithToken(token).create(DiscussionTopicsService::class.java)
+
+    fun createEntryToDiscussionTopic(token: String, courseId: Long, discussionId: Long, replyMessage: String): DiscussionTopicEntryResponse {
+        val discussionTopicEntry = DiscussionTopicEntryRequest(replyMessage)
+        return discussionTopicsService(token)
+            .createEntryToDiscussionTopic(courseId, discussionId, discussionTopicEntry)
+            .execute()
+            .body()!!
+    }
 
     fun createDiscussion(courseId: Long, token: String, isAnnouncement: Boolean = false, lockedForUser: Boolean = false, locked: Boolean = false): DiscussionApiModel {
         val discussionTopic = Randomizer.randomDiscussion(isAnnouncement, lockedForUser, locked)

--- a/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/model/DiscussionApiModel.kt
+++ b/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/model/DiscussionApiModel.kt
@@ -44,3 +44,14 @@ data class CreateDiscussionTopic(
         val locked: Boolean = true,
         val published: Boolean = true
 )
+
+data class DiscussionTopicEntryRequest(
+        @SerializedName("message")
+        val message: String
+)
+
+data class DiscussionTopicEntryResponse(
+        val id: String,
+        @SerializedName("message")
+        val message: String
+)

--- a/automation/espresso/src/main/kotlin/com/instructure/espresso/TestingUtils.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/espresso/TestingUtils.kt
@@ -16,11 +16,21 @@
 package com.instructure.espresso
 
 import android.os.Build
+import android.view.View
 import androidx.annotation.RequiresApi
+import androidx.test.espresso.web.sugar.Web
+import androidx.test.espresso.web.webdriver.DriverAtoms
+import androidx.test.espresso.web.webdriver.Locator
 import org.apache.commons.lang3.StringUtils
+import org.hamcrest.Matcher
+import org.junit.Assert
 import java.text.SimpleDateFormat
 import java.time.LocalDateTime
-import java.util.*
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+import java.util.Random
+import java.util.TimeZone
 
 private val RANDOM = Random()
 private val DIGITS = "0123456789"
@@ -118,4 +128,26 @@ fun extractInnerTextById(html: String, id: String): String? {
     val pattern = "<[^>]*?\\bid=\"$id\"[^>]*?>(.*?)</[^>]*?>".toRegex(RegexOption.DOT_MATCHES_ALL)
     val matchResult = pattern.find(html)
     return matchResult?.groupValues?.getOrNull(1)
+}
+
+fun waitForWebElement(
+    webViewMatcher: Matcher<View>,
+    locator: Locator,
+    value: String,
+    timeoutMillis: Long = 5000,
+    intervalMillis: Long = 500
+) {
+    val endTime = System.currentTimeMillis() + timeoutMillis
+
+    while (System.currentTimeMillis() < endTime) {
+        try {
+            Web.onWebView(webViewMatcher)
+                .withElement(DriverAtoms.findElement(locator, value))
+            return
+        } catch (e: Exception) {
+            Thread.sleep(intervalMillis)
+        }
+    }
+
+    Assert.fail("Element not found: $locator=$value within $timeoutMillis ms")
 }


### PR DESCRIPTION
Major refactor on E2E tests to handle new discussion redesign as default in both the Teacher and Student apps.
Rename, restructure some page objects.
Add some util functions.
Separate native and web view based Discussion Details Page.

refs: MBL-17668
affects: Teacher, Student
release note: none

## Checklist

- [x] Run E2E test suite
