### PR TITLE
[MBL-17719][Teacher] Route to quiz details from quiz list

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/QuizListFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/QuizListFragment.kt
@@ -35,6 +35,8 @@ import com.instructure.teacher.adapters.QuizListAdapter
 import com.instructure.teacher.databinding.FragmentQuizListBinding
 import com.instructure.teacher.events.QuizUpdatedEvent
 import com.instructure.teacher.factory.QuizListPresenterFactory
+import com.instructure.teacher.features.assignment.details.AssignmentDetailsFragment
+import com.instructure.teacher.features.assignment.list.AssignmentListFragment
 import com.instructure.teacher.presenters.QuizListPresenter
 import com.instructure.teacher.router.RouteMatcher
 import com.instructure.teacher.utils.RecyclerViewUtils
@@ -117,7 +119,13 @@ class QuizListFragment : BaseExpandableSyncFragment<
     override fun createAdapter(): QuizListAdapter {
         return QuizListAdapter(requireContext(), presenter, canvasContext.textAndIconColor) { quiz ->
             if (RouteMatcher.canRouteInternally(requireActivity(), quiz.htmlUrl, ApiPrefs.domain, false)) {
-                RouteMatcher.routeUrl(requireActivity(), quiz.htmlUrl!!, ApiPrefs.domain)
+                val route = RouteMatcher.getInternalRoute(quiz.htmlUrl!!, ApiPrefs.domain)
+                val secondaryClass = when (route?.primaryClass) {
+                    QuizListFragment::class.java -> QuizDetailsFragment::class.java
+                    AssignmentListFragment::class.java -> AssignmentDetailsFragment::class.java
+                    else -> null
+                }
+                RouteMatcher.route(requireActivity(), route?.copy(secondaryClass = secondaryClass))
             } else {
                 val args = QuizDetailsFragment.makeBundle(quiz)
                 RouteMatcher.route(requireActivity(), Route(null, QuizDetailsFragment::class.java, canvasContext, args))


### PR DESCRIPTION
Test plan: See ticket.

refs: MBL-17719
affects: Teacher
release note: Fixed a bug, where opening a Quiz from the Quiz list screen would navigate to the wrong destination.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/74f9b6f9-ad25-4550-a146-dcbcaa97792b" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/b43959bc-99f5-4bbe-9202-55e5dde893d9" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created or not needed