### PR TITLE
[MBL-18106][Student] Cross course tab reference handling fix

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/di/TestApplicationModule.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/di/TestApplicationModule.kt
@@ -1,0 +1,29 @@
+package com.instructure.student.di
+
+import com.instructure.pandautils.utils.LogoutHelper
+import com.instructure.student.espresso.fakes.FakeEnabledTabs
+import com.instructure.student.router.EnabledTabs
+import com.instructure.student.util.StudentLogoutHelper
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import javax.inject.Singleton
+
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [ApplicationModule::class]
+)
+class TestApplicationModule {
+    @Provides
+    fun provideLogoutHelper(): LogoutHelper {
+        return StudentLogoutHelper()
+    }
+
+    @Provides
+    @Singleton
+    fun provideEnabledTabs(): EnabledTabs {
+        return FakeEnabledTabs()
+    }
+}

--- a/apps/student/src/androidTest/java/com/instructure/student/espresso/fakes/FakeEnabledTabs.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/espresso/fakes/FakeEnabledTabs.kt
@@ -1,0 +1,12 @@
+package com.instructure.student.espresso.fakes
+
+import com.instructure.interactions.router.Route
+import com.instructure.student.router.EnabledTabs
+
+class FakeEnabledTabs: EnabledTabs {
+    override suspend fun initTabs() {}
+
+    override fun isPathTabNotEnabled(route: Route?): Boolean {
+        return false
+    }
+}

--- a/apps/student/src/main/java/com/instructure/student/di/ApplicationModule.kt
+++ b/apps/student/src/main/java/com/instructure/student/di/ApplicationModule.kt
@@ -21,6 +21,7 @@ package com.instructure.student.di
 import com.instructure.canvasapi2.apis.CourseAPI
 import com.instructure.pandautils.utils.LogoutHelper
 import com.instructure.student.router.EnabledTabs
+import com.instructure.student.router.EnabledTabsImpl
 import com.instructure.student.util.StudentLogoutHelper
 import dagger.Module
 import dagger.Provides
@@ -40,6 +41,6 @@ class ApplicationModule {
     @Provides
     @Singleton
     fun provideEnabledTabs(courseApi: CourseAPI.CoursesInterface): EnabledTabs {
-        return EnabledTabs(courseApi)
+        return EnabledTabsImpl(courseApi)
     }
 }

--- a/apps/student/src/main/java/com/instructure/student/router/EnabledTabs.kt
+++ b/apps/student/src/main/java/com/instructure/student/router/EnabledTabs.kt
@@ -7,9 +7,14 @@ import com.instructure.canvasapi2.models.Tab
 import com.instructure.canvasapi2.utils.depaginate
 import com.instructure.interactions.router.Route
 
