### PR TITLE
[MBL-17764][Student] Submission details crashes

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/common/ui/MobiusFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/common/ui/MobiusFragment.kt
@@ -103,7 +103,6 @@ abstract class MobiusFragment<MODEL, EVENT, EFFECT, VIEW : MobiusView<VIEW_STATE
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        retainInstance = true
 
         update = makeUpdate().apply { initialized = overrideInitModel != null || overrideInitViewState != null }
         globalEventSource = GlobalEventSource(update)


### PR DESCRIPTION
Test plan: Test config change (for example split-view) on all the mobius screens (all the screens related to submissions and observer pairing). 

refs: MBL-17764
affects: Student
release note: Fixed a crash on the submission details screen.

## Checklist

- [x] Tested in light mode
