### PR TITLE
[MBL-18571][Student] Fix quiz opening from webview in offline.

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/fragment/BasicQuizViewFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/BasicQuizViewFragment.kt
@@ -69,6 +69,7 @@ class BasicQuizViewFragment : InternalWebviewFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         // Anything that relies on intent data belongs here
+        noConnectionDialogWithNetworkCheck()
         if (apiURL != null) {
             getQuizDetails(apiURL!!)
         } else if (quiz != null && quiz?.lockInfo != null && CanvasContext.Type.isCourse(canvasContext) && !(canvasContext as Course).isTeacher) {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/ViewExtensions.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/ViewExtensions.kt
@@ -396,13 +396,24 @@ fun View.onClickWithRequireNetwork(clickListener: OnClickListener) = onClick {
         clickListener.onClick(this)
     } else {
         //show dialog
-        AlertDialog.Builder(context)
-                .setTitle(R.string.noInternetConnectionTitle)
-                .setMessage(R.string.noInternetConnectionMessage)
-                .setCancelable(true)
-                .setPositiveButton(android.R.string.ok, { dialog, _ -> dialog.dismiss() })
-                .showThemed()
+        showNoConnectionDialog(context)
     }
+}
+
+fun Fragment.noConnectionDialogWithNetworkCheck() {
+    if (!APIHelper.hasNetworkConnection()) {
+        showNoConnectionDialog(requireContext()) { requireActivity().onBackPressed() }
+    }
+}
+
+private fun showNoConnectionDialog(context: Context, actionAfterDismiss: () -> Unit = {}) {
+    AlertDialog.Builder(context)
+        .setTitle(R.string.noInternetConnectionTitle)
+        .setMessage(R.string.noInternetConnectionMessage)
+        .setCancelable(true)
+        .setPositiveButton(android.R.string.ok) { dialog, _ -> dialog.dismiss() }
+        .setOnDismissListener { _ -> actionAfterDismiss() }
+        .showThemed()
 }
 
 /**


### PR DESCRIPTION
Test plan:
- I fixed the issue with the quiz opening by showing a dialog on the quiz screen and then redirecting back.
- The other issue with the pages is a special case, it seems like the page was already renamed and it's embedded in the syllabus with the old link (page links are generated from the pages name). Somehow the API can handle these redirects, but it's impossible to handle this offline. This should be a rare case, and we won't fix it.

refs: MBL-18571
affects: Student
release note: none

## Checklist

- [x] Tested in light mode
