### PR TITLE
[MBL-17691][Student][Teacher] Recurrence edit does not consider the previous change in the calendar

### DIFF
--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CalendarEventAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/CalendarEventAPI.kt
@@ -107,6 +107,14 @@ object CalendarEventAPI {
         ): DataResult<List<ScheduleItem>>
 
         @PUT("calendar_events/{eventId}")
+        suspend fun updateRecurringCalendarEventOneOccurrence(
+            @Path("eventId") eventId: Long,
+            @Query(value = "which") modifyEventScope: String,
+            @Body body: ScheduleItem.ScheduleItemParamsWrapper,
+            @Tag restParams: RestParams
+        ): DataResult<ScheduleItem>
+
+        @PUT("calendar_events/{eventId}")
         suspend fun updateCalendarEvent(
             @Path("eventId") eventId: Long,
             @Body body: ScheduleItem.ScheduleItemParamsWrapper,

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendarevent/createupdate/CreateUpdateEventUiState.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendarevent/createupdate/CreateUpdateEventUiState.kt
@@ -83,7 +83,7 @@ sealed class CreateUpdateEventAction {
     data class UpdateLocation(val location: String) : CreateUpdateEventAction()
     data class UpdateAddress(val address: String) : CreateUpdateEventAction()
     data class UpdateDetails(val details: String) : CreateUpdateEventAction()
-    data class Save(val modifyEventScope: CalendarEventAPI.ModifyEventScope) : CreateUpdateEventAction()
+    data class Save(val modifyEventScope: CalendarEventAPI.ModifyEventScope, val isSeriesEvent: Boolean = false) : CreateUpdateEventAction()
     data object SnackbarDismissed : CreateUpdateEventAction()
     data object ShowSelectCalendarScreen : CreateUpdateEventAction()
     data object HideSelectCalendarScreen : CreateUpdateEventAction()

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendarevent/createupdate/CreateUpdateEventViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendarevent/createupdate/CreateUpdateEventViewModel.kt
@@ -137,7 +137,7 @@ class CreateUpdateEventViewModel @Inject constructor(
                 _uiState.update { it.copy(details = action.details) }
             }
 
-            is CreateUpdateEventAction.Save -> save(action.modifyEventScope)
+            is CreateUpdateEventAction.Save -> save(action.modifyEventScope, action.isSeriesEvent)
 
             is CreateUpdateEventAction.SnackbarDismissed -> {
                 _uiState.update { it.copy(errorSnack = null) }
@@ -461,7 +461,7 @@ class CreateUpdateEventViewModel @Inject constructor(
         }
     }
 
-    private fun save(modifyEventScope: CalendarEventAPI.ModifyEventScope) = with(uiState.value) {
+    private fun save(modifyEventScope: CalendarEventAPI.ModifyEventScope, isSeriesEvent: Boolean) = with(uiState.value) {
         _uiState.update { it.copy(saving = true) }
         viewModelScope.tryLaunch {
             val startDate = LocalDateTime.of(date, startTime ?: LocalTime.of(6, 0)).toApiString().orEmpty()
@@ -480,7 +480,8 @@ class CreateUpdateEventViewModel @Inject constructor(
                     locationName = location,
                     locationAddress = address,
                     description = details,
-                    modifyEventScope = modifyEventScope
+                    modifyEventScope = modifyEventScope,
+                    isSeriesEvent = isSeriesEvent
                 ).also {
                     CanvasRestAdapter.clearCacheUrls("calendar_events/")
                 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendarevent/createupdate/composables/CreateUpdateEventScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendarevent/createupdate/composables/CreateUpdateEventScreen.kt
@@ -262,7 +262,7 @@ private fun ActionsSegment(
             },
             onConfirmation = {
                 showModifyScopeDialog = false
-                actionHandler(CreateUpdateEventAction.Save(CalendarEventAPI.ModifyEventScope.entries[it]))
+                actionHandler(CreateUpdateEventAction.Save(CalendarEventAPI.ModifyEventScope.entries[it], true))
             }
         )
     }
@@ -275,7 +275,7 @@ private fun ActionsSegment(
             if (uiState.isSeriesEvent) {
                 showModifyScopeDialog = true
             } else {
-                actionHandler(CreateUpdateEventAction.Save(CalendarEventAPI.ModifyEventScope.ONE))
+                actionHandler(CreateUpdateEventAction.Save(CalendarEventAPI.ModifyEventScope.ONE, false))
             }
         },
         enabled = saveEnabled,

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/calendarevent/createupdate/CreateUpdateEventRepositoryTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/calendarevent/createupdate/CreateUpdateEventRepositoryTest.kt
@@ -138,7 +138,7 @@ class CreateUpdateEventRepositoryTest {
     }
 
     @Test
-    fun `Update single calendar event successful`() = runTest {
+    fun `Update single calendar event when rrule is empty and event is not recurring`() = runTest {
         val event = ScheduleItem("itemId")
 
         coEvery {
@@ -159,7 +159,8 @@ class CreateUpdateEventRepositoryTest {
             locationName = "locationName",
             locationAddress = "locationAddress",
             description = "description",
-            CalendarEventAPI.ModifyEventScope.ONE
+            CalendarEventAPI.ModifyEventScope.ONE,
+            isSeriesEvent = false
         )
 
         Assert.assertEquals(listOf(event), result)
@@ -188,7 +189,8 @@ class CreateUpdateEventRepositoryTest {
             locationName = "locationName",
             locationAddress = "locationAddress",
             description = "description",
-            CalendarEventAPI.ModifyEventScope.ONE
+            CalendarEventAPI.ModifyEventScope.ONE,
+            isSeriesEvent = false
         )
 
         Assert.assertEquals(events, result)
@@ -220,7 +222,7 @@ class CreateUpdateEventRepositoryTest {
     }
 
     @Test
-    fun `Update recurring calendar event successful`() = runTest {
+    fun `Update recurring calendar event successful when updating all events`() = runTest {
         val event = listOf(ScheduleItem("itemId"))
 
         coEvery {
@@ -242,9 +244,40 @@ class CreateUpdateEventRepositoryTest {
             locationName = "locationName",
             locationAddress = "locationAddress",
             description = "description",
-            CalendarEventAPI.ModifyEventScope.ALL
+            CalendarEventAPI.ModifyEventScope.ALL,
+            isSeriesEvent = true
         )
 
         Assert.assertEquals(event, result)
+    }
+
+    @Test
+    fun `Update recurring calendar event calls only one occurrence api call when only one occurrence is edited`() = runTest {
+        val event = ScheduleItem("itemId")
+
+        coEvery {
+            calendarEventApi.updateRecurringCalendarEventOneOccurrence(
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        } returns DataResult.Success(event)
+
+        val result = repository.updateEvent(
+            1L,
+            title = "title",
+            startDate = "startDate",
+            endDate = "endDate",
+            rrule = "rrule",
+            contextCode = "contextCode",
+            locationName = "locationName",
+            locationAddress = "locationAddress",
+            description = "description",
+            CalendarEventAPI.ModifyEventScope.ONE,
+            isSeriesEvent = true
+        )
+
+        Assert.assertEquals(listOf(event), result)
     }
 }


### PR DESCRIPTION
Test plan: In the ticket. The description might be a bit confusing, but the real issue is editing one occurrence from a recurring event. That should be working now. + Smoke test event editing in both apps.

refs: MBL-17691
affects: Student, Teacher
release note: Fixed an issue where editing a single occurrence in a recurring event would show an incorrect error message.

## Checklist

- [x] Tested in light mode
