### PR TITLE
[MBL-18183][Parent] Fix no submission assignments label

### DIFF
--- a/apps/flutter_parent/lib/models/assignment.dart
+++ b/apps/flutter_parent/lib/models/assignment.dart
@@ -148,7 +148,7 @@ abstract class Assignment implements Built<Assignment, AssignmentBuilder> {
 
   SubmissionStatus getStatus({required String? studentId}) {
     final submission = this.submission(studentId);
-    if ((!isSubmittable() && submission == null) || (!isSubmittable()) && submission?.isGraded() == false) {
+    if ((!isSubmittable() && submission == null) || (!isSubmittable() && submission?.isGraded() == false)) {
       return SubmissionStatus.NONE;
     } else if (submission?.isLate == true) {
       return SubmissionStatus.LATE;

--- a/apps/flutter_parent/lib/models/assignment.dart
+++ b/apps/flutter_parent/lib/models/assignment.dart
@@ -148,13 +148,13 @@ abstract class Assignment implements Built<Assignment, AssignmentBuilder> {
 
   SubmissionStatus getStatus({required String? studentId}) {
     final submission = this.submission(studentId);
-    if (!isSubmittable() && submission == null) {
+    if ((!isSubmittable() && submission == null) || (!isSubmittable()) && submission?.isGraded() == false) {
       return SubmissionStatus.NONE;
     } else if (submission?.isLate == true) {
       return SubmissionStatus.LATE;
     } else if (_isMissingSubmission(studentId)) {
       return SubmissionStatus.MISSING;
-    } else if (submission?.submittedAt == null) {
+    } else if (submission?.submittedAt == null && submission?.isGraded() == false) {
       return SubmissionStatus.NOT_SUBMITTED;
     } else {
       return SubmissionStatus.SUBMITTED;

--- a/apps/flutter_parent/lib/models/assignment.dart
+++ b/apps/flutter_parent/lib/models/assignment.dart
@@ -154,7 +154,7 @@ abstract class Assignment implements Built<Assignment, AssignmentBuilder> {
       return SubmissionStatus.LATE;
     } else if (_isMissingSubmission(studentId)) {
       return SubmissionStatus.MISSING;
-    } else if (submission?.submittedAt == null && submission?.isGraded() == false) {
+    } else if (submission?.submittedAt == null && (submission?.isGraded() ?? false) == false) {
       return SubmissionStatus.NOT_SUBMITTED;
     } else {
       return SubmissionStatus.SUBMITTED;

--- a/apps/flutter_parent/lib/screens/assignments/assignment_details_screen.dart
+++ b/apps/flutter_parent/lib/screens/assignments/assignment_details_screen.dart
@@ -149,7 +149,8 @@ class _AssignmentDetailsScreenState extends State<AssignmentDetailsScreen> {
     final missing = submission?.missing == true;
     final showStatus = missing || assignment.isSubmittable() || submission?.isGraded() == true;
     final submitted = submission?.submittedAt != null;
-    final submittedColor = submitted ? ParentTheme.of(context)?.successColor : textTheme.bodySmall?.color;
+    final graded = submission?.isGraded() == true;
+    final submittedColor = submitted || graded ? ParentTheme.of(context)?.successColor : textTheme.bodySmall?.color;
 
     final points = (assignment.pointsPossible.toInt() == assignment.pointsPossible)
         ? assignment.pointsPossible.toInt().toString()
@@ -173,13 +174,13 @@ class _AssignmentDetailsScreenState extends State<AssignmentDetailsScreen> {
                       semanticsLabel: l10n.assignmentTotalPointsAccessible(points),
                       key: Key("assignment_details_total_points")),
                 if (showStatus && !restrictQuantitativeData) SizedBox(width: 16),
-                if (showStatus) _statusIcon(submitted, submittedColor!),
+                if (showStatus) _statusIcon(submitted || graded, submittedColor!),
                 if (showStatus) SizedBox(width: 8),
                 if (showStatus)
                   Text(
                       missing ? l10n.assignmentMissingSubmittedLabel :
-                      !submitted ? l10n.assignmentNotSubmittedLabel :
-                      submission?.isGraded() == true ? l10n.assignmentGradedLabel : l10n.assignmentSubmittedLabel,
+                      graded ? l10n.assignmentGradedLabel :
+                      submitted ? l10n.assignmentSubmittedLabel : l10n.assignmentNotSubmittedLabel,
                       style: textTheme.bodySmall?.copyWith(
                         color: submittedColor,
                       ),


### PR DESCRIPTION
Test plan: See ticket for the Flutter Parent app. 

refs: MBL-18183
affects: Parent
release note: Remove Missing label for assignments with No Submission type.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/4c077969-341c-4ae1-83fe-809cd8218f96" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/e7262920-b1c3-455e-a5d8-b86c2ea527b4" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Run E2E test suite
- [ ] Tested in dark mode
- [ ] Tested in light mode
