### PR TITLE
[MBL-17827][Student][Teacher] Removed reply button for messages where reply is disabled

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/InboxConversationInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/InboxConversationInteractionTest.kt
@@ -414,6 +414,123 @@ class InboxConversationInteractionTest : StudentTest() {
         inboxConversationPage.assertMessageNotDisplayed(replyMessage)
     }
 
+    @Test
+    @TestMetaData(Priority.MANDATORY, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_showReplyButton() {
+        val data = createInitialData(studentCount = 3, teacherCount = 1)
+        val conversationSubject = "Test Subject"
+        val conversationMessageBody = "Test Message Body"
+        val conversation = data.addConversation(
+            senderId = data.students[2].id,
+            receiverIds = data.students.take(2).map {user -> user.id},
+            messageBody = conversationMessageBody,
+            messageSubject = conversationSubject
+        )
+
+        dashboardPage.clickInboxTab()
+        inboxPage.assertConversationDisplayed(conversationSubject)
+        inboxPage.openConversation(conversation)
+        inboxConversationPage.assertReplyButtonVisible(true)
+    }
+
+    @Test
+    @TestMetaData(Priority.MANDATORY, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_hideReplyButton() {
+        val data = createInitialData(studentCount = 3, teacherCount = 1)
+        val conversationSubject = "Test Subject"
+        val conversationMessageBody = "Test Message Body"
+        val conversation = data.addConversation(
+            senderId = data.students[2].id,
+            receiverIds = data.students.take(2).map {user -> user.id},
+            messageBody = conversationMessageBody,
+            messageSubject = conversationSubject,
+            cannotReply = true
+        )
+
+        dashboardPage.clickInboxTab()
+        inboxPage.assertConversationDisplayed(conversationSubject)
+        inboxPage.openConversation(conversation)
+        inboxConversationPage.assertReplyButtonVisible(false)
+    }
+
+    @Test
+    @TestMetaData(Priority.MANDATORY, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_showReplyMenuItems() {
+        val data = createInitialData(studentCount = 3, teacherCount = 1)
+        val conversationSubject = "Test Subject"
+        val conversationMessageBody = "Test Message Body"
+        val conversation = data.addConversation(
+            senderId = data.students[2].id,
+            receiverIds = data.students.take(2).map {user -> user.id},
+            messageBody = conversationMessageBody,
+            messageSubject = conversationSubject
+        )
+
+        dashboardPage.clickInboxTab()
+        inboxPage.assertConversationDisplayed(conversationSubject)
+        inboxPage.openConversation(conversation)
+        inboxConversationPage.assertReplyMenuItemsVisible(true)
+    }
+
+    @Test
+    @TestMetaData(Priority.MANDATORY, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_hideReplyMenuItems() {
+        val data = createInitialData(studentCount = 3, teacherCount = 1)
+        val conversationSubject = "Test Subject"
+        val conversationMessageBody = "Test Message Body"
+        val conversation = data.addConversation(
+            senderId = data.students[2].id,
+            receiverIds = data.students.take(2).map {user -> user.id},
+            messageBody = conversationMessageBody,
+            messageSubject = conversationSubject,
+            cannotReply = true
+        )
+
+        dashboardPage.clickInboxTab()
+        inboxPage.assertConversationDisplayed(conversationSubject)
+        inboxPage.openConversation(conversation)
+        inboxConversationPage.assertReplyMenuItemsVisible(false)
+    }
+
+    @Test
+    @TestMetaData(Priority.MANDATORY, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_showReplyMessageOptions() {
+        val data = createInitialData(studentCount = 3, teacherCount = 1)
+        val conversationSubject = "Test Subject"
+        val conversationMessageBody = "Test Message Body"
+        val conversation = data.addConversation(
+            senderId = data.students[2].id,
+            receiverIds = data.students.take(2).map {user -> user.id},
+            messageBody = conversationMessageBody,
+            messageSubject = conversationSubject
+        )
+
+        dashboardPage.clickInboxTab()
+        inboxPage.assertConversationDisplayed(conversationSubject)
+        inboxPage.openConversation(conversation)
+        inboxConversationPage.assertReplyMessageOptionsVisible(true)
+    }
+
+    @Test
+    @TestMetaData(Priority.MANDATORY, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_hideReplyMessageOptions() {
+        val data = createInitialData(studentCount = 3, teacherCount = 1)
+        val conversationSubject = "Test Subject"
+        val conversationMessageBody = "Test Message Body"
+        val conversation = data.addConversation(
+            senderId = data.students[2].id,
+            receiverIds = data.students.take(2).map {user -> user.id},
+            messageBody = conversationMessageBody,
+            messageSubject = conversationSubject,
+            cannotReply = true
+        )
+
+        dashboardPage.clickInboxTab()
+        inboxPage.assertConversationDisplayed(conversationSubject)
+        inboxPage.openConversation(conversation)
+        inboxConversationPage.assertReplyMessageOptionsVisible(false)
+    }
+
     private fun getFirstConversation(data: MockCanvas, includeIsAuthor: Boolean = false): Conversation {
         return data.conversations.values.toList()
             .filter { it.workflowState != Conversation.WorkflowState.ARCHIVED }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxConversationPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/InboxConversationPage.kt
@@ -32,8 +32,10 @@ import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.*
 import com.instructure.canvas.espresso.*
 import com.instructure.espresso.assertDisplayed
+import com.instructure.espresso.assertGone
 import com.instructure.espresso.click
 import com.instructure.espresso.page.BasePage
+import com.instructure.espresso.page.onView
 import com.instructure.espresso.page.onViewWithContentDescription
 import com.instructure.espresso.page.onViewWithText
 import com.instructure.espresso.page.plus
@@ -146,6 +148,45 @@ class InboxConversationPage : BasePage(R.id.inboxConversationPage) {
         onView(withId(R.id.starred)).check(matches(ImageViewDrawableMatcher(R.drawable.ic_star_outline, ThemePrefs.brandColor)))
     }
 
+    fun assertReplyButtonVisible(visible: Boolean) {
+        val replyButton = onView(withId(R.id.reply))
+        if (visible) {
+            replyButton.assertDisplayed()
+        } else {
+            replyButton.assertGone()
+        }
+    }
+
+    fun assertReplyMenuItemsVisible(visible: Boolean) {
+        onView(
+            allOf(
+                withContentDescription(stringContainsTextCaseInsensitive("More options")),
+                isDisplayed()
+            )
+        ).click()
+        val replyButton = onView(withText(R.string.reply))
+        val replyAllButton = onView(withText(R.string.replyAll))
+        if (visible) {
+            replyButton.assertDisplayed()
+            replyAllButton.assertDisplayed()
+        } else {
+            replyButton.check(doesNotExist())
+            replyAllButton.check(doesNotExist())
+        }
+    }
+
+    fun assertReplyMessageOptionsVisible(visible: Boolean) {
+        onView(withId(R.id.messageOptions)).click()
+        val replyButton = onView(withText(R.string.reply))
+        val replyAllButton = onView(withText(R.string.replyAll))
+        if (visible) {
+            replyButton.assertDisplayed()
+            replyAllButton.assertDisplayed()
+        } else {
+            replyButton.check(doesNotExist())
+            replyAllButton.check(doesNotExist())
+        }
+    }
 }
 
 // Arrgghh... I tried to put this in the canvas_espresso CustomMatchers module, but that required

--- a/apps/student/src/main/java/com/instructure/student/fragment/InboxConversationFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/InboxConversationFragment.kt
@@ -243,6 +243,9 @@ class InboxConversationFragment : ParentFragment() {
             }
         }
 
+        toolbar.menu.findItem(R.id.reply)?.isVisible = !conversation.cannotReply
+        toolbar.menu.findItem(R.id.replyAll)?.isVisible = !conversation.cannotReply
+
         toolbar.setOnMenuItemClickListener(menuListener)
     }
 

--- a/apps/student/src/main/java/com/instructure/student/holders/InboxMessageHolder.kt
+++ b/apps/student/src/main/java/com/instructure/student/holders/InboxMessageHolder.kt
@@ -80,7 +80,11 @@ class InboxMessageHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         // Set up message options
         messageOptions.onClick { v ->
             // Set up popup menu
-            val actions = MessageAdapterCallback.MessageClickAction.values()
+            val actions = MessageAdapterCallback.MessageClickAction.values().toMutableList()
+            if (conversation.cannotReply) {
+                actions.remove(MessageAdapterCallback.MessageClickAction.REPLY)
+                actions.remove(MessageAdapterCallback.MessageClickAction.REPLY_ALL)
+            }
             val popup = PopupMenu(v.context, v, Gravity.START)
             val menu = popup.menu
             for (action in actions) {
@@ -96,10 +100,18 @@ class InboxMessageHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
             // Show
             popup.show()
         }
-
-        reply.setTextColor(ThemePrefs.textButtonColor)
-        reply.setVisible(position == 0)
-        reply.onClick { callback.onMessageAction(MessageAdapterCallback.MessageClickAction.REPLY, message) }
+        if (!conversation.cannotReply) {
+            reply.setTextColor(ThemePrefs.textButtonColor)
+            reply.setVisible(position == 0)
+            reply.onClick {
+                callback.onMessageAction(
+                    MessageAdapterCallback.MessageClickAction.REPLY,
+                    message
+                )
+            }
+        } else {
+            reply.setVisible(false)
+        }
     }
 
     private val dateFormat = SimpleDateFormat(

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/InboxMessagePageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/InboxMessagePageTest.kt
@@ -16,9 +16,19 @@
  */
 package com.instructure.teacher.ui
 
+import com.instructure.canvas.espresso.FeatureCategory
+import com.instructure.canvas.espresso.Priority
+import com.instructure.canvas.espresso.TestCategory
+import com.instructure.canvas.espresso.TestMetaData
 import com.instructure.canvas.espresso.mockCanvas.MockCanvas
+import com.instructure.canvas.espresso.mockCanvas.addConversation
 import com.instructure.canvas.espresso.mockCanvas.addConversations
+import com.instructure.canvas.espresso.mockCanvas.addCoursePermissions
+import com.instructure.canvas.espresso.mockCanvas.addRecipientsToCourse
 import com.instructure.canvas.espresso.mockCanvas.init
+import com.instructure.canvasapi2.models.CanvasContextPermission
+import com.instructure.canvasapi2.models.Course
+import com.instructure.canvasapi2.models.User
 import com.instructure.teacher.ui.utils.TeacherTest
 import com.instructure.teacher.ui.utils.clickInboxTab
 import com.instructure.teacher.ui.utils.tokenLogin
@@ -27,6 +37,47 @@ import org.junit.Test
 
 @HiltAndroidTest
 class InboxMessagePageTest: TeacherTest() {
+
+    private lateinit var course1 : Course
+    private lateinit var student1 : User
+    private lateinit var teacher1 : User
+
+    private fun createInitialData(
+        studentCount: Int = 1,
+        teacherCount: Int = 1,
+        courseCount: Int = 1,
+        sendMessages: Boolean = true,
+        sendMessagesAll: Boolean = true
+    ): MockCanvas {
+        val data = MockCanvas.init(
+            studentCount = studentCount,
+            courseCount = courseCount,
+            teacherCount = teacherCount,
+            favoriteCourseCount = courseCount
+        )
+
+        student1 = data.students[0]
+        teacher1 = data.teachers[0]
+        course1 = data.courses.values.first()
+
+        data.addCoursePermissions(
+            course1.id,
+            CanvasContextPermission(send_messages_all = sendMessagesAll, send_messages = sendMessages)
+        )
+
+        data.addRecipientsToCourse(
+            course = course1,
+            students = data.students,
+            teachers = data.teachers
+        )
+
+        val token = data.tokenFor(student1)!!
+        tokenLogin(data.domain, token, student1)
+        dashboardPage.waitForRender()
+
+        return data
+    }
+
     @Test
     override fun displaysPageObjects() {
         getToMessageThread()
@@ -40,20 +91,134 @@ class InboxMessagePageTest: TeacherTest() {
     }
 
     private fun getToMessageThread() {
-        val data = MockCanvas.init(
-                teacherCount = 1,
-                courseCount = 1,
-                favoriteCourseCount = 1,
-                studentCount = 1
+        val data = createInitialData(studentCount = 3, teacherCount = 1)
+        val conversationSubject = "Test Subject"
+        val conversationMessageBody = "Test Message Body"
+        val conversation = data.addConversation(
+            senderId = data.students[2].id,
+            receiverIds = data.students.take(2).map {user -> user.id},
+            messageBody = conversationMessageBody,
+            messageSubject = conversationSubject
         )
 
-        val teacher = data.teachers[0]
-        data.addConversations(userId = teacher.id)
-        val chosenConversation = data.conversations.values.first { item -> item.isStarred }
-
-        val token = data.tokenFor(teacher)!!
-        tokenLogin(data.domain, token, teacher)
         dashboardPage.clickInboxTab()
-        inboxPage.openConversation(chosenConversation)
+        inboxPage.openConversation(conversation)
+    }
+
+    @Test
+    @TestMetaData(Priority.MANDATORY, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_showReplyButton() {
+        val data = createInitialData(studentCount = 3, teacherCount = 1)
+        val conversationSubject = "Test Subject"
+        val conversationMessageBody = "Test Message Body"
+        val conversation = data.addConversation(
+            senderId = data.students[2].id,
+            receiverIds = data.students.take(2).map {user -> user.id},
+            messageBody = conversationMessageBody,
+            messageSubject = conversationSubject
+        )
+
+        dashboardPage.clickInboxTab()
+        inboxPage.assertConversationDisplayed(conversationSubject)
+        inboxPage.openConversation(conversation)
+        inboxMessagePage.assertReplyButtonVisible(true)
+    }
+
+    @Test
+    @TestMetaData(Priority.MANDATORY, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_hideReplyButton() {
+        val data = createInitialData(studentCount = 3, teacherCount = 1)
+        val conversationSubject = "Test Subject"
+        val conversationMessageBody = "Test Message Body"
+        val conversation = data.addConversation(
+            senderId = data.students[2].id,
+            receiverIds = data.students.take(2).map {user -> user.id},
+            messageBody = conversationMessageBody,
+            messageSubject = conversationSubject,
+            cannotReply = true
+        )
+
+        dashboardPage.clickInboxTab()
+        inboxPage.assertConversationDisplayed(conversationSubject)
+        inboxPage.openConversation(conversation)
+        inboxMessagePage.assertReplyButtonVisible(false)
+    }
+
+    @Test
+    @TestMetaData(Priority.MANDATORY, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_showReplyMenuItems() {
+        val data = createInitialData(studentCount = 3, teacherCount = 1)
+        val conversationSubject = "Test Subject"
+        val conversationMessageBody = "Test Message Body"
+        val conversation = data.addConversation(
+            senderId = data.students[2].id,
+            receiverIds = data.students.take(2).map {user -> user.id},
+            messageBody = conversationMessageBody,
+            messageSubject = conversationSubject
+        )
+
+        dashboardPage.clickInboxTab()
+        inboxPage.assertConversationDisplayed(conversationSubject)
+        inboxPage.openConversation(conversation)
+        inboxMessagePage.assertReplyMenuItemsVisible(true)
+    }
+
+    @Test
+    @TestMetaData(Priority.MANDATORY, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_hideReplyMenuItems() {
+        val data = createInitialData(studentCount = 3, teacherCount = 1)
+        val conversationSubject = "Test Subject"
+        val conversationMessageBody = "Test Message Body"
+        val conversation = data.addConversation(
+            senderId = data.students[2].id,
+            receiverIds = data.students.take(2).map {user -> user.id},
+            messageBody = conversationMessageBody,
+            messageSubject = conversationSubject,
+            cannotReply = true
+        )
+
+        dashboardPage.clickInboxTab()
+        inboxPage.assertConversationDisplayed(conversationSubject)
+        inboxPage.openConversation(conversation)
+        inboxMessagePage.assertReplyMenuItemsVisible(false)
+    }
+
+    @Test
+    @TestMetaData(Priority.MANDATORY, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_showReplyMessageOptions() {
+        val data = createInitialData(studentCount = 3, teacherCount = 1)
+        val conversationSubject = "Test Subject"
+        val conversationMessageBody = "Test Message Body"
+        val conversation = data.addConversation(
+            senderId = data.students[2].id,
+            receiverIds = data.students.take(2).map {user -> user.id},
+            messageBody = conversationMessageBody,
+            messageSubject = conversationSubject
+        )
+
+        dashboardPage.clickInboxTab()
+        inboxPage.assertConversationDisplayed(conversationSubject)
+        inboxPage.openConversation(conversation)
+        inboxMessagePage.assertReplyMessageOptionsVisible(true)
+    }
+
+    @Test
+    @TestMetaData(Priority.MANDATORY, FeatureCategory.INBOX, TestCategory.INTERACTION)
+    fun testInbox_hideReplyMessageOptions() {
+        val data = createInitialData(studentCount = 3, teacherCount = 1)
+        val conversationSubject = "Test Subject"
+        val conversationMessageBody = "Test Message Body"
+        val conversation = data.addConversation(
+            senderId = data.students[2].id,
+            receiverIds = data.students.take(2).map {user -> user.id},
+            messageBody = conversationMessageBody,
+            messageSubject = conversationSubject,
+            cannotReply = true
+        )
+
+        dashboardPage.clickInboxTab()
+        inboxPage.assertConversationDisplayed(conversationSubject)
+        inboxPage.openConversation(conversation)
+        inboxMessagePage.assertReplyMessageOptionsVisible(false)
     }
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/InboxMessagePage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/InboxMessagePage.kt
@@ -19,19 +19,25 @@ package com.instructure.teacher.ui.pages
 import androidx.appcompat.widget.AppCompatButton
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.platform.app.InstrumentationRegistry
 import com.instructure.canvas.espresso.containsTextCaseInsensitive
+import com.instructure.canvas.espresso.stringContainsTextCaseInsensitive
 import com.instructure.espresso.OnViewWithId
 import com.instructure.espresso.OnViewWithMatcher
 import com.instructure.espresso.RecyclerViewItemCountAssertion
 import com.instructure.espresso.WaitForViewWithId
 import com.instructure.espresso.assertDisplayed
+import com.instructure.espresso.assertGone
 import com.instructure.espresso.click
 import com.instructure.espresso.page.BasePage
 import com.instructure.espresso.page.onView
 import com.instructure.espresso.page.withId
 import com.instructure.espresso.page.withParent
+import com.instructure.espresso.page.withText
 import com.instructure.teacher.R
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.Matchers
@@ -105,5 +111,45 @@ class InboxMessagePage: BasePage() {
             .perform(ViewActions.click())
         Espresso.onView(Matchers.allOf(ViewMatchers.isAssignableFrom(AppCompatButton::class.java),
             containsTextCaseInsensitive("DELETE"))).click()
+    }
+
+    fun assertReplyButtonVisible(visible: Boolean) {
+        val replyButton = onView(withId(R.id.reply))
+        if (visible) {
+            replyButton.assertDisplayed()
+        } else {
+            replyButton.assertGone()
+        }
+    }
+
+    fun assertReplyMenuItemsVisible(visible: Boolean) {
+        onView(
+            Matchers.allOf(
+                withContentDescription(stringContainsTextCaseInsensitive("Overflow")),
+                isDisplayed()
+            )
+        ).click()
+        val replyButton = onView(withText(R.string.reply))
+        val replyAllButton = onView(withText(R.string.replyAll))
+        if (visible) {
+            replyButton.assertDisplayed()
+            replyAllButton.assertDisplayed()
+        } else {
+            replyButton.check(doesNotExist())
+            replyAllButton.check(doesNotExist())
+        }
+    }
+
+    fun assertReplyMessageOptionsVisible(visible: Boolean) {
+        onView(withId(R.id.messageOptions)).click()
+        val replyButton = onView(withText(R.string.reply))
+        val replyAllButton = onView(withText(R.string.replyAll))
+        if (visible) {
+            replyButton.assertDisplayed()
+            replyAllButton.assertDisplayed()
+        } else {
+            replyButton.check(doesNotExist())
+            replyAllButton.check(doesNotExist())
+        }
     }
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/adapters/MessageAdapter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/adapters/MessageAdapter.kt
@@ -37,6 +37,15 @@ open class MessageAdapter(
     protected var mCallback: MessageAdapterCallback
 ) : SyncRecyclerAdapter<Message, MessageHolder, MessageThreadView>(context, presenter) {
 
+    fun updateConversation(conversation: Conversation?) {
+        conversation?.let {
+            if (conversation != mConversation) {
+                mConversation = conversation
+                notifyDataSetChanged()
+            }
+        }
+    }
+
     override fun bindHolder(model: Message, holder: MessageHolder, position: Int) = MessageBinder.bind(
         model, mConversation, mCallback.getParticipantById(model.authorId), position, mCallback, holder
     )

--- a/apps/teacher/src/main/java/com/instructure/teacher/binders/MessageBinder.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/binders/MessageBinder.kt
@@ -86,7 +86,11 @@ object MessageBinder {
         // Set up message options
         messageOptions.setOnClickListener { v ->
             // Set up popup menu
-            val actions = MessageAdapterCallback.MessageClickAction.values()
+            val actions = MessageAdapterCallback.MessageClickAction.values().toMutableList()
+            if (conversation.cannotReply) {
+                actions.remove(MessageAdapterCallback.MessageClickAction.REPLY)
+                actions.remove(MessageAdapterCallback.MessageClickAction.REPLY_ALL)
+            }
             val popup = PopupMenu(v.context, v, Gravity.START)
             val menu = popup.menu
             for (action in actions) {
@@ -104,9 +108,18 @@ object MessageBinder {
         }
 
         with(reply) {
-            setTextColor(ThemePrefs.textButtonColor)
-            setVisible(position == 0)
-            setOnClickListener { callback.onMessageAction(MessageAdapterCallback.MessageClickAction.REPLY, message) }
+            if (!conversation.cannotReply) {
+                setTextColor(ThemePrefs.textButtonColor)
+                setVisible(position == 0)
+                setOnClickListener {
+                    callback.onMessageAction(
+                        MessageAdapterCallback.MessageClickAction.REPLY,
+                        message
+                    )
+                }
+            } else {
+                setVisible(false)
+            }
         }
     }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/MessageThreadFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/MessageThreadFragment.kt
@@ -224,8 +224,6 @@ class MessageThreadFragment : BaseSyncFragment<Message, MessageThreadPresenter, 
     override fun onPresenterPrepared(presenter: MessageThreadPresenter) {
         conversationScope = nonNullArgs.getString(Const.SCOPE)
 
-        initToolbar()
-
         // We may not have the conversation yet (we don't when coming from a push notification)
         if (conversation != null) {
             setupConversationDetails()
@@ -262,6 +260,7 @@ class MessageThreadFragment : BaseSyncFragment<Message, MessageThreadPresenter, 
             toolbar.setupBackButton(this@MessageThreadFragment)
         }
 
+        toolbar.menu.clear()
         toolbar.inflateMenu(R.menu.message_thread)
 
         if (conversationScope != null && conversationScope == "sent") {
@@ -277,13 +276,21 @@ class MessageThreadFragment : BaseSyncFragment<Message, MessageThreadPresenter, 
             }
         }
 
+        conversation?.let {
+            toolbar.menu.findItem(R.id.reply)?.isVisible = (!it.cannotReply)
+            toolbar.menu.findItem(R.id.replyAll)?.isVisible = (!it.cannotReply)
+        }
+
         toolbar.setOnMenuItemClickListener(menuListener)
     }
 
     override fun setupConversationDetails() = with(binding) {
-        if(recyclerView.adapter == null) {
+        initToolbar()
+        if (recyclerView.adapter == null) {
             // If we didn't setup the adapter initially (we didn't start off with the conversation), then do it now
             recyclerView.adapter = adapter
+        } else {
+            (recyclerView.adapter as? MessageAdapter)?.updateConversation(conversation)
         }
 
         setupRecyclerView()

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/MockCanvas.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/MockCanvas.kt
@@ -887,7 +887,8 @@ fun MockCanvas.addConversation(
         senderId: Long,
         receiverIds: List<Long>,
         messageBody : String = Randomizer.randomConversationBody(),
-        messageSubject : String = Randomizer.randomConversationSubject()) : Conversation {
+        messageSubject : String = Randomizer.randomConversationSubject(),
+        cannotReply: Boolean = false) : Conversation {
 
     val sender = this.users[senderId]!!
     val senderBasic = BasicUser(
@@ -928,7 +929,8 @@ fun MockCanvas.addConversation(
             messages = listOf(basicMessage),
             avatarUrl = Randomizer.randomAvatarUrl(),
             participants = participants,
-            audience = null // Prevents "Monologue"
+            audience = null, // Prevents "Monologue"
+            cannotReply = cannotReply
     )
 
     this.conversations[result.id] = result

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Conversation.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Conversation.kt
@@ -58,7 +58,9 @@ data class Conversation(
         @SerializedName("context_name")
         val contextName: String? = null,
         @SerializedName("context_code")
-        val contextCode: String? = null
+        val contextCode: String? = null,
+        @SerializedName("cannot_reply")
+        val cannotReply: Boolean = false
 ) : CanvasModel<Conversation>() {
     // Helper variables
     @IgnoredOnParcel


### PR DESCRIPTION
Test plan: Intercept and edit response body when fetching conversation details, add field cannot_reply=true

refs: MBL-17827
affects: Student, Teacher
release note: Reply button is removed for messages where reply is disabled

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/cf6565ba-b204-4b38-8acf-e3be9ddd325f" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/c3a9e27b-be68-4531-8769-2286a38864ca" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/0ca99783-4610-4bb6-8c78-5ed18476a5df" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/385e2783-58ee-43e5-9086-e1f5ef5e5f25" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Run E2E test suite
- [x] Tested in dark mode
- [x] Tested in light mode
