### PR TITLE
Attempt to fix daytime breaking e2e offline tests

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/offline/ManageOfflineContentPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/offline/ManageOfflineContentPage.kt
@@ -69,7 +69,7 @@ class ManageOfflineContentPage : BasePage(R.id.manageOfflineContentPage) {
     }
 
     fun clickOnSyncButton() {
-        syncButton.click()
+        waitForView(withId(R.id.syncButton)).click()
     }
 
     fun clickOnSyncButtonAndConfirm() {
@@ -78,7 +78,9 @@ class ManageOfflineContentPage : BasePage(R.id.manageOfflineContentPage) {
     }
 
     private fun confirmSync() {
-        waitForView(withText("Sync") + withAncestor(R.id.buttonPanel)).click()
+        val syncDialogButton = waitForView(withText("Sync") + withAncestor(R.id.buttonPanel))
+        Thread.sleep(2000)
+        syncDialogButton.click()
     }
 
     fun confirmDiscardChanges() {


### PR DESCRIPTION
Attempt to fix daytime breaking e2e offline tests

There were 2 successful e2e-offline-standalone attempts at daytime, so I'm opening this PR to see how it works with the pipeline 'e2e-offline' workflow.

https://app.bitrise.io/build/82daa0fa-110c-4af0-aac4-175ba3909a35

https://app.bitrise.io/build/ec39316c-e98c-443e-9327-f524fb64353d


- [ ] Run E2E test suite
