### PR TITLE
[MBL-17860][Parent] Support submission view in case assignment enhancement is not enabled

### DIFF
--- a/apps/flutter_parent/lib/network/api/course_api.dart
+++ b/apps/flutter_parent/lib/network/api/course_api.dart
@@ -86,4 +86,9 @@ class CourseApi {
     var dio = canvasDio(forceRefresh: forceRefresh);
     return fetch(dio.get('courses/$courseId/permissions'));
   }
+
+  Future<List<String>?> getEnabledCourseFeatures(String courseId, {bool forceRefresh = false}) async {
+    var dio = canvasDio(forceRefresh: forceRefresh);
+    return fetchList(dio.get('courses/$courseId/features/enabled'));
+  }
 }

--- a/apps/flutter_parent/lib/screens/assignments/assignment_details_interactor.dart
+++ b/apps/flutter_parent/lib/screens/assignments/assignment_details_interactor.dart
@@ -32,13 +32,13 @@ class AssignmentDetailsInteractor {
     String? studentId,
   ) async {
     final course = locator<CourseApi>().getCourse(courseId, forceRefresh: forceRefresh);
-    final assignmentEnhancementEnabled = locator<CourseApi>().getEnabledCourseFeatures(courseId, forceRefresh: forceRefresh);
+    final enabledCourseFeatures = locator<CourseApi>().getEnabledCourseFeatures(courseId, forceRefresh: forceRefresh);
     final assignment = locator<AssignmentApi>().getAssignment(courseId, assignmentId, forceRefresh: forceRefresh);
 
     return AssignmentDetails(
         assignment: (await assignment),
         course: (await course),
-        assignmentEnhancementEnabled: (await assignmentEnhancementEnabled)?.contains(_ASSIGNMENT_ENHANCEMENT_KEY));
+        assignmentEnhancementEnabled: (await enabledCourseFeatures)?.contains(_ASSIGNMENT_ENHANCEMENT_KEY));
   }
 
   Future<AssignmentDetails> loadQuizDetails(
@@ -48,13 +48,13 @@ class AssignmentDetailsInteractor {
     String studentId,
   ) async {
     final course = locator<CourseApi>().getCourse(courseId, forceRefresh: forceRefresh);
-    final assignmentEnhancementEnabled = locator<CourseApi>().getEnabledCourseFeatures(courseId, forceRefresh: forceRefresh);
+    final enabledCourseFeatures = locator<CourseApi>().getEnabledCourseFeatures(courseId, forceRefresh: forceRefresh);
     final quiz = locator<AssignmentApi>().getAssignment(courseId, assignmentId, forceRefresh: forceRefresh);
 
     return AssignmentDetails(
         assignment: (await quiz),
         course: (await course),
-        assignmentEnhancementEnabled: (await assignmentEnhancementEnabled)?.contains(_ASSIGNMENT_ENHANCEMENT_KEY));
+        assignmentEnhancementEnabled: (await enabledCourseFeatures)?.contains(_ASSIGNMENT_ENHANCEMENT_KEY));
   }
 
   Future<Reminder?> loadReminder(String assignmentId) async {

--- a/apps/flutter_parent/lib/screens/assignments/assignment_details_interactor.dart
+++ b/apps/flutter_parent/lib/screens/assignments/assignment_details_interactor.dart
@@ -23,6 +23,8 @@ import 'package:flutter_parent/utils/notification_util.dart';
 import 'package:flutter_parent/utils/service_locator.dart';
 
 class AssignmentDetailsInteractor {
+  final String _ASSIGNMENT_ENHANCEMENT_KEY = "assignments_2_student";
+
   Future<AssignmentDetails?> loadAssignmentDetails(
     bool forceRefresh,
     String courseId,
@@ -30,12 +32,13 @@ class AssignmentDetailsInteractor {
     String? studentId,
   ) async {
     final course = locator<CourseApi>().getCourse(courseId, forceRefresh: forceRefresh);
+    final assignmentEnhancementEnabled = locator<CourseApi>().getEnabledCourseFeatures(courseId, forceRefresh: forceRefresh);
     final assignment = locator<AssignmentApi>().getAssignment(courseId, assignmentId, forceRefresh: forceRefresh);
 
     return AssignmentDetails(
-      assignment: (await assignment),
-      course: (await course),
-    );
+        assignment: (await assignment),
+        course: (await course),
+        assignmentEnhancementEnabled: (await assignmentEnhancementEnabled)?.contains(_ASSIGNMENT_ENHANCEMENT_KEY));
   }
 
   Future<AssignmentDetails> loadQuizDetails(
@@ -45,12 +48,13 @@ class AssignmentDetailsInteractor {
     String studentId,
   ) async {
     final course = locator<CourseApi>().getCourse(courseId, forceRefresh: forceRefresh);
+    final assignmentEnhancementEnabled = locator<CourseApi>().getEnabledCourseFeatures(courseId, forceRefresh: forceRefresh);
     final quiz = locator<AssignmentApi>().getAssignment(courseId, assignmentId, forceRefresh: forceRefresh);
 
     return AssignmentDetails(
-      assignment: (await quiz),
-      course: (await course),
-    );
+        assignment: (await quiz),
+        course: (await course),
+        assignmentEnhancementEnabled: (await assignmentEnhancementEnabled)?.contains(_ASSIGNMENT_ENHANCEMENT_KEY));
   }
 
   Future<Reminder?> loadReminder(String assignmentId) async {
@@ -100,7 +104,6 @@ class AssignmentDetailsInteractor {
       reminder = insertedReminder;
       await locator<NotificationUtil>().scheduleReminder(l10n, title, body, reminder);
     }
-
   }
 
   Future<void> deleteReminder(Reminder? reminder) async {
@@ -113,6 +116,7 @@ class AssignmentDetailsInteractor {
 class AssignmentDetails {
   final Course? course;
   final Assignment? assignment;
+  final bool? assignmentEnhancementEnabled;
 
-  AssignmentDetails({this.course, this.assignment});
+  AssignmentDetails({this.course, this.assignment, this.assignmentEnhancementEnabled});
 }

--- a/apps/flutter_parent/lib/screens/assignments/assignment_details_screen.dart
+++ b/apps/flutter_parent/lib/screens/assignments/assignment_details_screen.dart
@@ -143,6 +143,7 @@ class _AssignmentDetailsScreenState extends State<AssignmentDetailsScreen> {
     final course = snapshot.data?.course;
     final restrictQuantitativeData = course?.settings?.restrictQuantitativeData ?? false;
     final assignment = snapshot.data!.assignment!;
+    final assignmentEnhancementEnabled = snapshot.data?.assignmentEnhancementEnabled ?? false;
     final submission = assignment.submission(_currentStudent?.id);
     final fullyLocked = assignment.isFullyLocked;
     final missing = submission?.missing == true;
@@ -191,7 +192,11 @@ class _AssignmentDetailsScreenState extends State<AssignmentDetailsScreen> {
               padding: const EdgeInsets.only(top: 16.0, bottom: 16.0),
               child: OutlinedButton(
                   onPressed: () {
-                    _onSubmissionAndRubricClicked(assignment.htmlUrl, l10n.submission);
+                    _onSubmissionAndRubricClicked(
+                      assignment.htmlUrl,
+                      assignmentEnhancementEnabled,
+                      l10n.submission,
+                    );
                   },
                   child: Align(
                       alignment: Alignment.center,
@@ -400,12 +405,13 @@ class _AssignmentDetailsScreenState extends State<AssignmentDetailsScreen> {
     }
   }
 
-  _onSubmissionAndRubricClicked(String? assignmentUrl, String title) async {
+  _onSubmissionAndRubricClicked(String? assignmentUrl, bool assignmentEnhancementEnabled, String title) async {
     if (assignmentUrl == null) return;
     final parentId = ApiPrefs.getUser()?.id ?? 0;
     final currentStudentId = _currentStudent?.id ?? 0;
+    final url = assignmentEnhancementEnabled ? assignmentUrl : assignmentUrl + "/submissions/$currentStudentId";
     locator<QuickNav>().pushRoute(context, PandaRouter.submissionWebViewRoute(
-        await locator<WebContentInteractor>().getAuthUrl(assignmentUrl),
+        await locator<WebContentInteractor>().getAuthUrl(url),
         title,
         {"k5_observed_user_for_$parentId": "$currentStudentId"},
         false

--- a/apps/flutter_parent/test/screens/assignments/assignment_details_interactor_test.dart
+++ b/apps/flutter_parent/test/screens/assignments/assignment_details_interactor_test.dart
@@ -167,5 +167,21 @@ void main() {
 
       expect(details?.assignment, assignment);
     });
+
+    test('returns assignmentEnhancementEnabled as false if response does not contain key', () async {
+      final features = ["feature1", "feature2"];
+      when(courseApi.getEnabledCourseFeatures(courseId)).thenAnswer((_) async => features);
+      final details = await AssignmentDetailsInteractor().loadAssignmentDetails(false, courseId, assignmentId, studentId);
+
+      expect(details?.assignmentEnhancementEnabled, false);
+    });
+
+    test('returns assignmentEnhancementEnabled as true if response contains key', () async {
+      final features = ["feature1", "assignments_2_student", "feature3"];
+      when(courseApi.getEnabledCourseFeatures(courseId)).thenAnswer((_) async => features);
+      final details = await AssignmentDetailsInteractor().loadAssignmentDetails(false, courseId, assignmentId, studentId);
+
+      expect(details?.assignmentEnhancementEnabled, true);
+    });
   });
 }

--- a/apps/flutter_parent/test/screens/assignments/assignment_details_screen_test.dart
+++ b/apps/flutter_parent/test/screens/assignments/assignment_details_screen_test.dart
@@ -662,4 +662,66 @@ void main() {
     // Check that we have the correct title
     expect(find.text(AppLocalizations().submission), findsOneWidget);
   });
+
+  testWidgetsWithAccessibilityChecks(
+      'Submission & Rubric button opens SimpleWebViewScreen with the '
+      'correct url when assignment enhancements are enabled', (tester) async {
+    when(interactor.loadAssignmentDetails(any, courseId, assignmentId, studentId))
+        .thenAnswer((_) async => AssignmentDetails(assignment: assignment, assignmentEnhancementEnabled: true));
+
+    await tester.pumpWidget(TestApp(
+      AssignmentDetailsScreen(
+        courseId: courseId,
+        assignmentId: assignmentId,
+      ),
+      platformConfig: PlatformConfig(mockApiPrefs: {ApiPrefs.KEY_CURRENT_STUDENT: json.encode(serialize(student))}, initWebview: true),
+    ));
+
+    // Pump for a duration since we're delaying webview load for the animation
+    await tester.pumpAndSettle(Duration(seconds: 1));
+
+    await tester.tap(find.text(AppLocalizations().submissionAndRubric));
+    await tester.pumpAndSettle();
+
+    // Check to make sure we're on the SimpleWebViewScreen screen
+    final webViewScreenFinder = find.byType(SimpleWebViewScreen);
+    expect(find.byType(SimpleWebViewScreen), findsOneWidget);
+
+    final SimpleWebViewScreen webViewScreen = tester.widget(webViewScreenFinder) as SimpleWebViewScreen;
+    expect(webViewScreen.url, assignmentUrl);
+
+    // Check that we have the correct title
+    expect(find.text(AppLocalizations().submission), findsOneWidget);
+  });
+
+  testWidgetsWithAccessibilityChecks(
+      'Submission & Rubric button opens SimpleWebViewScreen with the '
+      'correct url when assignment enhancements are disabled', (tester) async {
+    when(interactor.loadAssignmentDetails(any, courseId, assignmentId, studentId))
+        .thenAnswer((_) async => AssignmentDetails(assignment: assignment, assignmentEnhancementEnabled: false));
+
+    await tester.pumpWidget(TestApp(
+      AssignmentDetailsScreen(
+        courseId: courseId,
+        assignmentId: assignmentId,
+      ),
+      platformConfig: PlatformConfig(mockApiPrefs: {ApiPrefs.KEY_CURRENT_STUDENT: json.encode(serialize(student))}, initWebview: true),
+    ));
+
+    // Pump for a duration since we're delaying webview load for the animation
+    await tester.pumpAndSettle(Duration(seconds: 1));
+
+    await tester.tap(find.text(AppLocalizations().submissionAndRubric));
+    await tester.pumpAndSettle();
+
+    // Check to make sure we're on the SimpleWebViewScreen screen
+    final webViewScreenFinder = find.byType(SimpleWebViewScreen);
+    expect(find.byType(SimpleWebViewScreen), findsOneWidget);
+
+    final SimpleWebViewScreen webViewScreen = tester.widget(webViewScreenFinder) as SimpleWebViewScreen;
+    expect(webViewScreen.url, assignmentUrl + '/submissions/' + studentId);
+
+    // Check that we have the correct title
+    expect(find.text(AppLocalizations().submission), findsOneWidget);
+  });
 }

--- a/apps/flutter_parent/test/utils/test_helpers/mock_helpers.mocks.dart
+++ b/apps/flutter_parent/test/utils/test_helpers/mock_helpers.mocks.dart
@@ -1670,6 +1670,20 @@ class MockCourseApi extends _i1.Mock implements _i52.CourseApi {
         returnValue: _i8.Future<_i56.CoursePermissions?>.value(),
         returnValueForMissingStub: _i8.Future<_i56.CoursePermissions?>.value(),
       ) as _i8.Future<_i56.CoursePermissions?>);
+  @override
+  _i8.Future<List<String>?> getEnabledCourseFeatures(
+    String? courseId, {
+    bool? forceRefresh = false,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getEnabledCourseFeatures,
+          [courseId],
+          {#forceRefresh: forceRefresh},
+        ),
+        returnValue: _i8.Future<List<String>?>.value(),
+        returnValueForMissingStub: _i8.Future<List<String>?>.value(),
+      ) as _i8.Future<List<String>?>);
 }
 
 /// A class which mocks [CourseDetailsInteractor].


### PR DESCRIPTION
Test plan:
- Turn assignment enhancements off.
- Create an assignment, submit an attempt, add a grade.
- Open the parent app and go to the assignment and view the submission.
- Submission viewer should show the attempt.
- Close the window.
- Turn assignment enhancements on.
- Pull to refresh the parent app's assignment screen.
- Open the submission viewer.
- Submission viewer should still show the attempt.

refs: MBL-17860
affects: Parent
release note: Add support to submission viewer to properly display for non-enhanced assignments.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/c43d7f04-5e19-4824-94bf-725b1945f0c8" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/69822315-4615-43b5-acd6-d32fb282fbfc" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested in dark mode
- [x] Tested in light mode