### PR TITLE
[MBL-17761][Student] - Implement E2E test case for uploading to 'Global' Files

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/FilesE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/FilesE2ETest.kt
@@ -235,8 +235,10 @@ class FilesE2ETest: StudentTest() {
         Log.d(PREPARATION_TAG,"Seeding data.")
         val data = seedData(students = 1, teachers = 1, courses = 1)
         val student = data.studentsList[0]
-
         val testFile = "samplepdf.pdf"
+
+        Log.d(PREPARATION_TAG, "Setup the '$testFile' file on the device and clear the cache to make sure that the file names won't interfere with the possible cached ones.")
+        setupFileOnDevice(testFile)
         File(InstrumentationRegistry.getInstrumentation().targetContext.cacheDir, "file_upload").deleteRecursively()
 
         Log.d(STEP_TAG,"Login with user: ${student.name}, login id: ${student.loginId}.")

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/ShareExtensionE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/ShareExtensionE2ETest.kt
@@ -159,11 +159,11 @@ class ShareExtensionE2ETest: StudentTest() {
         fileChooserPage.assertPageObjects()
         fileChooserPage.assertDialogTitle("Upload To My Files")
         fileChooserPage.assertFileDisplayed(jpgTestFileName)
-        fileChooserPage.assertFileDisplayed("samplepdf")
+        fileChooserPage.assertFileDisplayed(pdfTestFileName)
 
         Log.d(STEP_TAG,"Remove '$pdfTestFileName' file and assert that it's not displayed any more on the list but the other file is displayed.")
         fileChooserPage.removeFile("samplepdf")
-        fileChooserPage.assertFileNotDisplayed("samplepdf")
+        fileChooserPage.assertFileNotDisplayed(pdfTestFileName)
         fileChooserPage.assertFileDisplayed(jpgTestFileName)
 
         Log.d(STEP_TAG, "Click on 'Upload' button to upload the file.")

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/ShareExtensionE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/ShareExtensionE2ETest.kt
@@ -95,11 +95,11 @@ class ShareExtensionE2ETest: StudentTest() {
         shareExtensionTargetPage.pressNext()
 
         Log.d(STEP_TAG, "Assert that the File Upload page is displayed with the corresponding title.")
-        fileUploadPage.assertPageObjects()
-        fileUploadPage.assertDialogTitle("Submission")
+        fileChooserPage.assertPageObjects()
+        fileChooserPage.assertDialogTitle("Submission")
 
         Log.d(STEP_TAG, "Click on 'Turn In' button to upload both of the files.")
-        fileUploadPage.clickTurnIn()
+        fileChooserPage.clickTurnIn()
 
         Log.d(STEP_TAG, "Assert that the submission upload was successful.")
         shareExtensionStatusPage.assertPageObjects(30)
@@ -156,18 +156,18 @@ class ShareExtensionE2ETest: StudentTest() {
         shareExtensionTargetPage.pressNext()
 
         Log.d(STEP_TAG,"Assert that the title of the File Upload Page is correct and both of the shared files are displayed.")
-        fileUploadPage.assertPageObjects()
-        fileUploadPage.assertDialogTitle("Upload To My Files")
-        fileUploadPage.assertFileDisplayed(jpgTestFileName)
-        fileUploadPage.assertFileDisplayed("samplepdf")
+        fileChooserPage.assertPageObjects()
+        fileChooserPage.assertDialogTitle("Upload To My Files")
+        fileChooserPage.assertFileDisplayed(jpgTestFileName)
+        fileChooserPage.assertFileDisplayed("samplepdf")
 
         Log.d(STEP_TAG,"Remove '$pdfTestFileName' file and assert that it's not displayed any more on the list but the other file is displayed.")
-        fileUploadPage.removeFile("samplepdf")
-        fileUploadPage.assertFileNotDisplayed("samplepdf")
-        fileUploadPage.assertFileDisplayed(jpgTestFileName)
+        fileChooserPage.removeFile("samplepdf")
+        fileChooserPage.assertFileNotDisplayed("samplepdf")
+        fileChooserPage.assertFileDisplayed(jpgTestFileName)
 
         Log.d(STEP_TAG, "Click on 'Upload' button to upload the file.")
-        fileUploadPage.clickUpload()
+        fileChooserPage.clickUpload()
 
         Log.d(STEP_TAG, "Assert that the file upload (into my 'Files') was successful.")
         shareExtensionStatusPage.assertPageObjects()

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/usergroups/UserGroupFilesE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/usergroups/UserGroupFilesE2ETest.kt
@@ -94,12 +94,12 @@ class UserGroupFilesE2ETest : StudentTest() {
         Intents.init()
         try {
             stubFilePickerIntent("samplepdf.pdf")
-            fileUploadPage.chooseDevice()
+            fileChooserPage.chooseDevice()
         }
         finally {
             Intents.release()
         }
-        fileUploadPage.clickUpload()
+        fileChooserPage.clickUpload()
 
         Log.d(STEP_TAG, "Assert that the file upload was successful.")
         fileListPage.assertItemDisplayed("samplepdf.pdf")

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/ShareExtensionInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/ShareExtensionInteractionTest.kt
@@ -81,9 +81,9 @@ class ShareExtensionInteractionTest : StudentTest() {
 
         shareExtensionTargetPage.pressNext()
 
-        fileUploadPage.assertPageObjects()
-        fileUploadPage.assertDialogTitle("Upload To My Files")
-        fileUploadPage.assertFileDisplayed("sample.jpg")
+        fileChooserPage.assertPageObjects()
+        fileChooserPage.assertDialogTitle("Upload To My Files")
+        fileChooserPage.assertFileDisplayed("sample.jpg")
     }
 
     @Test
@@ -106,23 +106,23 @@ class ShareExtensionInteractionTest : StudentTest() {
 
         shareExtensionTargetPage.pressNext()
 
-        fileUploadPage.assertPageObjects()
-        fileUploadPage.assertFileDisplayed("sample.jpg")
+        fileChooserPage.assertPageObjects()
+        fileChooserPage.assertFileDisplayed("sample.jpg")
 
-        fileUploadPage.removeFile("sample.jpg")
+        fileChooserPage.removeFile("sample.jpg")
 
         // Add new file
         Intents.init()
         try {
             stubFilePickerIntent("samplepdf.pdf")
-            fileUploadPage.chooseDevice()
+            fileChooserPage.chooseDevice()
         }
         finally {
             Intents.release()
         }
 
-        fileUploadPage.assertFileNotDisplayed("sample.jpg")
-        fileUploadPage.assertFileDisplayed("samplepdf.pdf")
+        fileChooserPage.assertFileNotDisplayed("sample.jpg")
+        fileChooserPage.assertFileDisplayed("samplepdf.pdf")
     }
 
     @Test
@@ -147,9 +147,9 @@ class ShareExtensionInteractionTest : StudentTest() {
         shareExtensionTargetPage.assertAssignmentSelectorDisplayedWithAssignment(assignment.name!!)
         shareExtensionTargetPage.pressNext()
 
-        fileUploadPage.assertPageObjects()
-        fileUploadPage.assertDialogTitle("Submission")
-        fileUploadPage.assertFileDisplayed("sample.jpg")
+        fileChooserPage.assertPageObjects()
+        fileChooserPage.assertDialogTitle("Submission")
+        fileChooserPage.assertFileDisplayed("sample.jpg")
     }
 
     @Test
@@ -199,9 +199,9 @@ class ShareExtensionInteractionTest : StudentTest() {
 
         shareExtensionTargetPage.pressNext()
 
-        fileUploadPage.assertPageObjects()
-        fileUploadPage.assertDialogTitle("Submission")
-        fileUploadPage.assertFileDisplayed("sample.jpg")
+        fileChooserPage.assertPageObjects()
+        fileChooserPage.assertDialogTitle("Submission")
+        fileChooserPage.assertFileDisplayed("sample.jpg")
     }
 
     @Test
@@ -228,9 +228,9 @@ class ShareExtensionInteractionTest : StudentTest() {
 
         shareExtensionTargetPage.pressNext()
 
-        fileUploadPage.assertPageObjects()
-        fileUploadPage.assertFileDisplayed("sample.jpg")
-        fileUploadPage.assertFileDisplayed("samplepdf.pdf")
+        fileChooserPage.assertPageObjects()
+        fileChooserPage.assertFileDisplayed("sample.jpg")
+        fileChooserPage.assertFileDisplayed("samplepdf.pdf")
     }
 
     @Test
@@ -253,7 +253,7 @@ class ShareExtensionInteractionTest : StudentTest() {
 
         shareExtensionTargetPage.selectSubmission()
         shareExtensionTargetPage.pressNext()
-        fileUploadPage.clickTurnIn()
+        fileChooserPage.clickTurnIn()
 
         shareExtensionStatusPage.assertPageObjects()
         shareExtensionStatusPage.assertAssignmentSubmissionSuccess()

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/UserFilesInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/UserFilesInteractionTest.kt
@@ -107,14 +107,14 @@ class UserFilesInteractionTest : StudentTest() {
                             hasType("*/*")
                     )
             ).respondWith(activityResult)
-            fileUploadPage.chooseDevice()
+            fileChooserPage.chooseDevice()
         }
         finally {
             Intents.release()
         }
 
         // Now press the "Upload" button and verify that the file shows up in our list
-        fileUploadPage.clickUpload()
+        fileChooserPage.clickUpload()
         // Should be on file list page now
         fileListPage.refresh()
         fileListPage.assertItemDisplayed("sample.jpg")
@@ -149,14 +149,14 @@ class UserFilesInteractionTest : StudentTest() {
                     return Instrumentation.ActivityResult(Activity.RESULT_OK, resultData)
                 }
             })
-            fileUploadPage.chooseCamera()
+            fileChooserPage.chooseCamera()
         }
         finally {
             Intents.release()
         }
 
         // Now upload our new image and verify that it now shows up in the file list.
-        fileUploadPage.clickUpload()
+        fileChooserPage.clickUpload()
         // Should be on fileListPage by now
         fileListPage.refresh()
         fileListPage.assertItemDisplayed(fileName!!)
@@ -180,14 +180,14 @@ class UserFilesInteractionTest : StudentTest() {
                         hasType("image/*")
                     )
             ).respondWith(activityResult)
