### PR TITLE
[MBL-18072][All] Disable save button when event/todo title is blank

### DIFF
--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/interaction/CreateUpdateEventInteractionTest.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/interaction/CreateUpdateEventInteractionTest.kt
@@ -365,6 +365,26 @@ abstract class CreateUpdateEventInteractionTest : CanvasComposeTest() {
         createUpdateEventDetailsPage.assertUnsavedChangesDialog()
     }
 
+    @Test
+    fun saveDisabledWhenTitleBlank() {
+        val data = initData()
+        goToCreateEvent(data)
+
+        composeTestRule.waitForIdle()
+        createUpdateEventDetailsPage.typeTitle("  ")
+        createUpdateEventDetailsPage.assertSaveDisabled()
+    }
+
+    @Test
+    fun saveEnabledWhenTitleIsNotBlank() {
+        val data = initData()
+        goToCreateEvent(data)
+
+        composeTestRule.waitForIdle()
+        createUpdateEventDetailsPage.typeTitle("New Title")
+        createUpdateEventDetailsPage.assertSaveEnabled()
+    }
+
     abstract fun goToCreateEvent(data: MockCanvas)
 
     abstract fun goToEditEvent(data: MockCanvas)

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/interaction/CreateUpdateToDoInteractionTest.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/interaction/CreateUpdateToDoInteractionTest.kt
@@ -279,6 +279,27 @@ abstract class CreateUpdateToDoInteractionTest : CanvasComposeTest() {
         calendarToDoCreateUpdatePage.assertUnsavedChangesDialog()
     }
 
+    @Test
+    fun saveDisabledWhenTitleBlank() {
+        val data = initData()
+        goToCreateToDo(data)
+
+        composeTestRule.waitForIdle()
+        calendarToDoCreateUpdatePage.typeTodoTitle("  ")
+        calendarToDoCreateUpdatePage.assertSaveDisabled()
+    }
+
+    @Test
+    fun saveEnabledWhenTitleIsNotBlank() {
+        val data = initData()
+        goToCreateToDo(data)
+
+        composeTestRule.waitForIdle()
+        calendarToDoCreateUpdatePage.typeTodoTitle("New Title")
+        calendarToDoCreateUpdatePage.assertSaveEnabled()
+    }
+
+
     abstract fun goToCreateToDo(data: MockCanvas)
 
     abstract fun goToEditToDo(data: MockCanvas)

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/CalendarEventCreateEditPage.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/CalendarEventCreateEditPage.kt
@@ -18,6 +18,8 @@ package com.instructure.canvas.espresso.common.pages.compose
 import android.widget.DatePicker
 import android.widget.TimePicker
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasParent
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
@@ -108,5 +110,13 @@ class CalendarEventCreateEditPage(private val composeTestRule: ComposeTestRule) 
 
     fun clickClose() {
         composeTestRule.onNodeWithContentDescription("Close").performClick()
+    }
+
+    fun assertSaveDisabled() {
+        composeTestRule.onNodeWithText("Save").assertIsDisplayed().assertIsNotEnabled()
+    }
+
+    fun assertSaveEnabled() {
+        composeTestRule.onNodeWithText("Save").assertIsDisplayed().assertIsEnabled()
     }
 }

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/CalendarToDoCreateUpdatePage.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/CalendarToDoCreateUpdatePage.kt
@@ -19,6 +19,8 @@ import android.content.Context
 import android.widget.DatePicker
 import android.widget.TimePicker
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasParent
 import androidx.compose.ui.test.hasTestTag
@@ -124,5 +126,13 @@ class CalendarToDoCreateUpdatePage(private val composeTestRule: ComposeTestRule)
 
     fun clickClose() {
         composeTestRule.onNodeWithContentDescription("Close").performClick()
+    }
+
+    fun assertSaveDisabled() {
+        composeTestRule.onNodeWithText("Save").assertIsNotEnabled()
+    }
+
+    fun assertSaveEnabled() {
+        composeTestRule.onNodeWithText("Save").assertIsEnabled()
     }
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendarevent/createupdate/composables/CreateUpdateEventScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendarevent/createupdate/composables/CreateUpdateEventScreen.kt
@@ -32,6 +32,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ButtonColors
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.Scaffold
@@ -268,7 +270,7 @@ private fun ActionsSegment(
         )
     }
 
