### PR TITLE
[MBL-18565][All] Inbox course selector grouping

### DIFF
--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -1660,6 +1660,8 @@
     <string name="calendarAddNewCalendarItemContentDescription">Add new calendar item</string>
     <string name="calendarFilterCalendars">Calendars</string>
     <string name="calendarFilterUser">User</string>
+    <string name="calendarFilterFavoriteCourse">Favorite Courses</string>
+    <string name="calendarFilterMoreCourse">More Courses</string>
     <string name="calendarFilterCourse">Courses</string>
     <string name="calendarFilterGroup">Groups</string>
     <string name="calendarFilterExplanationLimited">Select the calendars you want to see, up to %d.</string>

--- a/libs/pandautils/src/androidTest/java/com/instructure/pandautils/compose/features/inbox/compose/ContextPickerScreenTest.kt
+++ b/libs/pandautils/src/androidTest/java/com/instructure/pandautils/compose/features/inbox/compose/ContextPickerScreenTest.kt
@@ -1,0 +1,129 @@
+package com.instructure.pandautils.compose.features.inbox.compose
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.instructure.canvasapi2.models.Course
+import com.instructure.canvasapi2.models.Group
+import com.instructure.pandautils.compose.composables.SelectContextScreen
+import com.instructure.pandautils.compose.composables.SelectContextUiState
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ContextPickerScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val title = "Select a course or a group"
+
+    @Test
+    fun testContextPickerCourses() {
+        setTestScreen(getUiState())
+
+        composeTestRule.onNode(hasText("Courses")).assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("calendar_Black Holes").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("calendar_Cosmology").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("calendar_Life in the Universe").assertIsDisplayed()
+
+        composeTestRule.onNode(hasText("Favorite Courses"))
+            .assertIsNotDisplayed()
+        composeTestRule.onNode(hasText("More Courses"))
+            .assertIsNotDisplayed()
+    }
+
+    @Test
+    fun testContextPickerWithFavorites() {
+        val uiState = getUiState()
+        setTestScreen(
+            uiState.copy(
+                canvasContexts = uiState.canvasContexts + Course(
+                    id = 4,
+                    name = "Biology",
+                    isFavorite = true
+                )
+            )
+        )
+
+        composeTestRule.onNode(hasText("Favorite Courses")).assertIsDisplayed()
+        composeTestRule.onNode(hasText("More Courses")).assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("calendar_Black Holes").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("calendar_Cosmology").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("calendar_Life in the Universe").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("calendar_Biology").assertIsDisplayed()
+    }
+
+    @Test
+    fun testContextPickerWithOnlyFavorites() {
+        setTestScreen(
+            getUiState().copy(
+                canvasContexts = listOf(
+                    Course(
+                        id = 4,
+                        name = "Biology",
+                        isFavorite = true
+                    )
+                )
+            )
+        )
+
+        composeTestRule.onNode(hasText("Courses")).assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("calendar_Biology").assertIsDisplayed()
+
+        composeTestRule.onNode(hasText("Favorite Courses"))
+            .assertIsNotDisplayed()
+        composeTestRule.onNode(hasText("More Courses"))
+            .assertIsNotDisplayed()
+    }
+
+    @Test
+    fun testContextPickerWithGroups() {
+        val uiState = getUiState()
+        setTestScreen(
+            uiState.copy(
+                canvasContexts = uiState.canvasContexts + Group(
+                    id = 4,
+                    name = "Group1"
+                )
+            )
+        )
+
+        composeTestRule.onNode(hasText("Courses")).assertIsDisplayed()
+        composeTestRule.onNodeWithTag("calendar_Black Holes").assertIsDisplayed()
+
+        composeTestRule.onNode(hasText("Groups")).assertIsDisplayed()
+        composeTestRule.onNodeWithTag("calendar_Group1").assertIsDisplayed()
+    }
+
+    private fun setTestScreen(uiState: SelectContextUiState = getUiState()) {
+        composeTestRule.setContent {
+            SelectContextScreen(
+                title = title,
+                uiState = uiState,
+                onContextSelected = {},
+                navigationActionClick = {}
+            )
+        }
+    }
+
+    private fun getUiState(
+    ): SelectContextUiState {
+        return SelectContextUiState(
+            show = true,
+            selectedCanvasContext = Course(id = 2),
+            canvasContexts = listOf(
+                Course(id = 1, name = "Black Holes"),
+                Course(id = 2, name = "Cosmology"),
+                Course(id = 3, name = "Life in the Universe"),
+            )
+        )
+    }
+}

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/compose/composables/SelectContextScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/compose/composables/SelectContextScreen.kt
@@ -115,52 +115,52 @@ private fun SelectContextContent(
                 val selected = user.contextId == uiState.selectedCanvasContext?.contextId
                 SelectContextItem(user, selected, onContextSelected, Modifier.fillMaxWidth())
             }
