### PR TITLE
[MBL-18005][Student] Offline conversation event handling

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/adapter/InboxConversationAdapter.kt
+++ b/apps/student/src/main/java/com/instructure/student/adapter/InboxConversationAdapter.kt
@@ -17,7 +17,6 @@ package com.instructure.student.adapter
 
 import android.content.Context
 import android.view.View
-import com.instructure.student.events.ConversationUpdatedEvent
 import com.instructure.student.holders.InboxMessageHolder
 import com.instructure.student.interfaces.MessageAdapterCallback
 import com.instructure.canvasapi2.managers.InboxManager
@@ -28,6 +27,7 @@ import com.instructure.canvasapi2.utils.weave.WeaveJob
 import com.instructure.canvasapi2.utils.weave.awaitApi
 import com.instructure.canvasapi2.utils.weave.catch
 import com.instructure.canvasapi2.utils.weave.tryWeave
+import com.instructure.pandautils.utils.ConversationUpdatedEvent
 import org.greenrobot.eventbus.EventBus
 
 class InboxConversationAdapter(

--- a/apps/student/src/main/java/com/instructure/student/events/RationedBusEvent.kt
+++ b/apps/student/src/main/java/com/instructure/student/events/RationedBusEvent.kt
@@ -17,7 +17,11 @@
 @file:Suppress("unused")
 package com.instructure.student.events
 
-import com.instructure.canvasapi2.models.*
+import com.instructure.canvasapi2.models.DiscussionTopicHeader
+import com.instructure.canvasapi2.models.ModuleObject
+import com.instructure.canvasapi2.models.Page
+import com.instructure.canvasapi2.models.Recipient
+import com.instructure.canvasapi2.models.User
 import org.greenrobot.eventbus.EventBus
 
 /**
@@ -114,9 +118,6 @@ fun RationedBusEvent<*>.post() = EventBus.getDefault().post(this)
 
 /** A RationedBusEvent for a User. @see [RationedBusEvent] */
 class UserUpdatedEvent(user: User, skipId: String? = null) : RationedBusEvent<User>(user, skipId)
-
-/** A RationedBusEvent for a Conversation. @see [RationedBusEvent] */
-class ConversationUpdatedEvent(conversation: Conversation, skipId: String? = null) : RationedBusEvent<Conversation>(conversation, skipId)
 
 /** A RationedBusEvent adding a new message to the MessageThreadFragment. @see [RationedBusEvent] */
 class MessageAddedEvent(shouldUpdate: Boolean, skipId: String? = null) : RationedBusEvent<Boolean>(shouldUpdate, skipId)

--- a/apps/student/src/main/java/com/instructure/student/features/inbox/list/StudentInboxRouter.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/inbox/list/StudentInboxRouter.kt
@@ -24,8 +24,9 @@ import com.instructure.canvasapi2.models.Conversation
 import com.instructure.pandautils.features.inbox.list.InboxFragment
 import com.instructure.pandautils.features.inbox.list.InboxRouter
 import com.instructure.pandautils.features.inbox.utils.InboxComposeOptions
+import com.instructure.pandautils.utils.ConversationUpdatedEvent
+import com.instructure.pandautils.utils.remove
 import com.instructure.student.activity.NavigationActivity
-import com.instructure.student.events.ConversationUpdatedEvent
 import com.instructure.student.fragment.InboxComposeMessageFragment
 import com.instructure.student.fragment.InboxConversationFragment
 import com.instructure.student.router.RouteMatcher
@@ -63,6 +64,7 @@ class StudentInboxRouter(private val activity: FragmentActivity, private val fra
     fun onUpdateConversation(event: ConversationUpdatedEvent) {
         event.get {
             if (fragment is InboxFragment) {
+                event.remove()
                 fragment.conversationUpdated()
             }
         }

--- a/apps/student/src/main/java/com/instructure/student/fragment/InboxComposeMessageFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/InboxComposeMessageFragment.kt
@@ -49,7 +49,6 @@ import com.instructure.student.adapter.NothingSelectedSpinnerAdapter
 import com.instructure.student.databinding.FragmentInboxComposeMessageBinding
 import com.instructure.student.dialog.UnsavedChangesExitDialog
 import com.instructure.student.events.ChooseRecipientsEvent
-import com.instructure.student.events.ConversationUpdatedEvent
 import com.instructure.student.events.MessageAddedEvent
 import com.instructure.student.router.RouteMatcher
 import com.instructure.student.view.AttachmentView

--- a/apps/student/src/main/java/com/instructure/student/fragment/InboxConversationFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/InboxConversationFragment.kt
@@ -44,7 +44,6 @@ import com.instructure.student.R
 import com.instructure.student.adapter.InboxConversationAdapter
 import com.instructure.student.databinding.FragmentInboxConversationBinding
 import com.instructure.student.databinding.PandaRecyclerRefreshLayoutBinding
-import com.instructure.student.events.ConversationUpdatedEvent
 import com.instructure.student.events.MessageAddedEvent
 import com.instructure.student.interfaces.MessageAdapterCallback
 import com.instructure.student.router.RouteMatcher

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/list/InboxFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/list/InboxFragment.kt
@@ -19,12 +19,12 @@ package com.instructure.pandautils.features.inbox.list
 import android.content.Context
 import android.content.res.Configuration
 import android.graphics.Canvas
-import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
 import android.graphics.Rect
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -59,7 +59,6 @@ import com.instructure.pandautils.binding.BindableViewHolder
 import com.instructure.pandautils.databinding.FragmentInboxBinding
 import com.instructure.pandautils.databinding.ItemInboxEntryBinding
 import com.instructure.pandautils.features.inbox.compose.InboxComposeFragment
-import com.instructure.pandautils.features.inbox.details.InboxDetailsFragment
 import com.instructure.pandautils.features.inbox.list.filter.ContextFilterFragment
 import com.instructure.pandautils.features.inbox.list.itemviewmodels.InboxEntryItemViewModel
 import com.instructure.pandautils.interfaces.NavigationCallbacks
@@ -152,10 +151,10 @@ class InboxFragment : Fragment(), NavigationCallbacks, FragmentInteractions {
 
     private fun setupFragmentResultListener() {
         setFragmentResultListener(InboxComposeFragment.FRAGMENT_RESULT_KEY) { key, bundle ->
-            if (key == InboxComposeFragment.FRAGMENT_RESULT_KEY) { conversationUpdated() }
-        }
-        setFragmentResultListener(InboxDetailsFragment.FRAGMENT_RESULT_KEY) { key, bundle ->
-            if (key == InboxDetailsFragment.FRAGMENT_RESULT_KEY) { conversationUpdated() }
+            if (key == InboxComposeFragment.FRAGMENT_RESULT_KEY) {
+                Log.d("InboxFragment", "setupFragmentResultListener")
+                conversationUpdated()
+            }
         }
     }
 

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/PandaRationedBusEvent.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/PandaRationedBusEvent.kt
@@ -2,6 +2,7 @@ package com.instructure.pandautils.utils
 
 import android.content.Intent
 import com.instructure.canvasapi2.models.Attachment
+import com.instructure.canvasapi2.models.Conversation
 import com.instructure.canvasapi2.models.FileFolder
 import com.instructure.canvasapi2.models.postmodels.FileSubmitObject
 
@@ -114,3 +115,5 @@ class OnBackStackChangedEvent(clazz: Class<*>?) : PandaRationedBusEvent<Class<*>
 
 class FileFolderDeletedEvent(val deletedFileFolder: FileFolder, skipId: String? = null) : PandaRationedBusEvent<FileFolder>(deletedFileFolder, skipId)
 class FileFolderUpdatedEvent(val updatedFileFolder: FileFolder, skipId: String? = null) : PandaRationedBusEvent<FileFolder>(updatedFileFolder, skipId)
+
+class ConversationUpdatedEvent(conversation: Conversation, skipId: String? = null) : PandaRationedBusEvent<Conversation>(conversation, skipId)


### PR DESCRIPTION
Test plan:

1. Sync a course for offline usage
2. Send a new conversation
3. Go offline
4. Switch to another app and go back to the app
5. Conversation refresh fail message should not appear

refs: MBL-18005
affects: Student
release note: none

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/650cd481-d40a-4748-810e-07095b2468ab" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/e853adc3-ea95-47b6-b618-2caf8148dca3" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested in dark mode
- [ ] Tested in light mode