-    val saveEnabled = uiState.title.isNotEmpty()
+    val saveEnabled = uiState.title.isNotBlank()
     val focusManager = LocalFocusManager.current
     TextButton(
         onClick = {
@@ -280,13 +282,16 @@ private fun ActionsSegment(
             }
         },
         enabled = saveEnabled,
-        modifier = modifier
+        modifier = modifier,
+        colors = ButtonDefaults.buttonColors(
+            backgroundColor = Color.Transparent,
+            contentColor = Color(color = ThemePrefs.textButtonColor),
+            disabledBackgroundColor = Color.Transparent,
+        )
     ) {
         Text(
             text = stringResource(id = R.string.save),
-            color = Color(color = ThemePrefs.textButtonColor),
             fontSize = 14.sp,
-            modifier = Modifier.alpha(if (saveEnabled) 1f else .4f)
         )
     }
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendarevent/createupdate/composables/CreateUpdateEventScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendarevent/createupdate/composables/CreateUpdateEventScreen.kt
@@ -32,8 +32,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.ButtonColors
-import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.Scaffold
@@ -282,16 +280,13 @@ private fun ActionsSegment(
             }
         },
         enabled = saveEnabled,
-        modifier = modifier,
-        colors = ButtonDefaults.buttonColors(
-            backgroundColor = Color.Transparent,
-            contentColor = Color(color = ThemePrefs.textButtonColor),
-            disabledBackgroundColor = Color.Transparent,
-        )
+        modifier = modifier
     ) {
         Text(
             text = stringResource(id = R.string.save),
+            color = Color(color = ThemePrefs.textButtonColor),
             fontSize = 14.sp,
+            modifier = Modifier.alpha(if (saveEnabled) 1f else .4f)
         )
     }
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendartodo/createupdate/composables/CreateUpdateToDoScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendartodo/createupdate/composables/CreateUpdateToDoScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.Scaffold
@@ -235,16 +234,13 @@ private fun ActionsSegment(
             actionHandler(CreateUpdateToDoAction.Save)
         },
         enabled = saveEnabled,
-        modifier = modifier,
-        colors = ButtonDefaults.buttonColors(
-            backgroundColor = Color.Transparent,
-            contentColor = Color(color = ThemePrefs.textButtonColor),
-            disabledBackgroundColor = Color.Transparent,
-        )
+        modifier = modifier
     ) {
         Text(
             text = stringResource(id = R.string.save),
+            color = Color(color = ThemePrefs.textButtonColor),
             fontSize = 14.sp,
+            modifier = Modifier.alpha(if (saveEnabled) 1f else .4f)
         )
     }
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendartodo/createupdate/composables/CreateUpdateToDoScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendartodo/createupdate/composables/CreateUpdateToDoScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.Scaffold
@@ -226,7 +227,7 @@ private fun ActionsSegment(
     actionHandler: (CreateUpdateToDoAction) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val saveEnabled = uiState.title.isNotEmpty()
+    val saveEnabled = uiState.title.isNotBlank()
     val focusManager = LocalFocusManager.current
     TextButton(
         onClick = {
@@ -234,13 +235,16 @@ private fun ActionsSegment(
             actionHandler(CreateUpdateToDoAction.Save)
         },
         enabled = saveEnabled,
-        modifier = modifier
+        modifier = modifier,
+        colors = ButtonDefaults.buttonColors(
+            backgroundColor = Color.Transparent,
+            contentColor = Color(color = ThemePrefs.textButtonColor),
+            disabledBackgroundColor = Color.Transparent,
+        )
     ) {
         Text(
             text = stringResource(id = R.string.save),
-            color = Color(color = ThemePrefs.textButtonColor),
             fontSize = 14.sp,
-            modifier = Modifier.alpha(if (saveEnabled) 1f else .4f)
         )
     }
 }


### PR DESCRIPTION
Test plan: See ticket. The save button should be disabled if the title is blank.

refs: MBL-18072
affects: Student, Teacher, Parent
release note: Fixed a bug, where calendar events could be saved with a blank title.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/b275256a-24ad-453a-afc3-67497ca9544e" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/5f1c7301-2c5f-4400-974b-c1a06f77325e" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested in dark mode
- [x] Tested in light mode
