### PR TITLE
[MBL-18583][Parent] Hide 'Not Graded' assignments from Grades

### DIFF
--- a/apps/parent/src/main/java/com/instructure/parentapp/features/grades/ParentGradesRepository.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/grades/ParentGradesRepository.kt
@@ -20,6 +20,8 @@ package com.instructure.parentapp.features.grades
 import com.instructure.canvasapi2.apis.AssignmentAPI
 import com.instructure.canvasapi2.apis.CourseAPI
 import com.instructure.canvasapi2.builders.RestParams
+import com.instructure.canvasapi2.models.Assignment
+import com.instructure.canvasapi2.models.Assignment.Companion.getGradingTypeFromAPIString
 import com.instructure.canvasapi2.models.AssignmentGroup
 import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.models.CourseGrade
@@ -46,7 +48,9 @@ class ParentGradesRepository(
             assignmentApi.getNextPageAssignmentGroupListWithAssignmentsForObserver(it, params)
         }.map {
             it.map { group ->
-                val filteredAssignments = group.assignments.filter { assignment -> assignment.published }
+                val filteredAssignments = group.assignments
+                    .filter { assignment -> assignment.published }
+                    .filter { assignment -> getGradingTypeFromAPIString(assignment.gradingType.orEmpty()) != Assignment.GradingType.NOT_GRADED }
                 group.copy(assignments = filteredAssignments).toAssignmentGroup(studentId)
             }
         }.dataOrThrow


### PR DESCRIPTION
Test plan: See ticket.

refs: MBL-18583
affects: Parent
release note: Fixed a bug where assignments with 'Not Graded' type would be visible on Grades.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/1669f334-7c34-41ce-abe6-c83253d14392" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/c1e14f52-9f93-4385-b8df-e8f6b1e78bfb" maxHeight=500></td>
</tr>
</table>