### PR TITLE
[MBL-17710][Student] Fixed 'File upload dialog remembers index of deleted file'

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/PickerSubmissionUploadEffectHandler.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/PickerSubmissionUploadEffectHandler.kt
@@ -126,6 +126,9 @@ class PickerSubmissionUploadEffectHandler(
             is PickerSubmissionUploadEffect.HandleSubmit -> {
                 handleSubmit(effect.model)
             }
+            is PickerSubmissionUploadEffect.RemoveTempFile -> {
+                removeTempFile(effect.path)
+            }
         }.exhaustive
     }
 
@@ -287,6 +290,10 @@ class PickerSubmissionUploadEffectHandler(
         }
 
         return false
+    }
+
+    private fun removeTempFile(path: String) {
+        FileUploadUtils.deleteTempFile(path)
     }
 
     companion object {

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/PickerSubmissionUploadModels.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/PickerSubmissionUploadModels.kt
@@ -39,6 +39,7 @@ sealed class PickerSubmissionUploadEffect {
     data class HandleSubmit(val model: PickerSubmissionUploadModel) : PickerSubmissionUploadEffect()
     data class LoadFileContents(val uri: Uri, val allowedExtensions: List<String>) :
         PickerSubmissionUploadEffect()
+    data class RemoveTempFile(val path: String) : PickerSubmissionUploadEffect()
 }
 
 data class PickerSubmissionUploadModel(

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/PickerSubmissionUploadUpdate.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/PickerSubmissionUploadUpdate.kt
@@ -46,8 +46,9 @@ class PickerSubmissionUploadUpdate :
         }
         is PickerSubmissionUploadEvent.OnFileRemoved -> {
             val files = model.files.toMutableList()
+            val tempFilePath = files[event.fileIndex].fullPath
             files.removeAt(event.fileIndex)
-            Next.next(model.copy(files = files.toList()))
+            Next.next(model.copy(files = files.toList()), setOf(PickerSubmissionUploadEffect.RemoveTempFile(tempFilePath)))
         }
         is PickerSubmissionUploadEvent.OnFileAdded -> {
             val files = model.files.toMutableList()

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/PickerSubmissionUploadEffectHandlerTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/PickerSubmissionUploadEffectHandlerTest.kt
@@ -23,15 +23,33 @@ import androidx.core.content.FileProvider
 import androidx.fragment.app.FragmentActivity
 import com.instructure.canvasapi2.models.CanvasContext
 import com.instructure.canvasapi2.models.postmodels.FileSubmitObject
-import com.instructure.pandautils.utils.*
+import com.instructure.pandautils.utils.ActivityResult
+import com.instructure.pandautils.utils.FilePrefs
+import com.instructure.pandautils.utils.FileUploadUtils
+import com.instructure.pandautils.utils.OnActivityResults
+import com.instructure.pandautils.utils.PermissionUtils
+import com.instructure.pandautils.utils.requestPermissions
 import com.instructure.student.R
 import com.instructure.student.mobius.assignmentDetails.isIntentAvailable
-import com.instructure.student.mobius.assignmentDetails.submission.picker.*
+import com.instructure.student.mobius.assignmentDetails.submission.picker.PickerSubmissionMode
+import com.instructure.student.mobius.assignmentDetails.submission.picker.PickerSubmissionUploadEffect
+import com.instructure.student.mobius.assignmentDetails.submission.picker.PickerSubmissionUploadEffectHandler
+import com.instructure.student.mobius.assignmentDetails.submission.picker.PickerSubmissionUploadEvent
+import com.instructure.student.mobius.assignmentDetails.submission.picker.PickerSubmissionUploadModel
 import com.instructure.student.mobius.assignmentDetails.submission.picker.ui.PickerSubmissionUploadView
 import com.instructure.student.mobius.common.ui.SubmissionHelper
 import com.instructure.student.mobius.common.ui.SubmissionService
 import com.spotify.mobius.functions.Consumer
-import io.mockk.*
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.invoke
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -553,5 +571,17 @@ class PickerSubmissionUploadEffectHandlerTest : Assert() {
     @Test
     fun `isPickerRequest with invalid code return false`() {
         assertFalse(PickerSubmissionUploadEffectHandler.isPickerRequest(1))
+    }
+
+    @Test
+    fun `RemoveTempFile removes temp file`() {
+        mockkObject(FileUploadUtils)
+        connection.accept(PickerSubmissionUploadEffect.RemoveTempFile("path"))
+
+        verify {
+            FileUploadUtils.deleteTempFile("path")
+        }
+
+        unmockkObject(FileUploadUtils)
     }
 }

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/PickerSubmissionUploadUpdateTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/submission/PickerSubmissionUploadUpdateTest.kt
@@ -19,7 +19,11 @@ package com.instructure.student.test.assignment.details.submission
 import android.net.Uri
 import com.instructure.canvasapi2.models.CanvasContext
 import com.instructure.canvasapi2.models.postmodels.FileSubmitObject
-import com.instructure.student.mobius.assignmentDetails.submission.picker.*
+import com.instructure.student.mobius.assignmentDetails.submission.picker.PickerSubmissionMode
+import com.instructure.student.mobius.assignmentDetails.submission.picker.PickerSubmissionUploadEffect
+import com.instructure.student.mobius.assignmentDetails.submission.picker.PickerSubmissionUploadEvent
+import com.instructure.student.mobius.assignmentDetails.submission.picker.PickerSubmissionUploadModel
+import com.instructure.student.mobius.assignmentDetails.submission.picker.PickerSubmissionUploadUpdate
 import com.instructure.student.test.util.matchesEffects
 import com.spotify.mobius.test.FirstMatchers
 import com.spotify.mobius.test.InitSpec
@@ -197,7 +201,7 @@ class PickerSubmissionUploadUpdateTest : Assert() {
     }
 
     @Test
-    fun `OnFileRemoved event results in model change to files and no effects`() {
+    fun `OnFileRemoved event results in model change to files and RemoveTempFile effect`() {
         val startModel = initModel.copy(files = listOf(initFile))
         val expectedModel = startModel.copy(files = emptyList())
 
@@ -207,7 +211,9 @@ class PickerSubmissionUploadUpdateTest : Assert() {
             .then(
                 assertThatNext(
                     NextMatchers.hasModel(expectedModel),
-                    NextMatchers.hasNoEffects()
+                    matchesEffects<PickerSubmissionUploadModel, PickerSubmissionUploadEffect>(
+                        PickerSubmissionUploadEffect.RemoveTempFile(initFile.fullPath)
+                    )
                 )
             )
     }


### PR DESCRIPTION
Test plan: in the ticket

refs: MBL-17710
affects: Student
release note: none

## Checklist

- [x] Follow-up e2e test ticket created or not needed
