### PR TITLE
[MBL-17938] [Student] Make HelpLinks class attributes nullable

### DIFF
--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/HelpLinks.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/HelpLinks.kt
@@ -31,7 +31,7 @@ data class HelpLink(
         val type: String,
         @SerializedName("available_to")
         val availableTo: List<String>,
-        val url: String,
-        val text: String,
-        val subtext: String
+        val url: String?,
+        val text: String?,
+        val subtext: String?
 )

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/help/HelpDialogViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/help/HelpDialogViewModel.kt
@@ -35,7 +35,8 @@ import com.instructure.pandautils.utils.PackageInfoProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.launch
-import java.util.*
+import java.util.Date
+import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
@@ -100,7 +101,8 @@ class HelpDialogViewModel @Inject constructor(
         return list
             // Only want links for students
             .filter { helpLinkFilter.isLinkAllowed(it, favoriteCourses) }
-            .map { HelpLinkItemViewModel(HelpLinkViewData(it.text, it.subtext, mapAction(it)), ::onLinkClicked) }
+            .filter { it.text != null && it.subtext != null && it.url != null }
+            .map { HelpLinkItemViewModel(HelpLinkViewData(it.text.orEmpty(), it.subtext.orEmpty(), mapAction(it)), ::onLinkClicked) }
             .plus(HelpLinkItemViewModel(rateLink, ::onLinkClicked))
     }
 
@@ -116,11 +118,11 @@ class HelpDialogViewModel @Inject constructor(
             link.url == "#teacher_feedback" -> HelpDialogAction.AskInstructor
             // External URL, but we handle within the app
             link.id.contains("submit_feature_idea") -> createSubmitFeatureIdea()
-            link.url.startsWith("tel:") -> HelpDialogAction.Phone(link.url)
-            link.url.startsWith("mailto:") -> HelpDialogAction.SendMail(link.url)
-            link.url.contains("cases.canvaslms.com/liveagentchat") -> HelpDialogAction.OpenExternalBrowser(link.url)
+            link.url.orEmpty().startsWith("tel:") -> HelpDialogAction.Phone(link.url.orEmpty())
+            link.url.orEmpty().startsWith("mailto:") -> HelpDialogAction.SendMail(link.url.orEmpty())
+            link.url.orEmpty().contains("cases.canvaslms.com/liveagentchat") -> HelpDialogAction.OpenExternalBrowser(link.url.orEmpty())
             // External URL
-            else -> HelpDialogAction.OpenWebView(link.url, link.text)
+            else -> HelpDialogAction.OpenWebView(link.url.orEmpty(), link.text.orEmpty())
         }
     }
 

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/help/HelpDialogViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/help/HelpDialogViewModel.kt
@@ -101,7 +101,7 @@ class HelpDialogViewModel @Inject constructor(
         return list
             // Only want links for students
             .filter { helpLinkFilter.isLinkAllowed(it, favoriteCourses) }
-            .filter { it.text != null && it.subtext != null && it.url != null }
+            .filter { it.text != null && it.url != null }
             .map { HelpLinkItemViewModel(HelpLinkViewData(it.text.orEmpty(), it.subtext.orEmpty(), mapAction(it)), ::onLinkClicked) }
             .plus(HelpLinkItemViewModel(rateLink, ::onLinkClicked))
     }

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/help/HelpDialogViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/help/HelpDialogViewModelTest.kt
@@ -227,10 +227,46 @@ class HelpDialogViewModelTest {
         assertEquals(HelpLinkViewData("Share your love title", "", HelpDialogAction.RateTheApp), linksViewData[5].helpLinkViewData)
     }
 
