### PR TITLE
[MBL-17987][Student] Clicking alerts regarding a Discussion mention gives an error

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/NotificationListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/NotificationListFragment.kt
@@ -274,6 +274,13 @@ class NotificationListFragment : ParentFragment(), Bookmarkable, FragmentManager
                 }
                 COLLABORATION -> UnsupportedTabFragment.makeRoute(canvasContext, Tab.COLLABORATIONS_ID)
                 CONFERENCE -> ConferenceListRepositoryFragment.makeRoute(canvasContext)
+                DISCUSSION_MENTION -> {
+                    if (streamItem.htmlUrl.isNotEmpty()) {
+                        RouteMatcher.getInternalRoute(streamItem.htmlUrl, ApiPrefs.domain)
+                    } else {
+                        UnknownItemFragment.makeRoute(canvasContext, streamItem)
+                    }
+                }
                 else -> UnsupportedFeatureFragment.makeRoute(canvasContext, featureName = streamItem.type, url = streamItem.url ?: streamItem.htmlUrl)
             }
 

--- a/apps/student/src/main/java/com/instructure/student/holders/NotificationViewHolder.kt
+++ b/apps/student/src/main/java/com/instructure/student/holders/NotificationViewHolder.kt
@@ -94,7 +94,7 @@ class NotificationViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)
         // Icon
         val drawableResId: Int
         when (item.getStreamItemType()) {
-            StreamItem.Type.DISCUSSION_TOPIC -> {
+            StreamItem.Type.DISCUSSION_TOPIC, StreamItem.Type.DISCUSSION_ENTRY, StreamItem.Type.DISCUSSION_MENTION -> {
                 drawableResId = R.drawable.ic_discussion
                 icon.contentDescription = context.getString(R.string.discussionIcon)
             }

--- a/apps/student/src/main/java/com/instructure/student/widget/NotificationViewWidgetService.kt
+++ b/apps/student/src/main/java/com/instructure/student/widget/NotificationViewWidgetService.kt
@@ -121,7 +121,7 @@ class NotificationViewWidgetService : BaseRemoteViewsService(), Serializable {
 
         private fun getDrawableId(streamItem: StreamItem): Int {
             when (streamItem.getStreamItemType()) {
-                StreamItem.Type.DISCUSSION_TOPIC -> return R.drawable.ic_discussion
+                StreamItem.Type.DISCUSSION_TOPIC, StreamItem.Type.DISCUSSION_ENTRY, StreamItem.Type.DISCUSSION_MENTION -> return R.drawable.ic_discussion
                 StreamItem.Type.ANNOUNCEMENT -> return R.drawable.ic_announcement
                 StreamItem.Type.SUBMISSION -> return R.drawable.ic_assignment
                 StreamItem.Type.CONVERSATION -> return R.drawable.ic_inbox

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/StreamItem.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/StreamItem.kt
@@ -155,7 +155,7 @@ data class StreamItem(
         } else discussion_topic_id
 
     enum class Type {
-        DISCUSSION_TOPIC, SUBMISSION, ANNOUNCEMENT, CONVERSATION, MESSAGE, CONFERENCE, COLLABORATION, COLLECTION_ITEM, UNKNOWN, NOT_SET;
+        DISCUSSION_TOPIC, SUBMISSION, ANNOUNCEMENT, CONVERSATION, MESSAGE, CONFERENCE, COLLABORATION, COLLECTION_ITEM, UNKNOWN, NOT_SET, DISCUSSION_MENTION, DISCUSSION_ENTRY;
 
 
         companion object {
@@ -193,11 +193,13 @@ data class StreamItem(
         type.lowercase(Locale.getDefault()) == "submission" -> Type.SUBMISSION
         type.lowercase(Locale.getDefault()) == "discussiontopic" -> Type.DISCUSSION_TOPIC
         type.lowercase(Locale.getDefault()) == "announcement" -> Type.ANNOUNCEMENT
+        type.lowercase(Locale.getDefault()) == "message" && notificationCategory.lowercase() == "discussionmention" -> Type.DISCUSSION_MENTION
         type.lowercase(Locale.getDefault()) == "message" -> Type.MESSAGE
         type.lowercase(Locale.getDefault()) == "conference" -> Type.CONFERENCE
         type.lowercase(Locale.getDefault()) == "webconference" -> Type.CONFERENCE
         type.lowercase(Locale.getDefault()) == "collaboration" -> Type.COLLABORATION
         type.lowercase(Locale.getDefault()) == "collectionitem" -> Type.COLLECTION_ITEM
+        type.lowercase(Locale.getDefault()) == "discussionentry" -> Type.DISCUSSION_ENTRY
         else -> Type.UNKNOWN
     }
 


### PR DESCRIPTION
Test plan: In the ticket

refs: MBL-17987
affects: Student
release note: Fixed a bug where discussion mention alerts couldn't be opened.

## Checklist

- [x] Tested in dark mode
- [x] Tested in light mode
