### PR TITLE
[MBL-17787][Student] Fetch course settings during offline sync

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/offline/sync/CourseSync.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/offline/sync/CourseSync.kt
@@ -59,7 +59,6 @@ import com.instructure.pandautils.room.offline.entities.CourseSyncProgressEntity
 import com.instructure.pandautils.room.offline.entities.CourseSyncSettingsEntity
 import com.instructure.pandautils.room.offline.entities.FileFolderEntity
 import com.instructure.pandautils.room.offline.entities.QuizEntity
-import com.instructure.pandautils.room.offline.entities.RemoteFileEntity
 import com.instructure.pandautils.room.offline.facade.AssignmentFacade
 import com.instructure.pandautils.room.offline.facade.ConferenceFacade
 import com.instructure.pandautils.room.offline.facade.CourseFacade
@@ -334,10 +333,11 @@ class CourseSync(
         val enrollments = course.enrollments.orEmpty().flatMap {
             enrollmentsApi.getEnrollmentsForUserInCourse(courseId, it.userId, params).dataOrThrow
         }.toMutableList()
+        val courseSettings = courseApi.getCourseSettings(courseId, params).dataOrThrow
 
         course.syllabusBody = parseHtmlContent(course.syllabusBody, courseId)
 
-        courseFacade.insertCourse(course.copy(enrollments = enrollments))
+        courseFacade.insertCourse(course.copy(enrollments = enrollments, settings = courseSettings))
 
         val courseFeatures = featuresApi.getEnabledFeaturesForCourse(courseId, params).dataOrNull
         courseFeatures?.let {


### PR DESCRIPTION
Test plan: See ticket.

refs: MBL-17787
affects: Student
release note: none

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/3df7d1cb-83f4-4d86-b08a-4482f65e1847" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/47b3c750-f4fa-41ea-be55-be266fe1fe7d" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Run E2E test suite