-            if (uiState.moreCourses.isNotEmpty() || uiState.favoriteCourses.isNotEmpty()) {
-                if (uiState.favoriteCourses.isNotEmpty()) {
-                    item(key = FAVORITE_COURSES_KEY, contentType = HEADER_CONTENT_TYPE) {
-                        val titleResource = if (uiState.moreCourses.isNotEmpty()) {
-                            stringResource(id = R.string.calendarFilterFavoriteCourse)
-                        } else {
-                            stringResource(id = R.string.calendarFilterCourse)
-                        }
-                        ListHeaderItem(text = titleResource)
+
+            if (uiState.favoriteCourses.isNotEmpty()) {
+                item(key = FAVORITE_COURSES_KEY, contentType = HEADER_CONTENT_TYPE) {
+                    val titleResource = if (uiState.moreCourses.isNotEmpty()) {
+                        stringResource(id = R.string.calendarFilterFavoriteCourse)
+                    } else {
+                        stringResource(id = R.string.calendarFilterCourse)
                     }
-                    items(
-                        uiState.favoriteCourses,
-                        key = { it.contextId },
-                        contentType = { FILTER_ITEM_CONTENT_TYPE }) { course ->
-                        val selected = course.contextId == uiState.selectedCanvasContext?.contextId
-                        SelectContextItem(
-                            course,
-                            selected,
-                            onContextSelected,
-                            Modifier.fillMaxWidth()
-                        )
-                    }
+                    ListHeaderItem(text = titleResource)
                 }
-                if (uiState.moreCourses.isNotEmpty()) {
-                    item(key = COURSES_KEY, contentType = HEADER_CONTENT_TYPE) {
-                        val titleResource = if (uiState.favoriteCourses.isNotEmpty()) {
-                            stringResource(id = R.string.calendarFilterMoreCourse)
-                        } else {
-                            stringResource(id = R.string.calendarFilterCourse)
-                        }
-                        ListHeaderItem(text = titleResource)
-                    }
-                    items(
-                        uiState.moreCourses,
-                        key = { it.contextId },
-                        contentType = { FILTER_ITEM_CONTENT_TYPE }) { course ->
-                        val selected = course.contextId == uiState.selectedCanvasContext?.contextId
-                        SelectContextItem(
-                            course,
-                            selected,
-                            onContextSelected,
-                            Modifier.fillMaxWidth()
-                        )
-                    }
+                items(
+                    uiState.favoriteCourses,
+                    key = { it.contextId },
+                    contentType = { FILTER_ITEM_CONTENT_TYPE }) { course ->
+                    val selected = course.contextId == uiState.selectedCanvasContext?.contextId
+                    SelectContextItem(
+                        course,
+                        selected,
+                        onContextSelected,
+                        Modifier.fillMaxWidth()
+                    )
                 }
             }
+            if (uiState.moreCourses.isNotEmpty()) {
+                item(key = COURSES_KEY, contentType = HEADER_CONTENT_TYPE) {
+                    val titleResource = if (uiState.favoriteCourses.isNotEmpty()) {
+                        stringResource(id = R.string.calendarFilterMoreCourse)
+                    } else {
+                        stringResource(id = R.string.calendarFilterCourse)
+                    }
+                    ListHeaderItem(text = titleResource)
+                }
+                items(
+                    uiState.moreCourses,
+                    key = { it.contextId },
+                    contentType = { FILTER_ITEM_CONTENT_TYPE }) { course ->
+                    val selected = course.contextId == uiState.selectedCanvasContext?.contextId
+                    SelectContextItem(
+                        course,
+                        selected,
+                        onContextSelected,
+                        Modifier.fillMaxWidth()
+                    )
+                }
+            }
+
             if (uiState.groups.isNotEmpty()) {
                 item(key = GROUPS_KEY, contentType = HEADER_CONTENT_TYPE) {
                     ListHeaderItem(text = stringResource(id = R.string.calendarFilterGroup))
@@ -246,7 +246,7 @@ data class SelectContextUiState(
     val favoriteCourses: List<CanvasContext>
         get() = canvasContexts.filter { it.isCourse && (it as Course).isFavorite }
     val moreCourses: List<CanvasContext>
-        get() = canvasContexts.filter { it.isCourse && !(it as Course).isFavorite}
+        get() = canvasContexts.filter { it.isCourse && !(it as Course).isFavorite }
     val groups: List<CanvasContext>
         get() = canvasContexts.filter { it.isGroup }
 

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/compose/composables/SelectContextScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/compose/composables/SelectContextScreen.kt
@@ -115,12 +115,10 @@ private fun SelectContextContent(
                 val selected = user.contextId == uiState.selectedCanvasContext?.contextId
                 SelectContextItem(user, selected, onContextSelected, Modifier.fillMaxWidth())
             }
-            if (uiState.courses.isNotEmpty()) {
-                val favoriteCourses = uiState.courses.filter { (it as Course).isFavorite }
-                val moreCourses = uiState.courses.filter { !(it as Course).isFavorite }
-                if (favoriteCourses.isNotEmpty()) {
+            if (uiState.moreCourses.isNotEmpty() || uiState.favoriteCourses.isNotEmpty()) {
+                if (uiState.favoriteCourses.isNotEmpty()) {
                     item(key = FAVORITE_COURSES_KEY, contentType = HEADER_CONTENT_TYPE) {
-                        val titleResource = if (moreCourses.isNotEmpty()) {
+                        val titleResource = if (uiState.moreCourses.isNotEmpty()) {
                             stringResource(id = R.string.calendarFilterFavoriteCourse)
                         } else {
                             stringResource(id = R.string.calendarFilterCourse)
@@ -128,7 +126,7 @@ private fun SelectContextContent(
                         ListHeaderItem(text = titleResource)
                     }
                     items(
-                        favoriteCourses,
+                        uiState.favoriteCourses,
                         key = { it.contextId },
                         contentType = { FILTER_ITEM_CONTENT_TYPE }) { course ->
                         val selected = course.contextId == uiState.selectedCanvasContext?.contextId
@@ -140,9 +138,9 @@ private fun SelectContextContent(
                         )
                     }
                 }
-                if (moreCourses.isNotEmpty()) {
+                if (uiState.moreCourses.isNotEmpty()) {
                     item(key = COURSES_KEY, contentType = HEADER_CONTENT_TYPE) {
-                        val titleResource = if (favoriteCourses.isNotEmpty()) {
+                        val titleResource = if (uiState.favoriteCourses.isNotEmpty()) {
                             stringResource(id = R.string.calendarFilterMoreCourse)
                         } else {
                             stringResource(id = R.string.calendarFilterCourse)
@@ -150,7 +148,7 @@ private fun SelectContextContent(
                         ListHeaderItem(text = titleResource)
                     }
                     items(
-                        moreCourses,
+                        uiState.moreCourses,
                         key = { it.contextId },
                         contentType = { FILTER_ITEM_CONTENT_TYPE }) { course ->
                         val selected = course.contextId == uiState.selectedCanvasContext?.contextId
@@ -245,8 +243,10 @@ data class SelectContextUiState(
 ) {
     val users: List<CanvasContext>
         get() = canvasContexts.filter { it.isUser }
-    val courses: List<CanvasContext>
-        get() = canvasContexts.filter { it.isCourse }
+    val favoriteCourses: List<CanvasContext>
+        get() = canvasContexts.filter { it.isCourse && (it as Course).isFavorite }
+    val moreCourses: List<CanvasContext>
+        get() = canvasContexts.filter { it.isCourse && !(it as Course).isFavorite}
     val groups: List<CanvasContext>
         get() = canvasContexts.filter { it.isGroup }
 

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/compose/composables/SelectContextScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/compose/composables/SelectContextScreen.kt
@@ -58,6 +58,7 @@ import com.instructure.pandautils.utils.isGroup
 import com.instructure.pandautils.utils.isUser
 import com.jakewharton.threetenabp.AndroidThreeTen
 
+private const val FAVORITE_COURSES_KEY = "favorite_courses"
 private const val COURSES_KEY = "courses"
 private const val GROUPS_KEY = "groups"
 private const val HEADER_CONTENT_TYPE = "header"
@@ -115,20 +116,51 @@ private fun SelectContextContent(
                 SelectContextItem(user, selected, onContextSelected, Modifier.fillMaxWidth())
             }
             if (uiState.courses.isNotEmpty()) {
-                item(key = COURSES_KEY, contentType = HEADER_CONTENT_TYPE) {
-                    ListHeaderItem(text = stringResource(id = R.string.calendarFilterCourse))
+                val favoriteCourses = uiState.courses.filter { (it as Course).isFavorite }
+                val moreCourses = uiState.courses.filter { !(it as Course).isFavorite }
+                if (favoriteCourses.isNotEmpty()) {
+                    item(key = FAVORITE_COURSES_KEY, contentType = HEADER_CONTENT_TYPE) {
+                        val titleResource = if (moreCourses.isNotEmpty()) {
+                            stringResource(id = R.string.calendarFilterFavoriteCourse)
+                        } else {
+                            stringResource(id = R.string.calendarFilterCourse)
+                        }
+                        ListHeaderItem(text = titleResource)
+                    }
+                    items(
+                        favoriteCourses,
+                        key = { it.contextId },
+                        contentType = { FILTER_ITEM_CONTENT_TYPE }) { course ->
+                        val selected = course.contextId == uiState.selectedCanvasContext?.contextId
+                        SelectContextItem(
+                            course,
+                            selected,
+                            onContextSelected,
+                            Modifier.fillMaxWidth()
+                        )
+                    }
                 }
-                items(
-                    uiState.courses,
-                    key = { it.contextId },
-                    contentType = { FILTER_ITEM_CONTENT_TYPE }) { course ->
-                    val selected = course.contextId == uiState.selectedCanvasContext?.contextId
-                    SelectContextItem(
-                        course,
-                        selected,
-                        onContextSelected,
-                        Modifier.fillMaxWidth()
-                    )
+                if (moreCourses.isNotEmpty()) {
+                    item(key = COURSES_KEY, contentType = HEADER_CONTENT_TYPE) {
+                        val titleResource = if (favoriteCourses.isNotEmpty()) {
+                            stringResource(id = R.string.calendarFilterMoreCourse)
+                        } else {
+                            stringResource(id = R.string.calendarFilterCourse)
+                        }
+                        ListHeaderItem(text = titleResource)
+                    }
+                    items(
+                        moreCourses,
+                        key = { it.contextId },
+                        contentType = { FILTER_ITEM_CONTENT_TYPE }) { course ->
+                        val selected = course.contextId == uiState.selectedCanvasContext?.contextId
+                        SelectContextItem(
+                            course,
+                            selected,
+                            onContextSelected,
+                            Modifier.fillMaxWidth()
+                        )
+                    }
                 }
             }
             if (uiState.groups.isNotEmpty()) {


### PR DESCRIPTION
Test plan: Open Student app, go to Inbox, select New Message FAB, tap course selector. Favorite and other courses are grouped.

refs: MBL-18565
affects: Student, Teacher, Parent
release note: Favorite and other courses are grouped in Course selector in Inbox screen

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/55405dfe-58ac-41d0-9821-dc707d59d4d5" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/ac9c6353-b42d-4620-854e-070a7e5ea35c" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Tested in dark mode
- [x] Tested in light mode
