### PR TITLE
[MBL-17865][All] Update Mobile Apps to authentication file links without UUID

### DIFF
--- a/apps/flutter_parent/lib/network/utils/dio_config.dart
+++ b/apps/flutter_parent/lib/network/utils/dio_config.dart
@@ -22,7 +22,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_parent/network/utils/api_prefs.dart';
 import 'package:flutter_parent/network/utils/authentication_interceptor.dart';
 import 'package:flutter_parent/utils/debug_flags.dart';
-import 'package:path_provider/path_provider.dart';
 
 import 'private_consts.dart';
 
@@ -153,8 +152,15 @@ class DioConfig {
     String? overrideToken = null,
     Map<String, String>? extraHeaders = null,
     PageSize pageSize = PageSize.none,
+    bool disableFileVerifiers = true,
   }) {
     Map<String, dynamic>? extraParams = ApiPrefs.isMasquerading() ? {'as_user_id': ApiPrefs.getUser()?.id} : null;
+
+    if (disableFileVerifiers) {
+      extraParams ??= {};
+      extraParams['no_verifiers'] = true;
+    }
+
     return DioConfig(
       baseUrl: includeApiPath ? ApiPrefs.getApiUrl() : '${ApiPrefs.getDomain()}/',
       baseHeaders: ApiPrefs.getHeaderMap(
@@ -236,6 +242,7 @@ Dio canvasDio({
   String? overrideToken = null,
   Map<String, String>? extraHeaders = null,
   PageSize pageSize = PageSize.none,
+  bool disableFileVerifiers = true,
 }) {
   return DioConfig.canvas(
           forceRefresh: forceRefresh,
@@ -243,7 +250,8 @@ Dio canvasDio({
           overrideToken: overrideToken,
           extraHeaders: extraHeaders,
           pageSize: pageSize,
-          includeApiPath: includeApiPath)
+          includeApiPath: includeApiPath,
+          disableFileVerifiers: disableFileVerifiers)
       .dio;
 }
 

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/RequestInterceptor.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/RequestInterceptor.kt
@@ -16,7 +16,6 @@
  */
 package com.instructure.canvasapi2
 
-import com.instructure.canvasapi2.apis.OAuthAPI
 import com.instructure.canvasapi2.builders.RestParams
 import com.instructure.canvasapi2.utils.APIHelper
 import com.instructure.canvasapi2.utils.ApiPrefs
@@ -90,6 +89,11 @@ class RequestInterceptor : Interceptor {
 
         if (params.usePerPageQueryParam) {
             val url = request.url.newBuilder().addQueryParameter("per_page", Integer.toString(ApiPrefs.perPageCount)).build()
+            request = request.newBuilder().url(url).build()
+        }
+
+        if (params.disableFileVerifiers) {
+            val url = request.url.newBuilder().addQueryParameter("no_verifiers", "true").build()
             request = request.newBuilder().url(url).build()
         }
 

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/builders/RestParams.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/builders/RestParams.kt
@@ -32,4 +32,5 @@ data class RestParams(
     val isForceReadFromCache: Boolean = false,
     val isForceReadFromNetwork: Boolean = false,
     val acceptLanguageOverride: String? = null,
+    val disableFileVerifiers: Boolean = true
 ) : Parcelable


### PR DESCRIPTION
Test plan: 
- Link and embed course files from a web browser all the places where rich content enabled. 
  - Assignment
  - Calendar event
  - Syllabus
  - Discussion
  - Page
  - Quiz
- Check the linked and embedded files are still working from the apps.

refs: MBL-17865
affects: All
release note: none

## Checklist

- [x] Run E2E test suite