### PR TITLE
[MBL-17776][Teacher] Assignments and discussions not opening from the Calendar on tablet

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/features/assignment/details/AssignmentDetailsFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/assignment/details/AssignmentDetailsFragment.kt
@@ -17,7 +17,6 @@ package com.instructure.teacher.features.assignment.details
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.webkit.WebChromeClient
 import android.webkit.WebView
 import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.Assignment.Companion.getSubmissionTypeFromAPIString
@@ -62,7 +61,6 @@ import com.instructure.teacher.events.AssignmentGradedEvent
 import com.instructure.teacher.events.AssignmentUpdatedEvent
 import com.instructure.teacher.events.post
 import com.instructure.teacher.factory.AssignmentDetailPresenterFactory
-import com.instructure.teacher.features.assignment.submission.AssignmentSubmissionListPresenter
 import com.instructure.teacher.features.assignment.submission.AssignmentSubmissionListFragment
 import com.instructure.teacher.features.assignment.submission.SubmissionListFilter
 import com.instructure.teacher.fragments.DueDatesFragment

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/calendar/TeacherCalendarRouter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/calendar/TeacherCalendarRouter.kt
@@ -28,6 +28,8 @@ import com.instructure.pandautils.features.calendartodo.details.ToDoFragment
 import com.instructure.pandautils.features.discussion.router.DiscussionRouterFragment
 import com.instructure.teacher.activities.InitActivity
 import com.instructure.teacher.features.assignment.details.AssignmentDetailsFragment
+import com.instructure.teacher.features.assignment.list.AssignmentListFragment
+import com.instructure.teacher.fragments.DiscussionsListFragment
 import com.instructure.teacher.router.RouteMatcher
 
 class TeacherCalendarRouter(val activity: FragmentActivity) : CalendarRouter {
@@ -36,11 +38,11 @@ class TeacherCalendarRouter(val activity: FragmentActivity) : CalendarRouter {
     }
 
     override fun openAssignment(canvasContext: CanvasContext, assignmentId: Long) {
-        RouteMatcher.route(activity, AssignmentDetailsFragment.makeRoute(canvasContext, assignmentId))
+        RouteMatcher.route(activity, AssignmentDetailsFragment.makeRoute(canvasContext, assignmentId).copy(primaryClass = AssignmentListFragment::class.java))
     }
 
     override fun openDiscussion(canvasContext: CanvasContext, discussionId: Long) {
-        val route = DiscussionRouterFragment.makeRoute(canvasContext, discussionId)
+        val route = DiscussionRouterFragment.makeRoute(canvasContext, discussionId).copy(primaryClass = DiscussionsListFragment::class.java)
         RouteMatcher.route(activity, route)
     }
 

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/interaction/CalendarInteractionTest.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/interaction/CalendarInteractionTest.kt
@@ -346,7 +346,6 @@ abstract class CalendarInteractionTest : CanvasComposeTest() {
     }
 
     @Test
-    @StubTablet("Known issue, see MBL-17776")
     fun selectDiscussionOpensDiscussionDetails() {
         val data = initData()
 


### PR DESCRIPTION
Test plan: Check that assignments and discussions route correctly on tablet.

refs: MBL-17776
affects: Techer
release note: Fixed an issue where assignments and discussions wouldn't open from the calendar on tablets.

## Checklist

- [x] Tested in light mode
