### PR TITLE
[MBL-18160][Teacher] Edit file empty title bug fixed

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/EditFileFolderFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/EditFileFolderFragment.kt
@@ -18,6 +18,8 @@ package com.instructure.teacher.fragments
 
 import android.graphics.Typeface
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -119,6 +121,17 @@ class EditFileFolderFragment : BasePresenterFragment<
         }.show(requireActivity().supportFragmentManager, TimePickerDialogFragment::class.java.simpleName)
     }
 
+    private val titleTextWatcher = object : TextWatcher {
+        override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+        override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+
+        override fun afterTextChanged(s: Editable?) {
+            if (s?.isBlank() == false) {
+                binding.titleLabel.error = null
+            }
+        }
+    }
+
     override val bindingInflater: (layoutInflater: LayoutInflater) -> FragmentEditFilefolderBinding = FragmentEditFilefolderBinding::inflate
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -189,6 +202,8 @@ class EditFileFolderFragment : BasePresenterFragment<
         lockTimeEditText.setOnClickListener { timeClickListener(it, true) }
         unlockDateEditText.setOnClickListener { dateClickListener(it, false) }
         unlockTimeEditText.setOnClickListener { timeClickListener(it, false) }
+
+        titleEditText.addTextChangedListener(titleTextWatcher)
 
         // Apply theming
         ViewStyler.themeEditText(requireActivity(), titleEditText, ThemePrefs.brandColor)
@@ -412,6 +427,10 @@ class EditFileFolderFragment : BasePresenterFragment<
     }
 
     private fun saveFileFolder() = with(binding) {
+        if (binding.titleEditText.text?.isBlank() == true) {
+            binding.titleLabel.error = getString(R.string.errorEmptyTitle)
+            return
+        }
 
         // Check unlock/lock dates
         if (unlockDate != null && lockDate != null)

--- a/apps/teacher/src/main/res/values/strings.xml
+++ b/apps/teacher/src/main/res/values/strings.xml
@@ -840,6 +840,7 @@
     <string name="errorDeletingFolder">An error occurred deleting this folder</string>
     <string name="errorUpdatingFile">An error occurred updating this file</string>
     <string name="errorUpdatingFolder">An error occurred updating this folder</string>
+    <string name="errorEmptyTitle">The title cannot be blank</string>
 
     <string name="toDoEmpty">Nothing more to do!\n Enjoy your day.</string>
     <string name="toDoNoSubmissions">There are no submissions to grade for this assignment.</string>


### PR DESCRIPTION
Test plan:
- In the Teacher app, select a module, go to files, and open the edit dialog on a file
- Set file name to blank or add only whitespaces to title
- Error message should be shown, file should not be saved

refs: MBL-18160
affects: Teacher
release note: Fixed an issue where a file could be renamed to blank.

## Checklist

- [x] Tested in dark mode
- [x] Tested in light mode
