### PR TITLE
[MBL-17379][Student][Teacher] - Implement E2E Tests for Push Notifications UI

### DIFF
--- a/apps/student/build.gradle
+++ b/apps/student/build.gradle
@@ -116,6 +116,9 @@ android {
             buildConfigField "String", "PRONOUN_STUDENT_TEST_USER", "\"$pronounTestStudent\""
             buildConfigField "String", "PRONOUN_STUDENT_TEST_PASSWORD", "\"$pronounTestStudentPassword\""
 
+            buildConfigField "String", "PUSH_NOTIFICATIONS_STUDENT_TEST_USER", "\"$pushNotificationsTestStudent\""
+            buildConfigField "String", "PUSH_NOTIFICATIONS_STUDENT_TEST_PASSWORD", "\"$pushNotificationsTestStudentPassword\""
+
             ext {
                 heapEnabled = true
             }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/PushNotificationsE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/PushNotificationsE2ETest.kt
@@ -1,0 +1,61 @@
+package com.instructure.student.ui.e2e
+
+import android.util.Log
+import com.instructure.canvas.espresso.E2E
+import com.instructure.canvas.espresso.FeatureCategory
+import com.instructure.canvas.espresso.Priority
+import com.instructure.canvas.espresso.TestCategory
+import com.instructure.canvas.espresso.TestMetaData
+import com.instructure.student.BuildConfig
+import com.instructure.student.ui.utils.StudentTest
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Test
+
+@HiltAndroidTest
+class PushNotificationsE2ETest : StudentTest() {
+
+    override fun displaysPageObjects() = Unit
+
+    override fun enableAndConfigureAccessibilityChecks() = Unit
+
+    @E2E
+    @Test
+    @TestMetaData(Priority.MANDATORY, FeatureCategory.PAGES, TestCategory.E2E)
+    fun testPushNotificationsUIE2E() {
+
+        Log.d(STEP_TAG, "Click 'Find My School' button.")
+        loginLandingPage.clickFindMySchoolButton()
+
+        Log.d(STEP_TAG,"Enter domain: 'mobileqa.instructure.com'.") //Push Notifications page is giving 'Unexpected Error' on beta yet, so we test it on original instance until it's fixed.
+        loginFindSchoolPage.enterDomain("mobileqa.instructure.com")
+
+        Log.d(STEP_TAG,"Click on 'Next' button on the Toolbar.")
+        loginFindSchoolPage.clickToolbarNextMenuItem()
+
+        Log.d(STEP_TAG, "Log in with any existing teacher user to test the Push Notification Page.")
+        loginSignInPage.loginAs(BuildConfig.PUSH_NOTIFICATIONS_STUDENT_TEST_USER, BuildConfig.PUSH_NOTIFICATIONS_STUDENT_TEST_PASSWORD)
+        dashboardPage.waitForRender()
+
+        Log.d(STEP_TAG, "Navigate to User Settings Page.")
+        leftSideNavigationDrawerPage.clickSettingsMenu()
+
+        Log.d(STEP_TAG, "Open Push Notifications Page.")
+        settingsPage.openPushNotificationsPage()
+
+        Log.d(ASSERTION_TAG, "Assert that the toolbar title is 'Push Notifications' on the Push Notifications Page.")
+        pushNotificationsPage.assertToolbarTitle()
+
+        Log.d(ASSERTION_TAG, "Assert that all the 'Course Activities' push notifications (with their descriptions) are displayed.")
+        pushNotificationsPage.assertCourseActivitiesPushNotificationsDisplayed()
+
+        Log.d(ASSERTION_TAG, "Assert that all the 'Discussions' push notifications (with their descriptions) are displayed.")
+        pushNotificationsPage.assertDiscussionsPushNotificationsDisplayed()
+
+        Log.d(ASSERTION_TAG, "Assert that all the 'Conversations' push notifications (with their descriptions) are displayed.")
+        pushNotificationsPage.assertConversationsPushNotificationsDisplayed()
+
+        Log.d(ASSERTION_TAG, "Assert that all the 'Scheduling' push notifications (with their descriptions) are displayed.")
+        pushNotificationsPage.assertSchedulingPushNotificationsDisplayed()
+    }
+
+}

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/SettingsE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/SettingsE2ETest.kt
@@ -57,7 +57,7 @@ class SettingsE2ETest : StudentTest() {
         val data = seedData(students = 1, teachers = 1, courses = 1)
         val student = data.studentsList[0]
 
-        Log.d(STEP_TAG, "Login with user: ${student.name}, login id: ${student.loginId}.")
+        Log.d(STEP_TAG, "Login with user: '${student.name}', login id: '${student.loginId}'.")
         tokenLogin(student)
         dashboardPage.waitForRender()
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/PushNotificationsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/PushNotificationsPage.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2024 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.instructure.student.ui.pages
+
+import androidx.test.espresso.matcher.ViewMatchers
+import com.instructure.espresso.WaitForViewWithText
+import com.instructure.espresso.assertDisplayed
+import com.instructure.espresso.page.BasePage
+import com.instructure.espresso.page.getStringFromResource
+import com.instructure.espresso.page.onView
+import com.instructure.espresso.page.plus
+import com.instructure.espresso.page.withId
+import com.instructure.espresso.page.withParent
+import com.instructure.espresso.page.withText
+import com.instructure.espresso.scrollTo
+import com.instructure.espresso.swipeUp
+import com.instructure.student.R
+
+class PushNotificationsPage : BasePage() {
+
+    private val courseActivitiesLabel by WaitForViewWithText(R.string.notification_cat_course_activities)
+    private val discussionsLabel by WaitForViewWithText(R.string.notification_cat_discussions)
+    private val conversationsLabel by WaitForViewWithText(R.string.notification_cat_conversations)
+    private val schedulingLabel by WaitForViewWithText(R.string.notification_cat_scheduling)
+
+    fun swipeUp() {
+        onView(withId(R.id.swipeRefreshLayout) + ViewMatchers.withParent(withId(R.id.pushNotificationPreferencesFragment))).swipeUp()
+    }
+
+    fun assertToolbarTitle() {
+       onView(withText(getStringFromResource(R.string.pushNotifications)) + withParent(R.id.toolbar)).assertDisplayed()
+    }
+
+    fun assertCourseActivitiesPushNotificationsDisplayed() {
+
+        //Course Activities group label
+        courseActivitiesLabel.scrollTo().assertDisplayed()
+
+        //Due Date
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_due_date))).scrollTo().assertDisplayed()
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_due_date))).scrollTo().assertDisplayed()
+
+        //Course Content
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_course_content))).scrollTo().assertDisplayed()
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_course_content))).scrollTo().assertDisplayed()
+
+        //Announcement
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_announcement))).scrollTo().assertDisplayed()
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_announcement))).scrollTo().assertDisplayed()
+
+        //Grading
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_grading))).scrollTo().assertDisplayed()
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_grading))).scrollTo().assertDisplayed()
+
+        //Invitation
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_invitation))).scrollTo().assertDisplayed()
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_invitation))).scrollTo().assertDisplayed()
+
+        //Submission Comment
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_submission_comment))).scrollTo().assertDisplayed()
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_submission_comment))).scrollTo().assertDisplayed()
+    }
+
+    fun assertDiscussionsPushNotificationsDisplayed() {
+
+        //Discussion group label
+        discussionsLabel.assertDisplayed()
+
+        swipeUp() //Need to swipe up the page for the other notifications as they
+        //Discussion
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_discussion))).assertDisplayed()
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_discussion))).assertDisplayed()
+
+        //Discussion Post
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_discussion_post))).assertDisplayed()
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_discussion_post))).assertDisplayed()
+    }
+
+    fun assertConversationsPushNotificationsDisplayed() {
+
+        //Conversations group label
+        conversationsLabel.scrollTo().assertDisplayed()
+
+        //Conversation Message
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_conversation_message))).scrollTo().assertDisplayed()
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_conversation_message))).scrollTo().assertDisplayed()
+    }
+
+    fun assertSchedulingPushNotificationsDisplayed() {
+
+        //Scheduling group label
+        schedulingLabel.assertDisplayed()
+
+        //Student Appointment Signups
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_student_appointment_signups)))
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_student_appointment_signups)))
+
+        //Appointment Cancellations
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_appointment_cancelations)))
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_appointment_cancelations)))
+
+        //Appointment Availability
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_appointment_availability)))
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_appointment_availability)))
+
+        //Calendar
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_calendar)))
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_calendar)))
+    }
+
+}

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SettingsPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/SettingsPage.kt
@@ -66,6 +66,11 @@ class SettingsPage : BasePage(R.id.settingsFragment) {
         profileSettingLabel.scrollTo().click()
     }
 
