### PR TITLE
[MBL-17741][Student] Embedded Kaltura playlist video's do not show on Pages.

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/features/modules/progression/LockedModuleItemFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/modules/progression/LockedModuleItemFragment.kt
@@ -75,7 +75,6 @@ class LockedModuleItemFragment : ParentFragment() {
         canvasWebView.settings.loadWithOverviewMode = true
         canvasWebView.settings.displayZoomControls = false
         canvasWebView.settings.setSupportZoom(true)
-        canvasWebView.settings.userAgentString = ApiPrefs.userAgent
         canvasWebView.addVideoClient(requireActivity())
         canvasWebView.setInitialScale(100)
 

--- a/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/InternalWebviewFragment.kt
@@ -77,9 +77,6 @@ open class InternalWebviewFragment : ParentFragment() {
 
     var hideToolbar: Boolean by BooleanArg(key = Const.HIDDEN_TOOLBAR)
 
-    // Used for external urls that reject the candroid user agent string
-    var originalUserAgentString: String = ""
-
     /*
      * Our router has some catch-all routes which open the UnsupportedFeatureFragment for urls that match the user's
      * domain but don't match any other internal routes. In some cases, such as viewing an HTML file preview, we need to
@@ -112,8 +109,6 @@ open class InternalWebviewFragment : ParentFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) = with(binding) {
         super.onViewCreated(view, savedInstanceState)
         canvasWebViewWrapper.webView.settings.loadWithOverviewMode = true
-        originalUserAgentString = canvasWebViewWrapper.webView.settings.userAgentString
-        canvasWebViewWrapper.webView.settings.userAgentString = ApiPrefs.userAgent
         canvasWebViewWrapper.webView.setInitialScale(100)
         webViewLoading.setVisible(true)
 
@@ -395,9 +390,6 @@ open class InternalWebviewFragment : ParentFragment() {
                     } catch (e: StatusCallbackError) {
                         e.printStackTrace()
                     }
-                } else {
-                    // External URL, use the non-Canvas specific user agent string
-                    binding.canvasWebViewWrapper.webView.settings.userAgentString = originalUserAgentString
                 }
 
                 if (getIsUnsupportedFeature()) {

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/InternalWebViewFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/InternalWebViewFragment.kt
@@ -75,9 +75,6 @@ open class InternalWebViewFragment : BaseFragment() {
 
     override fun layoutResId() = R.layout.fragment_internal_webview
 
-    // Used for external urls that reject the candroid user agent string
-    var originalUserAgentString: String = ""
-
     override fun onPause() {
         super.onPause()
         binding.canvasWebView.onPause()
@@ -139,8 +136,6 @@ open class InternalWebViewFragment : BaseFragment() {
         canvasWebView.settings.loadWithOverviewMode = true
         canvasWebView.settings.displayZoomControls = false
         canvasWebView.settings.setSupportZoom(true)
-        originalUserAgentString = canvasWebView.settings.userAgentString
-        canvasWebView.settings.userAgentString = ApiPrefs.userAgent
         canvasWebView.addVideoClient(requireActivity())
         canvasWebView.setInitialScale(100)
 
@@ -229,9 +224,6 @@ open class InternalWebViewFragment : BaseFragment() {
                         url = awaitApi<AuthenticatedSession> { OAuthManager.getAuthenticatedSession(url, it) }.sessionUrl
                     } catch (e: StatusCallbackError) {
                     }
-                } else {
-                    // External URL, use the non-Canvas specific user agent string
-                    canvasWebView.settings.userAgentString = originalUserAgentString
                 }
 
                 canvasWebView.loadUrl(url, getReferer())

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/fragments/HtmlContentFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/fragments/HtmlContentFragment.kt
@@ -68,7 +68,6 @@ class HtmlContentFragment : Fragment() {
         canvasWebView.settings.loadWithOverviewMode = true
         canvasWebView.settings.displayZoomControls = false
         canvasWebView.settings.setSupportZoom(true)
-        canvasWebView.settings.userAgentString = ApiPrefs.userAgent
         canvasWebView.addVideoClient(requireActivity())
         canvasWebView.setInitialScale(100)
 


### PR DESCRIPTION
Test plan: In the ticket. The change that caused that issue was introduced in this PR: https://github.com/instructure/canvas-android/pull/325. Since then Google Drive LTI has changed and it works on my sandbox, but you can double check with yours as well. By the way the change introduced in the mentioned PR does not work on the old Google Drive LTI anymore (the one example that is linked in the ticket).

refs: MBL-17741
affects: Student
release note: Fixed an issue where embedded Kaltura videos wouldn't show on pages.

## Checklist

- [x] Tested in light mode
