### PR TITLE
[MBL-18558][Student][Teacher] -  Extend Help Menu E2E tests with testing clicking on menu items

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/DashboardE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/DashboardE2ETest.kt
@@ -18,6 +18,7 @@ package com.instructure.student.ui.e2e
 
 import android.util.Log
 import androidx.test.espresso.Espresso
+import androidx.test.espresso.intent.Intents
 import com.instructure.canvas.espresso.E2E
 import com.instructure.canvas.espresso.FeatureCategory
 import com.instructure.canvas.espresso.Priority
@@ -242,6 +243,22 @@ class DashboardE2ETest : StudentTest() {
 
         Log.d(STEP_TAG, "Assert that all the corresponding Help menu content are displayed.")
         helpPage.assertHelpMenuContent()
+
+        Log.d(STEP_TAG, "Click on 'Report a problem' menu and assert that it is possible to write into the input fields and the corresponding buttons are displayed as well.")
+        helpPage.verifyReportAProblem("Test Subject", "Test Description")
+        helpPage.assertReportProblemDialogDisplayed()
+
+        Log.d(STEP_TAG, "Assert that when clicking on the different help menu items then the corresponding intents will be fired and has the proper URLs.")
+        Intents.init()
+
+        try {
+            helpPage.assertHelpMenuURL("Search the Canvas Guides", "https://community.canvaslms.com/t5/Canvas/ct-p/canvas")
+            helpPage.assertHelpMenuURL("Submit a Feature Idea", "https://community.canvaslms.com/t5/Idea-Conversations/idb-p/ideas")
+            helpPage.assertHelpMenuURL("Share Your Love for the App", "https://community.canvaslms.com/t5/Canvas/ct-p/canvas")
+        }
+        finally {
+            Intents.release()
+        }
     }
 
 }

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/NavigationDrawerInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/NavigationDrawerInteractionTest.kt
@@ -19,7 +19,6 @@ import android.app.Activity
 import android.app.Instrumentation
 import android.content.Intent
 import android.os.Build
-import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers
@@ -157,7 +156,7 @@ class NavigationDrawerInteractionTest : StudentTest() {
         signInStudent()
 
         leftSideNavigationDrawerPage.clickHelpMenu()
-        helpPage.launchGuides()
+        helpPage.clickSearchGuidesLabel()
         canvasWebViewPage.assertTitle(R.string.searchGuides)
     }
 
@@ -191,7 +190,7 @@ class NavigationDrawerInteractionTest : StudentTest() {
                 )
             )
             Intents.intending(expectedIntent).respondWith(Instrumentation.ActivityResult(0, null))