+    @Test
+    fun `Filter out list items that has null attribute`() {
+        // Given
+        val defaultLinks = listOf(
+            createHelpLink(listOf("student"), text = null, subText = "Test", url = "Test"),
+            createHelpLink(listOf("student"), text = "Test", subText = "Test", url = null),
+            createHelpLink(listOf("student"), text = "Test", subText = null, url = "Test"),
+            createHelpLink(listOf("student"), text = null, subText = null, url = null),
+            createHelpLink(listOf("student"), text = "Test title", subText = "Test", url = "Test url"),
+        )
+        val helpLinks = HelpLinks(emptyList(), defaultLinks)
+
+        every { helpLinksManager.getHelpLinksAsync(any()) } returns mockk {
+            coEvery { await() } returns DataResult.Success(helpLinks)
+        }
+
+        every { courseManager.getAllFavoriteCoursesAsync(any()) } returns mockk {
+            coEvery { await() } returns DataResult.Success(emptyList())
+        }
+
+        every { context.getString(R.string.shareYourLove) } returns "Share your love title"
+
+        // When
+        viewModel = createViewModel()
+        viewModel.state.observe(lifecycleOwner, Observer {})
+        viewModel.data.observe(lifecycleOwner, Observer {})
+
+        // Then
+        assertTrue(viewModel.state.value is ViewState.Success)
+
+        val linksViewData = viewModel.data.value?.helpLinks ?: emptyList()
+        assertEquals(2, linksViewData.size)
+        assertEquals(HelpLinkViewData("Test title", "Test", HelpDialogAction.OpenWebView("Test url", "Test title")), linksViewData[0].helpLinkViewData)
+        assertEquals(HelpLinkViewData("Share your love title", "", HelpDialogAction.RateTheApp), linksViewData[1].helpLinkViewData)
+    }
+
     private fun createViewModel() =
         HelpDialogViewModel(helpLinksManager, courseManager, context, apiPrefs, packageInfoProvider, helpLinkFilter)
 
-    private fun createHelpLink(availableTo: List<String>, text: String, id: String = "", url: String = ""): HelpLink {
-        return HelpLink(id, "", availableTo, url, text, "")
+    private fun createHelpLink(availableTo: List<String>, text: String?, subText: String? = "", id: String = "", url: String? = ""): HelpLink {
+        return HelpLink(id, "", availableTo, url, text, subText)
     }
 }

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/help/HelpDialogViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/help/HelpDialogViewModelTest.kt
@@ -233,7 +233,7 @@ class HelpDialogViewModelTest {
         val defaultLinks = listOf(
             createHelpLink(listOf("student"), text = null, subText = "Test", url = "Test"),
             createHelpLink(listOf("student"), text = "Test", subText = "Test", url = null),
-            createHelpLink(listOf("student"), text = "Test", subText = null, url = "Test"),
+            createHelpLink(listOf("student"), text = "Test title", subText = null, url = "Test url"),
             createHelpLink(listOf("student"), text = null, subText = null, url = null),
             createHelpLink(listOf("student"), text = "Test title", subText = "Test", url = "Test url"),
         )
@@ -258,9 +258,10 @@ class HelpDialogViewModelTest {
         assertTrue(viewModel.state.value is ViewState.Success)
 
         val linksViewData = viewModel.data.value?.helpLinks ?: emptyList()
-        assertEquals(2, linksViewData.size)
-        assertEquals(HelpLinkViewData("Test title", "Test", HelpDialogAction.OpenWebView("Test url", "Test title")), linksViewData[0].helpLinkViewData)
-        assertEquals(HelpLinkViewData("Share your love title", "", HelpDialogAction.RateTheApp), linksViewData[1].helpLinkViewData)
+        assertEquals(3, linksViewData.size)
+        assertEquals(HelpLinkViewData("Test title", "", HelpDialogAction.OpenWebView("Test url", "Test title")), linksViewData[0].helpLinkViewData)
+        assertEquals(HelpLinkViewData("Test title", "Test", HelpDialogAction.OpenWebView("Test url", "Test title")), linksViewData[1].helpLinkViewData)
+        assertEquals(HelpLinkViewData("Share your love title", "", HelpDialogAction.RateTheApp), linksViewData[2].helpLinkViewData)
     }
 
     private fun createViewModel() =


### PR DESCRIPTION
Test plan: Open Help dialog on beta environment.

refs: MBL-17938
affects: Student
release note: none

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/52876f8f-0c09-46dc-9c32-717ec5685d33" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/d09bbf0d-dea7-4c63-958c-dbaa02103914" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Run E2E test suite
- [x] Tested in dark mode
- [x] Tested in light mode
