### PR TITLE
[MBL-17945][Student][Parent] Filter hidden New Quizzes in the Grades list

### DIFF
--- a/apps/flutter_parent/lib/models/assignment.dart
+++ b/apps/flutter_parent/lib/models/assignment.dart
@@ -119,6 +119,9 @@ abstract class Assignment implements Built<Assignment, AssignmentBuilder> {
   @BuiltValueField(wireName: 'submission_types')
   BuiltList<SubmissionTypes>? get submissionTypes;
 
+  @BuiltValueField(wireName: 'hide_in_gradebook')
+  bool? get isHiddenInGradeBook;
+
   static void _initializeBuilder(AssignmentBuilder b) => b
     ..pointsPossible = 0.0
     ..useRubricForGrading = false

--- a/apps/flutter_parent/lib/models/assignment.g.dart
+++ b/apps/flutter_parent/lib/models/assignment.g.dart
@@ -248,6 +248,11 @@ class _$AssignmentSerializer implements StructuredSerializer<Assignment> {
       ..add(serializers.serialize(value,
           specifiedType: const FullType(
               BuiltList, const [const FullType(SubmissionTypes)])));
+    value = object.isHiddenInGradeBook;
+
+    result
+      ..add('hide_in_gradebook')
+      ..add(serializers.serialize(value, specifiedType: const FullType(bool)));
 
     return result;
   }
@@ -381,6 +386,10 @@ class _$AssignmentSerializer implements StructuredSerializer<Assignment> {
                   specifiedType: const FullType(
                       BuiltList, const [const FullType(SubmissionTypes)]))!
               as BuiltList<Object?>);
+          break;
+        case 'hide_in_gradebook':
+          result.isHiddenInGradeBook = serializers.deserialize(value,
+              specifiedType: const FullType(bool)) as bool?;
           break;
       }
     }
@@ -523,6 +532,8 @@ class _$Assignment extends Assignment {
   final bool isStudioEnabled;
   @override
   final BuiltList<SubmissionTypes>? submissionTypes;
+  @override
+  final bool? isHiddenInGradeBook;
 
   factory _$Assignment([void Function(AssignmentBuilder)? updates]) =>
       (new AssignmentBuilder()..update(updates))._build();
@@ -556,7 +567,8 @@ class _$Assignment extends Assignment {
       required this.moderatedGrading,
       required this.anonymousGrading,
       required this.isStudioEnabled,
-      this.submissionTypes})
+      this.submissionTypes,
+      this.isHiddenInGradeBook})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(id, r'Assignment', 'id');
     BuiltValueNullFieldError.checkNotNull(
@@ -626,7 +638,8 @@ class _$Assignment extends Assignment {
         moderatedGrading == other.moderatedGrading &&
         anonymousGrading == other.anonymousGrading &&
         isStudioEnabled == other.isStudioEnabled &&
-        submissionTypes == other.submissionTypes;
+        submissionTypes == other.submissionTypes &&
+        isHiddenInGradeBook == other.isHiddenInGradeBook;
   }
 
   @override
@@ -661,6 +674,7 @@ class _$Assignment extends Assignment {
     _$hash = $jc(_$hash, anonymousGrading.hashCode);
     _$hash = $jc(_$hash, isStudioEnabled.hashCode);
     _$hash = $jc(_$hash, submissionTypes.hashCode);
+    _$hash = $jc(_$hash, isHiddenInGradeBook.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -696,7 +710,8 @@ class _$Assignment extends Assignment {
           ..add('moderatedGrading', moderatedGrading)
           ..add('anonymousGrading', anonymousGrading)
           ..add('isStudioEnabled', isStudioEnabled)
-          ..add('submissionTypes', submissionTypes))
+          ..add('submissionTypes', submissionTypes)
+          ..add('isHiddenInGradeBook', isHiddenInGradeBook))
         .toString();
   }
 }