-            fileUploadPage.chooseGallery()
+            fileChooserPage.chooseGallery()
         }
         finally {
             Intents.release()
         }
 
         // Now upload our file and verify that it shows up in the file list
-        fileUploadPage.clickUpload()
+        fileChooserPage.clickUpload()
         // Should be on file list page now
         fileListPage.refresh()
         fileListPage.assertItemDisplayed("sample.jpg")

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/FileChooserPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/FileChooserPage.kt
@@ -19,26 +19,39 @@ package com.instructure.student.ui.pages
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.hasSibling
+import androidx.test.espresso.matcher.ViewMatchers.withChild
 import com.instructure.canvas.espresso.containsTextCaseInsensitive
 import com.instructure.espresso.OnViewWithId
+import com.instructure.espresso.WaitForViewWithId
 import com.instructure.espresso.assertDisplayed
+import com.instructure.espresso.assertHasText
 import com.instructure.espresso.click
 import com.instructure.espresso.matchers.WaitForViewMatcher.waitForViewToBeClickable
 import com.instructure.espresso.page.BasePage
-import com.instructure.espresso.page.onViewWithText
 import com.instructure.espresso.page.plus
 import com.instructure.espresso.page.withDescendant
+import com.instructure.espresso.page.withId
+import com.instructure.espresso.page.withParent
 import com.instructure.espresso.page.withText
 import com.instructure.espresso.scrollTo
 import com.instructure.student.R
 
