### PR TITLE
[MBL-17687][Teacher] - Extend DiscussionE2E test with replies and close/open for comments filtering

### DIFF
--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/DiscussionsE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/DiscussionsE2ETest.kt
@@ -23,6 +23,7 @@ import com.instructure.canvas.espresso.FeatureCategory
 import com.instructure.canvas.espresso.Priority
 import com.instructure.canvas.espresso.TestCategory
 import com.instructure.canvas.espresso.TestMetaData
+import com.instructure.dataseeding.api.DiscussionTopicsApi
 import com.instructure.teacher.ui.utils.TeacherTest
 import com.instructure.teacher.ui.utils.seedData
 import com.instructure.teacher.ui.utils.tokenLogin
@@ -45,9 +46,16 @@ class DiscussionsE2ETest : TeacherTest() {
         Log.d(PREPARATION_TAG, "Seeding data.")
         val data = seedData(students = 1, teachers = 1, courses = 1, discussions = 2)
         val teacher = data.teachersList[0]
+        val student = data.studentsList[0]
         val course = data.coursesList[0]
         val discussion = data.discussionsList[0]
         val discussion2 = data.discussionsList[1]
+
+        val discussionEntryMessage = "Discussion entry test message"
+        val testDiscussionTopicEntry = DiscussionTopicsApi.createEntryToDiscussionTopic(student.token, course.id, discussion.id, discussionEntryMessage)
+
+        val testDiscussionEntryReplyMessage = "This is a reply for the entry for testing purposes!"
+        DiscussionTopicsApi.createReplyToDiscussionTopicEntry(student.token, course.id, discussion.id, testDiscussionTopicEntry.id, testDiscussionEntryReplyMessage)
 
         Log.d(STEP_TAG, "Login with user: '${teacher.name}', login id: '${teacher.loginId}'.")
         tokenLogin(teacher)
@@ -83,16 +91,54 @@ class DiscussionsE2ETest : TeacherTest() {
         discussionDetailsPage.assertMoreMenuButtonDisplayed("Copy To...")
         discussionDetailsPage.assertMoreMenuButtonDisplayed("Share to Commons")
 
+        Log.d(STEP_TAG, "Assert that the '$discussionEntryMessage' discussion entry message is displayed.")
+        discussionDetailsPage.assertDiscussionEntryMessageDisplayed(discussionEntryMessage)
+
+        Log.d(STEP_TAG, "Assert that there is 1 reply and that is unread.")
+        discussionDetailsPage.assertReplyCounter(1, 1)
+
+        Log.d(STEP_TAG, "Expand the replies and wait for the reply to be displayed. Assert that it's displayed.")
+        discussionDetailsPage.clickOnExpandRepliesButton()
+        discussionDetailsPage.waitForReplyDisplayed(testDiscussionEntryReplyMessage)
+        discussionDetailsPage.assertReplyDisplayed(testDiscussionEntryReplyMessage)
+
         Log.d(STEP_TAG, "Navigate back to Discussion List Page. Select 'Pin' overflow menu of '${discussion2.title}' discussion and assert that it has became Pinned.")
         Espresso.pressBack()
         discussionsListPage.clickDiscussionOverFlowMenu(discussion2.title)
         discussionsListPage.selectOverFlowMenu("Pin")
         discussionsListPage.assertGroupDisplayed("Pinned")
         discussionsListPage.assertDiscussionInGroup("Pinned", discussion2.title)
+        discussionsListPage.assertDiscussionNotInGroup("Discussions", discussion2.title)
+
+        Log.d(STEP_TAG, "Select 'Unpin' overflow menu of '${discussion2.title}' discussion and assert that it has became Unpinned, so it will be displayed (again) in the 'Discussions' group.")
+        discussionsListPage.clickDiscussionOverFlowMenu(discussion2.title)
+        discussionsListPage.selectOverFlowMenu("Unpin")
+        discussionsListPage.assertGroupDisplayed("Pinned")
+        discussionsListPage.assertDiscussionInGroup("Discussions", discussion2.title)
+        discussionsListPage.assertDiscussionNotInGroup("Pinned", discussion2.title)
 
         Log.d(STEP_TAG, "Assert that both of the discussions, '${discussion.title}' and '${discussion2.title}' discussions are displayed.")
         discussionsListPage.assertHasDiscussion(discussion)
         discussionsListPage.assertHasDiscussion(discussion2)
+
+        Log.d(STEP_TAG, "Select 'Closed for Comments' overflow menu of '${discussion.title}' discussion and assert that it has became 'Closed for Comments'.")
+        discussionsListPage.clickDiscussionOverFlowMenu(discussion.title)
+        discussionsListPage.selectOverFlowMenu("Closed for Comments")
+        discussionsListPage.assertGroupDisplayed("Closed for Comments")
+        discussionsListPage.assertDiscussionInGroup("Closed for Comments", discussion.title)
+
+        Log.d(STEP_TAG, "Assert that the 'Discussions' group will be still displayed despite it has no items in it. Assert that the '${discussion2.title}' discussion is not in the 'Discussions' group any more.")
+        discussionsListPage.assertGroupDisplayed("Discussions")
+        discussionsListPage.assertDiscussionNotInGroup("Discussions", discussion.title)
+
+        Log.d(STEP_TAG, "Select 'Open for Comments' overflow menu of '${discussion.title}' discussion and assert that it will be (again) displayed under the 'Discussions' group.")
+        discussionsListPage.clickDiscussionOverFlowMenu(discussion.title)
+        discussionsListPage.selectOverFlowMenu("Open for Comments")
+        discussionsListPage.assertDiscussionInGroup("Discussions", discussion.title)
+
+        Log.d(STEP_TAG, "Assert that the 'Closed for Comments' group will be still displayed despite it has no items in it. Assert that the '${discussion2.title}' discussion is not in the 'Closed for Comments' group any more.")
+        discussionsListPage.assertGroupDisplayed("Closed for Comments")
+        discussionsListPage.assertDiscussionNotInGroup("Closed for Comments", discussion.title)
 
         Log.d(STEP_TAG,"Click on more menu of '${discussion.title}' discussion and delete it.")
         discussionsListPage.deleteDiscussionFromOverflowMenu(discussion.title)

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/DiscussionsDetailsPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/DiscussionsDetailsPage.kt
@@ -59,11 +59,44 @@ class DiscussionsDetailsPage(val moduleItemInteractions: ModuleItemInteractions)
         )).assertDisplayed()
     }
 
