### PR TITLE
Remove KnownBug annotation from Offline Syllabus E2E test

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineSyllabusE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/offline/OfflineSyllabusE2ETest.kt
@@ -19,7 +19,6 @@ package com.instructure.student.ui.e2e.offline
 import android.util.Log
 import com.google.android.material.checkbox.MaterialCheckBox
 import com.instructure.canvas.espresso.FeatureCategory
-import com.instructure.canvas.espresso.KnownBug
 import com.instructure.canvas.espresso.OfflineE2E
 import com.instructure.canvas.espresso.Priority
 import com.instructure.canvas.espresso.SecondaryFeatureCategory
@@ -47,7 +46,6 @@ class OfflineSyllabusE2ETest : StudentComposeTest() {
     override fun enableAndConfigureAccessibilityChecks() = Unit
 
     @OfflineE2E
-    @KnownBug(bugLink = "https://instructure.atlassian.net/browse/MBL-17787", explanation = "Syllabus tabs are not displaying in offline mode while only assignment summary type items exists.")
     @Test
     @TestMetaData(Priority.MANDATORY, FeatureCategory.SYLLABUS, TestCategory.E2E, SecondaryFeatureCategory.OFFLINE_MODE)
     fun testOfflineSyllabusE2E() {


### PR DESCRIPTION
Remove KnownBug annotation from Offline Syllabus E2E test (as the bug has been fixed yet).