-class FileUploadPage : BasePage() {
+class FileChooserPage : BasePage() {
     private val cameraButton by OnViewWithId(R.id.fromCamera)
     private val galleryButton by OnViewWithId(R.id.fromGallery)
     private val deviceButton by OnViewWithId(R.id.fromDevice)
     private val chooseFileTitle by OnViewWithId(R.id.chooseFileTitle)
     private val chooseFileSubtitle by OnViewWithId(R.id.chooseFileSubtitle)
+    private val fileChooserTitle by WaitForViewWithId(R.id.alertTitle)
+
+    fun assertFileChooserDetails() {
+        chooseFileTitle.assertDisplayed().assertHasText(R.string.chooseFile)
+        chooseFileSubtitle.assertDisplayed().assertHasText(R.string.chooseFileForUploadSubtext)
+        cameraButton.assertDisplayed()
+        galleryButton.assertDisplayed()
+        deviceButton.assertDisplayed()
+    }
 
     fun chooseCamera() {
         cameraButton.scrollTo().click()
@@ -60,6 +73,10 @@ class FileUploadPage : BasePage() {
         onView(withText(R.string.turnIn)).click()
     }
 
+    fun clickCancel() {
+        onView(withText(R.string.cancel)).click()
+    }
+
     fun removeFile(filename: String) {
         val fileItemMatcher = withId(R.id.fileItem) + withDescendant(withId(R.id.fileName) + containsTextCaseInsensitive(filename))
 
@@ -68,11 +85,15 @@ class FileUploadPage : BasePage() {
     }
 
     fun assertDialogTitle(title: String) {
-        onViewWithText(title).assertDisplayed()
+        fileChooserTitle.assertHasText(title)
     }
 
     fun assertFileDisplayed(filename: String) {
-        onView(withId(R.id.fileName) + containsTextCaseInsensitive(filename)).assertDisplayed()
+        val fileNameMatcher = withId(R.id.fileName) + withText(filename)
+        onView(fileNameMatcher).assertDisplayed()
+        onView(withId(R.id.fileSize) + hasSibling(fileNameMatcher)).assertDisplayed()
+        onView(withId(R.id.fileIcon)  + withParent(withId(R.id.iconWrapper) + hasSibling(withId(R.id.content) + withChild(fileNameMatcher)))).assertDisplayed()
+        onView(withId(R.id.removeFile)  + hasSibling(withId(R.id.content) + withChild(fileNameMatcher))).assertDisplayed()
     }
 
     fun assertFileNotDisplayed(filename: String) {

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTest.kt
@@ -32,6 +32,7 @@ import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.instructure.canvas.espresso.CanvasTest
+import com.instructure.canvas.espresso.common.pages.InboxPage
 import com.instructure.espresso.InstructureActivityTestRule
 import com.instructure.espresso.ModuleItemInteractions
 import com.instructure.espresso.Searchable
@@ -56,8 +57,8 @@ import com.instructure.student.ui.pages.DashboardPage
 import com.instructure.student.ui.pages.DiscussionListPage
 import com.instructure.student.ui.pages.ElementaryCoursePage
 import com.instructure.student.ui.pages.ElementaryDashboardPage
+import com.instructure.student.ui.pages.FileChooserPage
 import com.instructure.student.ui.pages.FileListPage
-import com.instructure.student.ui.pages.FileUploadPage
 import com.instructure.student.ui.pages.GoToQuizPage
 import com.instructure.student.ui.pages.GradesPage
 import com.instructure.student.ui.pages.GroupBrowserPage
@@ -65,7 +66,6 @@ import com.instructure.student.ui.pages.HelpPage
 import com.instructure.student.ui.pages.HomeroomPage
 import com.instructure.student.ui.pages.ImportantDatesPage
 import com.instructure.student.ui.pages.InboxConversationPage
-import com.instructure.canvas.espresso.common.pages.InboxPage
 import com.instructure.student.ui.pages.LeftSideNavigationDrawerPage
 import com.instructure.student.ui.pages.LegalPage
 import com.instructure.student.ui.pages.LoginFindSchoolPage
@@ -137,7 +137,7 @@ abstract class StudentTest : CanvasTest() {
     val discussionListPage = DiscussionListPage(Searchable(R.id.search, R.id.search_src_text, R.id.search_close_btn))
     val allCoursesPage = AllCoursesPage()
     val fileListPage = FileListPage(Searchable(R.id.search, R.id.queryInput, R.id.clearButton, R.id.backButton))
-    val fileUploadPage = FileUploadPage()
+    val fileChooserPage = FileChooserPage()
     val helpPage = HelpPage()
     val inboxConversationPage = InboxConversationPage()
     val inboxPage = InboxPage()


### PR DESCRIPTION
Implement E2E test case for uploading to 'global' files.
Also, covering a bug to try to add and remove multiple times to see if a "counter" is displayed in the file name, because it shouldn't).

Rename FileUploadPage to FileChooserPage as it is actually the file chooser dialog.
Add some page object methods and assertions.

refs: MBL-17761
affects: Student
release note: none

## Checklist

- [x] Run E2E test suite