### PR TITLE
[MBL-18257][Teacher][A11y] Fix navigation drawer accessibility

### DIFF
--- a/apps/teacher/src/main/res/layout/navigation_drawer.xml
+++ b/apps/teacher/src/main/res/layout/navigation_drawer.xml
@@ -201,6 +201,7 @@
                 android:paddingStart="20dp"
                 android:paddingEnd="20dp"
                 android:text="@string/options"
+                android:importantForAccessibility="no"
                 android:textAllCaps="true"
                 android:letterSpacing="0.14"
                 android:layout_marginBottom="16dp"/>


### PR DESCRIPTION
Test plan: See ticket

- Note that the options headline had been excluded from accessibility as it's just a decorative item. The same solution had been used as the Student app.

refs: MBL-18257
affects: Teacher
release note: none

## Checklist

- [ ] A11y checked
