### PR TITLE
[MBL-18002][Student] Fix file list crash and file header color

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/features/files/list/FileListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/files/list/FileListFragment.kt
@@ -313,9 +313,10 @@ class FileListFragment : ParentFragment(), Bookmarkable, FileUploadDialogParent 
     private fun themeToolbar() = with(binding) {
         // We style the toolbar white for user files
         Handler(Looper.getMainLooper()).post {
+            if (!isAdded) return@post
             if (canvasContext.type == CanvasContext.Type.USER) {
-                ViewStyler.themeProgressBar(fileLoadingProgressBar, ThemePrefs.brandColor)
-                ViewStyler.themeToolbarColored(requireActivity(), toolbar, ThemePrefs.primaryColor, ThemePrefs.brandColor)
+                ViewStyler.themeProgressBar(fileLoadingProgressBar, ThemePrefs.primaryTextColor)
+                ViewStyler.themeToolbarColored(requireActivity(), toolbar, ThemePrefs.primaryColor, ThemePrefs.primaryTextColor)
             } else {
                 ViewStyler.themeProgressBar(fileLoadingProgressBar, requireContext().getColor(R.color.textLightest))
                 ViewStyler.themeToolbarColored(requireActivity(), toolbar, canvasContext)


### PR DESCRIPTION
Test plan: In the ticket. For the crash you need to open a folder in the file list and instantly navigate back.

refs: MBL-18002
affects: Student
release note: none

## Checklist

- [ ] Tested in dark mode
- [ ] Tested in light mode