+    fun openPushNotificationsPage() {
+        pushNotificationsLabel.scrollTo().click()
+    }
+
+
     fun openSubscribeToCalendar() {
         subscribeCalendarLabel.scrollTo().click()
     }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/utils/StudentTest.kt
@@ -32,6 +32,7 @@ import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.instructure.canvas.espresso.CanvasTest
+import com.instructure.canvas.espresso.common.pages.InboxPage
 import com.instructure.espresso.InstructureActivityTestRule
 import com.instructure.espresso.ModuleItemInteractions
 import com.instructure.espresso.Searchable
@@ -65,7 +66,6 @@ import com.instructure.student.ui.pages.HelpPage
 import com.instructure.student.ui.pages.HomeroomPage
 import com.instructure.student.ui.pages.ImportantDatesPage
 import com.instructure.student.ui.pages.InboxConversationPage
-import com.instructure.canvas.espresso.common.pages.InboxPage
 import com.instructure.student.ui.pages.LeftSideNavigationDrawerPage
 import com.instructure.student.ui.pages.LegalPage
 import com.instructure.student.ui.pages.LoginFindSchoolPage
@@ -83,6 +83,7 @@ import com.instructure.student.ui.pages.PeopleListPage
 import com.instructure.student.ui.pages.PersonDetailsPage
 import com.instructure.student.ui.pages.PickerSubmissionUploadPage
 import com.instructure.student.ui.pages.ProfileSettingsPage
