### PR TITLE
[MBL-17736][Student] Hide Studio submission type if video file submission is not allowed

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/features/assignments/details/AssignmentDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/assignments/details/AssignmentDetailsFragment.kt
@@ -323,7 +323,7 @@ class AssignmentDetailsFragment : ParentFragment(), Bookmarkable {
             setupDialogRow(
                 dialog,
                 dialogBinding.submissionEntryStudio,
-                (submissionTypes.contains(SubmissionType.ONLINE_UPLOAD) && assignment.isStudioEnabled)
+                viewModel.isStudioAccepted()
             ) {
                 navigateToStudioScreen(assignment, studioLTITool)
             }

--- a/apps/student/src/main/java/com/instructure/student/features/assignments/details/AssignmentDetailsViewModel.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/assignments/details/AssignmentDetailsViewModel.kt
@@ -56,6 +56,7 @@ import com.instructure.pandautils.utils.AssignmentUtils2
 import com.instructure.pandautils.utils.ColorKeeper
 import com.instructure.pandautils.utils.Const
 import com.instructure.pandautils.utils.HtmlContentFormatter
+import com.instructure.pandautils.utils.isAudioVisualExtension
 import com.instructure.pandautils.utils.orDefault
 import com.instructure.student.R
 import com.instructure.student.features.assignments.details.gradecellview.GradeCellViewData
@@ -674,5 +675,15 @@ class AssignmentDetailsViewModel @Inject constructor(
     private fun getAlarmTimeInMillis(reminderChoice: ReminderChoice): Long? {
         val dueDate = assignment?.dueDate?.time ?: return null
         return dueDate - reminderChoice.getTimeInMillis()
+    }
+
+    fun isStudioAccepted(): Boolean {
+        if (assignment?.isStudioEnabled == false) return false
+
+        if (assignment?.getSubmissionTypes()?.contains(SubmissionType.ONLINE_UPLOAD) == false) return false
+
+        if (assignment?.allowedExtensions?.isEmpty() == true) return true
+
+        return assignment?.allowedExtensions?.any { isAudioVisualExtension(it) } ?: true
     }
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/FileExtensions.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/FileExtensions.kt
@@ -3,6 +3,7 @@ package com.instructure.pandautils.utils
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.webkit.MimeTypeMap
 import androidx.core.content.FileProvider
 import com.instructure.pandautils.R
 import java.io.File
@@ -29,4 +30,9 @@ fun Uri.viewExternally(context: Context, contentType: String, onNoApps: () -> Un
     intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
     val appCount = context.packageManager.queryIntentActivities(intent, 0).size
     if (appCount > 0) context.startActivity(intent) else onNoApps()
+}
+
+fun isAudioVisualExtension(extension: String): Boolean {
+    val type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
+    return type?.startsWith("audio/") == true || type?.startsWith("video/") == true
 }


### PR DESCRIPTION
Test plan: See ticket.

refs: MBL-17736
affects: Student
release note: Fixed a bug, where Studio submission was allowed incorrectly.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/301a59a3-20e9-4aa8-b09d-7f4beb3c65ac" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/9cb2f93c-5c0b-496c-8653-77717f814cb5" maxHeight=500></td>
</tr>
</table>
