### PR TITLE
[MBL-18132][Teacher] Fixed calendar context limit api change

### DIFF
--- a/apps/parent/src/main/java/com/instructure/parentapp/features/calendar/ParentCalendarRepository.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/calendar/ParentCalendarRepository.kt
@@ -126,9 +126,8 @@ class ParentCalendarRepository(
     override suspend fun getCalendarFilterLimit(): Int {
         val result = featuresApi.getAccountSettingsFeatures(RestParams())
         return if (result.isSuccess) {
-            val features = result.dataOrThrow
-            val increasedContextLimit = features["calendar_contexts_limit"]
-            if (increasedContextLimit == true) 20 else 10
+            val settings = result.dataOrThrow
+            settings.calendarContextsLimit
         } else {
             10
         }

--- a/apps/parent/src/test/java/com/instructure/parentapp/features/calendar/ParentCalendarRepositoryTest.kt
+++ b/apps/parent/src/test/java/com/instructure/parentapp/features/calendar/ParentCalendarRepositoryTest.kt
@@ -23,6 +23,7 @@ import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.CanvasContext
 import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.models.Enrollment
+import com.instructure.canvasapi2.models.EnvironmentSettings
 import com.instructure.canvasapi2.models.Plannable
 import com.instructure.canvasapi2.models.PlannableType
 import com.instructure.canvasapi2.models.ScheduleItem
@@ -292,21 +293,12 @@ class ParentCalendarRepositoryTest {
     }
 
     @Test
-    fun `Return 20 for calendar filter limit when context limit is increased`() = runTest {
-        coEvery { featuresApi.getAccountSettingsFeatures(any()) } returns DataResult.Success(mapOf("calendar_contexts_limit" to true))
+    fun `Return context limit from api when request is success`() = runTest {
+        coEvery { featuresApi.getAccountSettingsFeatures(any()) } returns DataResult.Success(EnvironmentSettings(calendarContextsLimit = 20))
 
         val result = calendarRepository.getCalendarFilterLimit()
 
         assertEquals(20, result)
-    }
-
-    @Test
-    fun `Return 10 for calendar filter limit when context limit is not increased`() = runTest {
-        coEvery { featuresApi.getAccountSettingsFeatures(any()) } returns DataResult.Success(mapOf("calendar_contexts_limit" to false))
-
-        val result = calendarRepository.getCalendarFilterLimit()
-
-        assertEquals(10, result)
     }
 
     @Test

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/UpdateFilePermissionsPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/UpdateFilePermissionsPage.kt
@@ -123,7 +123,7 @@ class UpdateFilePermissionsPage : BasePage() {
     }
 
     fun assertUnlockDate(unlockDate: Date) {
-        val dateString = SimpleDateFormat("MMM d, YYYY").format(unlockDate)
+        val dateString = SimpleDateFormat("MMM d, yyyy").format(unlockDate)
         val timeString = SimpleDateFormat("h:mm a").format(unlockDate)
 
         waitForViewWithId(R.id.availableFromDate).scrollTo().assertDisplayed()
@@ -132,7 +132,7 @@ class UpdateFilePermissionsPage : BasePage() {
     }
 
     fun assertLockDate(lockDate: Date) {
-        val dateString = SimpleDateFormat("MMM d, YYYY").format(lockDate)
+        val dateString = SimpleDateFormat("MMM d, yyyy").format(lockDate)
         val timeString = SimpleDateFormat("h:mm a").format(lockDate)
 
         waitForViewWithId(R.id.availableUntilDate).scrollTo().assertDisplayed()

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/calendar/TeacherCalendarRepository.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/calendar/TeacherCalendarRepository.kt
@@ -119,9 +119,8 @@ class TeacherCalendarRepository(
     override suspend fun getCalendarFilterLimit(): Int {
         val result = featuresApi.getAccountSettingsFeatures(RestParams())
         return if (result.isSuccess) {
-            val features = result.dataOrThrow
-            val increasedContextLimit = features["calendar_contexts_limit"]
-            if (increasedContextLimit == true) 20 else 10
+            val settings = result.dataOrThrow
+            settings.calendarContextsLimit
         } else {
             10
         }

--- a/apps/teacher/src/test/java/com/instructure/teacher/features/calendar/TeacherCalendarRepositoryTest.kt
+++ b/apps/teacher/src/test/java/com/instructure/teacher/features/calendar/TeacherCalendarRepositoryTest.kt
@@ -25,6 +25,7 @@ import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.CanvasContext
 import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.models.Enrollment
+import com.instructure.canvasapi2.models.EnvironmentSettings
 import com.instructure.canvasapi2.models.Plannable
 import com.instructure.canvasapi2.models.PlannableType
 import com.instructure.canvasapi2.models.ScheduleItem
@@ -252,21 +253,12 @@ class TeacherCalendarRepositoryTest {
     }
 
     @Test
-    fun `Return 20 for calendar filter limit when context limit is increased`() = runTest {
-        coEvery { featuresApi.getAccountSettingsFeatures(any()) } returns DataResult.Success(mapOf("calendar_contexts_limit" to true))
+    fun `Return context limit from api when request is success`() = runTest {
+        coEvery { featuresApi.getAccountSettingsFeatures(any()) } returns DataResult.Success(EnvironmentSettings(calendarContextsLimit = 20))
 
         val result = calendarRepository.getCalendarFilterLimit()
 
         assertEquals(20, result)
-    }
-
-    @Test
-    fun `Return 10 for calendar filter limit when context limit is not increased`() = runTest {
-        coEvery { featuresApi.getAccountSettingsFeatures(any()) } returns DataResult.Success(mapOf("calendar_contexts_limit" to false))
-
-        val result = calendarRepository.getCalendarFilterLimit()
-
-        assertEquals(10, result)
     }
 
     @Test

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/FeaturesAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/FeaturesAPI.kt
@@ -21,6 +21,7 @@ package com.instructure.canvasapi2.apis
 import com.instructure.canvasapi2.StatusCallback
 import com.instructure.canvasapi2.builders.RestBuilder
 import com.instructure.canvasapi2.builders.RestParams
+import com.instructure.canvasapi2.models.EnvironmentSettings
 import com.instructure.canvasapi2.utils.APIHelper
 import com.instructure.canvasapi2.utils.DataResult
 import retrofit2.Call
@@ -44,7 +45,7 @@ object FeaturesAPI {
         suspend fun getEnvironmentFeatureFlags(@Tag restParams: RestParams): DataResult<Map<String, Boolean>>
 
         @GET("settings/environment")
-        suspend fun getAccountSettingsFeatures(@Tag restParams: RestParams): DataResult<Map<String, Boolean>>
+        suspend fun getAccountSettingsFeatures(@Tag restParams: RestParams): DataResult<EnvironmentSettings>
     }
 
     fun getEnabledFeaturesForCourse(adapter: RestBuilder, courseId: Long, callback: StatusCallback<List<String>>, params: RestParams) {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/EnvironmentSettings.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/EnvironmentSettings.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2024 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package com.instructure.canvasapi2.models
+
+import com.google.gson.annotations.SerializedName
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class EnvironmentSettings(
+    @SerializedName("calendar_contexts_limit")
+    val calendarContextsLimit: Int = 10,
+) : CanvasModel<EnvironmentSettings>()


### PR DESCRIPTION
Test plan: In the ticket. The new Parent app should be tested as well.

refs: MBL-18132
affects: Teacher
release note: Fixed an issue where only 10 calendars could be selected.

## Checklist

- [x] Tested in dark mode