+    fun assertDiscussionEntryMessageDisplayed(entryMessage: String) {
+        Web.onWebView()
+            .check(WebViewAssertions.webContent(DomMatchers.hasElementWithXpath("//span[text()='$entryMessage']")))
+    }
+
+    fun assertReplyCounter(replyCount: Int, unreadCount: Int) {
+        Web.onWebView()
+            .check(WebViewAssertions.webContent(DomMatchers.hasElementWithXpath("//div[@data-testid='replies-counter' and .='$replyCount Reply ($unreadCount)']/ancestor::button[@data-testid='expand-button']")))
+    }
+
+    fun clickOnExpandRepliesButton() {
+        Web.onWebView()
+            .withElement(DriverAtoms.findElement(Locator.XPATH, "//div[@data-testid='replies-counter']/ancestor::button[@data-testid='expand-button']"))
+            .perform(webClick())
+    }
+
+    fun assertReplyDisplayed(replyMessage: String) {
+        Web.onWebView()
+            .check(WebViewAssertions.webContent(DomMatchers.hasElementWithXpath("//span[text()='$replyMessage']")))
+    }
+
+
+
     fun waitForReplyButtonDisplayed() {
         waitForWebElement(
             webViewMatcher = withId(R.id.discussionWebView),
             locator = Locator.XPATH,
             value = "//button[@data-testid='discussion-topic-reply']",
+            timeoutMillis = 10000,
+            intervalMillis = 500
+        )
+    }
+
+    fun waitForReplyDisplayed(replyMessage: String) {
+        waitForWebElement(
+            webViewMatcher = withId(R.id.discussionWebView),
+            locator = Locator.XPATH,
+            value = "//span[text()='$replyMessage']",
             timeoutMillis = 10000,
             intervalMillis = 500
         )

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/DiscussionsListPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/DiscussionsListPage.kt
@@ -20,6 +20,7 @@ import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.matcher.ViewMatchers
 import com.instructure.canvasapi2.models.DiscussionTopicHeader
 import com.instructure.dataseeding.model.DiscussionApiModel
+import com.instructure.espresso.DoesNotExistAssertion
 import com.instructure.espresso.OnViewWithId
 import com.instructure.espresso.RecyclerViewItemCountAssertion
 import com.instructure.espresso.Searchable
@@ -193,5 +194,17 @@ class DiscussionsListPage(val searchable: Searchable) : BasePage() {
         val groupChildMatcher = withId(R.id.groupName) + withText(groupName)
         waitForView(withId(R.id.discussionTitle) + withText(discussionTitle) +
                 withAncestor(withId(R.id.discussionRecyclerView) + withDescendant(groupChildMatcher))).assertDisplayed()
+    }
+
+    /**
+     * Asserts that a discussion with the specified [discussionTitle] is NOT present in the specified [groupName] group.
+     *
+     * @param groupName The name of the group NOT containing the discussion.
+     * @param discussionTitle The title of the discussion to be asserted.
+     */
+    fun assertDiscussionNotInGroup(groupName: String, discussionTitle: String) {
+        val groupChildMatcher = withId(R.id.groupName) + withText(groupName)
+        onView(withId(R.id.discussionTitle) + withText(discussionTitle) +
+                withAncestor(withId(R.id.discussionRecyclerView) + withDescendant(groupChildMatcher))).check(DoesNotExistAssertion(5))
     }
 }

