### PR TITLE
[MBL-17733][Student][Teacher] - Add 'making an archived conversation unread' process to Inbox E2E tests

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/InboxE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/InboxE2ETest.kt
@@ -102,7 +102,7 @@ class InboxE2ETest: StudentTest() {
         inboxPage.openConversation(seededConversation.subject)
         inboxConversationPage.archive() //After select 'Archive', we will be navigated back to Inbox Page
 
-        Log.d(STEP_TAG,"Assert that '${seededConversation.subject}' conversation has removed from 'All' tab.") //TODO: Discuss this logic if it's ok if we don't show Archived messages on 'All' tab...
+        Log.d(STEP_TAG,"Assert that '${seededConversation.subject}' conversation has removed from 'Inbox' tab.")
         inboxPage.assertConversationNotDisplayed(seededConversation.subject)
 
         Log.d(STEP_TAG,"Select 'Archived' conversation filter.")
@@ -115,6 +115,41 @@ class InboxE2ETest: StudentTest() {
                 "Unarchive it, and assert that it is not displayed in the 'ARCHIVED' scope any more.")
         inboxPage.selectConversation(seededConversation.subject)
         inboxPage.assertSelectedConversationNumber("1")
+
+        Log.d(STEP_TAG, "Click on the 'Mark as Unread' button and assert that the empty view will be displayed and the '${seededConversation.subject}' conversation is not because it should disappear from 'Archived' list.")
+        inboxPage.clickMarkAsUnread()
+        inboxPage.assertInboxEmpty()
+        inboxPage.assertConversationNotDisplayed(seededConversation.subject)
+
+        Log.d(STEP_TAG,"Select 'Unread' conversation filter.")
+        inboxPage.filterInbox("Unread")
+
+        Log.d(STEP_TAG,"Assert that '${seededConversation.subject}' conversation is displayed on the 'Inbox' tab.")
+        inboxPage.assertConversationDisplayed(seededConversation.subject)
+
+        Log.d(STEP_TAG,"Assert that '${seededConversation.subject}' conversation has been marked as unread.")
+        inboxPage.assertUnreadMarkerVisibility(seededConversation.subject, ViewMatchers.Visibility.VISIBLE)
+
+        Log.d(STEP_TAG,"Select '${seededConversation.subject}' conversation. Archive it by clicking on the 'More Options' menu, 'Archive' menu point.")
+        inboxPage.openConversation(seededConversation.subject)
+        inboxConversationPage.archive() //After select 'Archive', we will be navigated back to Inbox Page
+
+        Log.d(STEP_TAG,"Assert that '${seededConversation.subject}' conversation has removed from 'Inbox' tab.")
+        inboxPage.assertConversationNotDisplayed(seededConversation.subject)
+
+        Log.d(STEP_TAG,"Select 'Archived' conversation filter.")
+        inboxPage.filterInbox("Archived")
+
+        Log.d(STEP_TAG,"Assert that '${seededConversation.subject}' conversation is displayed by the 'Archived' filter.")
+        inboxPage.assertConversationDisplayed(seededConversation.subject)
+
+        Log.d(STEP_TAG,"Assert that '${seededConversation.subject}' conversation does not have the unread mark because an archived conversation cannot be unread.")
+        inboxPage.assertUnreadMarkerVisibility(seededConversation.subject, ViewMatchers.Visibility.GONE)
+
+        Log.d(STEP_TAG,"Select '${seededConversation.subject}' conversation.")
+        inboxPage.selectConversation(seededConversation.subject)
+
+        Log.d(STEP_TAG, "Click on the 'Unarchive' button and assert that the empty view will be displayed and the '${seededConversation.subject}' conversation is not because it should disappear from 'Archived' list.")
         inboxPage.clickUnArchive()
         inboxPage.assertInboxEmpty()
         inboxPage.assertConversationNotDisplayed(seededConversation.subject)

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/InboxE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/InboxE2ETest.kt
@@ -131,8 +131,8 @@ class InboxE2ETest : TeacherTest() {
         inboxPage.openConversation(seedConversation[0].subject)
 
         Log.d(STEP_TAG, "Archive the '${seedConversation[0]}' conversation and assert that it has disappeared from the list," +
-                "because archived conversations does not displayed within the 'All' section.")
-        inboxMessagePage.openOptionMenuFor("Archive")
+                "because archived conversations does not displayed within the 'Inbox' section.")
+        inboxMessagePage.archive()
         dashboardPage.assertPageObjects()
         inboxPage.assertInboxEmpty()
 
@@ -219,7 +219,43 @@ class InboxE2ETest : TeacherTest() {
                 "Assert that the selected number of conversation on the toolbar is 1 and '${seedConversation2[0].subject}' conversation is not displayed in the 'ARCHIVED' scope.")
         inboxPage.selectConversation(seedConversation2[0].subject)
         inboxPage.assertSelectedConversationNumber("1")
+
+        Log.d(STEP_TAG, "Click on the 'Mark as Unread' button and assert that the empty view will be displayed and the '${seedConversation2[0].subject}' conversation is not because it should disappear from 'Archived' list.")
+        inboxPage.clickMarkAsUnread()
+        inboxPage.assertInboxEmpty()
+        inboxPage.assertConversationNotDisplayed(seedConversation2[0].subject)
+
+        Log.d(STEP_TAG,"Select 'Unread' conversation filter.")
+        inboxPage.filterInbox("Unread")
+
+        Log.d(STEP_TAG,"Assert that '${seedConversation2[0].subject}' conversation is displayed on the 'Inbox' tab.")
+        inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
+
+        Log.d(STEP_TAG,"Assert that '${seedConversation2[0].subject}' conversation has been marked as unread.")
+        inboxPage.assertUnreadMarkerVisibility(seedConversation2[0].subject, ViewMatchers.Visibility.VISIBLE)
+
+        Log.d(STEP_TAG,"Select '${seedConversation2[0].subject}' conversation. Archive it by clicking on the 'More Options' menu, 'Archive' menu point.")
+        inboxPage.openConversation(seedConversation2[0].subject)
+        inboxMessagePage.archive() //After select 'Archive', we will be navigated back to Inbox Page
+
+        Log.d(STEP_TAG,"Assert that '${seedConversation2[0].subject}' conversation has removed from 'Inbox' tab.")
+        inboxPage.assertConversationNotDisplayed(seedConversation2[0].subject)
+
+        Log.d(STEP_TAG,"Select 'Archived' conversation filter.")
+        inboxPage.filterInbox("Archived")
+
+        Log.d(STEP_TAG,"Assert that '${seedConversation2[0].subject}' conversation is displayed by the 'Archived' filter.")
+        inboxPage.assertConversationDisplayed(seedConversation2[0].subject)
+
+        Log.d(STEP_TAG,"Assert that '${seedConversation2[0].subject}' conversation does not have the unread mark because an archived conversation cannot be unread.")
+        inboxPage.assertUnreadMarkerVisibility(seedConversation2[0].subject, ViewMatchers.Visibility.GONE)
+
+        Log.d(STEP_TAG,"Select '${seedConversation2[0].subject}' conversation.")
+        inboxPage.selectConversation(seedConversation2[0].subject)
+
+        Log.d(STEP_TAG, "Click on the 'Unarchive' button and assert that the empty view will be displayed and the '${seedConversation2[0].subject}' conversation is not because it should disappear from 'Archived' list.")
         inboxPage.clickUnArchive()
+        inboxPage.assertInboxEmpty()
         inboxPage.assertConversationNotDisplayed(seedConversation2[0].subject)
 
         Log.d(STEP_TAG,"Navigate to 'INBOX' scope and assert that '${seedConversation2[0].subject}' conversation is displayed.")

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/InboxMessagePage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/InboxMessagePage.kt
@@ -89,21 +89,20 @@ class InboxMessagePage: BasePage() {
     }
 
     /**
-     * Opens the option menu for the specified item.
-     *
-     * @param itemName The name of the item to open the option menu for.
+     * Archives the conversation.
      */
-    fun openOptionMenuFor(itemName: String) {
-        Espresso.openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getInstrumentation().getTargetContext());
-        Espresso.onView(ViewMatchers.withText(itemName))
-            .perform(ViewActions.click());
+    fun archive() {
+        Espresso.openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getInstrumentation().getTargetContext())
+        Espresso.onView(ViewMatchers.withText("Archive")).perform(ViewActions.click())
     }
 
     /**
      * Deletes the conversation.
      */
     fun deleteConversation() {
-        openOptionMenuFor("Delete")
+        Espresso.openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getInstrumentation().getTargetContext())
+        Espresso.onView(ViewMatchers.withText("Delete"))
+            .perform(ViewActions.click())
         Espresso.onView(Matchers.allOf(ViewMatchers.isAssignableFrom(AppCompatButton::class.java),
             containsTextCaseInsensitive("DELETE"))).click()
     }


### PR DESCRIPTION
Refactor InboxE2E tests in both the Student and Teacher app to assert that making a conversation unread in the 'Archived' filter will dismiss it from the 'Archived' list.

refs: MBL-17733
affects: Student, Teacher
release note: none