-            helpPage.shareYourLove()
+            helpPage.clickShareLoveLabel()
             Intents.intended(expectedIntent)
         } finally {
             Intents.release()

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/HelpPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/HelpPage.kt
@@ -16,9 +16,13 @@
  */
 package com.instructure.student.ui.pages
 
+import android.app.Instrumentation
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.BundleMatchers
+import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
@@ -33,9 +37,11 @@ import com.instructure.espresso.click
 import com.instructure.espresso.matchers.WaitForViewMatcher.waitForView
 import com.instructure.espresso.page.BasePage
 import com.instructure.espresso.page.plus
+import com.instructure.espresso.page.waitForViewWithText
 import com.instructure.espresso.scrollTo
 import com.instructure.espresso.typeText
 import com.instructure.student.R
+import org.hamcrest.CoreMatchers
 
 // This is a little hokey, as the options that appear are somewhat governed by the results of
 // the /api/v1/accounts/self/help_links call.  If that changes a lot over time (thus breaking
@@ -70,7 +76,7 @@ class HelpPage : BasePage(R.id.helpDialog) {
         onView(containsTextCaseInsensitive("Send")).click()
     }
 
-    fun launchGuides() {
+    fun clickSearchGuidesLabel() {
         searchGuidesLabel.scrollTo().click()
     }
 
@@ -84,11 +90,16 @@ class HelpPage : BasePage(R.id.helpDialog) {
         onView(containsTextCaseInsensitive("Send")).scrollTo().assertDisplayed()
     }
 
-    fun shareYourLove() {
+    fun assertReportProblemDialogDisplayed() {
+        waitForViewWithText("Report A Problem").assertDisplayed()
+        onView(withId(R.id.cancelButton)).click()
+    }
+
+    fun clickShareLoveLabel() {
         shareLoveLabel.scrollTo().click()
     }
 
-    fun submitFeature() {
+    fun clickSubmitFeatureLabel() {
         submitFeatureLabel.scrollTo().click()
     }
 
@@ -116,5 +127,26 @@ class HelpPage : BasePage(R.id.helpDialog) {
 
         onView(withId(R.id.title) + withText("Share Your Love for the App")).assertDisplayed()
         onView(withId(R.id.subtitle) + withText("Tell us about your favorite parts of the app")).assertDisplayed()
+    }
+
+    fun assertHelpMenuURL(helpMenuText: String, expectedURL: String) {
+        val expectedIntent = CoreMatchers.allOf(
+            IntentMatchers.hasExtras(
+                BundleMatchers.hasEntry(
+                    "bundledExtras",
+                    BundleMatchers.hasEntry("internalURL", expectedURL)
+                )
+            )
+        )
+
+        Intents.intending(expectedIntent).respondWith(Instrumentation.ActivityResult(0, null))
+
+        when (helpMenuText) {
+            "Search the Canvas Guides" -> clickSearchGuidesLabel()
+            "Submit a Feature Idea" -> clickSubmitFeatureLabel()
+            "Share Your Love for the App" -> clickShareLoveLabel()
+        }
+
+        Intents.intended(expectedIntent)
     }
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/DashboardE2ETest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/e2e/DashboardE2ETest.kt
@@ -18,6 +18,7 @@ package com.instructure.teacher.ui.e2e
 
 import android.util.Log
 import androidx.test.espresso.Espresso
+import androidx.test.espresso.intent.Intents
 import com.instructure.canvas.espresso.E2E
 import com.instructure.canvas.espresso.FeatureCategory
 import com.instructure.canvas.espresso.Priority
@@ -163,5 +164,24 @@ class DashboardE2ETest : TeacherTest() {
 
         Log.d(STEP_TAG, "Assert that all the corresponding Help menu content are displayed.")
         helpPage.assertHelpMenuContent()
+
+        Log.d(STEP_TAG, "Click on 'Report a problem' menu and assert that it is possible to write into the input fields and the corresponding buttons are displayed as well.")
+        helpPage.verifyReportAProblem("Test Subject", "Test Description")
+        helpPage.assertReportProblemDialogDisplayed()
+
+        Log.d(STEP_TAG, "Assert that when clicking on the different help menu items then the corresponding intents will be fired and has the proper URLs.")
+        Intents.init()
+
+        try {
+            helpPage.assertHelpMenuURL("Search the Canvas Guides", "https://community.canvaslms.com/t5/Canvas/ct-p/canvas")
+            helpPage.assertHelpMenuURL("Submit a Feature Idea", "https://community.canvaslms.com/t5/Idea-Conversations/idb-p/ideas")
+            helpPage.assertHelpMenuURL("Ask the Community", "https://community.canvaslms.com/community/answers")
+            helpPage.assertHelpMenuURL("Training Services Portal", "https://training-portal-beta-pdx.insproserv.net?canvas_domain=mobileqa.instructure.com&sf_id=")
+            helpPage.assertHelpMenuURL("Conference Guides for Remote Classrooms", "https://community.canvaslms.com/docs/DOC-18572-conferences-resources")
+            helpPage.assertHelpMenuURL("Share Your Love for the App", "https://community.canvaslms.com/t5/Canvas/ct-p/canvas")
+        }
+        finally {
+            Intents.release()
+        }
     }
 }

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/HelpPage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/HelpPage.kt
@@ -16,9 +16,12 @@
  */
 package com.instructure.teacher.ui.pages
 
+import android.app.Instrumentation
+import android.content.Intent
 import androidx.test.espresso.Espresso
-import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
@@ -31,10 +34,13 @@ import com.instructure.espresso.assertDisplayed
 import com.instructure.espresso.click
 import com.instructure.espresso.matchers.WaitForViewMatcher.waitForView
 import com.instructure.espresso.page.BasePage
+import com.instructure.espresso.page.onView
 import com.instructure.espresso.page.plus
+import com.instructure.espresso.page.waitForViewWithText
 import com.instructure.espresso.scrollTo
 import com.instructure.espresso.typeText
 import com.instructure.teacher.R
+import org.hamcrest.CoreMatchers
 
 /**
  * A page representing the Help menu in the application.
@@ -82,9 +88,9 @@ class HelpPage : BasePage(R.id.helpDialog) {
     }
 
     /**
-     * Launches the guides page.
+     * Clicks on the 'Search the Canvas Guides' help menu.
      */
-    fun launchGuides() {
+    fun clickSearchGuidesLabel() {
         searchGuidesLabel.scrollTo().click()
     }
 
@@ -104,16 +110,45 @@ class HelpPage : BasePage(R.id.helpDialog) {
     }
 
     /**
-     * Launches the share your love page.
+     * Assert that the 'Report A Problem' dialog is displayed and then dismiss the dialog.
      */
-    fun shareYourLove() {
+    fun assertReportProblemDialogDisplayed() {
+        waitForViewWithText("Report A Problem").assertDisplayed()
+        onView(withId(R.id.cancelButton)).click()
+    }
+
+    /**
+     * Clicks on the 'Conference Guides for Remote Classrooms' help menu.
+     */
+    private fun clickConferenceGuidesForRemoteClassroomsLabel() {
+        onView(withText("Conference Guides for Remote Classrooms")).scrollTo().click()
+    }
+
+    /**
+     * Clicks on the 'Ask the Community' help menu.
+     */
+    private fun clickAskTheCommunityLabel() {
+        onView(withText("Ask the Community")).scrollTo().click()
+    }
+
+    /**
+     * Clicks on the 'Training Services Portal' help menu.
+     */
+    private fun clickTrainingServicesPortalLabel() {
+        onView(withText("Training Services Portal")).scrollTo().click()
+    }
+
+    /**
+     * Clicks on the 'Share Your Love for the App' help menu.
+     */
+    private fun clickShareLoveLabel() {
         shareLoveLabel.scrollTo().click()
     }
 
     /**
-     * Submits a feature idea.
+     * Clicks on the 'Submit a Feature Idea' help menu.
      */
-    fun submitFeature() {
+    private fun clickSubmitFeatureLabel() {
         submitFeatureLabel.scrollTo().click()
     }
 
@@ -153,5 +188,26 @@ class HelpPage : BasePage(R.id.helpDialog) {
 
         onView(withId(R.id.title) + withText("Share Your Love for the App")).assertDisplayed()
         onView(withId(R.id.subtitle) + withText("Tell us about your favorite parts of the app")).assertDisplayed()
+    }
+
+    fun assertHelpMenuURL(helpMenuText: String, expectedURL: String) {
+        val expectedIntent = CoreMatchers.allOf(
+            IntentMatchers.hasAction(Intent.ACTION_VIEW),
+            CoreMatchers.anyOf(
+                IntentMatchers.hasData(expectedURL),
+            )
+        )
+        Intents.intending(expectedIntent).respondWith(Instrumentation.ActivityResult(0, null))
+
+        when (helpMenuText) {
+            "Search the Canvas Guides" -> clickSearchGuidesLabel()
+            "Submit a Feature Idea" -> clickSubmitFeatureLabel()
+            "Share Your Love for the App" -> clickShareLoveLabel()
+            "Conference Guides for Remote Classrooms" -> clickConferenceGuidesForRemoteClassroomsLabel()
+            "Ask the Community" -> clickAskTheCommunityLabel()
+            "Training Services Portal" -> clickTrainingServicesPortalLabel()
+        }
+
+        Intents.intended(expectedIntent)
     }
 }


### PR DESCRIPTION
Add testing clicking Help menu items in both the Student and Teacher apps.
Minor refactors/renamings.

refs: MBL-18558
affects: Student, Teacher
release note:

## Checklist

- [ ] Run E2E test suite