-class EnabledTabs(
+interface EnabledTabs {
+    fun isPathTabNotEnabled(route: Route?): Boolean
+    suspend fun initTabs()
+}
+
+class EnabledTabsImpl(
     private val courseApi: CourseAPI.CoursesInterface
-) {
+): EnabledTabs {
     private var enabledTabs: Map<Long, List<Tab>>? = null
 
     private fun isPathTabEnabled(courseId: Long, uri: Uri): Boolean {
@@ -30,7 +35,7 @@ class EnabledTabs(
         }
     }
 
-    fun isPathTabNotEnabled(route: Route?): Boolean {
+    override fun isPathTabNotEnabled(route: Route?): Boolean {
         route?.uri?.let { uri ->
             route.courseId?.let { courseId ->
                 return !isPathTabEnabled(courseId, uri)
@@ -45,7 +50,7 @@ class EnabledTabs(
         return false
     }
 
-    suspend fun initTabs() {
+    override suspend fun initTabs() {
         enabledTabs = courseApi.getFirstPageCourses(RestParams(usePerPageQueryParam = true))
             .depaginate {
                 courseApi.next(it, RestParams(usePerPageQueryParam = true))

--- a/apps/student/src/test/java/com/instructure/student/router/EnabledTabsTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/router/EnabledTabsTest.kt
@@ -37,7 +37,7 @@ import org.junit.Test
 class EnabledTabsTest {
     private val mockUri: Uri = mockk(relaxed = true)
     private val courseApi: CourseAPI.CoursesInterface = mockk(relaxed = true)
-    private val enabledTabs = EnabledTabs(courseApi)
+    private val enabledTabs = EnabledTabsImpl(courseApi)
 
     @Before
     fun setup() {

--- a/apps/student/src/test/java/com/instructure/student/router/EnabledTabsTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/router/EnabledTabsTest.kt
@@ -108,7 +108,7 @@ class EnabledTabsTest {
     fun `isPathTabNotEnabled should return false value for valid details urls`() = runTest {
         coEvery { courseApi.getFirstPageCourses(any()) } returns DataResult.Success(
             listOf(
-                Course(tabs = listOf(Tab(tabId = "assignment", htmlUrl = "/courses/1/assignments"))),
+                Course(id = 1, tabs = listOf(Tab(tabId = "assignment", htmlUrl = "/courses/1/assignments"))),
             )
         )
         enabledTabs.initTabs()
@@ -126,7 +126,7 @@ class EnabledTabsTest {
     fun `isPathTabNotEnabled handle home urls correctly`() = runTest {
         coEvery { courseApi.getFirstPageCourses(any()) } returns DataResult.Success(
             listOf(
-                Course(tabs = listOf(Tab(tabId = "home", htmlUrl = "/courses/1"))),
+                Course(id = 1, tabs = listOf(Tab(tabId = "home", htmlUrl = "/courses/1"))),
             )
         )
         enabledTabs.initTabs()
@@ -144,7 +144,7 @@ class EnabledTabsTest {
     fun `isPathTabNotEnabled handle syllabus urls correctly with disabled tab`() = runTest {
         coEvery { courseApi.getFirstPageCourses(any()) } returns DataResult.Success(
             listOf(
-                Course(tabs = listOf(Tab(tabId = "assignments", htmlUrl = "/courses/1/assignments"))),
+                Course(id = 1, tabs = listOf(Tab(tabId = "assignments", htmlUrl = "/courses/1/assignments"))),
             )
         )
         enabledTabs.initTabs()
@@ -162,7 +162,7 @@ class EnabledTabsTest {
     fun `isPathTabNotEnabled handle syllabus urls correctly with enabled tab`() = runTest {
         coEvery { courseApi.getFirstPageCourses(any()) } returns DataResult.Success(
             listOf(
-                Course(tabs = listOf(Tab(tabId = "syllabus", htmlUrl = "/courses/1/assignments/syllabus"))),
+                Course(id = 1, tabs = listOf(Tab(tabId = "syllabus", htmlUrl = "/courses/1/assignments/syllabus"))),
             )
         )
         enabledTabs.initTabs()
@@ -173,6 +173,45 @@ class EnabledTabsTest {
 
         val result = enabledTabs.isPathTabNotEnabled(route)
 
+        assertFalse(result)
+    }
+
+    @Test
+    fun `isPathTabNotEnabled can handle cross-course navigation`() = runTest {
+        coEvery { courseApi.getFirstPageCourses(any()) } returns DataResult.Success(
+            listOf(
+                Course(id = 1, tabs = listOf(Tab(tabId = "assignments", htmlUrl = "/courses/1/assignments"))),
+                Course(id = 2, tabs = listOf(Tab(tabId = "syllabus", htmlUrl = "/courses/2/assignments/syllabus"))),
+            )
+        )
+        enabledTabs.initTabs()
+
+        // Check course 1 disabled tab
+        var route = Route(uri = mockUri)
+        every { mockUri.path } returns "http://www.google.com/courses/1/assignments/syllabus"
+        every { mockUri.pathSegments } returns listOf("courses", "1", "assignments", "syllabus")
+        var result = enabledTabs.isPathTabNotEnabled(route)
+        assertTrue(result)
+
+        // Check course 1 enabled tab
+        route = Route(uri = mockUri)
+        every { mockUri.path } returns "http://www.google.com/courses/1/assignments"
+        every { mockUri.pathSegments } returns listOf("courses", "1", "assignments")
+        result = enabledTabs.isPathTabNotEnabled(route)
+        assertFalse(result)
+
+        // Check course 2 disabled tab
+        route = Route(uri = mockUri)
+        every { mockUri.path } returns "http://www.google.com/courses/2/assignments"
+        every { mockUri.pathSegments } returns listOf("courses", "2", "assignments")
+        result = enabledTabs.isPathTabNotEnabled(route)
+        assertTrue(result)
+
+        // Check course 2 enabled tab
+        route = Route(uri = mockUri)
+        every { mockUri.path } returns "http://www.google.com/courses/2/assignments/syllabus"
+        every { mockUri.pathSegments } returns listOf("courses", "2", "assignments", "syllabus")
+        result = enabledTabs.isPathTabNotEnabled(route)
         assertFalse(result)
     }
 }


### PR DESCRIPTION
Test plan: Test multiple tab and details screen navigations in the Student application. Test if both enabled and disabled tabs are handled properly. Try out cross course references as well.
I've created a navigation description to easily test it: /assignments/Navigation assignment. Please don't modify my sandbox's settings, test other configurations in your own sandbox.

refs: MBL-18106
affects: Student
release note: none

## Checklist

- [ ] Tested in light mode
