### PR TITLE
[MBL-17822][Teacher] Filtering submissions by section doesn't open the correct students submission

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/features/assignment/submission/AssignmentSubmissionListFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/assignment/submission/AssignmentSubmissionListFragment.kt
@@ -156,7 +156,8 @@ class AssignmentSubmissionListFragment : BaseSyncFragment<
                     selectedIdx = selectedIdx,
                     anonymousGrading = assignment.anonymousGrading,
                     filter = presenter.getFilter(),
-                    filterValue = presenter.getFilterPoints()
+                    filterValue = presenter.getFilterPoints(),
+                    filteredSubmissionIds = filteredSubmissions.map { it.id }.toLongArray(),
                 )
                 RouteMatcher.route(requireActivity(), Route(bundle, RouteContext.SPEED_GRADER))
             }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/assignment/submission/AssignmentSubmissionListFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/assignment/submission/AssignmentSubmissionListFragment.kt
@@ -207,8 +207,8 @@ class AssignmentSubmissionListFragment : BaseSyncFragment<
 
     private fun setupListeners() = with(binding) {
         clearFilterTextView.setOnClickListener {
-            presenter.setFilter(SubmissionListFilter.ALL)
             presenter.clearFilterList()
+            presenter.setFilter(SubmissionListFilter.ALL)
             filterTitle.setText(R.string.all_submissions)
             clearFilterTextView.setGone()
         }


### PR DESCRIPTION
Test plan: See ticket.

refs: MBL-17822
affects: Teacher
release note: Fixed a bug, where not the correct student's submission was opened in SpeedGrader in some cases.
