### PR TITLE
[MBL-18148][Student][Teacher] Freetext annotation comments on a submission do not zoom correctly for students

### DIFF
--- a/libs/annotations/src/main/java/com/instructure/annotations/AnnotationConverter.kt
+++ b/libs/annotations/src/main/java/com/instructure/annotations/AnnotationConverter.kt
@@ -129,6 +129,7 @@ private fun convertFreeTextType(canvaDocAnnotation: CanvaDocAnnotation, context:
     freeTextAnnotation.name = canvaDocAnnotation.annotationId
     freeTextAnnotation.textSize = getTextSizeFromFont(canvaDocAnnotation.font)
     freeTextAnnotation.fillColor = Color.TRANSPARENT
+    freeTextAnnotation.flags.remove(AnnotationFlags.NOZOOM)
 
     return freeTextAnnotation
 }

--- a/libs/annotations/src/main/java/com/instructure/annotations/PdfSubmissionView.kt
+++ b/libs/annotations/src/main/java/com/instructure/annotations/PdfSubmissionView.kt
@@ -624,6 +624,10 @@ abstract class PdfSubmissionView(context: Context, private val studentAnnotation
 
     //region Annotation Manipulation
     fun createNewAnnotation(annotation: Annotation) {
+        if (annotation.type == AnnotationType.FREETEXT) {
+            annotation.flags.remove(AnnotationFlags.NOZOOM)
+        }
+
         if (docSession.annotationMetadata?.canWrite() != true) return
 
         // This is a new annotation; Post it


### PR DESCRIPTION
Test plan: In the ticket. Ticket only mentions the Student app, but this affects the Teacher as well.

refs: MBL-18148
affects: Student, Teacher
release note: none

## Checklist

- [ ] Tested in dark mode
- [ ] Tested in light mode