--- a/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/api/DiscussionTopicsApi.kt
+++ b/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/api/DiscussionTopicsApi.kt
@@ -19,6 +19,8 @@ package com.instructure.dataseeding.api
 
 import com.instructure.dataseeding.model.CreateDiscussionTopic
 import com.instructure.dataseeding.model.DiscussionApiModel
+import com.instructure.dataseeding.model.DiscussionTopicEntryReplyRequest
+import com.instructure.dataseeding.model.DiscussionTopicEntryReplyResponse
 import com.instructure.dataseeding.model.DiscussionTopicEntryRequest
 import com.instructure.dataseeding.model.DiscussionTopicEntryResponse
 import com.instructure.dataseeding.util.CanvasNetworkAdapter
@@ -36,6 +38,9 @@ object DiscussionTopicsApi {
         @POST("courses/{courseId}/discussion_topics/{discussionId}/entries")
         fun createEntryToDiscussionTopic(@Path("courseId") courseId: Long, @Path("discussionId") discussionId: Long, @Body discussionTopicEntry: DiscussionTopicEntryRequest): Call<DiscussionTopicEntryResponse>
 
+        @POST("courses/{courseId}/discussion_topics/{discussionId}/entries/{entryId}/replies")
+        fun createReplyToDiscussionTopicEntry(@Path("courseId") courseId: Long, @Path("discussionId") discussionId: Long, @Path("entryId") entryId: Long, @Body discussionTopicEntry: DiscussionTopicEntryReplyRequest): Call<DiscussionTopicEntryReplyResponse>
+
     }
 
     private fun discussionTopicsService(token: String): DiscussionTopicsService
@@ -45,6 +50,14 @@ object DiscussionTopicsApi {
         val discussionTopicEntry = DiscussionTopicEntryRequest(replyMessage)
         return discussionTopicsService(token)
             .createEntryToDiscussionTopic(courseId, discussionId, discussionTopicEntry)
+            .execute()
+            .body()!!
+    }
+
+    fun createReplyToDiscussionTopicEntry(token: String, courseId: Long, discussionId: Long, entryId: Long, replyMessage: String): DiscussionTopicEntryReplyResponse {
+        val discussionTopicEntryReply = DiscussionTopicEntryReplyRequest(replyMessage)
+        return discussionTopicsService(token)
+            .createReplyToDiscussionTopicEntry(courseId, discussionId, entryId, discussionTopicEntryReply)
             .execute()
             .body()!!
     }

--- a/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/model/DiscussionApiModel.kt
+++ b/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/model/DiscussionApiModel.kt
@@ -51,6 +51,17 @@ data class DiscussionTopicEntryRequest(
 )
 
 data class DiscussionTopicEntryResponse(
+        val id: Long,
+        @SerializedName("message")
+        val message: String
+)
+
+data class DiscussionTopicEntryReplyRequest(
+        @SerializedName("message")
+        val message: String
+)
+
+data class DiscussionTopicEntryReplyResponse(
         val id: String,
         @SerializedName("message")
         val message: String


### PR DESCRIPTION
Extend DiscussionE2E test with testing the Close/Open for Comments filter and replies on the new discussion webview.
Add some page object methods.
Add the API methods for seeding (replies/entries).

refs: MBL-17687
affects: Teacher
release note: none

- [x] Run E2E test suite
