### PR TITLE
[MBL-18279][All] Settings screen a11y improvements

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/settings/SettingsScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/settings/SettingsScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -58,6 +59,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.invisibleToUser
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -237,6 +239,7 @@ private fun AppThemeItem(appTheme: Int, appThemeSelected: (AppTheme, Int, Int) -
     }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun AppThemeButton(
     @DrawableRes icon: Int,
@@ -273,7 +276,8 @@ private fun AppThemeButton(
         }
         Text(
             modifier = Modifier
-                .padding(top = 8.dp),
+                .padding(top = 8.dp)
+                .semantics { this.invisibleToUser() },
             text = stringResource(title),
             fontSize = 12.sp,
             color = colorResource(id = R.color.textDarkest),


### PR DESCRIPTION
Test plan: The ticket is about the old settings screen, so that is not relevant, but I found an issue in the new settings screen as well, when the talkback announces the theme change buttons separately from the texts under them so removed the announcements from the labels (those are not relevant, because they are not clickable and announce the same as the icon)

refs: MBL-18279
affects: All
release note: none

## Checklist

- [ ] Tested in light mode
- [ ] A11y checked