@@ -838,6 +853,11 @@ class AssignmentBuilder implements Builder<Assignment, AssignmentBuilder> {
   set submissionTypes(ListBuilder<SubmissionTypes>? submissionTypes) =>
       _$this._submissionTypes = submissionTypes;
 
+  bool? _isHiddenInGradeBook;
+  bool? get isHiddenInGradeBook => _$this._isHiddenInGradeBook;
+  set isHiddenInGradeBook(bool? isHiddenInGradeBook) =>
+      _$this._isHiddenInGradeBook = isHiddenInGradeBook;
+
   AssignmentBuilder() {
     Assignment._initializeBuilder(this);
   }
@@ -874,6 +894,7 @@ class AssignmentBuilder implements Builder<Assignment, AssignmentBuilder> {
       _anonymousGrading = $v.anonymousGrading;
       _isStudioEnabled = $v.isStudioEnabled;
       _submissionTypes = $v.submissionTypes?.toBuilder();
+      _isHiddenInGradeBook = $v.isHiddenInGradeBook;
       _$v = null;
     }
     return this;
@@ -936,7 +957,8 @@ class AssignmentBuilder implements Builder<Assignment, AssignmentBuilder> {
               moderatedGrading: BuiltValueNullFieldError.checkNotNull(moderatedGrading, r'Assignment', 'moderatedGrading'),
               anonymousGrading: BuiltValueNullFieldError.checkNotNull(anonymousGrading, r'Assignment', 'anonymousGrading'),
               isStudioEnabled: BuiltValueNullFieldError.checkNotNull(isStudioEnabled, r'Assignment', 'isStudioEnabled'),
-              submissionTypes: _submissionTypes?.build());
+              submissionTypes: _submissionTypes?.build(),
+              isHiddenInGradeBook: isHiddenInGradeBook);
     } catch (_) {
       late String _$failedField;
       try {

--- a/apps/flutter_parent/lib/screens/courses/details/course_details_model.dart
+++ b/apps/flutter_parent/lib/screens/courses/details/course_details_model.dart
@@ -84,7 +84,7 @@ class CourseDetailsModel extends BaseModel {
     final groupFuture = _interactor()
         .loadAssignmentGroups(courseId, student?.id, _nextGradingPeriod?.id, forceRefresh: forceRefresh).then((groups) async {
       // Remove unpublished assignments to match web
-      return groups?.map((group) => (group.toBuilder()..assignments.removeWhere((assignment) => !assignment.published)).build()).toList();
+      return groups?.map((group) => (group.toBuilder()..assignments.removeWhere((assignment) => !assignment.published || assignment.isHiddenInGradeBook == true)).build()).toList();
     });
 
     final gradingPeriodsFuture =

--- a/apps/student/src/main/java/com/instructure/student/features/grades/GradesListRepository.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/grades/GradesListRepository.kt
@@ -25,6 +25,7 @@ import com.instructure.canvasapi2.models.Submission
 import com.instructure.pandautils.repository.Repository
 import com.instructure.pandautils.utils.FeatureFlagProvider
 import com.instructure.pandautils.utils.NetworkStateProvider
+import com.instructure.pandautils.utils.filterHiddenAssignments
 import com.instructure.student.features.grades.datasource.GradesListDataSource
 import com.instructure.student.features.grades.datasource.GradesListLocalDataSource
 import com.instructure.student.features.grades.datasource.GradesListNetworkDataSource
@@ -84,9 +85,5 @@ class GradesListRepository(
         forceNetwork: Boolean,
     ): List<AssignmentGroup> {
         return dataSource().getAssignmentGroupsWithAssignments(courseId, forceNetwork).filterHiddenAssignments()
-    }
-
-    private fun List<AssignmentGroup>.filterHiddenAssignments(): List<AssignmentGroup> {
-        return this.map { it.copy(assignments = it.assignments.filterNot { it.isHiddenInGradeBook }) }
     }
 }

--- a/apps/student/src/main/java/com/instructure/student/features/grades/GradesListRepository.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/grades/GradesListRepository.kt
@@ -17,7 +17,11 @@
 
 package com.instructure.student.features.grades
 
-import com.instructure.canvasapi2.models.*
+import com.instructure.canvasapi2.models.AssignmentGroup
+import com.instructure.canvasapi2.models.Course
+import com.instructure.canvasapi2.models.Enrollment
+import com.instructure.canvasapi2.models.GradingPeriod
+import com.instructure.canvasapi2.models.Submission
 import com.instructure.pandautils.repository.Repository
 import com.instructure.pandautils.utils.FeatureFlagProvider
 import com.instructure.pandautils.utils.NetworkStateProvider
@@ -46,7 +50,7 @@ class GradesListRepository(
         scopeToStudent: Boolean,
         forceNetwork: Boolean
     ): List<AssignmentGroup> {
-        return dataSource().getAssignmentGroupsWithAssignmentsForGradingPeriod(courseId, gradingPeriodId, scopeToStudent, forceNetwork)
+        return dataSource().getAssignmentGroupsWithAssignmentsForGradingPeriod(courseId, gradingPeriodId, scopeToStudent, forceNetwork).filterHiddenAssignments()
     }
 
     suspend fun getSubmissionsForMultipleAssignments(
@@ -79,6 +83,10 @@ class GradesListRepository(
         courseId: Long,
         forceNetwork: Boolean,
     ): List<AssignmentGroup> {
-        return dataSource().getAssignmentGroupsWithAssignments(courseId, forceNetwork)
+        return dataSource().getAssignmentGroupsWithAssignments(courseId, forceNetwork).filterHiddenAssignments()
+    }
+
+    private fun List<AssignmentGroup>.filterHiddenAssignments(): List<AssignmentGroup> {
+        return this.map { it.copy(assignments = it.assignments.filterNot { it.isHiddenInGradeBook }) }
     }
 }

--- a/apps/student/src/test/java/com/instructure/student/features/grades/GradesListRepositoryTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/features/grades/GradesListRepositoryTest.kt
@@ -17,8 +17,12 @@
 
 package com.instructure.student.features.grades
 
-import com.instructure.canvasapi2.models.*
-import com.instructure.pandautils.utils.FEATURE_FLAG_OFFLINE
+import com.instructure.canvasapi2.models.Assignment
+import com.instructure.canvasapi2.models.AssignmentGroup
+import com.instructure.canvasapi2.models.Course
+import com.instructure.canvasapi2.models.Enrollment
+import com.instructure.canvasapi2.models.GradingPeriod
+import com.instructure.canvasapi2.models.Submission
 import com.instructure.pandautils.utils.FeatureFlagProvider
 import com.instructure.pandautils.utils.NetworkStateProvider
 import com.instructure.student.features.grades.datasource.GradesListLocalDataSource
@@ -131,6 +135,40 @@ class GradesListRepositoryTest {
         every { networkStateProvider.isOnline() } returns false
         coEvery { networkDataSource.getAssignmentGroupsWithAssignmentsForGradingPeriod(any(), any(), any(), any()) } returns onlineExpected
         coEvery { localDataSource.getAssignmentGroupsWithAssignmentsForGradingPeriod(any(), any(), any(), any()) } returns offlineExpected
+
+        val result = repository.getAssignmentGroupsWithAssignmentsForGradingPeriod(1, 1, scopeToStudent = true, forceNetwork = true)
+
+        coVerify { localDataSource.getAssignmentGroupsWithAssignmentsForGradingPeriod(1, 1, scopeToStudent = true, forceNetwork = true) }
+        assertEquals(offlineExpected, result)
+    }
+
+    @Test
+    fun `Get assignment groups with assignments for grading period if there are hidden assignments and device is online`() = runTest {
+        val onlineExpected = listOf(AssignmentGroup(id = 1, assignments = listOf(Assignment(1))), AssignmentGroup(id = 2, assignments = listOf(Assignment(3))))
+        val onlineResult = listOf(AssignmentGroup(id = 1, assignments = listOf(Assignment(1), Assignment(2, isHiddenInGradeBook = true))), AssignmentGroup(id = 2, assignments = listOf(Assignment(3), Assignment(4, isHiddenInGradeBook = true))))
+        val offlineExpected = listOf(AssignmentGroup(id = 3, assignments = listOf(Assignment(5))), AssignmentGroup(id = 4, assignments = listOf(Assignment(7))))
+        val offlineResult = listOf(AssignmentGroup(id = 3, assignments = listOf(Assignment(5), Assignment(6, isHiddenInGradeBook = true))), AssignmentGroup(id = 4, assignments = listOf(Assignment(7), Assignment(8, isHiddenInGradeBook = true))))
+
+        every { networkStateProvider.isOnline() } returns true
+        coEvery { networkDataSource.getAssignmentGroupsWithAssignmentsForGradingPeriod(any(), any(), any(), any()) } returns onlineResult
+        coEvery { localDataSource.getAssignmentGroupsWithAssignmentsForGradingPeriod(any(), any(), any(), any()) } returns offlineResult
+
+        val result = repository.getAssignmentGroupsWithAssignmentsForGradingPeriod(1, 1, scopeToStudent = true, forceNetwork = true)
+
+        coVerify { networkDataSource.getAssignmentGroupsWithAssignmentsForGradingPeriod(1, 1, scopeToStudent = true, forceNetwork = true) }
+        assertEquals(onlineExpected, result)
+    }
+
+    @Test
+    fun `Get assignment groups with assignments for grading period if there are hidden assignments and device is offline`() = runTest {
+        val onlineExpected = listOf(AssignmentGroup(id = 1, assignments = listOf(Assignment(1))), AssignmentGroup(id = 2, assignments = listOf(Assignment(3))))
+        val onlineResult = listOf(AssignmentGroup(id = 1, assignments = listOf(Assignment(1), Assignment(2, isHiddenInGradeBook = true))), AssignmentGroup(id = 2, assignments = listOf(Assignment(3), Assignment(4, isHiddenInGradeBook = true))))
+        val offlineExpected = listOf(AssignmentGroup(id = 3, assignments = listOf(Assignment(5))), AssignmentGroup(id = 4, assignments = listOf(Assignment(7))))
+        val offlineResult = listOf(AssignmentGroup(id = 3, assignments = listOf(Assignment(5), Assignment(6, isHiddenInGradeBook = true))), AssignmentGroup(id = 4, assignments = listOf(Assignment(7), Assignment(8, isHiddenInGradeBook = true))))
+
+        every { networkStateProvider.isOnline() } returns false
+        coEvery { networkDataSource.getAssignmentGroupsWithAssignmentsForGradingPeriod(any(), any(), any(), any()) } returns onlineResult
+        coEvery { localDataSource.getAssignmentGroupsWithAssignmentsForGradingPeriod(any(), any(), any(), any()) } returns offlineResult
 
         val result = repository.getAssignmentGroupsWithAssignmentsForGradingPeriod(1, 1, scopeToStudent = true, forceNetwork = true)
 
@@ -281,6 +319,40 @@ class GradesListRepositoryTest {
         every { networkStateProvider.isOnline() } returns false
         coEvery { networkDataSource.getAssignmentGroupsWithAssignments(any(), any()) } returns onlineExpected
         coEvery { localDataSource.getAssignmentGroupsWithAssignments(any(), any()) } returns offlineExpected
+
+        val result = repository.getAssignmentGroupsWithAssignments(1, true)
+
+        coVerify { localDataSource.getAssignmentGroupsWithAssignments(1, true) }
+        assertEquals(offlineExpected, result)
+    }
+
+    @Test
+    fun `Get assignment groups with assignments if there are hidden assignments and device is online`() = runTest {
+        val onlineExpected = listOf(AssignmentGroup(id = 1, assignments = listOf(Assignment(1))), AssignmentGroup(id = 2, assignments = listOf(Assignment(3))))
+        val onlineResult = listOf(AssignmentGroup(id = 1, assignments = listOf(Assignment(1), Assignment(2, isHiddenInGradeBook = true))), AssignmentGroup(id = 2, assignments = listOf(Assignment(3), Assignment(4, isHiddenInGradeBook = true))))
+        val offlineExpected = listOf(AssignmentGroup(id = 3, assignments = listOf(Assignment(5))), AssignmentGroup(id = 4, assignments = listOf(Assignment(7))))
+        val offlineResult = listOf(AssignmentGroup(id = 3, assignments = listOf(Assignment(5), Assignment(6, isHiddenInGradeBook = true))), AssignmentGroup(id = 4, assignments = listOf(Assignment(7), Assignment(8, isHiddenInGradeBook = true))))
+
+        every { networkStateProvider.isOnline() } returns true
+        coEvery { networkDataSource.getAssignmentGroupsWithAssignments(any(), any()) } returns onlineResult
+        coEvery { localDataSource.getAssignmentGroupsWithAssignments(any(), any()) } returns offlineResult
+
+        val result = repository.getAssignmentGroupsWithAssignments(1, true)
+
+        coVerify { networkDataSource.getAssignmentGroupsWithAssignments(1, true) }
+        assertEquals(onlineExpected, result)
+    }
+
+    @Test
+    fun `Get assignment groups with assignments if there are hidden assignments and device is offline`() = runTest {
+        val onlineExpected = listOf(AssignmentGroup(id = 1, assignments = listOf(Assignment(1))), AssignmentGroup(id = 2, assignments = listOf(Assignment(3))))
+        val onlineResult = listOf(AssignmentGroup(id = 1, assignments = listOf(Assignment(1), Assignment(2, isHiddenInGradeBook = true))), AssignmentGroup(id = 2, assignments = listOf(Assignment(3), Assignment(4, isHiddenInGradeBook = true))))
+        val offlineExpected = listOf(AssignmentGroup(id = 3, assignments = listOf(Assignment(5))), AssignmentGroup(id = 4, assignments = listOf(Assignment(7))))
+        val offlineResult = listOf(AssignmentGroup(id = 3, assignments = listOf(Assignment(5), Assignment(6, isHiddenInGradeBook = true))), AssignmentGroup(id = 4, assignments = listOf(Assignment(7), Assignment(8, isHiddenInGradeBook = true))))
+
+        every { networkStateProvider.isOnline() } returns false
+        coEvery { networkDataSource.getAssignmentGroupsWithAssignments(any(), any()) } returns onlineResult
+        coEvery { localDataSource.getAssignmentGroupsWithAssignments(any(), any()) } returns offlineResult
 
         val result = repository.getAssignmentGroupsWithAssignments(1, true)
 

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Assignment.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Assignment.kt
@@ -23,7 +23,8 @@ import com.google.gson.annotations.SerializedName
 import com.instructure.canvasapi2.R
 import com.instructure.canvasapi2.utils.toDate
 import kotlinx.parcelize.Parcelize
-import java.util.*
+import java.util.Date
+import java.util.Locale
 
 @Parcelize
 data class Assignment(
@@ -112,7 +113,9 @@ data class Assignment(
         @SerializedName("anonymous_submissions")
         val anonymousSubmissions: Boolean = false,
         @SerializedName("omit_from_final_grade")
-        val omitFromFinalGrade: Boolean = false
+        val omitFromFinalGrade: Boolean = false,
+        @SerializedName("hide_in_gradebook")
+        val isHiddenInGradeBook: Boolean = false
 ) : CanvasModel<Assignment>() {
     override val comparisonDate get() = dueDate
     override val comparisonString get() = dueAt

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/ObserveeAssignment.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/ObserveeAssignment.kt
@@ -97,7 +97,9 @@ data class ObserveeAssignment(
         val anonymousGrading: Boolean = false,
         @SerializedName("allowed_attempts")
         val allowedAttempts: Long = -1, // API gives -1 for unlimited submissions
-        var isStudioEnabled: Boolean = false
+        var isStudioEnabled: Boolean = false,
+        @SerializedName("hide_in_gradebook")
+        val isHiddenInGradeBook: Boolean = false
 ) : CanvasModel<Assignment>() {
     override val comparisonDate get() = dueAt.toDate()
     override val comparisonString get() = dueAt
@@ -200,6 +202,7 @@ data class ObserveeAssignment(
         moderatedGrading = moderatedGrading,
         anonymousGrading = anonymousGrading,
         allowedAttempts = allowedAttempts,
-        isStudioEnabled = isStudioEnabled
+        isStudioEnabled = isStudioEnabled,
+        isHiddenInGradeBook = isHiddenInGradeBook
     )
 }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/ObserveeAssignment.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/ObserveeAssignment.kt
@@ -152,7 +152,8 @@ data class ObserveeAssignment(
                 moderatedGrading = this.moderatedGrading,
                 anonymousGrading = this.anonymousGrading,
                 allowedAttempts = this.allowedAttempts,
-                isStudioEnabled = this.isStudioEnabled
+                isStudioEnabled = this.isStudioEnabled,
+                isHiddenInGradeBook = this.isHiddenInGradeBook
             )
         } else {
             return null

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/grades/GradesViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/grades/GradesViewModel.kt
@@ -31,6 +31,7 @@ import com.instructure.canvasapi2.utils.weave.catch
 import com.instructure.canvasapi2.utils.weave.tryLaunch
 import com.instructure.pandautils.R
 import com.instructure.pandautils.features.grades.gradepreferences.SortBy
+import com.instructure.pandautils.utils.filterHiddenAssignments
 import com.instructure.pandautils.utils.getGrade
 import com.instructure.pandautils.utils.orDefault
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -89,7 +90,7 @@ class GradesViewModel @Inject constructor(
             this@GradesViewModel.course = course
             val gradingPeriods = repository.loadGradingPeriods(courseId, forceRefresh)
             val selectedGradingPeriodId = _uiState.value.gradePreferencesUiState.selectedGradingPeriod?.id
-            val assignmentGroups = repository.loadAssignmentGroups(courseId, selectedGradingPeriodId, forceRefresh)
+            val assignmentGroups = repository.loadAssignmentGroups(courseId, selectedGradingPeriodId, forceRefresh).filterHiddenAssignments()
             val enrollments = repository.loadEnrollments(courseId, selectedGradingPeriodId, forceRefresh)
 
             courseGrade = repository.getCourseGrade(course, repository.studentId, enrollments, selectedGradingPeriodId)

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/AssignmentGroupExtensions.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/AssignmentGroupExtensions.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2024 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.pandautils.utils
+
+import com.instructure.canvasapi2.models.AssignmentGroup
+
+fun List<AssignmentGroup>.filterHiddenAssignments(): List<AssignmentGroup> {
+    return this.map { it.copy(assignments = it.assignments.filterNot { it.isHiddenInGradeBook }) }
+}

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/grades/GradesViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/grades/GradesViewModelTest.kt
@@ -692,6 +692,66 @@ class GradesViewModelTest {
         Assert.assertEquals(expected, viewModel.uiState.value)
     }
 
+    @Test
+    fun `Filter hidden grades in Grade list`() {
+        coEvery { gradesRepository.loadCourse(1, any()) } returns Course(id = 1, name = "Course 1")
+        coEvery { gradesRepository.loadGradingPeriods(1, any()) } returns emptyList()
+        coEvery { gradesRepository.loadEnrollments(1, any(), any()) } returns listOf()
+        coEvery { gradesRepository.loadAssignmentGroups(1, any(), any()) } returns listOf(
+            AssignmentGroup(
+                id = 1,
+                name = "Group 1",
+                assignments = listOf(
+                    Assignment(
+                        id = 1,
+                        name = "Assignment 1",
+                        submissionTypesRaw = listOf(
+                            SubmissionType.ONLINE_TEXT_ENTRY.rawValue()
+                        )
+                    ),
+                    Assignment(
+                        id = 2,
+                        name = "Assignment 2",
+                        submissionTypesRaw = listOf(
+                            SubmissionType.ONLINE_TEXT_ENTRY.rawValue()
+                        ),
+                        isHiddenInGradeBook = true
+                    ),
+                )
+            )
+        )
+
+        createViewModel()
+
+        val expected = GradesUiState(
+            isLoading = false,
+            canvasContextColor = 1,
+            gradePreferencesUiState = GradePreferencesUiState(
+                canvasContextColor = 1,
+                courseName = "Course 1"
+            ),
+            items = listOf(
+                AssignmentGroupUiState(
+                    id = 2,
+                    name = "Undated Assignments",
+                    expanded = true,
+                    assignments = listOf(
+                        AssignmentUiState(
+                            id = 1,
+                            iconRes = R.drawable.ic_assignment,
+                            name = "Assignment 1",
+                            dueDate = "No due date",
+                            submissionStateLabel = SubmissionStateLabel.NOT_SUBMITTED,
+                            displayGrade = DisplayGrade("")
+                        )
+                    )
+                )
+            )
+        )
+
+        Assert.assertEquals(expected, viewModel.uiState.value)
+    }
+
     private fun createViewModel() {
         viewModel = GradesViewModel(context, gradesBehaviour, gradesRepository, gradeFormatter, savedStateHandle)
     }


### PR DESCRIPTION
Test plan: See ticket

refs: MBL-17945
affects: Student, Parent
release note: Hidden New Quizzes are now not displayed in the Grades list

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/294f397d-3a34-407a-9cf8-7fd562fdc4c0" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/8209b2d6-84f0-41d3-b278-23f01c434941" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/dfd0e6e5-55a4-4785-86fd-98925941e23e" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/f52472a9-ca5f-4469-9a13-1cd9f1fd1f66" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Run E2E test suite
- [ ] Tested in dark mode
- [ ] Tested in light mode
