### PR TITLE
[MBL-16939][Student] - Extend Conferences E2E test

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/ConferencesE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/ConferencesE2ETest.kt
@@ -20,14 +20,6 @@ class ConferencesE2ETest: StudentTest() {
 
     override fun enableAndConfigureAccessibilityChecks() = Unit
 
-    // Fairly basic test that we can create and view a conference with the app.
-    // I didn't attempt to actually start the conference because that goes through
-    // an external web browser and would be really gross (if not impossible) to
-    // test.
-    //
-    // Re-stubbing for now because the interface has changed from webview to native
-    // and this test no longer passes.  MBL-14127 is being tracked to re-write this
-    // test against the new native interface.
     @E2E
     @Test
     @TestMetaData(Priority.MANDATORY, FeatureCategory.CONFERENCES, TestCategory.E2E)
@@ -57,24 +49,40 @@ class ConferencesE2ETest: StudentTest() {
 
         val testConferenceTitle2 = "E2E test conference 2"
         val testConferenceDescription2 = "Nightly E2E Test conference description 2"
+        Log.d(PREPARATION_TAG,"Create a conference with '$testConferenceTitle2' title and '$testConferenceDescription2' description.")
         ConferencesApi.createCourseConference(course.id, teacher.token, testConferenceTitle2, testConferenceDescription2, longRunning = true, duration = 120, recipientUserIds = listOf(student.id))
 
-        Log.d(STEP_TAG,"Refresh the page. Assert that $testConferenceTitle conference is displayed on the Conference List Page with the corresponding status.")
+        Log.d(STEP_TAG,"Refresh the page. Assert that $testConferenceTitle conference is displayed on the Conference List Page with the corresponding status and description.")
         refresh()
         conferenceListPage.assertConferenceDisplayed(testConferenceTitle)
         conferenceListPage.assertConferenceStatus(testConferenceTitle,"Not Started")
+        conferenceListPage.assertConferenceDescription(testConferenceTitle, testConferenceDescription)
 
-        Log.d(STEP_TAG,"Assert that $testConferenceTitle2 conference is displayed on the Conference List Page with the corresponding status.")
+        Log.d(STEP_TAG, "Assert that the toolbar title is 'Conferences' and there is the '${course.name}' course's name displayed as a subtitle.")
+        conferenceListPage.assertConferencesToolbarText(course.name)
+
+        Log.d(STEP_TAG, "Assert that the 'New Conferences' text is displayed as a conference group type on the Conferences List Page.")
+        conferenceListPage.assertNewConferencesDisplayed()
+
+        Log.d(STEP_TAG, "Assert that the 'Open Externally' icon (button) is displayed on the top-right corner of the Conferences List Page.")
+        conferenceListPage.assertOpenExternallyButtonDisplayed()
+
+        Log.d(STEP_TAG,"Assert that $testConferenceTitle2 conference is displayed on the Conference List Page with the corresponding status and description.")
         conferenceListPage.assertConferenceDisplayed(testConferenceTitle2)
         conferenceListPage.assertConferenceStatus(testConferenceTitle2,"Not Started")
+        conferenceListPage.assertConferenceDescription(testConferenceTitle2, testConferenceDescription2)
 
-        Log.d(STEP_TAG,"Open '$testConferenceTitle' conference details page.")
+        Log.d(STEP_TAG,"Open '$testConferenceTitle' conference's detailer page.")
         conferenceListPage.openConferenceDetails(testConferenceTitle)
 
-        Log.d(STEP_TAG,"Assert that the proper conference title '$testConferenceTitle', status and description '$testConferenceDescription' are displayed.")
-        conferenceDetailsPage.assertConferenceTitleDisplayed()
+        Log.d(STEP_TAG, "Assert that the toolbar title is 'Conference Details' and there is the '${course.name}' course's name displayed as a subtitle.")
+        conferenceDetailsPage.assertConferenceDetailsToolbarText(course.name)
+
+        Log.d(STEP_TAG,"Assert that the proper conference title '$testConferenceTitle', status ('Not Started') and description, '$testConferenceDescription' are displayed.")
+        conferenceDetailsPage.assertConferenceTitleDisplayed(testConferenceTitle)
         conferenceDetailsPage.assertConferenceStatus("Not Started")
         conferenceDetailsPage.assertDescription(testConferenceDescription)
 
     }
+
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/ConferenceDetailsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/ConferenceDetailsPage.kt
@@ -18,14 +18,20 @@ package com.instructure.student.ui.pages
 
 import androidx.test.espresso.matcher.ViewMatchers.hasSibling
 import com.instructure.espresso.assertDisplayed
-import com.instructure.espresso.page.*
+import com.instructure.espresso.page.BasePage
+import com.instructure.espresso.page.onView
+import com.instructure.espresso.page.plus
+import com.instructure.espresso.page.withAncestor
+import com.instructure.espresso.page.withId
+import com.instructure.espresso.page.withParent
+import com.instructure.espresso.page.withText
 import com.instructure.student.R
 import org.hamcrest.CoreMatchers.allOf
 
 open class ConferenceDetailsPage : BasePage(R.id.conferenceDetailsPage) {
 
-    fun assertConferenceTitleDisplayed() {
-        onView(allOf(withId(R.id.title), hasSibling(withId(R.id.statusDetails)))).assertDisplayed()
+    fun assertConferenceTitleDisplayed(conferenceTitle: String) {
+        onView(allOf(withId(R.id.title), withText(conferenceTitle), hasSibling(withId(R.id.statusDetails)))).assertDisplayed()
     }
 
     fun assertConferenceStatus(expectedStatus: String) {
@@ -33,6 +39,13 @@ open class ConferenceDetailsPage : BasePage(R.id.conferenceDetailsPage) {
     }
 
     fun assertDescription(expectedDescription: String) {
+        onView(allOf(withText(R.string.description), hasSibling(withId(R.id.statusDetails)), hasSibling(withId(R.id.description)))).assertDisplayed()
         onView(allOf(withId(R.id.description) + withText(expectedDescription), hasSibling(withId(R.id.statusDetails)))).assertDisplayed()
     }
+
+    fun assertConferenceDetailsToolbarText(courseName: String) {
+        onView(withText(R.string.conferenceDetails) + withParent(R.id.toolbar) + withAncestor(R.id.conferenceDetailsPage)).assertDisplayed()
+        onView(withText(courseName) + withParent(R.id.toolbar) + withAncestor(R.id.conferenceDetailsPage)).assertDisplayed()
+    }
+
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/ConferenceListPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/ConferenceListPage.kt
@@ -22,7 +22,10 @@ import com.instructure.espresso.assertDisplayed
 import com.instructure.espresso.click
 import com.instructure.espresso.page.BasePage
 import com.instructure.espresso.page.onView
+import com.instructure.espresso.page.plus
+import com.instructure.espresso.page.withAncestor
 import com.instructure.espresso.page.withId
+import com.instructure.espresso.page.withParent
 import com.instructure.espresso.page.withText
 import com.instructure.student.R
 import org.hamcrest.CoreMatchers.allOf
@@ -44,6 +47,10 @@ open class ConferenceListPage : BasePage(R.id.conferenceListPage) {
         onView(allOf(withId(R.id.title), withText(conferenceTitle))).assertDisplayed()
     }
 
+    fun assertConferenceDescription(conferenceTitle: String, expectedDescription: String) {
+        onView(allOf(withId(R.id.subtitle), withText(expectedDescription), hasSibling(allOf(withId(R.id.title), withText(conferenceTitle)))))
+    }
+
     fun clickOnOpenExternallyButton() {
         onView(withId(R.id.openExternallyButton)).click()
     }
@@ -52,8 +59,20 @@ open class ConferenceListPage : BasePage(R.id.conferenceListPage) {
         onView(withId(R.id.openExternallyButton)).check(doesNotExist())
     }
 
+    fun assertOpenExternallyButtonDisplayed() {
+        onView(withId(R.id.openExternallyButton)).assertDisplayed()
+    }
+
     fun openConferenceDetails(conferenceTitle: String) {
         onView(withText(conferenceTitle)).click()
     }
 
+    fun assertConferencesToolbarText(courseName: String) {
+        onView(withText(R.string.conferences) + withParent(R.id.toolbar) + withAncestor(R.id.conferenceListPage)).assertDisplayed()
+        onView(withText(courseName) + withParent(R.id.toolbar) + withAncestor(R.id.conferenceListPage)).assertDisplayed()
+    }
+
+    fun assertNewConferencesDisplayed() {
+        onView(withId(R.id.title) + withText(R.string.newConferences) + withAncestor(R.id.conferenceListPage)).assertDisplayed()
+    }
 }


### PR DESCRIPTION
Extend Conferences E2E test. (Asserting toolbar titles,subtitles, openexternally button, description, type)
Add some page object methods.

refs: MBL-16939
affects: Student
release note: none