### PR TITLE
[MBL-18599][Parent] Alert list can scroll to top

### DIFF
--- a/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/list/AlertsScreen.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/list/AlertsScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -72,6 +73,7 @@ import com.instructure.pandautils.utils.drawableId
 import java.util.Date
 
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun AlertsScreen(
     uiState: AlertsUiState,
@@ -167,6 +169,11 @@ fun AlertsListContent(
                 modifier = Modifier.animateItem()
             )
             Spacer(modifier = Modifier.size(8.dp))
+        }
+    }
+    LaunchedEffect(uiState.scrollToTop) {
+        if (uiState.scrollToTop) {
+            lazyListState.animateScrollToItem(0)
         }
     }
 }

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/list/AlertsUiState.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/list/AlertsUiState.kt
@@ -25,7 +25,8 @@ data class AlertsUiState(
     @ColorInt val studentColor: Int = Color.BLACK,
     val isLoading: Boolean = false,
     val isError: Boolean = false,
-    val isRefreshing: Boolean = false
+    val isRefreshing: Boolean = false,
+    val scrollToTop: Boolean = false
 )
 
 data class AlertsItemUiState(

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/list/AlertsViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/list/AlertsViewModel.kt
@@ -165,7 +165,8 @@ class AlertsViewModel @Inject constructor(
                 uiState.copy(
                     alerts = uiState.alerts.map { alertItem ->
                         if (alertItem.alertId == alertId) alertItem.copy(unread = false) else alertItem
-                    }
+                    },
+                    scrollToTop = false
                 )
             }
             repository.updateAlertWorkflow(alertId, AlertWorkflowState.READ)

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/list/AlertsViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/list/AlertsViewModel.kt
@@ -183,13 +183,16 @@ class AlertsViewModel @Inject constructor(
             viewModelScope.launch {
                 _uiState.update { it.copy(alerts = alerts) }
                 alertCountUpdater.updateShouldRefreshAlertCount(true)
+                if (alerts.indexOf(alert) == 0) {
+                    _uiState.update { it.copy(scrollToTop = true) }
+                }
             }
         }
 
         val alerts = _uiState.value.alerts.toMutableList()
         val alert = alerts.find { it.alertId == alertId } ?: return
         alerts.removeIf { it.alertId == alertId }
-        _uiState.update { it.copy(alerts = alerts) }
+        _uiState.update { it.copy(alerts = alerts, scrollToTop = false) }
 
         try {
             repository.updateAlertWorkflow(alertId, AlertWorkflowState.DISMISSED)


### PR DESCRIPTION
Test plan: 
- Open parent app
- Select a user with a lot of alerts
- Go to Alert screen
- Delete top item
- Press UNDO on Snackbar
- List should scroll to top


refs: MBL-18599
affects: Parent
release note:
