### PR TITLE
[MBL-17786][Student] UI glitches

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/features/files/details/FileDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/files/details/FileDetailsFragment.kt
@@ -203,7 +203,7 @@ class FileDetailsFragment : ParentFragment() {
                         if (!TextUtils.isEmpty(it.thumbnailUrl)) {
 
                             fileIcon.layoutParams.apply {
-                                height = requireActivity().DP(230).toInt()
+                                height = requireActivity().DP(0).toInt()
                                 width = height
                             }
 

--- a/apps/student/src/main/res/layout/fragment_file_details.xml
+++ b/apps/student/src/main/res/layout/fragment_file_details.xml
@@ -15,7 +15,7 @@
   ~
   -->
 
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/activity_root"
@@ -27,7 +27,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?android:attr/actionBarSize"
-        android:layout_alignParentTop="true"
+        app:layout_constraintTop_toTopOf="parent"
         android:background="@color/textDarkest"
         android:elevation="6dp"
         app:popupTheme="@style/ToolBarPopupStyle"
@@ -38,7 +38,7 @@
         android:id="@+id/fileName"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/toolbar"
+        app:layout_constraintTop_toBottomOf="@+id/toolbar"
         android:layout_marginTop="12dp"
         android:ellipsize="end"
         android:focusable="true"
@@ -54,7 +54,7 @@
         android:id="@+id/fileType"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/fileName"
+        app:layout_constraintTop_toBottomOf="@+id/fileName"
         android:layout_marginTop="12dp"
         android:focusable="true"
         android:gravity="center"
@@ -68,7 +68,10 @@
         android:id="@+id/fileIcon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
+        app:layout_constraintTop_toBottomOf="@+id/fileType"
+        app:layout_constraintBottom_toTopOf="@id/buttonContainer"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         android:contentDescription="@string/fileIcon"
         android:focusable="true"
         android:minHeight="48dp"
@@ -79,8 +82,9 @@
         android:id="@+id/fileLoadingProgressBar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_above="@+id/buttonContainer"
-        android:layout_centerHorizontal="true"
+        app:layout_constraintBottom_toTopOf="@id/buttonContainer"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         android:visibility="gone"
         tools:visibility="visible"/>
 
@@ -88,7 +92,7 @@
         android:id="@+id/buttonContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
+        app:layout_constraintBottom_toBottomOf="parent"
         android:orientation="horizontal"
         android:padding="12dp">
 
@@ -112,4 +116,4 @@
 
     </LinearLayout>
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/student/src/main/res/layout/fragment_file_details.xml
+++ b/apps/student/src/main/res/layout/fragment_file_details.xml
@@ -74,6 +74,8 @@
         app:layout_constraintEnd_toEndOf="parent"
         android:contentDescription="@string/fileIcon"
         android:focusable="true"
+        app:layout_constraintHeight_max="230dp"
+        app:layout_constraintWidth_max="230dp"
         android:minHeight="48dp"
         android:minWidth="48dp"
         app:srcCompat="@drawable/ic_document"/>

--- a/apps/student/src/main/res/layout/viewholder_discussion_group_header.xml
+++ b/apps/student/src/main/res/layout/viewholder_discussion_group_header.xml
@@ -42,6 +42,7 @@
         android:id="@+id/collapseIcon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        app:tint="@color/textDark"
         android:importantForAccessibility="no"
         app:srcCompat="@drawable/ic_expand" />
 


### PR DESCRIPTION
Test plan:

- Check file details screen on mobile landscape when file is locked
- Check file details screen on mobile landscape when file is not locked
- Check discussion list on dark mode

refs: MBL-17786
affects: student
release note: none

## Screenshots
![Screenshot_20240919_092139](https://github.com/user-attachments/assets/f5a6ebe6-b2dc-4de0-98ca-393267623462)
![Screenshot_20240919_092119](https://github.com/user-attachments/assets/eea53aee-5f52-4e22-b825-73745f535003)
![Screenshot_20240920_094659](https://github.com/user-attachments/assets/b80e0252-170d-484a-aa42-10eefd61da7a)
![Screenshot_20240919_094131](https://github.com/user-attachments/assets/fa8eb471-6b07-4a83-869e-96f22065d403)



## Checklist

- [x] Tested in dark mode
- [x] Tested in light mode
