### PR TITLE
[MBL-17387][Student] - Implement Offline Syllabus E2E Test

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/SyllabusE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/SyllabusE2ETest.kt
@@ -58,10 +58,11 @@ class SyllabusE2ETest: StudentTest() {
         dashboardPage.waitForRender()
         dashboardPage.selectCourse(course)
 
-        Log.d(STEP_TAG,"Navigate to Syllabus Page. Assert that the syllabus body string is displayed, and there are no tabs yet.")
+        Log.d(STEP_TAG,"Navigate to Syllabus Page. Assert that the syllabus body string is displayed, and there are no tabs yet, and the toolbar subtitle is the '${course.name}' course name.")
         courseBrowserPage.selectSyllabus()
         syllabusPage.assertNoTabs()
         syllabusPage.assertSyllabusBody("this is the syllabus body")
+        syllabusPage.assertToolbarCourseTitle(course.name)
 
         Log.d(PREPARATION_TAG,"Seed an assignment for '${course.name}' course.")
         val assignment = AssignmentsApi.createAssignment(course.id, teacher.token, submissionTypes = listOf(SubmissionType.ON_PAPER), withDescription = true, pointsPossible = 15.0, dueAt = 1.days.fromNow.iso8601)

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineSyllabusE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineSyllabusE2ETest.kt
@@ -51,7 +51,8 @@ class OfflineSyllabusE2ETest : StudentComposeTest() {
     fun testOfflineSyllabusE2E() {
 
         Log.d(PREPARATION_TAG,"Seeding data.")
-        val data = seedData(students = 1, teachers = 1, courses = 1, syllabusBody = "this is the syllabus body")
+        val syllabusBody = "this is the syllabus body"
+        val data = seedData(students = 1, teachers = 1, courses = 1, syllabusBody = syllabusBody)
         val student = data.studentsList[0]
         val teacher = data.teachersList[0]
         val course = data.coursesList[0]
@@ -89,7 +90,7 @@ class OfflineSyllabusE2ETest : StudentComposeTest() {
 
         Log.d(STEP_TAG,"Navigate to Syllabus Page. Assert that the syllabus body string is displayed. Assert that the toolbar subtitle is the '${course.name}' course name.")
         courseBrowserPage.selectSyllabus()
-        syllabusPage.assertSyllabusBody("this is the syllabus body")
+        syllabusPage.assertSyllabusBody(syllabusBody)
         syllabusPage.assertToolbarCourseTitle(course.name)
 
         Log.d(STEP_TAG,"Navigate to 'Summary' tab. Assert that all of the items, so '${assignment.name}' assignment is displayed.")
@@ -98,7 +99,6 @@ class OfflineSyllabusE2ETest : StudentComposeTest() {
 
         Log.d(STEP_TAG, "Assert that the Offline Indicator (bottom banner) is displayed on the Page List Page.")
         assertOfflineIndicator()
-
     }
 
     @After

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineSyllabusE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineSyllabusE2ETest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2024 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.instructure.student.ui.e2e.offline
+
+import android.util.Log
+import com.google.android.material.checkbox.MaterialCheckBox
+import com.instructure.canvas.espresso.FeatureCategory
+import com.instructure.canvas.espresso.OfflineE2E
+import com.instructure.canvas.espresso.Priority
+import com.instructure.canvas.espresso.SecondaryFeatureCategory
+import com.instructure.canvas.espresso.TestCategory
+import com.instructure.canvas.espresso.TestMetaData
+import com.instructure.dataseeding.api.AssignmentsApi
+import com.instructure.dataseeding.model.SubmissionType
+import com.instructure.dataseeding.util.days
+import com.instructure.dataseeding.util.fromNow
+import com.instructure.dataseeding.util.iso8601
+import com.instructure.student.ui.e2e.offline.utils.OfflineTestUtils.assertOfflineIndicator
+import com.instructure.student.ui.e2e.offline.utils.OfflineTestUtils.waitForNetworkToGoOffline
+import com.instructure.student.ui.utils.StudentComposeTest
+import com.instructure.student.ui.utils.seedData
+import com.instructure.student.ui.utils.tokenLogin
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.After
+import org.junit.Test
+
+@HiltAndroidTest
+class OfflineSyllabusE2ETest : StudentComposeTest() {
+
+    override fun displaysPageObjects() = Unit
+
+    override fun enableAndConfigureAccessibilityChecks() = Unit
+
+    @OfflineE2E
+    @Test
+    @TestMetaData(Priority.MANDATORY, FeatureCategory.SYLLABUS, TestCategory.E2E, SecondaryFeatureCategory.OFFLINE_MODE)
+    fun testOfflineSyllabusE2E() {
+
+        Log.d(PREPARATION_TAG,"Seeding data.")
+        val data = seedData(students = 1, teachers = 1, courses = 1, syllabusBody = "this is the syllabus body")
+        val student = data.studentsList[0]
+        val teacher = data.teachersList[0]
+        val course = data.coursesList[0]
+
+        Log.d(PREPARATION_TAG,"Seed an assignment for '${course.name}' course.")
+        val assignment = AssignmentsApi.createAssignment(course.id, teacher.token, submissionTypes = listOf(
+            SubmissionType.ON_PAPER), withDescription = true, pointsPossible = 15.0, dueAt = 1.days.fromNow.iso8601)
+
+        Log.d(STEP_TAG,"Login with user: '${student.name}', login id: '${student.loginId}'.")
+        tokenLogin(student)
+        dashboardPage.waitForRender()
+
+        Log.d(STEP_TAG, "Open the '${course.name}' course's 'Manage Offline Content' page via the more menu of the Dashboard Page.")
+        dashboardPage.clickCourseOverflowMenu(course.name, "Manage Offline Content")
+
+        Log.d(STEP_TAG, "Assert that the '${course.name}' course's checkbox state is 'Unchecked'.")
+        manageOfflineContentPage.assertCheckedStateOfItem(course.name, MaterialCheckBox.STATE_UNCHECKED)
+
+        Log.d(STEP_TAG, "Expand the course. Select the 'Syllabus' of '${course.name}' course for sync. Click on the 'Sync' button.")
+        manageOfflineContentPage.expandCollapseItem(course.name)
+        manageOfflineContentPage.changeItemSelectionState("Syllabus")
+        manageOfflineContentPage.clickOnSyncButtonAndConfirm()
+
+        Log.d(STEP_TAG, "Assert that the offline sync icon only displayed on the synced course's course card.")
+        dashboardPage.assertCourseOfflineSyncIconVisible(course.name)
+        device.waitForIdle()
+
+        Log.d(PREPARATION_TAG, "Turn off the Wi-Fi and Mobile Data on the device, so it will go offline.")
+        turnOffConnectionViaADB()
+        waitForNetworkToGoOffline(device)
+
+        Log.d(STEP_TAG,"Wait for the Dashboard Page to be rendered. Select '${course.name}' course.")
+        dashboardPage.waitForRender()
+        dashboardPage.selectCourse(course)
+
+        Log.d(STEP_TAG,"Navigate to Syllabus Page. Assert that the syllabus body string is displayed. Assert that the toolbar subtitle is the '${course.name}' course name.")
+        courseBrowserPage.selectSyllabus()
+        syllabusPage.assertSyllabusBody("this is the syllabus body")
+        syllabusPage.assertToolbarCourseTitle(course.name)
+
+        Log.d(STEP_TAG,"Navigate to 'Summary' tab. Assert that all of the items, so '${assignment.name}' assignment is displayed.")
+        syllabusPage.selectSummaryTab()
+        syllabusPage.assertItemDisplayed(assignment.name)
+
+        Log.d(STEP_TAG, "Assert that the Offline Indicator (bottom banner) is displayed on the Page List Page.")
+        assertOfflineIndicator()
+
+    }
+
+    @After
+    fun tearDown() {
+        Log.d(PREPARATION_TAG, "Turn back on the Wi-Fi and Mobile Data on the device, so it will come back online.")
+        turnOnConnectionViaADB()
+    }
+
+}

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineSyllabusE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineSyllabusE2ETest.kt
@@ -19,6 +19,7 @@ package com.instructure.student.ui.e2e.offline
 import android.util.Log
 import com.google.android.material.checkbox.MaterialCheckBox
 import com.instructure.canvas.espresso.FeatureCategory
+import com.instructure.canvas.espresso.KnownBug
 import com.instructure.canvas.espresso.OfflineE2E
 import com.instructure.canvas.espresso.Priority
 import com.instructure.canvas.espresso.SecondaryFeatureCategory
@@ -46,6 +47,7 @@ class OfflineSyllabusE2ETest : StudentComposeTest() {
     override fun enableAndConfigureAccessibilityChecks() = Unit
 
     @OfflineE2E
+    @KnownBug(bugLink = "https://instructure.atlassian.net/browse/MBL-17787", explanation = "Syllabus tabs are not displaying in offline mode while only assignment summary type items exists.")
     @Test
     @TestMetaData(Priority.MANDATORY, FeatureCategory.SYLLABUS, TestCategory.E2E, SecondaryFeatureCategory.OFFLINE_MODE)
     fun testOfflineSyllabusE2E() {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/SyllabusInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/SyllabusInteractionTest.kt
@@ -59,6 +59,21 @@ class SyllabusInteractionTest : StudentComposeTest() {
         calendarEventDetailsPage.verifyDescription(event.description!!)
     }
 
+    @Test
+    @TestMetaData(Priority.MANDATORY, FeatureCategory.SYLLABUS, TestCategory.INTERACTION)
+    fun testSyllabus_assignment() {
+        val data = goToSyllabus(eventCount = 0, assignmentCount = 1)
+
+        val course = data.courses.values.first()
+        data.coursePermissions[course.id] = CanvasContextPermission(manageCalendar = true)
+        val assignment = data.assignments.entries.firstOrNull()!!.value
+
+        syllabusPage.selectSummaryTab()
+        syllabusPage.assertItemDisplayed(assignment.name!!)
+        syllabusPage.selectSummaryEvent(assignment.name!!)
+        assignmentDetailsPage.assertAssignmentTitle(assignment.name!!)
+    }
+
     private fun goToSyllabus(eventCount: Int, assignmentCount: Int) : MockCanvas {
 
         val data = MockCanvas.init(studentCount = 1, teacherCount = 1, courseCount = 1, favoriteCourseCount = 1)

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SyllabusPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SyllabusPage.kt
@@ -25,10 +25,12 @@ import androidx.test.espresso.web.sugar.Web
 import androidx.test.espresso.web.webdriver.DriverAtoms
 import androidx.test.espresso.web.webdriver.Locator
 import com.instructure.canvas.espresso.containsTextCaseInsensitive
+import com.instructure.canvas.espresso.matchToolbarText
 import com.instructure.canvas.espresso.scrollRecyclerView
 import com.instructure.espresso.assertDisplayed
 import com.instructure.espresso.click
 import com.instructure.espresso.page.BasePage
+import com.instructure.espresso.page.getStringFromResource
 import com.instructure.espresso.page.plus
 import com.instructure.espresso.page.withAncestor
 import com.instructure.espresso.swipeDown
@@ -37,6 +39,11 @@ import org.hamcrest.Matchers
 import org.hamcrest.Matchers.allOf
 
 open class SyllabusPage : BasePage(R.id.syllabusPage) {
+
+    fun assertToolbarCourseTitle(courseName: String) {
+        onView(withId(R.id.toolbar) + withAncestor(R.id.syllabusPage)).assertDisplayed().check(ViewAssertions.matches(matchToolbarText(Matchers.`is`(getStringFromResource(R.string.syllabus)), true)))
+        onView(withId(R.id.toolbar) + withAncestor(R.id.syllabusPage)).assertDisplayed().check(ViewAssertions.matches(matchToolbarText(Matchers.`is`(courseName), false)))
+    }
 
     fun assertItemDisplayed(itemText: String) {
         scrollRecyclerView(R.id.syllabusEventsRecycler, itemText)


### PR DESCRIPTION
Implement Offline Syllabus E2E Test.
Implement Assignment base Syllabus interaction test.
Add asserting to toolbar title and course name on Syllabus page. (add this assertion to existing 'online' Syllabus E2E Test as well).

refs: MBL-17387
affects: Student
release note: none