### PR TITLE
[MBL-18081][Parent] Fix last domain handling

### DIFF
--- a/apps/flutter_parent/lib/screens/login_landing_screen.dart
+++ b/apps/flutter_parent/lib/screens/login_landing_screen.dart
@@ -63,7 +63,8 @@ class LoginLandingScreen extends StatelessWidget {
                                 // TODO: needs test
                                 locator<QuickNav>().push(
                                   context,
-                                  WebLoginScreen(snicker.domain,
+                                  WebLoginScreen(
+                                      snicker.domain,
                                       user: snicker.username,
                                       pass: snicker.password),
                                 );
@@ -361,7 +362,7 @@ class LoginLandingScreen extends StatelessWidget {
     locator<QuickNav>().pushRoute(
         context,
         PandaRouter.loginWeb(lastAccount.item1.domain,
-            accountName: lastAccount.item1.name!, loginFlow: lastAccount.item2));
+            accountName: lastAccount.item1.name!, authenticationProvider: lastAccount.item1.authenticationProvider, loginFlow: lastAccount.item2));
   }
 
   void _changeLoginFlow(BuildContext context) {

--- a/apps/flutter_parent/lib/screens/web_login/web_login_screen.dart
+++ b/apps/flutter_parent/lib/screens/web_login/web_login_screen.dart
@@ -216,6 +216,7 @@ class _WebLoginScreenState extends State<WebLoginScreen> {
         );
         final lastAccount = new SchoolDomain((builder) =>
         builder
+          ..authenticationProvider = widget.authenticationProvider
           ..domain = widget.domain
           ..name = widget.accountName);
         ApiPrefs.setLastAccount(lastAccount, widget.loginFlow);


### PR DESCRIPTION
Test plan: Use the user credentials from the ticket.

1. Login to the Canvas domain.
2. Log out 
3. Select the last school's login button
4. Proper Canvas login page should be visible

Previously auth provider handling wasn't correct in the Parent app and domain's AuthProvider wasn't saved. Now it's fixed with this PR, but the last domain's shortcut button won't work immediately because of the missing information. You have to search for the domain in the Find my school list and login. After the relogin the last school's shortcut button will work properly.

refs: MBL-18081
affects: Parent
release note: Login providers are now properly handled at the last domain's button.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/87dc3611-0e1c-4126-afa4-6830552d7a4d" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/61e5e272-7808-42bf-8288-e278dcae13e9" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested in dark mode
- [ ] Tested in light mode
