### PR TITLE
[MBL-17947][Parent] Fixed student colors and theme colors

### DIFF
--- a/apps/parent/src/main/java/com/instructure/parentapp/features/addstudent/AddStudentViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/addstudent/AddStudentViewModel.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.instructure.pandautils.utils.ColorKeeper
+import com.instructure.pandautils.utils.studentColor
 import com.instructure.parentapp.features.dashboard.SelectedStudentHolder
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -41,9 +42,7 @@ class AddStudentViewModel @Inject constructor(
     private val _uiState =
         MutableStateFlow(
             AddStudentUiState(
-                color = colorKeeper.getOrGenerateUserColor(
-                    selectedStudentHolder.selectedStudentState.value
-                ).color(),
+                color = selectedStudentHolder.selectedStudentState.value.studentColor,
                 actionHandler = this::handleAction
             )
         )
@@ -56,7 +55,7 @@ class AddStudentViewModel @Inject constructor(
         viewModelScope.launch {
             selectedStudentHolder.selectedStudentChangedFlow.collectLatest { user ->
                 _uiState.value = _uiState.value.copy(
-                    color = colorKeeper.getOrGenerateUserColor(user).color()
+                    color = user.studentColor
                 )
             }
         }

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/list/AlertsViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/list/AlertsViewModel.kt
@@ -23,6 +23,7 @@ import com.instructure.canvasapi2.models.AlertThreshold
 import com.instructure.canvasapi2.models.AlertWorkflowState
 import com.instructure.canvasapi2.models.User
 import com.instructure.pandautils.utils.ColorKeeper
+import com.instructure.pandautils.utils.studentColor
 import com.instructure.parentapp.R
 import com.instructure.parentapp.features.dashboard.AlertCountUpdater
 import com.instructure.parentapp.features.dashboard.SelectedStudentHolder
@@ -66,7 +67,7 @@ class AlertsViewModel @Inject constructor(
             selectedStudent = student
             _uiState.update {
                 it.copy(
-                    studentColor = colorKeeper.getOrGenerateUserColor(student).color(),
+                    studentColor = student.studentColor,
                     isLoading = true
                 )
             }

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/list/AlertsViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/list/AlertsViewModel.kt
@@ -40,7 +40,6 @@ import javax.inject.Inject
 @HiltViewModel
 class AlertsViewModel @Inject constructor(
     private val repository: AlertsRepository,
-    private val colorKeeper: ColorKeeper,
     private val selectedStudentHolder: SelectedStudentHolder,
     private val alertCountUpdater: AlertCountUpdater
 ) : ViewModel() {
@@ -59,6 +58,20 @@ class AlertsViewModel @Inject constructor(
             selectedStudentHolder.selectedStudentState.collectLatest {
                 studentChanged(it)
             }
+        }
+
+        viewModelScope.launch {
+            selectedStudentHolder.selectedStudentColorChanged.collect {
+                updateColor()
+            }
+        }
+    }
+
+    private fun updateColor() {
+        _uiState.update {
+            selectedStudent?.let { student ->
+                it.copy(studentColor = student.studentColor)
+            } ?: it
         }
     }
 

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/list/AlertsViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/list/AlertsViewModel.kt
@@ -22,7 +22,6 @@ import com.instructure.canvasapi2.models.Alert
 import com.instructure.canvasapi2.models.AlertThreshold
 import com.instructure.canvasapi2.models.AlertWorkflowState
 import com.instructure.canvasapi2.models.User
-import com.instructure.pandautils.utils.ColorKeeper
 import com.instructure.pandautils.utils.studentColor
 import com.instructure.parentapp.R
 import com.instructure.parentapp.features.dashboard.AlertCountUpdater

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/list/AlertsViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/list/AlertsViewModel.kt
@@ -67,10 +67,10 @@ class AlertsViewModel @Inject constructor(
     }
 
     private fun updateColor() {
-        _uiState.update {
-            selectedStudent?.let { student ->
+        selectedStudent?.let { student ->
+            _uiState.update {
                 it.copy(studentColor = student.studentColor)
-            } ?: it
+            }
         }
     }
 

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/settings/AlertSettingsScreen.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/settings/AlertSettingsScreen.kt
@@ -114,7 +114,7 @@ fun AlertSettingsScreen(
                         }
                         OverflowMenu(
                             modifier = Modifier
-                                .background(color = colorResource(id = com.instructure.pandautils.R.color.backgroundLightestElevated)),
+                                .background(color = colorResource(id = R.color.backgroundLightestElevated)),
                             showMenu = showMenu,
                             iconColor = colorResource(id = R.color.textLightest),
                             onDismissRequest = { showMenu = !showMenu }) {

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/settings/AlertSettingsScreen.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/settings/AlertSettingsScreen.kt
@@ -99,7 +99,7 @@ fun AlertSettingsScreen(
                     navIconRes = R.drawable.ic_back_arrow,
                     navigationActionClick = navigationActionClick,
                     backgroundColor = Color(uiState.userColor),
-                    textColor = colorResource(id = R.color.white),
+                    textColor = colorResource(id = R.color.textLightest),
                     actions = {
                         var showMenu by remember { mutableStateOf(false) }
                         var showConfirmationDialog by remember { mutableStateOf(false) }
@@ -113,7 +113,10 @@ fun AlertSettingsScreen(
                             }
                         }
                         OverflowMenu(
+                            modifier = Modifier
+                                .background(color = colorResource(id = com.instructure.pandautils.R.color.backgroundLightestElevated)),
                             showMenu = showMenu,
+                            iconColor = colorResource(id = R.color.textLightest),
                             onDismissRequest = { showMenu = !showMenu }) {
                             DropdownMenuItem(
                                 modifier = Modifier.testTag("deleteMenuItem"),
@@ -123,7 +126,7 @@ fun AlertSettingsScreen(
                                         showConfirmationDialog = true
                                     }
                                 }) {
-                                Text(text = stringResource(id = R.string.delete))
+                                Text(text = stringResource(id = R.string.delete), color = colorResource(id = R.color.textDarkest))
                             }
                         }
                     }

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/settings/AlertSettingsViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/settings/AlertSettingsViewModel.kt
@@ -23,7 +23,7 @@ import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.instructure.canvasapi2.models.AlertType
 import com.instructure.canvasapi2.models.User
 import com.instructure.pandautils.utils.Const
-import com.instructure.pandautils.utils.color
+import com.instructure.pandautils.utils.studentColor
 import com.instructure.parentapp.R
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
@@ -50,7 +50,7 @@ class AlertSettingsViewModel @Inject constructor(
             avatarUrl = student.avatarUrl.orEmpty(),
             studentName = student.shortName ?: student.name,
             studentPronouns = student.pronouns,
-            userColor = student.color,
+            userColor = student.studentColor,
             actionHandler = this::handleAction
         )
     )

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/calendar/ParentCalendarFragment.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/calendar/ParentCalendarFragment.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.lifecycleScope
 import com.instructure.pandautils.features.calendar.BaseCalendarFragment
 import com.instructure.pandautils.utils.ColorKeeper
 import com.instructure.pandautils.utils.ViewStyler
+import com.instructure.pandautils.utils.studentColor
 import com.instructure.parentapp.features.dashboard.SelectedStudentHolder
 import com.instructure.parentapp.util.ParentPrefs
 import dagger.hilt.android.AndroidEntryPoint
@@ -48,7 +49,7 @@ class ParentCalendarFragment : BaseCalendarFragment() {
 
     override fun applyTheme() {
         val student = ParentPrefs.currentStudent
-        val color = ColorKeeper.getOrGenerateUserColor(student).color()
+        val color = student.studentColor
         ViewStyler.setStatusBarDark(requireActivity(), color)
     }
 

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/courses/details/CourseDetailsFragment.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/courses/details/CourseDetailsFragment.kt
@@ -30,7 +30,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.instructure.pandautils.utils.ViewStyler
 import com.instructure.pandautils.utils.collectOneOffEvents
-import com.instructure.pandautils.utils.color
+import com.instructure.pandautils.utils.studentColor
 import com.instructure.parentapp.util.ParentPrefs
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -58,7 +58,7 @@ class CourseDetailsFragment : Fragment() {
     }
 
     private fun applyTheme() {
-        val color = ParentPrefs.currentStudent.color
+        val color = ParentPrefs.currentStudent.studentColor
         ViewStyler.setStatusBarDark(requireActivity(), color)
     }
 

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/courses/details/CourseDetailsViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/courses/details/CourseDetailsViewModel.kt
@@ -24,8 +24,8 @@ import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.models.Tab
 import com.instructure.canvasapi2.utils.weave.catch
 import com.instructure.canvasapi2.utils.weave.tryLaunch
-import com.instructure.pandautils.utils.color
 import com.instructure.pandautils.utils.orDefault
+import com.instructure.pandautils.utils.studentColor
 import com.instructure.parentapp.util.ParentPrefs
 import com.instructure.parentapp.util.navigation.Navigation
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -62,7 +62,7 @@ class CourseDetailsViewModel @Inject constructor(
             _uiState.update {
                 it.copy(
                     isLoading = true,
-                    studentColor = parentPrefs.currentStudent.color
+                    studentColor = parentPrefs.currentStudent.studentColor
                 )
             }
 

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/courses/list/CoursesViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/courses/list/CoursesViewModel.kt
@@ -23,6 +23,7 @@ import com.instructure.canvasapi2.models.User
 import com.instructure.canvasapi2.utils.weave.catch
 import com.instructure.canvasapi2.utils.weave.tryLaunch
 import com.instructure.pandautils.utils.ColorKeeper
+import com.instructure.pandautils.utils.studentColor
 import com.instructure.parentapp.features.dashboard.SelectedStudentHolder
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
@@ -60,7 +61,7 @@ class CoursesViewModel @Inject constructor(
 
     private fun loadCourses(forceRefresh: Boolean = false) {
         viewModelScope.tryLaunch {
-            val color = colorKeeper.getOrGenerateUserColor(selectedStudent).color()
+            val color = selectedStudent.studentColor
 
             _uiState.update {
                 it.copy(

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/courses/list/CoursesViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/courses/list/CoursesViewModel.kt
@@ -38,9 +38,8 @@ import javax.inject.Inject
 @HiltViewModel
 class CoursesViewModel @Inject constructor(
     private val repository: CoursesRepository,
-    private val colorKeeper: ColorKeeper,
     private val selectedStudentHolder: SelectedStudentHolder,
-    private val courseGradeFormatter: CourseGradeFormatter
+    private val courseGradeFormatter: CourseGradeFormatter,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(CoursesUiState())
@@ -56,6 +55,20 @@ class CoursesViewModel @Inject constructor(
             selectedStudentHolder.selectedStudentState.collect {
                 studentChanged(it)
             }
+        }
+
+        viewModelScope.launch {
+            selectedStudentHolder.selectedStudentColorChanged.collect {
+                updateColor()
+            }
+        }
+    }
+
+    private fun updateColor() {
+        _uiState.update {
+            selectedStudent?.let { student ->
+                it.copy(studentColor = student.studentColor)
+            } ?: it
         }
     }
 
@@ -104,10 +117,8 @@ class CoursesViewModel @Inject constructor(
     }
 
     private fun studentChanged(student: User?) {
-        if (selectedStudent != student) {
             selectedStudent = student
             loadCourses()
-        }
     }
 
     fun handleAction(action: CoursesAction) {

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/courses/list/CoursesViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/courses/list/CoursesViewModel.kt
@@ -65,10 +65,10 @@ class CoursesViewModel @Inject constructor(
     }
 
     private fun updateColor() {
-        _uiState.update {
-            selectedStudent?.let { student ->
+        selectedStudent?.let { student ->
+            _uiState.update {
                 it.copy(studentColor = student.studentColor)
-            } ?: it
+            }
         }
     }
 

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/courses/list/CoursesViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/courses/list/CoursesViewModel.kt
@@ -39,7 +39,7 @@ import javax.inject.Inject
 class CoursesViewModel @Inject constructor(
     private val repository: CoursesRepository,
     private val selectedStudentHolder: SelectedStudentHolder,
-    private val courseGradeFormatter: CourseGradeFormatter,
+    private val courseGradeFormatter: CourseGradeFormatter
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(CoursesUiState())
@@ -117,8 +117,10 @@ class CoursesViewModel @Inject constructor(
     }
 
     private fun studentChanged(student: User?) {
+        if (selectedStudent != student) {
             selectedStudent = student
             loadCourses()
+        }
     }
 
     fun handleAction(action: CoursesAction) {

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/dashboard/AddStudentItemViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/dashboard/AddStudentItemViewModel.kt
@@ -16,13 +16,21 @@
  */    package com.instructure.parentapp.features.dashboard
 
 import androidx.annotation.ColorInt
+import androidx.databinding.BaseObservable
+import androidx.databinding.Bindable
 import com.instructure.pandautils.mvvm.ItemViewModel
 import com.instructure.parentapp.R
+import com.instructure.parentapp.BR
 
 data class AddStudentItemViewModel(
-    @ColorInt val color: Int,
+    @Bindable @ColorInt var color: Int,
     val onAddStudentClicked: () -> Unit
-) : ItemViewModel {
+) : BaseObservable(), ItemViewModel {
     override val viewType: Int = StudentListViewType.ADD_STUDENT.viewType
     override val layoutId = R.layout.item_add_student
+
+    fun updateColor(@ColorInt color: Int) {
+        this.color = color
+        notifyPropertyChanged(BR.color)
+    }
 }

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/dashboard/DashboardFragment.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/dashboard/DashboardFragment.kt
@@ -53,6 +53,7 @@ import com.instructure.pandautils.utils.onClick
 import com.instructure.pandautils.utils.setGone
 import com.instructure.pandautils.utils.setVisible
 import com.instructure.pandautils.utils.showThemed
+import com.instructure.pandautils.utils.studentColor
 import com.instructure.pandautils.utils.toPx
 import com.instructure.parentapp.R
 import com.instructure.parentapp.databinding.FragmentDashboardBinding
@@ -281,7 +282,7 @@ class DashboardFragment : Fragment(), NavigationCallbacks {
     }
 
     private fun setupAppColors(student: User?) {
-        val color = ColorKeeper.getOrGenerateUserColor(student).color()
+        val color = student.studentColor
         if (binding.toolbar.background == null) {
             binding.toolbar.setBackgroundColor(color)
         } else {
@@ -318,7 +319,7 @@ class DashboardFragment : Fragment(), NavigationCallbacks {
                 ParentLogoutTask(LogoutTask.Type.LOGOUT).execute()
             }
             .setNegativeButton(android.R.string.cancel, null)
-            .showThemed(ColorKeeper.getOrGenerateUserColor(ParentPrefs.currentStudent).color())
+            .showThemed(ParentPrefs.currentStudent.studentColor)
     }
 
     private fun onSwitchUsers() {

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/dashboard/DashboardFragment.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/dashboard/DashboardFragment.kt
@@ -298,6 +298,7 @@ class DashboardFragment : Fragment(), NavigationCallbacks {
         binding.unreadCountBadge.setTextColor(color)
 
         binding.bottomNav.getOrCreateBadge(R.id.alerts).backgroundColor = color
+        viewModel.updateColor(color)
     }
 
     private fun openNavigationDrawer() {

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/dashboard/DashboardViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/dashboard/DashboardViewModel.kt
@@ -32,6 +32,7 @@ import com.instructure.loginapi.login.util.PreviousUsersUtils
 import com.instructure.pandautils.mvvm.ViewState
 import com.instructure.pandautils.utils.ColorKeeper
 import com.instructure.pandautils.utils.orDefault
+import com.instructure.pandautils.utils.studentColor
 import com.instructure.parentapp.R
 import com.instructure.parentapp.features.alerts.list.AlertsRepository
 import com.instructure.parentapp.util.ParentPrefs
@@ -182,7 +183,7 @@ class DashboardViewModel @Inject constructor(
 
         val studentItemsWithAddStudent = if (studentItems.isNotEmpty()) {
             studentItems + AddStudentItemViewModel(
-                colorKeeper.getOrGenerateUserColor(selectedStudent).color(),
+                selectedStudent.studentColor,
                 ::addStudent
             )
         } else {
@@ -224,7 +225,7 @@ class DashboardViewModel @Inject constructor(
                 selectedStudent = student,
                 studentItems = it.studentItems.map { item ->
                     if (item is AddStudentItemViewModel) {
-                        item.copy(color = colorKeeper.getOrGenerateUserColor(student).color())
+                        item.copy(color = student.studentColor)
                     } else {
                         item
                     }

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/dashboard/DashboardViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/dashboard/DashboardViewModel.kt
@@ -20,6 +20,7 @@ package com.instructure.parentapp.features.dashboard
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
+import androidx.annotation.ColorInt
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -59,7 +60,6 @@ class DashboardViewModel @Inject constructor(
     private val selectedStudentHolder: SelectedStudentHolder,
     private val inboxCountUpdater: InboxCountUpdater,
     private val alertCountUpdater: AlertCountUpdater,
-    private val colorKeeper: ColorKeeper,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -248,8 +248,8 @@ class DashboardViewModel @Inject constructor(
     }
 
     private suspend fun updateAlertCount() {
-        _data.value.selectedStudent?.id?.let {
-            val alertCount = alertsRepository.getUnreadAlertCount(it)
+        _data.value.selectedStudent?.id?.let { selectedStudentId ->
+            val alertCount = alertsRepository.getUnreadAlertCount(selectedStudentId)
             _data.update {
                 it.copy(
                     alertCount = alertCount
@@ -261,6 +261,12 @@ class DashboardViewModel @Inject constructor(
     fun toggleStudentSelector() {
         _data.update {
             it.copy(studentSelectorExpanded = !it.studentSelectorExpanded)
+        }
+    }
+
+    fun updateColor(@ColorInt color: Int) {
+        _data.value.studentItems.find { it is AddStudentItemViewModel }?.let { addStudentItem ->
+            (addStudentItem as AddStudentItemViewModel).updateColor(color)
         }
     }
 }

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/dashboard/SelectedStudentHolder.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/dashboard/SelectedStudentHolder.kt
@@ -29,7 +29,9 @@ import kotlinx.coroutines.flow.asStateFlow
 interface SelectedStudentHolder {
     val selectedStudentState: StateFlow<User?>
     val selectedStudentChangedFlow: SharedFlow<User>
+    val selectedStudentColorChanged: SharedFlow<Unit>
     suspend fun updateSelectedStudent(user: User)
+    suspend fun selectedStudentColorChanged()
 }
 
 class SelectedStudentHolderImpl : SelectedStudentHolder {
@@ -39,8 +41,15 @@ class SelectedStudentHolderImpl : SelectedStudentHolder {
     private val _selectedStudentChangedFlow = MutableSharedFlow<User>()
     override val selectedStudentChangedFlow: SharedFlow<User> = _selectedStudentChangedFlow.asSharedFlow()
 
+    private val _selectedStudentColorChanged = MutableSharedFlow<Unit>()
+    override val selectedStudentColorChanged: SharedFlow<Unit> = _selectedStudentColorChanged.asSharedFlow()
+
     override suspend fun updateSelectedStudent(user: User) {
         _selectedStudentState.value = user
         _selectedStudentChangedFlow.emit(user)
+    }
+
+    override suspend fun selectedStudentColorChanged() {
+        _selectedStudentColorChanged.emit(Unit)
     }
 }

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/grades/ParentGradesBehaviour.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/grades/ParentGradesBehaviour.kt
@@ -18,7 +18,7 @@
 package com.instructure.parentapp.features.grades
 
 import com.instructure.pandautils.features.grades.GradesBehaviour
-import com.instructure.pandautils.utils.color
+import com.instructure.pandautils.utils.studentColor
 import com.instructure.parentapp.util.ParentPrefs
 
 
@@ -26,5 +26,5 @@ class ParentGradesBehaviour(
     parentPrefs: ParentPrefs
 ) : GradesBehaviour {
 
-    override val canvasContextColor = parentPrefs.currentStudent.color
+    override val canvasContextColor = parentPrefs.currentStudent.studentColor
 }

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/main/MainActivity.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/main/MainActivity.kt
@@ -19,6 +19,7 @@ package com.instructure.parentapp.features.main
 
 import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
@@ -29,6 +30,7 @@ import androidx.navigation.fragment.NavHostFragment
 import com.instructure.pandautils.binding.viewBinding
 import com.instructure.pandautils.features.inbox.list.OnUnreadCountInvalidated
 import com.instructure.pandautils.interfaces.NavigationCallbacks
+import com.instructure.pandautils.utils.ColorKeeper
 import com.instructure.pandautils.utils.Const
 import com.instructure.parentapp.R
 import com.instructure.parentapp.databinding.ActivityMainBinding
@@ -56,7 +58,13 @@ class MainActivity : AppCompatActivity(), OnUnreadCountInvalidated {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
+        setupTheme()
         setupNavigation()
+    }
+
+    private fun setupTheme() {
+        val nightModeFlags: Int = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        ColorKeeper.darkTheme = nightModeFlags == Configuration.UI_MODE_NIGHT_YES
     }
 
     override fun onNewIntent(intent: Intent?) {

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/main/MainActivity.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/main/MainActivity.kt
@@ -32,6 +32,7 @@ import com.instructure.pandautils.features.inbox.list.OnUnreadCountInvalidated
 import com.instructure.pandautils.interfaces.NavigationCallbacks
 import com.instructure.pandautils.utils.ColorKeeper
 import com.instructure.pandautils.utils.Const
+import com.instructure.pandautils.utils.ThemePrefs
 import com.instructure.parentapp.R
 import com.instructure.parentapp.databinding.ActivityMainBinding
 import com.instructure.parentapp.features.dashboard.InboxCountUpdater
@@ -63,6 +64,7 @@ class MainActivity : AppCompatActivity(), OnUnreadCountInvalidated {
     }
 
     private fun setupTheme() {
+        ThemePrefs.reapplyCanvasTheme(this)
         val nightModeFlags: Int = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
         ColorKeeper.darkTheme = nightModeFlags == Configuration.UI_MODE_NIGHT_YES
     }

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/managestudents/ManageStudentViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/managestudents/ManageStudentViewModel.kt
@@ -18,14 +18,12 @@
 package com.instructure.parentapp.features.managestudents
 
 import android.content.Context
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.instructure.canvasapi2.models.User
 import com.instructure.canvasapi2.utils.weave.catch
 import com.instructure.canvasapi2.utils.weave.tryLaunch
 import com.instructure.pandautils.utils.ColorKeeper
-import com.instructure.pandautils.utils.createThemedColor
 import com.instructure.pandautils.utils.orDefault
 import com.instructure.parentapp.R
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -75,7 +73,7 @@ class ManageStudentViewModel @Inject constructor(
         colorKeeper.userColors.map {
             UserColor(
                 colorRes = it,
-                color = createThemedColor(context.getColor(it)),
+                color = colorKeeper.createThemedColor(context.getColor(it)),
                 contentDescriptionRes = userColorContentDescriptionMap[it].orDefault()
             )
         }
@@ -120,7 +118,7 @@ class ManageStudentViewModel @Inject constructor(
     private fun saveStudentColor(studentId: Long, selected: UserColor) {
         viewModelScope.tryLaunch {
             val contextId = "user_$studentId"
-            val color = ContextCompat.getColor(context, selected.colorRes)
+            val color = context.getColor(selected.colorRes)
 
             _uiState.update {
                 it.copy(

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/managestudents/ManageStudentViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/managestudents/ManageStudentViewModel.kt
@@ -26,6 +26,7 @@ import com.instructure.canvasapi2.utils.weave.tryLaunch
 import com.instructure.pandautils.utils.ColorKeeper
 import com.instructure.pandautils.utils.orDefault
 import com.instructure.parentapp.R
+import com.instructure.parentapp.features.dashboard.SelectedStudentHolder
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.channels.Channel
@@ -41,7 +42,8 @@ import javax.inject.Inject
 class ManageStudentViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val colorKeeper: ColorKeeper,
-    private val repository: ManageStudentsRepository
+    private val repository: ManageStudentsRepository,
+    private val selectedStudentHolder: SelectedStudentHolder
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ManageStudentsUiState())
@@ -146,6 +148,7 @@ class ManageStudentViewModel @Inject constructor(
             } else {
                 showSavingError()
             }
+            selectedStudentHolder.selectedStudentColorChanged()
         } catch {
             showSavingError()
         }

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/managestudents/StudentColorPickerDialog.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/managestudents/StudentColorPickerDialog.kt
@@ -57,7 +57,6 @@ import com.instructure.canvasapi2.utils.ContextKeeper
 import com.instructure.pandautils.R
 import com.instructure.pandautils.utils.ColorKeeper
 import com.instructure.pandautils.utils.ThemePrefs
-import com.instructure.pandautils.utils.createThemedColor
 
 
 @Composable
@@ -183,7 +182,7 @@ fun StudentColorPickerDialogPreview() {
     val colors = ColorKeeper.userColors.map {
         UserColor(
             colorRes = it,
-            color = createThemedColor(context.getColor(it)),
+            color = ColorKeeper.createThemedColor(context.getColor(it)),
             contentDescriptionRes = 0
         )
     }

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/splash/SplashAction.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/splash/SplashAction.kt
@@ -17,9 +17,12 @@
 
 package com.instructure.parentapp.features.splash
 
+import com.instructure.canvasapi2.models.CanvasTheme
+
 
 sealed class SplashAction {
     data object LocaleChanged : SplashAction()
     data object InitialDataLoadingFinished : SplashAction()
     data object NavigateToNotAParentScreen : SplashAction()
+    data class ApplyTheme(val canvasTheme: CanvasTheme) : SplashAction()
 }

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/splash/SplashFragment.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/splash/SplashFragment.kt
@@ -37,6 +37,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.instructure.canvasapi2.utils.LocaleUtils
 import com.instructure.loginapi.login.view.CanvasLoadingView
+import com.instructure.pandautils.utils.ThemePrefs
 import com.instructure.pandautils.utils.collectOneOffEvents
 import com.instructure.parentapp.R
 import com.instructure.parentapp.util.navigation.Navigation
@@ -92,6 +93,8 @@ class SplashFragment : Fragment() {
                 findNavController().popBackStack()
                 navigation.navigate(activity, navigation.notAParent)
             }
+
+            is SplashAction.ApplyTheme -> ThemePrefs.applyCanvasTheme(action.canvasTheme, requireContext())
         }
     }
 

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/splash/SplashViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/splash/SplashViewModel.kt
@@ -59,7 +59,7 @@ class SplashViewModel @Inject constructor(
             colors?.let { colorKeeper.addToCache(it) }
 
             val theme = repository.getTheme()
-            theme?.let { themePrefs.applyCanvasTheme(it, context) }
+            theme?.let { _events.send(SplashAction.ApplyTheme(it)) }
 
             val students = repository.getStudents()
             if (students.isEmpty()) {

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/splash/SplashViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/splash/SplashViewModel.kt
@@ -39,8 +39,7 @@ class SplashViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val repository: SplashRepository,
     private val apiPrefs: ApiPrefs,
-    private val colorKeeper: ColorKeeper,
-    private val themePrefs: ThemePrefs,
+    private val colorKeeper: ColorKeeper
 ) : ViewModel() {
 
     private val _events = Channel<SplashAction>()

--- a/apps/parent/src/test/java/com/instructure/parentapp/features/addstudent/AddStudentViewModelTest.kt
+++ b/apps/parent/src/test/java/com/instructure/parentapp/features/addstudent/AddStudentViewModelTest.kt
@@ -16,12 +16,14 @@
  */
 package com.instructure.parentapp.features.addstudent
 
+import android.content.Context
 import android.graphics.Color
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.instructure.canvasapi2.utils.ContextKeeper
 import com.instructure.canvasapi2.utils.DataResult
 import com.instructure.pandautils.utils.ColorKeeper
 import com.instructure.pandautils.utils.ThemedColor
@@ -58,11 +60,13 @@ class AddStudentViewModelTest {
     private val colorKeeper: ColorKeeper = mockk(relaxed = true)
     private val repository: AddStudentRepository = mockk(relaxed = true)
     private val crashlytics: FirebaseCrashlytics = mockk(relaxed = true)
+    private val context: Context = mockk(relaxed = true)
 
     @Before
     fun setup() {
         lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
         Dispatchers.setMain(testDispatcher)
+        ContextKeeper.appContext = context
 
         every { colorKeeper.getOrGenerateUserColor(any()) } returns ThemedColor(Color.BLACK)
         every { selectedStudentHolder.selectedStudentState.value } returns mockk(relaxed = true)

--- a/apps/parent/src/test/java/com/instructure/parentapp/features/alerts/list/AlertsViewModelTest.kt
+++ b/apps/parent/src/test/java/com/instructure/parentapp/features/alerts/list/AlertsViewModelTest.kt
@@ -75,6 +75,7 @@ class AlertsViewModelTest {
     fun setup() {
         lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
         Dispatchers.setMain(testDispatcher)
+        mockkStatic(User::studentColor)
 
         coEvery { repository.getAlertThresholdForStudent(any(), any()) } returns emptyList()
     }
@@ -82,11 +83,13 @@ class AlertsViewModelTest {
     @After
     fun tearDown() {
         Dispatchers.resetMain()
+        unmockkAll()
     }
 
     @Test
     fun `Load alerts on student change`() = runTest {
         val student = User(1L)
+        every { student.studentColor } returns 1
 
         val alerts = listOf(
             Alert(
@@ -176,6 +179,7 @@ class AlertsViewModelTest {
     @Test
     fun `Empty state`() = runTest {
         val student = User(1L)
+        every { student.studentColor } returns 1
 
         coEvery {
             repository.getAlertsForStudent(student.id, any())
@@ -213,6 +217,7 @@ class AlertsViewModelTest {
     @Test
     fun `Error state if getting alerts fail`() = runTest {
         val student = User(1L)
+        every { student.studentColor } returns 1
 
         coEvery {
             repository.getAlertsForStudent(student.id, any())
@@ -234,6 +239,7 @@ class AlertsViewModelTest {
     @Test
     fun `Refresh data`() = runTest {
         val student = User(1L)
+        every { student.studentColor } returns 1
 
         val alerts = listOf(
             Alert(
@@ -295,6 +301,7 @@ class AlertsViewModelTest {
     @Test
     fun `Dismiss alert`() = runTest {
         val student = User(1L)
+        every { student.studentColor } returns 1
 
         val alerts = listOf(
             Alert(
@@ -357,6 +364,7 @@ class AlertsViewModelTest {
     @Test
     fun `Dismiss error resets event`() = runTest {
         val student = User(1L)
+        every { student.studentColor } returns 1
 
         val alerts = listOf(
             Alert(
@@ -418,6 +426,7 @@ class AlertsViewModelTest {
     @Test
     fun `Undo dismissal`() = runTest {
         val student = User(1L)
+        every { student.studentColor } returns 1
 
         val alerts = listOf(
             Alert(
@@ -484,6 +493,7 @@ class AlertsViewModelTest {
     @Test
     fun `Undo does not reset event on error`() = runTest {
         val student = User(1L)
+        every { student.studentColor } returns 1
 
         val alerts = listOf(
             Alert(
@@ -548,6 +558,7 @@ class AlertsViewModelTest {
     @Test
     fun `Navigate to URL`() = runTest {
         val student = User(1L)
+        every { student.studentColor } returns 1
 
         val alerts = listOf(
             Alert(
@@ -607,6 +618,7 @@ class AlertsViewModelTest {
     @Test
     fun `Navigation to alert marks it read`() = runTest {
         val student = User(1L)
+        every { student.studentColor } returns 1
 
         val alerts = listOf(
             Alert(
@@ -669,6 +681,7 @@ class AlertsViewModelTest {
     @Test
     fun `If marking the alert read fails the alert will remain read until refresh`() = runTest {
         val student = User(1L)
+        every { student.studentColor } returns 1
 
         val alerts = listOf(
             Alert(

--- a/apps/parent/src/test/java/com/instructure/parentapp/features/alerts/list/AlertsViewModelTest.kt
+++ b/apps/parent/src/test/java/com/instructure/parentapp/features/alerts/list/AlertsViewModelTest.kt
@@ -37,8 +37,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
-import io.mockk.mockkObject
-import io.mockk.unmockkAll
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/apps/parent/src/test/java/com/instructure/parentapp/features/courses/list/CoursesViewModelTest.kt
+++ b/apps/parent/src/test/java/com/instructure/parentapp/features/courses/list/CoursesViewModelTest.kt
@@ -67,12 +67,14 @@ class CoursesViewModelTest {
     @Before
     fun setup() {
         lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+        mockkStatic(User::studentColor)
         Dispatchers.setMain(testDispatcher)
     }
 
     @After
     fun tearDown() {
         Dispatchers.resetMain()
+        unmockkAll()
     }
 
     @Test
@@ -80,6 +82,7 @@ class CoursesViewModelTest {
         val student = User(1L)
         coEvery { repository.getCourses(student.id, any()) } returns listOf(Course(id = 1L, name = "Course 1", courseCode = "code-1"))
         every { courseGradeFormatter.getGradeText(any(), any()) } returns "A+"
+        every { student.studentColor } returns 1
 
         createViewModel()
         selectedStudentFlow.emit(student)
@@ -111,6 +114,7 @@ class CoursesViewModelTest {
         )
         coEvery { repository.getCourses(any(), any()) } returns courses
         every { courseGradeFormatter.getGradeText(any(), any()) } returns "A+"
+        every { student.studentColor } returns 1
 
         createViewModel()
         selectedStudentFlow.emit(student)
@@ -136,6 +140,7 @@ class CoursesViewModelTest {
     fun `Error load courses`() = runTest {
         val student = User(1L)
         coEvery { repository.getCourses(student.id, any()) } throws Exception()
+        every { student.studentColor } returns 1
 
         createViewModel()
         selectedStudentFlow.emit(student)
@@ -152,7 +157,9 @@ class CoursesViewModelTest {
     @Test
     fun `Refresh reloads courses`() = runTest {
         createViewModel()
-        selectedStudentHolder.updateSelectedStudent(User(1L))
+        val student = User(1L)
+        selectedStudentHolder.updateSelectedStudent(student)
+        every { student.studentColor } returns 1
 
         viewModel.handleAction(CoursesAction.Refresh)
 

--- a/apps/parent/src/test/java/com/instructure/parentapp/features/dashboard/DashboardViewModelTest.kt
+++ b/apps/parent/src/test/java/com/instructure/parentapp/features/dashboard/DashboardViewModelTest.kt
@@ -19,7 +19,6 @@ package com.instructure.parentapp.features.dashboard
 
 import android.content.Context
 import android.content.Intent
-import android.graphics.Color
 import android.net.Uri
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Lifecycle
@@ -33,8 +32,6 @@ import com.instructure.canvasapi2.utils.ContextKeeper
 import com.instructure.loginapi.login.model.SignedInUser
 import com.instructure.loginapi.login.util.PreviousUsersUtils
 import com.instructure.pandautils.mvvm.ViewState
-import com.instructure.pandautils.utils.ColorKeeper
-import com.instructure.pandautils.utils.ThemedColor
 import com.instructure.parentapp.R
 import com.instructure.parentapp.features.alerts.list.AlertsRepository
 import com.instructure.parentapp.util.ParentPrefs
@@ -82,14 +79,12 @@ class DashboardViewModelTest {
     private val alertCountUpdaterFlow = MutableSharedFlow<Boolean>()
     private val alertCountUpdater: AlertCountUpdater = TestAlertCountUpdater(alertCountUpdaterFlow)
     private val savedStateHandle: SavedStateHandle = mockk(relaxed = true)
-    private val colorKeeper: ColorKeeper = mockk(relaxed = true)
 
     private lateinit var viewModel: DashboardViewModel
 
     @Before
     fun setup() {
         every { savedStateHandle.get<Intent>(KEY_DEEP_LINK_INTENT) } returns null
-        every { colorKeeper.getOrGenerateUserColor(any()) } returns ThemedColor(Color.BLUE)
         lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
         Dispatchers.setMain(testDispatcher)
         ContextKeeper.appContext = context
@@ -272,6 +267,19 @@ class DashboardViewModelTest {
         assertEquals(DashboardViewModelAction.NavigateDeepLink(uri), events.first())
     }
 
+    @Test
+    fun `Update color updates add student item color`() {
+        val students = listOf(User(id = 1L), User(id = 2L))
+        coEvery { repository.getStudents(any()) } returns students
+
+        createViewModel()
+
+        val items = viewModel.data.value.studentItems
+        viewModel.updateColor(123)
+
+        assertEquals(123, (items[2] as AddStudentItemViewModel).color)
+    }
+
     private fun createViewModel() {
         viewModel = DashboardViewModel(
             context = context,
@@ -283,7 +291,6 @@ class DashboardViewModelTest {
             selectedStudentHolder = selectedStudentHolder,
             inboxCountUpdater = inboxCountUpdater,
             alertCountUpdater = alertCountUpdater,
-            colorKeeper = colorKeeper,
             savedStateHandle = savedStateHandle
         )
     }

--- a/apps/parent/src/test/java/com/instructure/parentapp/features/dashboard/TestSelectStudentHolder.kt
+++ b/apps/parent/src/test/java/com/instructure/parentapp/features/dashboard/TestSelectStudentHolder.kt
@@ -25,9 +25,14 @@ import kotlinx.coroutines.flow.SharedFlow
 
 class TestSelectStudentHolder(
     override val selectedStudentState: MutableStateFlow<User?>,
-    override val selectedStudentChangedFlow: SharedFlow<User> = MutableSharedFlow()
+    override val selectedStudentChangedFlow: SharedFlow<User> = MutableSharedFlow(),
+    override val selectedStudentColorChanged: SharedFlow<Unit> = MutableSharedFlow()
 ) : SelectedStudentHolder {
     override suspend fun updateSelectedStudent(user: User) {
         selectedStudentState.emit(user)
+    }
+
+    override suspend fun selectedStudentColorChanged() {
+        (selectedStudentColorChanged as MutableSharedFlow).emit(Unit)
     }
 }

--- a/apps/parent/src/test/java/com/instructure/parentapp/features/managestudents/ManageStudentsViewModelTest.kt
+++ b/apps/parent/src/test/java/com/instructure/parentapp/features/managestudents/ManageStudentsViewModelTest.kt
@@ -28,8 +28,8 @@ import com.instructure.canvasapi2.utils.ContextKeeper
 import com.instructure.pandautils.utils.ColorKeeper
 import com.instructure.pandautils.utils.ColorUtils
 import com.instructure.pandautils.utils.ThemedColor
-import com.instructure.pandautils.utils.createThemedColor
 import com.instructure.parentapp.R
+import com.instructure.parentapp.features.dashboard.SelectedStudentHolder
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -49,6 +49,7 @@ import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
+import org.junit.Test
 
 
 @ExperimentalCoroutinesApi
@@ -64,6 +65,7 @@ class ManageStudentsViewModelTest {
     private val context: Context = mockk(relaxed = true)
     private val repository: ManageStudentsRepository = mockk(relaxed = true)
     private val colorKeeper: ColorKeeper = spyk()
+    private val selectedStudentHolder: SelectedStudentHolder = mockk(relaxed = true)
 
     private lateinit var viewModel: ManageStudentViewModel
 
@@ -76,7 +78,7 @@ class ManageStudentsViewModelTest {
         every { ColorUtils.correctContrastForText(any(), any()) } answers { firstArg() }
         every { ColorUtils.correctContrastForButtonBackground(any(), any(), any()) } answers { firstArg() }
         every { context.getColor(any()) } answers { firstArg() }
-        every { createThemedColor(any()) } answers { ThemedColor(firstArg()) }
+        every { colorKeeper.createThemedColor(any()) } answers { ThemedColor(firstArg()) }
     }
 
     @After
@@ -85,7 +87,7 @@ class ManageStudentsViewModelTest {
         unmockkObject(ColorUtils)
     }
 
-    //@Test - Gonna be fixed when new student colors will be added
+    @Test
     fun `Load students`() {
         val students = listOf(User(id = 1, shortName = "Student 1", pronouns = "He/Him"))
         val expectedState = ManageStudentsUiState(
@@ -101,7 +103,7 @@ class ManageStudentsViewModelTest {
         Assert.assertEquals(expectedState, viewModel.uiState.value)
     }
 
-    //@Test - Gonna be fixed when new student colors will be added
+    @Test
     fun `Load students error`() {
         val expectedState = ManageStudentsUiState(isLoadError = true)
         coEvery { repository.getStudents(any()) } throws Exception()
@@ -111,7 +113,7 @@ class ManageStudentsViewModelTest {
         Assert.assertEquals(expectedState, viewModel.uiState.value)
     }
 
-    //@Test - Gonna be fixed when new student colors will be added
+    @Test
     fun `Load students empty`() {
         val expectedState = ManageStudentsUiState(isLoading = false, isLoadError = false, studentListItems = emptyList())
         coEvery { repository.getStudents(any()) } returns emptyList()
@@ -121,7 +123,7 @@ class ManageStudentsViewModelTest {
         Assert.assertEquals(expectedState, viewModel.uiState.value)
     }
 
-    //@Test - Gonna be fixed when new student colors will be added
+    @Test
     fun `Navigate to alert settings screen`() = runTest {
         coEvery { repository.getStudents(any()) } returns listOf(User(id = 1))
         createViewModel()
@@ -137,7 +139,7 @@ class ManageStudentsViewModelTest {
         Assert.assertEquals(expected, events.last())
     }
 
-    //@Test - Gonna be fixed when new student colors will be added
+    @Test
     fun `Refresh reloads students`() {
         createViewModel()
 
@@ -146,7 +148,7 @@ class ManageStudentsViewModelTest {
         coVerify { repository.getStudents(true) }
     }
 
-    //@Test - Gonna be fixed when new student colors will be added
+    @Test
     fun `Show color picker dialog`() {
         val userColors = listOf(
             UserColor(
@@ -198,7 +200,7 @@ class ManageStudentsViewModelTest {
         Assert.assertEquals(expected, viewModel.uiState.value)
     }
 
-    //@Test - Gonna be fixed when new student colors will be added
+    @Test
     fun `Hide color picker dialog`() = runTest {
         every { colorKeeper.userColors } returns emptyList()
 
@@ -211,7 +213,7 @@ class ManageStudentsViewModelTest {
         Assert.assertFalse(viewModel.uiState.value.colorPickerDialogUiState.showColorPickerDialog)
     }
 
-    //@Test - Gonna be fixed when new student colors will be added
+    @Test
     fun `Save student color`() {
         val expectedUiState = ManageStudentsUiState(
             colorPickerDialogUiState = ColorPickerDialogUiState(),
@@ -237,7 +239,7 @@ class ManageStudentsViewModelTest {
         Assert.assertEquals(expectedUiState, viewModel.uiState.value)
     }
 
-    //@Test - Gonna be fixed when new student colors will be added
+    @Test
     fun `Save student color error`() {
         val expectedUiState = ManageStudentsUiState(
             colorPickerDialogUiState = ColorPickerDialogUiState(isSavingColorError = true),
@@ -264,6 +266,6 @@ class ManageStudentsViewModelTest {
     }
 
     private fun createViewModel() {
-        viewModel = ManageStudentViewModel(context, colorKeeper, repository)
+        viewModel = ManageStudentViewModel(context, colorKeeper, repository, selectedStudentHolder)
     }
 }

--- a/apps/parent/src/test/java/com/instructure/parentapp/features/splash/SplashViewModelTest.kt
+++ b/apps/parent/src/test/java/com/instructure/parentapp/features/splash/SplashViewModelTest.kt
@@ -62,7 +62,6 @@ class SplashViewModelTest {
     private val repository: SplashRepository = mockk(relaxed = true)
     private val apiPrefs: ApiPrefs = mockk(relaxed = true)
     private val colorKeeper: ColorKeeper = mockk(relaxed = true)
-    private val themePrefs: ThemePrefs = mockk(relaxed = true)
 
     private lateinit var viewModel: SplashViewModel
 
@@ -96,7 +95,6 @@ class SplashViewModelTest {
 
         coVerify { apiPrefs.user = user }
         coVerify { colorKeeper.addToCache(colors) }
-        coVerify { themePrefs.applyCanvasTheme(theme, context) }
 
         val events = mutableListOf<SplashAction>()
         backgroundScope.launch(testDispatcher) {
@@ -104,6 +102,7 @@ class SplashViewModelTest {
         }
 
         Assert.assertEquals(SplashAction.InitialDataLoadingFinished, events.last())
+        Assert.assertEquals(SplashAction.ApplyTheme(theme), events.first())
     }
 
     @Test
@@ -166,8 +165,7 @@ class SplashViewModelTest {
             context = context,
             repository = repository,
             apiPrefs = apiPrefs,
-            colorKeeper = colorKeeper,
-            themePrefs = themePrefs,
+            colorKeeper = colorKeeper
         )
     }
 }

--- a/libs/pandares/src/main/res/values/colors.xml
+++ b/libs/pandares/src/main/res/values/colors.xml
@@ -151,12 +151,13 @@
     <color name="courseColor12dark">#9C9C9C</color>
 
     <!-- Student Colors -->
-    <color name="studentBlue">#FF007BC2</color>
-    <color name="studentPurple">#FF5F4DCE</color>
-    <color name="studentPink">#FFBF32A4</color>
-    <color name="studentRed">#FFE9162E</color>
-    <color name="studentOrange">#FFD34503</color>
-    <color name="studentGreen">#FF008A12</color>
+    <!-- We have dark variants of these, but we only use the light resource and generate the dark variant because those are derived from the course colors -->
+    <color name="studentBlue">#2573DF</color> <!-- Course 4 -->
+    <color name="studentGreen">#27872B</color> <!-- Course 8 -->
+    <color name="studentOrange">#BF5811</color> <!-- Course 10 -->
+    <color name="studentPink">#C54396</color> <!-- Course 2 -->
+    <color name="studentPurple">#9E58BD</color> <!-- Course 3 -->
+    <color name="studentRed">#ED0000</color> <!-- Course 11 -->
 
     <!-- Attachment View colors -->
     <color name="attachmentColorDoc">#2ca3de</color>

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/utils/InboxMessageView.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/utils/InboxMessageView.kt
@@ -140,7 +140,7 @@ private fun InboxMessageDetailsView(
                 onClick = { messageState.message?.let { actionHandler( MessageAction.Reply(it) ) } },
                 colors = ButtonDefaults.buttonColors(
                     backgroundColor = colorResource(id = R.color.backgroundLightest),
-                    contentColor = Color(ThemePrefs.brandColor)
+                    contentColor = Color(ThemePrefs.textButtonColor)
                 ),
                 contentPadding = PaddingValues(start = 0.dp, top = 8.dp, end = 8.dp, bottom = 8.dp),
                 content = {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/CanvasContextExtensions.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/CanvasContextExtensions.kt
@@ -36,7 +36,7 @@ val CanvasContext?.lightColor: Int get() {
 }
 
 @get:ColorInt
-val User?.color: Int get() {
+val User?.studentColor: Int get() {
     val themedColor = ColorKeeper.getOrGenerateUserColor(this)
     return if (ColorKeeper.darkTheme) themedColor.dark else themedColor.light
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/ThemePrefs.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/ThemePrefs.kt
@@ -26,6 +26,7 @@ import com.instructure.canvasapi2.utils.IntPref
 import com.instructure.canvasapi2.utils.PrefManager
 import com.instructure.canvasapi2.utils.StringPref
 import com.instructure.pandautils.R
+import dagger.hilt.android.qualifiers.ActivityContext
 
 const val MIN_CONTRAST_FOR_BUTTONS = 3.0
 const val MIN_CONTRAST_FOR_TEXT = 4.5
@@ -63,6 +64,8 @@ object ThemePrefs : PrefManager("CanvasTheme") {
 
     var themeSelectionShown by BooleanPref()
 
+    private var canvasTheme: CanvasTheme? = null
+
     override fun keepBaseProps() = listOf(::appTheme, ::themeSelectionShown)
 
     override fun onClearPrefs() {
@@ -97,7 +100,13 @@ object ThemePrefs : PrefManager("CanvasTheme") {
 
     }
 
-    fun applyCanvasTheme(theme: CanvasTheme, context: Context) {
+    // This should not be called with application context.
+    fun reapplyCanvasTheme(@ActivityContext context: Context) {
+        applyCanvasTheme(canvasTheme ?: return, context)
+    }
+
+    // This should not be called with application context.
+    fun applyCanvasTheme(theme: CanvasTheme, @ActivityContext context: Context) {
         val tempBrandColor = parseColor(theme.brand, brandColor) // ic-brand-primary - Primary Brand Color
         brandColor = ColorUtils.correctContrastForText(tempBrandColor, context.getColor(R.color.backgroundLightestElevated))
 
@@ -112,6 +121,7 @@ object ThemePrefs : PrefManager("CanvasTheme") {
 
         logoUrl = theme.logoUrl
         isThemeApplied = true
+        canvasTheme = theme
     }
 
     private fun parseColor(hexColor: String, defaultColor: Int): Int {


### PR DESCRIPTION
Test plan: Test that the app is accessible in both dark mode and light mode. Some notes:
- I fixed the student colors so they have different shade in dark/light mode.
- Fixed canvas brand colors and theme/student color switching.
- Same things apply as for the other apps, when we have a colored background it should have dark text in dark mode, light in light mode and it should be clearly visible.
- I made some refactoring and corrected some other color issues throughout the Parent app.

refs: MBL-17947
affects: Parent
release note: none

## Screenshots

## Checklist

- [x] Tested in dark mode
- [x] Tested in light mode
- [x] A11y checked
