### PR TITLE
[MBL-17866][All] Change Inbox recipient search behavior

### DIFF
--- a/apps/parent/src/test/java/com/instructure/parentapp/features/inbox/compose/ParentInboxComposeRepositoryTest.kt
+++ b/apps/parent/src/test/java/com/instructure/parentapp/features/inbox/compose/ParentInboxComposeRepositoryTest.kt
@@ -125,7 +125,7 @@ class ParentInboxComposeRepositoryTest {
 
         coEvery { recipientAPI.getFirstPageRecipientListNoSyntheticContexts(any(), any(), any()) } returns DataResult.Success(expected)
 
-        val result = inboxComposeRepository.getRecipients("", course, true).dataOrThrow
+        val result = inboxComposeRepository.getRecipients("", course.contextId, true).dataOrThrow
 
         assertEquals(expected, result)
     }
@@ -134,7 +134,7 @@ class ParentInboxComposeRepositoryTest {
     fun `Get recipients with error`() = runTest {
         coEvery { recipientAPI.getFirstPageRecipientListNoSyntheticContexts(any(), any(), any()) } returns DataResult.Fail()
 
-        inboxComposeRepository.getRecipients("", Course(), true).dataOrThrow
+        inboxComposeRepository.getRecipients("", Course(id = 1L).contextId, true).dataOrThrow
     }
 
     @Test

--- a/apps/student/src/test/java/com/instructure/student/features/inbox/compose/StudentInboxComposeRepositoryTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/features/inbox/compose/StudentInboxComposeRepositoryTest.kt
@@ -140,7 +140,7 @@ class StudentInboxComposeRepositoryTest {
 
         coEvery { recipientAPI.getFirstPageRecipientListNoSyntheticContexts(any(), any(), any()) } returns DataResult.Success(expected)
 
-        val result = inboxComposeRepository.getRecipients("", course, true).dataOrThrow
+        val result = inboxComposeRepository.getRecipients("", course.contextId, true).dataOrThrow
 
         assertEquals(expected, result)
     }
@@ -149,7 +149,7 @@ class StudentInboxComposeRepositoryTest {
     fun `Get recipients with error`() = runTest {
         coEvery { recipientAPI.getFirstPageRecipientListNoSyntheticContexts(any(), any(), any()) } returns DataResult.Fail()
 
-        inboxComposeRepository.getRecipients("", Course(), true).dataOrThrow
+        inboxComposeRepository.getRecipients("", Course(id = 1L).contextId, true).dataOrThrow
     }
 
     @Test

--- a/apps/teacher/src/test/java/com/instructure/teacher/features/inbox/compose/TeacherInboxComposeRepositoryTest.kt
+++ b/apps/teacher/src/test/java/com/instructure/teacher/features/inbox/compose/TeacherInboxComposeRepositoryTest.kt
@@ -111,7 +111,7 @@ class TeacherInboxComposeRepositoryTest {
 
         coEvery { recipientAPI.getFirstPageRecipientListNoSyntheticContexts(any(), any(), any()) } returns DataResult.Success(expected)
 
-        val result = inboxComposeRepository.getRecipients("", course, true).dataOrThrow
+        val result = inboxComposeRepository.getRecipients("", course.contextId, true).dataOrThrow
 
         assertEquals(expected, result)
     }
@@ -120,7 +120,7 @@ class TeacherInboxComposeRepositoryTest {
     fun `Get recipients with error`() = runTest {
         coEvery { recipientAPI.getFirstPageRecipientListNoSyntheticContexts(any(), any(), any()) } returns DataResult.Fail()
 
-        inboxComposeRepository.getRecipients("", Course(), true).dataOrThrow
+        inboxComposeRepository.getRecipients("", Course(id = 1L).contextId, true).dataOrThrow
     }
 
     @Test

--- a/libs/pandares/src/main/res/values-en/strings.xml
+++ b/libs/pandares/src/main/res/values-en/strings.xml
@@ -1950,4 +1950,6 @@
     <string name="smartSearchEmptyMessage">We didn’t find exactly what you’re looking for. Maybe try searching for something else?</string>
     <string name="webAccessLimitedMessage">Interactions on this page are limited by your institution.</string>
     <string name="a11y_submissionFiltersHaveBeenUpdated">Filters have been updated</string>
+    <string name="inboxAllRecipients">All Recipients</string>
+    <string name="inboxSearchIn">Search in %1$s</string>
 </resources>

--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -1989,4 +1989,6 @@
     <string name="a11y_indeterminate">Partially checked</string>
     <string name="a11y_offlineContentItemContentDescription">%1$s, %2$s, %3$s</string>
     <string name="a11y_submissionFiltersHaveBeenUpdated">Filters have been updated</string>
+    <string name="inboxAllRecipients">All Recipients</string>
+    <string name="inboxSearchIn">Search in %1$s</string>
 </resources>

--- a/libs/pandautils/src/androidTest/java/com/instructure/pandautils/compose/features/inbox/compose/RecipientPickerScreenTest.kt
+++ b/libs/pandautils/src/androidTest/java/com/instructure/pandautils/compose/features/inbox/compose/RecipientPickerScreenTest.kt
@@ -91,7 +91,7 @@ class RecipientPickerScreenTest {
             .assertIsDisplayed()
             .assertHasClickAction()
 
-        composeTestRule.onNode(hasText("Search"))
+        composeTestRule.onNode(hasText("Search in All Recipients"))
             .assertIsDisplayed()
             .assertHasClickAction()
 
@@ -114,7 +114,7 @@ class RecipientPickerScreenTest {
             .assertIsDisplayed()
             .assertHasClickAction()
 
-        composeTestRule.onNode(hasText("Search"))
+        composeTestRule.onNode(hasText("Search in Students"))
             .assertIsDisplayed()
             .assertHasClickAction()
 

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/compose/InboxComposeRepository.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/compose/InboxComposeRepository.kt
@@ -41,13 +41,13 @@ abstract class InboxComposeRepository(
 
     open suspend fun getRecipients(
         searchQuery: String,
-        context: CanvasContext,
+        contextId: String,
         forceRefresh: Boolean
     ): DataResult<List<Recipient>> {
         val params = RestParams(usePerPageQueryParam = true, isForceReadFromNetwork = forceRefresh)
         return recipientAPI.getFirstPageRecipientListNoSyntheticContexts(
             searchQuery = searchQuery,
-            context = context.contextId,
+            context = contextId,
             restParams = params,
         ).depaginate {
             recipientAPI.getNextPageRecipientList(it, params)

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/compose/InboxComposeViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/compose/InboxComposeViewModel.kt
@@ -68,10 +68,10 @@ class InboxComposeViewModel @Inject constructor(
     private val options = savedStateHandle.get<InboxComposeOptions>(InboxComposeOptions.COMPOSE_PARAMETERS)
 
     private val debouncedInnerSearch = debounce<String>(waitMs = 200, coroutineScope = viewModelScope) { searchQuery ->
+        val contextId = uiState.value.selectContextUiState.selectedCanvasContext?.contextId ?: return@debounce
         val recipients = getRecipientList(
             searchQuery,
-            uiState.value.selectContextUiState.selectedCanvasContext
-                ?: return@debounce
+            contextId
         ).dataOrNull.orEmpty().filterNot { uiState.value.recipientPickerUiState.selectedRecipients.contains(it) }
 
         _uiState.update {
@@ -85,7 +85,11 @@ class InboxComposeViewModel @Inject constructor(
     }
 
     private val debouncedRecipientScreenSearch = debounce<String>(waitMs = 200, coroutineScope = viewModelScope) { searchQuery ->
-        loadRecipients(searchQuery, uiState.value.selectContextUiState.selectedCanvasContext ?: return@debounce)
+        loadRecipients(
+            searchQuery,
+            uiState.value.selectContextUiState.selectedCanvasContext ?: return@debounce,
+            uiState.value.recipientPickerUiState.selectedRole
+        )
     }
 
     init {
@@ -98,7 +102,12 @@ class InboxComposeViewModel @Inject constructor(
     private fun initFromOptions(options: InboxComposeOptions?) {
         options?.let {
             val context = CanvasContext.fromContextCode(options.defaultValues.contextCode, options.defaultValues.contextName)
-            context?.let { loadRecipients("", it, false) }
+            context?.let { loadRecipients(
+                "",
+                it,
+                uiState.value.recipientPickerUiState.selectedRole,
+                false
+            ) }
             _uiState.update {
                 it.copy(
                     inboxComposeMode = options.mode,
@@ -133,7 +142,7 @@ class InboxComposeViewModel @Inject constructor(
                             )
                         }
 
-                        val recipients = getRecipientList("", context, false).dataOrNull.orEmpty()
+                        val recipients = getRecipientList("", context.contextId, false).dataOrNull.orEmpty()
                         val roleRecipients = groupRecipientList(context, recipients)
                         val selectedRecipients = mutableListOf<Recipient>()
                         options.autoSelectRecipientsFromRoles?.forEach { role ->
@@ -282,7 +291,7 @@ class InboxComposeViewModel @Inject constructor(
                     screenOption = InboxComposeScreenOptions.None
                 ) }
 
-                loadRecipients("", action.context)
+                loadRecipients("", action.context, uiState.value.recipientPickerUiState.selectedRole)
             }
         }
     }
@@ -290,7 +299,12 @@ class InboxComposeViewModel @Inject constructor(
     fun handleAction(action: RecipientPickerActionHandler) {
         when (action) {
             is RecipientPickerActionHandler.RefreshCalled -> {
-                loadRecipients(uiState.value.recipientPickerUiState.searchValue.text, uiState.value.selectContextUiState.selectedCanvasContext ?: return, forceRefresh = true)
+                loadRecipients(
+                    uiState.value.recipientPickerUiState.searchValue.text,
+                    uiState.value.selectContextUiState.selectedCanvasContext ?: return,
+                    uiState.value.recipientPickerUiState.selectedRole,
+                    forceRefresh = true
+                )
             }
             is RecipientPickerActionHandler.DoneClicked -> {
                 recipientPickerDone()
@@ -385,7 +399,7 @@ class InboxComposeViewModel @Inject constructor(
         }
     }
 
-    private fun loadRecipients(searchQuery: String, context: CanvasContext, forceRefresh: Boolean = false) {
+    private fun loadRecipients(searchQuery: String, context: CanvasContext, selectedRole: EnrollmentType?, forceRefresh: Boolean = false) {
         viewModelScope.launch {
 
             canSendToAll = inboxComposeRepository.canSendToAll(context).dataOrNull.orDefault()
@@ -393,7 +407,8 @@ class InboxComposeViewModel @Inject constructor(
             var recipients: List<Recipient> = emptyList()
             var newState: ScreenState = ScreenState.Empty
             try {
-                recipients = getRecipientList(searchQuery, context, forceRefresh).dataOrThrow
+                val contextId = context.contextId + getEnrollmentTypeString(selectedRole)
+                recipients = getRecipientList(searchQuery, contextId, forceRefresh).dataOrThrow
                 if (recipients.isEmpty().not()) { newState = ScreenState.Data }
             } catch (e: Exception) {
                 newState = ScreenState.Error
@@ -402,17 +417,18 @@ class InboxComposeViewModel @Inject constructor(
             val roleRecipients = groupRecipientList(context, recipients)
 
             val recipientsToShow =
-                if (uiState.value.recipientPickerUiState.searchValue.text.isEmpty() && uiState.value.recipientPickerUiState.selectedRole != null) {
-                    roleRecipients[uiState.value.recipientPickerUiState.selectedRole] ?: emptyList()
+                if (searchQuery.isEmpty() && selectedRole != null) {
+                    roleRecipients[selectedRole] ?: emptyList()
                 } else {
                     recipients
                 }
+            val allRecipient = if (searchQuery.isEmpty()) getAllRecipients(roleRecipients = roleRecipients) else null
             _uiState.update { it.copy(
                 recipientPickerUiState = it.recipientPickerUiState.copy(
                     recipientsByRole = roleRecipients,
                     screenState = newState,
                     recipientsToShow = recipientsToShow,
-                    allRecipientsToShow = getAllRecipients(roleRecipients = roleRecipients)
+                    allRecipientsToShow = allRecipient
                 )
             ) }
         }
@@ -446,8 +462,8 @@ class InboxComposeViewModel @Inject constructor(
         return roleRecipients
     }
 
-    private suspend fun getRecipientList(searchQuery: String, context: CanvasContext, forceRefresh: Boolean = false): DataResult<List<Recipient>> {
-        return inboxComposeRepository.getRecipients(searchQuery, context, forceRefresh)
+    private suspend fun getRecipientList(searchQuery: String, contextId: String, forceRefresh: Boolean = false): DataResult<List<Recipient>> {
+        return inboxComposeRepository.getRecipients(searchQuery, contextId, forceRefresh)
     }
 
     private fun createConversation() {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/compose/composables/RecipientPickerScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/compose/composables/RecipientPickerScreen.kt
@@ -106,8 +106,10 @@ fun RecipientPickerScreen(
                                 .padding(padding)
                         ) {
                             if (uiState.screenState != ScreenState.Loading && uiState.screenState != ScreenState.Error) {
+                                val searchContext = if (uiState.selectedRole == null) "All Recipients" else uiState.selectedRole.displayText
                                 SearchField(
                                     value = uiState.searchValue,
+                                    placeholder = "Search in $searchContext",
                                     actionHandler = actionHandler
                                 )
                             }
@@ -386,6 +388,7 @@ private fun RecipientRow(
 @Composable
 private fun SearchField(
     value: TextFieldValue,
+    placeholder: String?,
     actionHandler: (RecipientPickerActionHandler) -> Unit
 ) {
     Column {
@@ -409,7 +412,7 @@ private fun SearchField(
                 value = value,
                 onValueChange = { actionHandler(RecipientPickerActionHandler.SearchValueChanged(it)) },
                 singleLine = true,
-                placeholder = stringResource(id = R.string.search),
+                placeholder = placeholder,
                 modifier = Modifier.fillMaxWidth()
             )
         }
@@ -613,6 +616,7 @@ fun RecipientPickerEmptyScreenPreview() {
 fun SearchFieldPreview() {
     SearchField(
         value = TextFieldValue(""),
+        placeholder = "Search",
         actionHandler = {}
     )
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/compose/composables/RecipientPickerScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/compose/composables/RecipientPickerScreen.kt
@@ -106,10 +106,15 @@ fun RecipientPickerScreen(
                                 .padding(padding)
                         ) {
                             if (uiState.screenState != ScreenState.Loading && uiState.screenState != ScreenState.Error) {
-                                val searchContext = if (uiState.selectedRole == null) "All Recipients" else uiState.selectedRole.displayText
+                                val searchContext = if (uiState.selectedRole == null) stringResource(
+                                    R.string.inboxAllRecipients
+                                ) else uiState.selectedRole.displayText
                                 SearchField(
                                     value = uiState.searchValue,
-                                    placeholder = "Search in $searchContext",
+                                    placeholder = stringResource(
+                                        R.string.inboxSearchIn,
+                                        searchContext
+                                    ),
                                     actionHandler = actionHandler
                                 )
                             }

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/inbox/compose/InboxComposeViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/inbox/compose/InboxComposeViewModelTest.kt
@@ -398,14 +398,15 @@ class InboxComposeViewModelTest {
     fun `Inline search value changed`() = runTest {
         val viewmodel = getViewModel()
         val searchValue = TextFieldValue("searchValue")
-        val canvasContext: CanvasContext = mockk(relaxed = true)
+        val courseId = 1L
+        val canvasContext: CanvasContext = Course(id = courseId)
         val recipients = listOf(
             Recipient(stringId = "1"),
             Recipient(stringId = "2"),
             Recipient(stringId = "3"),
         )
 
-        coEvery { inboxComposeRepository.getRecipients(searchValue.text, canvasContext, any()) } returns DataResult.Success(recipients)
+        coEvery { inboxComposeRepository.getRecipients(searchValue.text, canvasContext.contextId, any()) } returns DataResult.Success(recipients)
 
         viewmodel.handleAction(ContextPickerActionHandler.ContextClicked(canvasContext))
         viewmodel.handleAction(RecipientPickerActionHandler.RecipientClicked(recipients.first()))
@@ -426,14 +427,15 @@ class InboxComposeViewModelTest {
     fun `Hide search results`() = runTest {
         val viewmodel = getViewModel()
         val searchValue = TextFieldValue("searchValue")
-        val canvasContext: CanvasContext = mockk(relaxed = true)
+        val courseId = 1L
+        val canvasContext: CanvasContext = Course(id = courseId)
         val recipients = listOf(
             Recipient(stringId = "1"),
             Recipient(stringId = "2"),
             Recipient(stringId = "3"),
         )
 
-        coEvery { inboxComposeRepository.getRecipients(searchValue.text, canvasContext, any()) } returns DataResult.Success(recipients)
+        coEvery { inboxComposeRepository.getRecipients(searchValue.text, canvasContext.contextId, any()) } returns DataResult.Success(recipients)
 
         viewmodel.handleAction(ContextPickerActionHandler.ContextClicked(canvasContext))
         viewmodel.handleAction(InboxComposeActionHandler.SearchRecipientQueryChanged(searchValue))
@@ -471,14 +473,15 @@ class InboxComposeViewModelTest {
     @Test
     fun `Context Clicked action handler`() {
         val viewmodel = getViewModel()
-        val context = Course()
+        val courseId = 1L
+        val context = Course(id = courseId)
         coEvery { inboxComposeRepository.canSendToAll(any()) } returns DataResult.Success(false)
         viewmodel.handleAction(ContextPickerActionHandler.ContextClicked(context))
 
         assertEquals(context, viewmodel.uiState.value.selectContextUiState.selectedCanvasContext)
         assertEquals(InboxComposeScreenOptions.None, viewmodel.uiState.value.screenOption)
 
-        coVerify(exactly = 1) { inboxComposeRepository.getRecipients(any(), context, any()) }
+        coVerify(exactly = 1) { inboxComposeRepository.getRecipients(any(), context.contextId, any()) }
     }
     //endregion
 
@@ -532,7 +535,7 @@ class InboxComposeViewModelTest {
         viewmodel.handleAction(ContextPickerActionHandler.ContextClicked(course))
         viewmodel.handleAction(RecipientPickerActionHandler.RefreshCalled)
 
-        coVerify(exactly = 1) { inboxComposeRepository.getRecipients("", course, true) }
+        coVerify(exactly = 1) { inboxComposeRepository.getRecipients("", course.contextId, true) }
     }
 
     @Test


### PR DESCRIPTION
Test plan: See ticket

- Note that there is currently a bug in the recipient picker where the search field is not reset after closing the picker. This has already been fixed on the release branch but has not yet been merged back.

refs: MBL-17866
affects: Student, Teacher
release note: Inbox recipient picker search field is now aware of the selected role.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/da6fb650-e4ff-4273-8775-04a944b24ead" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/1aeab7b9-4468-4057-906b-2adaa62bc87a" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Run E2E test suite
- [ ] Tested in dark mode
- [ ] Tested in light mode
