### PR TITLE
[MBL-17963][Teacher] Open native speedgrader in discussion redesign

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/features/discussion/routing/StudentDiscussionRouter.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/discussion/routing/StudentDiscussionRouter.kt
@@ -44,4 +44,6 @@ class StudentDiscussionRouter(
 
         RouteMatcher.route(fragmentActivity, route)
     }
+
+    override fun routeToNativeSpeedGrader(courseId: Long, assignmentId: Long, submissionIds: List<Long>, selectedIdx: Int, anonymousGrading: Boolean?) = Unit
 }

--- a/apps/student/src/main/java/com/instructure/student/features/discussion/routing/StudentDiscussionRouter.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/discussion/routing/StudentDiscussionRouter.kt
@@ -45,5 +45,5 @@ class StudentDiscussionRouter(
         RouteMatcher.route(fragmentActivity, route)
     }
 
-    override fun routeToNativeSpeedGrader(courseId: Long, assignmentId: Long, submissionIds: List<Long>, selectedIdx: Int, anonymousGrading: Boolean?) = Unit
+    override fun routeToNativeSpeedGrader(courseId: Long, assignmentId: Long, submissionIds: List<Long>, selectedIdx: Int, anonymousGrading: Boolean?, discussionTopicEntryId: Long?) = Unit
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/activities/SpeedGraderActivity.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/activities/SpeedGraderActivity.kt
@@ -24,11 +24,13 @@ import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
 import android.os.Bundle
+import android.util.Log
 import android.util.TypedValue
 import android.view.View
 import androidx.activity.viewModels
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.core.os.bundleOf
 import androidx.viewpager.widget.ViewPager
 import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.DiscussionTopicHeader
@@ -97,6 +99,7 @@ class SpeedGraderActivity : BasePresenterActivity<SpeedGraderPresenter, SpeedGra
     val assignmentId: Long by lazy { intent.extras!!.getLong(Const.ASSIGNMENT_ID) }
     private val submissionId: Long by lazy { intent.extras!!.getLong(RouterParams.SUBMISSION_ID) }
     private val discussionTopicHeader: DiscussionTopicHeader? by lazy { intent.extras!!.getParcelable(Const.DISCUSSION_HEADER) }
+    private val discussionEntryId: Long? by lazy { intent.extras?.getLong(DISCUSSION_ENTRY_ID) }
     private val anonymousGrading: Boolean? by lazy { intent.extras?.getBoolean(Const.ANONYMOUS_GRADING) }
     private val filteredSubmissionIds: LongArray by lazy { intent.extras?.getLongArray(FILTERED_SUBMISSION_IDS) ?: longArrayOf() }
     private val filter: SubmissionListFilter by lazy {
@@ -178,12 +181,15 @@ class SpeedGraderActivity : BasePresenterActivity<SpeedGraderPresenter, SpeedGra
         } else {
             assignment
         }
+        val selection = if (discussionEntryId != null) {
+            submissions.indexOfFirst { it.submission?.discussionEntries?.map{ it.id }?.contains(discussionEntryId).orDefault() }
+        } else { initialSelection }
         adapter = SubmissionContentAdapter(assignmentWithAnonymousGrading, presenter!!.course, submissions)
         submissionContentPager.offscreenPageLimit = 1
         submissionContentPager.pageMargin = Math.round(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 1f, resources.displayMetrics))
         submissionContentPager.setPageMarginDrawable(R.color.backgroundMedium)
         submissionContentPager.adapter = adapter
