### PR TITLE
[MBL-18603][Parent] Tapping Alert Settings toggles too fast may can result 'unexpected error' bottom message

### DIFF
--- a/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/settings/AlertSettingsViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/settings/AlertSettingsViewModel.kt
@@ -91,10 +91,8 @@ class AlertSettingsViewModel @Inject constructor(
 
                 is AlertSettingsAction.DeleteThreshold -> {
                     try {
-                        deleteAlertThreshold(
-                            _uiState.value.thresholds[alertSettingsAction.alertType]?.id
-                                ?: throw IllegalArgumentException("Threshold not found")
-                        )
+                        val id = _uiState.value.thresholds.getOrDefault(alertSettingsAction.alertType, null)?.id
+                        id?.let { deleteAlertThreshold(it) }
                     } catch (e: Exception) {
                         crashlytics.recordException(e)
                         e.printStackTrace()


### PR DESCRIPTION
Test plan: in the ticket

refs: MBL-18603
affects: Parent
release note: none