+import com.instructure.student.ui.pages.PushNotificationsPage
 import com.instructure.student.ui.pages.QRLoginPage
 import com.instructure.student.ui.pages.QuizListPage
 import com.instructure.student.ui.pages.QuizTakingPage
@@ -164,6 +165,7 @@ abstract class StudentTest : CanvasTest() {
     val goToQuizPage = GoToQuizPage(ModuleItemInteractions(R.id.moduleName, R.id.next_item, R.id.prev_item))
     val remoteConfigSettingsPage = RemoteConfigSettingsPage()
     val settingsPage = SettingsPage()
+    val pushNotificationsPage = PushNotificationsPage()
     val submissionDetailsPage = SubmissionDetailsPage()
     val textSubmissionUploadPage = TextSubmissionUploadPage()
     val syllabusPage = SyllabusPage()

--- a/apps/teacher/build.gradle
+++ b/apps/teacher/build.gradle
@@ -110,6 +110,9 @@ android {
             buildConfigField "String", "PRONOUN_TEACHER_TEST_USER", "\"$pronounTestTeacher\""
             buildConfigField "String", "PRONOUN_TEACHER_TEST_PASSWORD", "\"$pronounTestTeacherPassword\""
 
+            buildConfigField "String", "PUSH_NOTIFICATIONS_TEACHER_TEST_USER", "\"$pushNotificationsTestTeacher\""
+            buildConfigField "String", "PUSH_NOTIFICATIONS_TEACHER_TEST_PASSWORD", "\"$pushNotificationsTestTeacherPassword\""
+
             ext {
                 heapEnabled = true
             }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/PushNotificationsE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/PushNotificationsE2ETest.kt
@@ -1,0 +1,62 @@
+package com.instructure.teacher.ui.e2e
+
+import android.util.Log
+import com.instructure.canvas.espresso.E2E
+import com.instructure.canvas.espresso.FeatureCategory
+import com.instructure.canvas.espresso.Priority
+import com.instructure.canvas.espresso.TestCategory
+import com.instructure.canvas.espresso.TestMetaData
+import com.instructure.teacher.BuildConfig
+import com.instructure.teacher.ui.utils.TeacherTest
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Test
+
+@HiltAndroidTest
+class PushNotificationsE2ETest : TeacherTest() {
+
+    override fun displaysPageObjects() = Unit
+
+    override fun enableAndConfigureAccessibilityChecks() = Unit
+
+    @E2E
+    @Test
+    @TestMetaData(Priority.MANDATORY, FeatureCategory.PAGES, TestCategory.E2E)
+    fun testPushNotificationsUIE2E() {
+
+        Log.d(STEP_TAG, "Click 'Find My School' button.")
+        loginLandingPage.clickFindMySchoolButton()
+
+        Log.d(STEP_TAG,"Enter domain: 'mobileqa.instructure.com'.") //Push Notifications page is giving 'Unexpected Error' on beta yet, so we test it on original instance until it's fixed.
+        loginFindSchoolPage.enterDomain("mobileqa.instructure.com")
+
+        Log.d(STEP_TAG,"Click on 'Next' button on the Toolbar.")
+        loginFindSchoolPage.clickToolbarNextMenuItem()
+
+        Log.d(STEP_TAG, "Log in with any existing teacher user to test the Push Notification Page.")
+        loginSignInPage.loginAs(BuildConfig.PUSH_NOTIFICATIONS_TEACHER_TEST_USER, BuildConfig.PUSH_NOTIFICATIONS_TEACHER_TEST_PASSWORD)
+        dashboardPage.waitForRender()
+
+        Log.d(STEP_TAG, "Navigate to User Settings Page.")
+        leftSideNavigationDrawerPage.clickSettingsMenu()
+        settingsPage.assertPageObjects()
+
+        Log.d(STEP_TAG, "Open Push Notifications Page.")
+        settingsPage.openPushNotificationsPage()
+
+        Log.d(ASSERTION_TAG, "Assert that the toolbar title is 'Push Notifications' on the Push Notifications Page.")
+        pushNotificationsPage.assertToolbarTitle()
+
+        Log.d(ASSERTION_TAG, "Assert that all the 'Course Activities' push notifications (with their descriptions) are displayed.")
+        pushNotificationsPage.assertCourseActivitiesPushNotificationsDisplayed()
+
+        Log.d(ASSERTION_TAG, "Assert that all the 'Discussions' push notifications (with their descriptions) are displayed.")
+        pushNotificationsPage.assertDiscussionsPushNotificationsDisplayed()
+
+        Log.d(ASSERTION_TAG, "Assert that all the 'Conversations' push notifications (with their descriptions) are displayed.")
+        pushNotificationsPage.assertConversationsPushNotificationsDisplayed()
+
+        Log.d(ASSERTION_TAG, "Assert that all the 'Scheduling' push notifications (with their descriptions) are displayed.")
+        pushNotificationsPage.assertSchedulingPushNotificationsDisplayed()
+    }
+
+}

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/PushNotificationsPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/PushNotificationsPage.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2024 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.instructure.teacher.ui.pages
+
+import androidx.test.espresso.matcher.ViewMatchers
+import com.instructure.espresso.WaitForViewWithText
+import com.instructure.espresso.assertDisplayed
+import com.instructure.espresso.page.BasePage
+import com.instructure.espresso.page.getStringFromResource
+import com.instructure.espresso.page.onView
+import com.instructure.espresso.page.plus
+import com.instructure.espresso.page.withId
+import com.instructure.espresso.page.withParent
+import com.instructure.espresso.page.withText
+import com.instructure.espresso.scrollTo
+import com.instructure.espresso.swipeUp
+import com.instructure.teacher.R
+
+class PushNotificationsPage : BasePage() {
+
+    private val courseActivitiesLabel by WaitForViewWithText(R.string.notification_cat_course_activities)
+    private val discussionsLabel by WaitForViewWithText(R.string.notification_cat_discussions)
+    private val conversationsLabel by WaitForViewWithText(R.string.notification_cat_conversations)
+    private val schedulingLabel by WaitForViewWithText(R.string.notification_cat_scheduling)
+
+    fun swipeUp() {
+        onView(withId(R.id.swipeRefreshLayout) + ViewMatchers.withParent(withId(R.id.pushNotificationPreferencesFragment))).swipeUp()
+    }
+
+    fun assertToolbarTitle() {
+       onView(withText(getStringFromResource(R.string.pushNotifications)) + withParent(R.id.toolbar)).assertDisplayed()
+    }
+
+    fun assertCourseActivitiesPushNotificationsDisplayed() {
+
+        //Course Activities group label
+        courseActivitiesLabel.scrollTo().assertDisplayed()
+
+        //Due Date
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_due_date))).scrollTo().assertDisplayed()
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_due_date))).scrollTo().assertDisplayed()
+
+        //Course Content
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_course_content))).scrollTo().assertDisplayed()
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_course_content))).scrollTo().assertDisplayed()
+
+        //Announcement
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_announcement))).scrollTo().assertDisplayed()
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_announcement))).scrollTo().assertDisplayed()
+
+        //Grading
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_grading))).scrollTo().assertDisplayed()
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_grading))).scrollTo().assertDisplayed()
+
+        //Invitation
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_invitation))).scrollTo().assertDisplayed()
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_invitation))).scrollTo().assertDisplayed()
+
+        //Submission Comment
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_submission_comment))).scrollTo().assertDisplayed()
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_submission_comment))).scrollTo().assertDisplayed()
+    }
+
+    fun assertDiscussionsPushNotificationsDisplayed() {
+
+        //Discussion group label
+        discussionsLabel.assertDisplayed()
+
+        swipeUp() //Need to swipe up the page for the other notifications as they
+        //Discussion
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_discussion))).assertDisplayed()
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_discussion))).assertDisplayed()
+
+        //Discussion Post
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_discussion_post))).assertDisplayed()
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_discussion_post))).assertDisplayed()
+    }
+
+    fun assertConversationsPushNotificationsDisplayed() {
+
+        //Conversations group label
+        conversationsLabel.scrollTo().assertDisplayed()
+
+        //Conversation Message
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_conversation_message))).scrollTo().assertDisplayed()
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_conversation_message))).scrollTo().assertDisplayed()
+    }
+
+    fun assertSchedulingPushNotificationsDisplayed() {
+
+        //Scheduling group label
+        schedulingLabel.assertDisplayed()
+
+        //Student Appointment Signups
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_student_appointment_signups)))
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_student_appointment_signups)))
+
+        //Appointment Cancellations
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_appointment_cancelations)))
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_appointment_cancelations)))
+
+        //Appointment Availability
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_appointment_availability)))
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_appointment_availability)))
+
+        //Calendar
+        onView(withId(R.id.title) + withText(getStringFromResource(R.string.notification_pref_calendar)))
+        onView(withId(R.id.description) + withText(getStringFromResource(R.string.notification_desc_calendar)))
+    }
+
+}

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/utils/TeacherTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/utils/TeacherTest.kt
@@ -70,6 +70,7 @@ import com.instructure.teacher.ui.pages.PeopleListPage
 import com.instructure.teacher.ui.pages.PersonContextPage
 import com.instructure.teacher.ui.pages.PostSettingsPage
 import com.instructure.teacher.ui.pages.ProfileSettingsPage
+import com.instructure.teacher.ui.pages.PushNotificationsPage
 import com.instructure.teacher.ui.pages.QuizDetailsPage
 import com.instructure.teacher.ui.pages.QuizListPage
 import com.instructure.teacher.ui.pages.QuizSubmissionListPage
@@ -116,6 +117,7 @@ abstract class TeacherTest : CanvasTest() {
     val leftSideNavigationDrawerPage = LeftSideNavigationDrawerPage()
     val editDashboardPage = EditDashboardPage()
     val settingsPage = SettingsPage()
+    val pushNotificationsPage = PushNotificationsPage()
     val legalPage = LegalPage()
     val helpPage = HelpPage()
     val aboutPage = AboutPage()

--- a/libs/pandautils/src/main/res/layout/fragment_notification_preferences.xml
+++ b/libs/pandautils/src/main/res/layout/fragment_notification_preferences.xml
@@ -35,6 +35,7 @@
         tools:context=".features.notification.preferences.PushNotificationPreferencesFragment">
 
         <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/pushNotificationPreferencesFragment"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
@@ -51,6 +52,7 @@
                 tools:ignore="UnusedAttribute" />
 
             <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+                android:id="@+id/swipeRefreshLayout"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
                 app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
Implement E2E Tests for Push Notifications screen UI checks in both apps.

Add new page objects.
Add some ids.
Add dedicated users' vault variables to build gradle and use them in tests.

refs: MBL-17379
affects: Student, Teacher
release note: none

## Checklist

- [x] Run E2E test suite
