### PR TITLE
[MBL-18076][Teacher] Tablet: Toolbar back button for new discussions/announcements only refreshing the page when clicked on first opened item's detailer

### DIFF
--- a/apps/parent/src/main/java/com/instructure/parentapp/di/DefaultBindingsModule.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/di/DefaultBindingsModule.kt
@@ -20,6 +20,7 @@ package com.instructure.parentapp.di
 import com.instructure.pandautils.features.dashboard.edit.EditDashboardRepository
 import com.instructure.pandautils.features.dashboard.edit.EditDashboardRouter
 import com.instructure.pandautils.features.dashboard.notifications.DashboardRouter
+import com.instructure.pandautils.features.discussion.details.DiscussionDetailsWebViewFragmentBehavior
 import com.instructure.pandautils.features.discussion.router.DiscussionRouteHelperRepository
 import com.instructure.pandautils.features.discussion.router.DiscussionRouter
 import com.instructure.pandautils.features.elementary.grades.GradesRouter
@@ -102,6 +103,11 @@ class DefaultBindingsModule {
 
     @Provides
     fun provideSyncRouter(): SyncRouter {
+        throw NotImplementedError()
+    }
+
+    @Provides
+    fun provideDiscussionDetailsWebViewFragmentBehavior(): DiscussionDetailsWebViewFragmentBehavior {
         throw NotImplementedError()
     }
 }

--- a/apps/student/src/main/java/com/instructure/student/di/DiscussionModule.kt
+++ b/apps/student/src/main/java/com/instructure/student/di/DiscussionModule.kt
@@ -1,8 +1,10 @@
 package com.instructure.student.di
 
 import androidx.fragment.app.FragmentActivity
+import com.instructure.pandautils.features.discussion.details.DiscussionDetailsWebViewFragmentBehavior
 import com.instructure.pandautils.features.discussion.router.DiscussionRouter
 import com.instructure.pandautils.utils.NetworkStateProvider
+import com.instructure.student.features.discussion.details.StudentDiscussionDetailsWebViewFragmentBehavior
 import com.instructure.student.features.discussion.routing.StudentDiscussionRouter
 import dagger.Module
 import dagger.Provides
@@ -16,5 +18,10 @@ class DiscussionModule {
     @Provides
     fun provideDiscussionRouter(fragmentActivity: FragmentActivity, networkStateProvider: NetworkStateProvider): DiscussionRouter {
         return StudentDiscussionRouter(fragmentActivity, networkStateProvider)
+    }
+
+    @Provides
+    fun provideDiscussionWebViewFragmentBehavior(): DiscussionDetailsWebViewFragmentBehavior {
+        return StudentDiscussionDetailsWebViewFragmentBehavior()
     }
 }

--- a/apps/student/src/main/java/com/instructure/student/features/discussion/details/StudentDiscussionDetailsWebViewFragmentBehavior.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/discussion/details/StudentDiscussionDetailsWebViewFragmentBehavior.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.instructure.student.features.discussion.details
+
+import com.instructure.pandautils.features.discussion.details.DiscussionDetailsWebViewFragmentBehavior
+
+class StudentDiscussionDetailsWebViewFragmentBehavior : DiscussionDetailsWebViewFragmentBehavior {
+    override val showBackButton = true
+}

--- a/apps/teacher/src/main/java/com/instructure/teacher/di/DiscussionModule.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/di/DiscussionModule.kt
@@ -1,7 +1,9 @@
 package com.instructure.teacher.di
 
 import androidx.fragment.app.FragmentActivity
+import com.instructure.pandautils.features.discussion.details.DiscussionDetailsWebViewFragmentBehavior
 import com.instructure.pandautils.features.discussion.router.DiscussionRouter
+import com.instructure.teacher.features.discussion.TeacherDiscussionDetailsWebViewFragmentBehavior
 import com.instructure.teacher.features.discussion.routing.TeacherDiscussionRouter
 import dagger.Module
 import dagger.Provides
