### PR TITLE
[MBL-18604] 'Save' button disabled state on alert settings dialog is not accessible in dark mode

### DIFF
--- a/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/settings/AlertSettingsScreen.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/settings/AlertSettingsScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.AlertDialog
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.ContentAlpha
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Switch
@@ -489,7 +490,10 @@ private fun ThresholdDialog(
                 TextButton(
                     modifier = Modifier.testTag("thresholdDialogSaveButton"),
                     enabled = enabled,
-                    colors = ButtonDefaults.textButtonColors(contentColor = color),
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = color,
+                        disabledContentColor = color.copy(alpha = ContentAlpha.disabled)
+                    ),
                     onClick = {
                         actionHandler(
                             AlertSettingsAction.CreateThreshold(


### PR DESCRIPTION
Test plan: in the ticket

refs: MBL-18604
affects: Parent
release note: none