-        submissionContentPager.setCurrentItem(initialSelection, false)
+        submissionContentPager.setCurrentItem(selection, false)
         submissionContentPager.addOnPageChangeListener(object : ViewPager.OnPageChangeListener {
             override fun onPageScrollStateChanged(state: Int) {}
             override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {}
@@ -384,6 +390,7 @@ class SpeedGraderActivity : BasePresenterActivity<SpeedGraderPresenter, SpeedGra
         const val FILTER = "filter"
         const val FILTER_VALUE = "filter_value"
         const val FILTERED_SUBMISSION_IDS = "filtered_submission_ids"
+        const val DISCUSSION_ENTRY_ID = "discussion_entry_id"
 
         fun makeBundle(
             courseId: Long,

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/discussion/routing/TeacherDiscussionRouter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/discussion/routing/TeacherDiscussionRouter.kt
@@ -4,9 +4,12 @@ import androidx.fragment.app.FragmentActivity
 import com.instructure.canvasapi2.models.CanvasContext
 import com.instructure.canvasapi2.models.DiscussionTopicHeader
 import com.instructure.canvasapi2.models.Group
+import com.instructure.interactions.router.Route
+import com.instructure.interactions.router.RouteContext
 import com.instructure.pandautils.features.discussion.details.DiscussionDetailsWebViewFragment
 import com.instructure.pandautils.features.discussion.router.DiscussionRouter
 import com.instructure.teacher.activities.FullscreenActivity
+import com.instructure.teacher.activities.SpeedGraderActivity
 import com.instructure.teacher.router.RouteMatcher
 
 class TeacherDiscussionRouter(private val activity: FragmentActivity) : DiscussionRouter {
@@ -28,4 +31,21 @@ class TeacherDiscussionRouter(private val activity: FragmentActivity) : Discussi
     }
 
     override fun routeToGroupDiscussion(group: Group, id: Long, header: DiscussionTopicHeader, isRedesign: Boolean) = Unit
+
+    override fun routeToNativeSpeedGrader(
+        courseId: Long,
+        assignmentId: Long,
+        submissionIds: List<Long>,
+        selectedIdx: Int,
+        anonymousGrading: Boolean?
+    ) {
+        val bundle = SpeedGraderActivity.makeBundle(
+            courseId = courseId,
+            assignmentId = assignmentId,
+            selectedIdx = selectedIdx,
+            anonymousGrading = anonymousGrading,
+            filteredSubmissionIds = submissionIds.toLongArray(),
+        )
+        RouteMatcher.route(activity, Route(bundle, RouteContext.SPEED_GRADER))
+    }
 }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/discussion/routing/TeacherDiscussionRouter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/discussion/routing/TeacherDiscussionRouter.kt
@@ -10,6 +10,7 @@ import com.instructure.pandautils.features.discussion.details.DiscussionDetailsW
 import com.instructure.pandautils.features.discussion.router.DiscussionRouter
 import com.instructure.teacher.activities.FullscreenActivity
 import com.instructure.teacher.activities.SpeedGraderActivity
+import com.instructure.teacher.activities.SpeedGraderActivity.Companion.DISCUSSION_ENTRY_ID
 import com.instructure.teacher.router.RouteMatcher
 
 class TeacherDiscussionRouter(private val activity: FragmentActivity) : DiscussionRouter {
@@ -37,7 +38,8 @@ class TeacherDiscussionRouter(private val activity: FragmentActivity) : Discussi
         assignmentId: Long,
         submissionIds: List<Long>,
         selectedIdx: Int,
-        anonymousGrading: Boolean?
+        anonymousGrading: Boolean?,
+        discussionTopicEntryId: Long?,
     ) {
         val bundle = SpeedGraderActivity.makeBundle(
             courseId = courseId,
@@ -45,7 +47,9 @@ class TeacherDiscussionRouter(private val activity: FragmentActivity) : Discussi
             selectedIdx = selectedIdx,
             anonymousGrading = anonymousGrading,
             filteredSubmissionIds = submissionIds.toLongArray(),
-        )
+        ).apply {
+            discussionTopicEntryId?.let { putLong(DISCUSSION_ENTRY_ID, it) }
+        }
         RouteMatcher.route(activity, Route(bundle, RouteContext.SPEED_GRADER))
     }
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/discussion/details/DiscussionDetailsWebViewFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/discussion/details/DiscussionDetailsWebViewFragment.kt
@@ -118,12 +118,14 @@ class DiscussionDetailsWebViewFragment : BaseCanvasFragment() {
                 } else if (url.contains("speed_grader")) {
                     val uri = url.toUri()
                     val assignmentId = uri.getQueryParameter("assignment_id")?.toLongOrNull() ?: 0
+                    val entryId = uri.getQueryParameter("entry_id")?.toLongOrNull()
                     discussionRouter.routeToNativeSpeedGrader(
                         canvasContext.id,
                         assignmentId,
                         emptyList(),
                         0,
-                        null
+                        null,
+                        entryId
                     )
 
                 } else if (!webViewRouter.canRouteInternally(url, routeIfPossible = true)) {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/discussion/details/DiscussionDetailsWebViewFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/discussion/details/DiscussionDetailsWebViewFragment.kt
@@ -23,7 +23,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebView
 import android.widget.Toast
-import com.instructure.pandautils.base.BaseCanvasFragment
+import androidx.core.net.toUri
 import androidx.fragment.app.viewModels
 import com.instructure.canvasapi2.models.CanvasContext
 import com.instructure.canvasapi2.models.DiscussionTopicHeader
@@ -34,7 +34,9 @@ import com.instructure.interactions.router.RouterParams
 import com.instructure.pandautils.R
 import com.instructure.pandautils.analytics.SCREEN_VIEW_DISCUSSION_DETAILS_REDESIGN
 import com.instructure.pandautils.analytics.ScreenView
+import com.instructure.pandautils.base.BaseCanvasFragment
 import com.instructure.pandautils.databinding.FragmentDiscussionDetailsWebViewBinding
+import com.instructure.pandautils.features.discussion.router.DiscussionRouter
 import com.instructure.pandautils.navigation.WebViewRouter
 import com.instructure.pandautils.utils.Const
 import com.instructure.pandautils.utils.LongArg
@@ -60,6 +62,9 @@ class DiscussionDetailsWebViewFragment : BaseCanvasFragment() {
 
     @Inject
     lateinit var webViewRouter: WebViewRouter
+
+    @Inject
+    lateinit var discussionRouter: DiscussionRouter
 
     @Inject
     lateinit var discussionDetailsWebViewFragmentBehavior: DiscussionDetailsWebViewFragmentBehavior
@@ -110,6 +115,17 @@ class DiscussionDetailsWebViewFragment : BaseCanvasFragment() {
             override fun routeInternallyCallback(url: String) {
                 if (url.contains("discussion_topics") || url.contains("announcements")) {
                     binding.discussionWebView.loadUrl(url)
+                } else if (url.contains("speed_grader")) {
+                    val uri = url.toUri()
+                    val assignmentId = uri.getQueryParameter("assignment_id")?.toLongOrNull() ?: 0
+                    discussionRouter.routeToNativeSpeedGrader(
+                        canvasContext.id,
+                        assignmentId,
+                        emptyList(),
+                        0,
+                        null
+                    )
+
                 } else if (!webViewRouter.canRouteInternally(url, routeIfPossible = true)) {
                     webViewRouter.routeExternally(url)
                 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/discussion/router/DiscussionRouter.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/discussion/router/DiscussionRouter.kt
@@ -10,5 +10,5 @@ interface DiscussionRouter {
 
     fun routeToGroupDiscussion(group: Group, id: Long, header: DiscussionTopicHeader, isRedesign: Boolean)
 
-    fun routeToNativeSpeedGrader(courseId: Long, assignmentId: Long, submissionIds: List<Long>, selectedIdx: Int, anonymousGrading: Boolean?)
+    fun routeToNativeSpeedGrader(courseId: Long, assignmentId: Long, submissionIds: List<Long>, selectedIdx: Int, anonymousGrading: Boolean?, discussionTopicEntryId: Long?)
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/discussion/router/DiscussionRouter.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/discussion/router/DiscussionRouter.kt
@@ -9,4 +9,6 @@ interface DiscussionRouter {
     fun routeToDiscussion(canvasContext: CanvasContext, isRedesign: Boolean, discussionTopicHeader: DiscussionTopicHeader, isAnnouncement: Boolean)
 
     fun routeToGroupDiscussion(group: Group, id: Long, header: DiscussionTopicHeader, isRedesign: Boolean)
+
+    fun routeToNativeSpeedGrader(courseId: Long, assignmentId: Long, submissionIds: List<Long>, selectedIdx: Int, anonymousGrading: Boolean?)
 }


### PR DESCRIPTION
Test plan: See in ticket

refs: MBL-17963
affects: Teacher
release note: Native SpeedGrader opens from graded Discussions.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/d415a4f6-6215-4c64-822f-ee7115f55755" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/053f2736-7a70-475b-bbb2-bbd27ba14922" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested in dark mode
- [ ] Tested in light mode