@@ -15,5 +17,10 @@ class DiscussionModule {
     @Provides
     fun provideDiscussionRouter(activity: FragmentActivity): DiscussionRouter {
         return TeacherDiscussionRouter(activity)
+    }
+
+    @Provides
+    fun provideDiscussionWebViewFragmentBehavior(activity: FragmentActivity): DiscussionDetailsWebViewFragmentBehavior {
+        return TeacherDiscussionDetailsWebViewFragmentBehavior(activity)
     }
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/discussion/TeacherDiscussionDetailsWebViewFragmentBehavior.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/discussion/TeacherDiscussionDetailsWebViewFragmentBehavior.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2024 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.instructure.teacher.features.discussion
+
+import androidx.fragment.app.FragmentActivity
+import com.instructure.pandautils.features.discussion.details.DiscussionDetailsWebViewFragmentBehavior
+import com.instructure.teacher.utils.isTablet
+
+
+class TeacherDiscussionDetailsWebViewFragmentBehavior(activity: FragmentActivity) : DiscussionDetailsWebViewFragmentBehavior {
+    override val showBackButton = !activity.isTablet
+}

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/discussion/details/DiscussionDetailsWebViewFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/discussion/details/DiscussionDetailsWebViewFragment.kt
@@ -36,7 +36,17 @@ import com.instructure.pandautils.analytics.SCREEN_VIEW_DISCUSSION_DETAILS_REDES
 import com.instructure.pandautils.analytics.ScreenView
 import com.instructure.pandautils.databinding.FragmentDiscussionDetailsWebViewBinding
 import com.instructure.pandautils.navigation.WebViewRouter
-import com.instructure.pandautils.utils.*
+import com.instructure.pandautils.utils.Const
+import com.instructure.pandautils.utils.LongArg
+import com.instructure.pandautils.utils.NullableParcelableArg
+import com.instructure.pandautils.utils.ParcelableArg
+import com.instructure.pandautils.utils.PermissionRequester
+import com.instructure.pandautils.utils.PermissionUtils
+import com.instructure.pandautils.utils.ViewStyler
+import com.instructure.pandautils.utils.enableAlgorithmicDarkening
+import com.instructure.pandautils.utils.makeBundle
+import com.instructure.pandautils.utils.setMenu
+import com.instructure.pandautils.utils.setupAsBackButton
 import com.instructure.pandautils.views.CanvasWebView
 import dagger.hilt.android.AndroidEntryPoint
 import org.greenrobot.eventbus.Subscribe
@@ -50,6 +60,9 @@ class DiscussionDetailsWebViewFragment : Fragment() {
 
     @Inject
     lateinit var webViewRouter: WebViewRouter
+
+    @Inject
+    lateinit var discussionDetailsWebViewFragmentBehavior: DiscussionDetailsWebViewFragmentBehavior
 
     private var canvasContext: CanvasContext by ParcelableArg(key = Const.CANVAS_CONTEXT)
     private var discussionTopicHeader: DiscussionTopicHeader? by NullableParcelableArg(key = DISCUSSION_TOPIC_HEADER)
@@ -147,12 +160,17 @@ class DiscussionDetailsWebViewFragment : Fragment() {
 
     private fun setupToolbar(title: String) = with(binding) {
         toolbar.title = title
-        toolbar.setupAsBackButton(this@DiscussionDetailsWebViewFragment)
+
+        if (discussionDetailsWebViewFragmentBehavior.showBackButton) {
+            toolbar.setupAsBackButton(this@DiscussionDetailsWebViewFragment)
+        }
+
         binding.toolbar.setMenu(R.menu.menu_discussion_details) {
             when (it.itemId) {
                 R.id.refresh -> binding.discussionWebView.reload()
             }
         }
+
         ViewStyler.themeToolbarColored(requireActivity(), toolbar, canvasContext)
     }
 

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/discussion/details/DiscussionDetailsWebViewFragmentBehavior.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/discussion/details/DiscussionDetailsWebViewFragmentBehavior.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.instructure.pandautils.features.discussion.details
+
+
+interface DiscussionDetailsWebViewFragmentBehavior {
+
+    val showBackButton: Boolean
+}


### PR DESCRIPTION
Test plan: in the ticket

refs: MBL-18076
affects: Teacher
release note: none
