### PR TITLE
Fix inbox recipients update

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/compose/InboxComposeViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/compose/InboxComposeViewModel.kt
@@ -279,7 +279,10 @@ class InboxComposeViewModel @Inject constructor(
                         selectedRole = null,
                         selectedRecipients = emptyList()
                     ),
-                    screenOption = InboxComposeScreenOptions.None
+                    screenOption = InboxComposeScreenOptions.None,
+                    inlineRecipientSelectorState = it.inlineRecipientSelectorState.copy(
+                        selectedValues = emptyList(),
+                    )
                 ) }
 
                 loadRecipients("", action.context)


### PR DESCRIPTION
RC finding: When selecting a recipient on the inbox compose message screen, and then change the course to a course in which that recipient is not in, the recipient name will remain in the recipient list, However the 'send' button will remain disabled (which prevents the user from sending messages to a particular course with recipients who are not enrolled to that course and it's good), but on the UI it could be misleading.