### PR TITLE
[MBL-18569][Student][Teacher] Unread count updated offline on batch operations

### DIFF
--- a/apps/parent/src/androidTest/java/com/instructure/parentapp/ui/e2e/SettingsE2ETest.kt
+++ b/apps/parent/src/androidTest/java/com/instructure/parentapp/ui/e2e/SettingsE2ETest.kt
@@ -62,7 +62,7 @@ class SettingsE2ETest : ParentComposeTest() {
         dashboardPage.waitForRender()
 
         Log.d(STEP_TAG, "Open the Left Side Navigation Drawer menu.")
-        dashboardPage.openNavigationDrawer()
+        dashboardPage.openLeftSideMenu()
 
         Log.d(STEP_TAG, "Navigate to User Settings Page.")
         leftSideNavigationDrawerPage.clickSettings()
@@ -80,7 +80,7 @@ class SettingsE2ETest : ParentComposeTest() {
 
         Log.d(STEP_TAG, "Navigate back and open the Left Side Navigation Drawer menu.")
         Espresso.pressBack()
-        dashboardPage.openNavigationDrawer()
+        dashboardPage.openLeftSideMenu()
 
         Log.d(STEP_TAG,"Navigate to Settings Page and open App Theme Settings again.")
         leftSideNavigationDrawerPage.clickSettings()
@@ -110,7 +110,7 @@ class SettingsE2ETest : ParentComposeTest() {
         dashboardPage.waitForRender()
 
         Log.d(STEP_TAG, "Open the Left Side Navigation Drawer menu.")
-        dashboardPage.openNavigationDrawer()
+        dashboardPage.openLeftSideMenu()
 
         Log.d(STEP_TAG, "Navigate to User Settings Page.")
         leftSideNavigationDrawerPage.clickSettings()
@@ -133,7 +133,7 @@ class SettingsE2ETest : ParentComposeTest() {
         dashboardPage.waitForRender()
 
         Log.d(STEP_TAG, "Open the Left Side Navigation Drawer menu.")
-        dashboardPage.openNavigationDrawer()
+        dashboardPage.openLeftSideMenu()
 
         Log.d(STEP_TAG, "Navigate to User Settings Page.")
         leftSideNavigationDrawerPage.clickSettings()

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/dashboard/DashboardViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/dashboard/DashboardViewModel.kt
@@ -111,6 +111,16 @@ class DashboardViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
+            inboxCountUpdater.increaseInboxCountFlow.collect { increaseBy ->
+                _data.update { data ->
+                    data.copy(
+                        unreadCount = data.unreadCount + increaseBy
+                    )
+                }
+            }
+        }
+
+        viewModelScope.launch {
             alertCountUpdater.shouldRefreshAlertCountFlow.collect { shouldUpdate ->
                 if (shouldUpdate) {
                     updateAlertCount()

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/dashboard/InboxCountUpdater.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/dashboard/InboxCountUpdater.kt
@@ -22,14 +22,23 @@ import kotlinx.coroutines.flow.asSharedFlow
 
 interface InboxCountUpdater {
     val shouldRefreshInboxCountFlow: SharedFlow<Boolean>
+    val increaseInboxCountFlow: SharedFlow<Int>
     suspend fun updateShouldRefreshInboxCount(shouldRefresh: Boolean)
+    suspend fun increaseInboxCount(increaseBy: Int)
 }
 
 class InboxCountUpdaterImpl : InboxCountUpdater {
     private val _shouldRefreshInboxCountFlow = MutableSharedFlow<Boolean>(replay = 1)
     override val shouldRefreshInboxCountFlow = _shouldRefreshInboxCountFlow.asSharedFlow()
+    private val _increaseInboxCountFlow = MutableSharedFlow<Int>(replay = 1)
+    override val increaseInboxCountFlow = _increaseInboxCountFlow.asSharedFlow()
+
 
     override suspend fun updateShouldRefreshInboxCount(shouldRefresh: Boolean) {
         _shouldRefreshInboxCountFlow.emit(shouldRefresh)
+    }
+
+    override suspend fun increaseInboxCount(increaseBy: Int) {
+        _increaseInboxCountFlow.emit(increaseBy)
     }
 }

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/main/MainActivity.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/main/MainActivity.kt
@@ -162,6 +162,10 @@ class MainActivity : BaseCanvasActivity(), OnUnreadCountInvalidated, Masqueradin
         }
     }
 
+    override fun updateUnreadCountOffline(increaseBy: Int) {
+        // Parent app does not have batch operations on alerts screen, so we don't need this
+    }
+
     override fun onStartMasquerading(domain: String, userId: Long) {
         MasqueradeHelper.startMasquerading(userId, domain, MainActivity::class.java)
     }

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/main/MainActivity.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/main/MainActivity.kt
@@ -163,7 +163,9 @@ class MainActivity : BaseCanvasActivity(), OnUnreadCountInvalidated, Masqueradin
     }
 
     override fun updateUnreadCountOffline(increaseBy: Int) {
-        // Parent app does not have batch operations on alerts screen, so we don't need this
+        lifecycleScope.launch {
+            inboxCountUpdater.increaseInboxCount(increaseBy)
+        }
     }
 
     override fun onStartMasquerading(domain: String, userId: Long) {

--- a/apps/parent/src/test/java/com/instructure/parentapp/features/dashboard/DashboardViewModelTest.kt
+++ b/apps/parent/src/test/java/com/instructure/parentapp/features/dashboard/DashboardViewModelTest.kt
@@ -82,7 +82,8 @@ class DashboardViewModelTest {
     private val parentPrefs: ParentPrefs = mockk(relaxed = true)
     private val selectedStudentHolder: SelectedStudentHolder = mockk(relaxed = true)
     private val inboxCountUpdaterFlow = MutableSharedFlow<Boolean>()
-    private val inboxCountUpdater: InboxCountUpdater = TestInboxCountUpdater(inboxCountUpdaterFlow)
+    private val increaseInboxCountFlow = MutableSharedFlow<Int>()
+    private val inboxCountUpdater: InboxCountUpdater = TestInboxCountUpdater(inboxCountUpdaterFlow, increaseInboxCountFlow)
     private val alertCountUpdaterFlow = MutableSharedFlow<Boolean>()
     private val alertCountUpdater: AlertCountUpdater = TestAlertCountUpdater(alertCountUpdaterFlow)
     private val analytics: Analytics = mockk(relaxed = true)
@@ -270,6 +271,21 @@ class DashboardViewModelTest {
 
         coEvery { repository.getUnreadCounts() } returns 1
         inboxCountUpdaterFlow.emit(true)
+
+        assertEquals(1, viewModel.data.value.unreadCount)
+    }
+
+    @Test
+    fun `Update unread count when the increase unread count flow triggers an update`() = runTest {
+        val students = listOf(User(id = 1L), User(id = 2L))
+        coEvery { repository.getStudents(any()) } returns students
+        coEvery { repository.getUnreadCounts() } returns 0
+
+        createViewModel()
+
+        assertEquals(0, viewModel.data.value.unreadCount)
+
+        increaseInboxCountFlow.emit(1)
 
         assertEquals(1, viewModel.data.value.unreadCount)
     }

--- a/apps/parent/src/test/java/com/instructure/parentapp/features/dashboard/TestInboxCountUpdater.kt
+++ b/apps/parent/src/test/java/com/instructure/parentapp/features/dashboard/TestInboxCountUpdater.kt
@@ -19,9 +19,14 @@ package com.instructure.parentapp.features.dashboard
 import kotlinx.coroutines.flow.MutableSharedFlow
 
 class TestInboxCountUpdater(
-    override val shouldRefreshInboxCountFlow: MutableSharedFlow<Boolean>
+    override val shouldRefreshInboxCountFlow: MutableSharedFlow<Boolean>,
+    override val increaseInboxCountFlow: MutableSharedFlow<Int>
 ) : InboxCountUpdater {
     override suspend fun updateShouldRefreshInboxCount(shouldRefresh: Boolean) {
         shouldRefreshInboxCountFlow.emit(shouldRefresh)
+    }
+
+    override suspend fun increaseInboxCount(increaseBy: Int) {
+        increaseInboxCountFlow.emit(increaseBy)
     }
 }

--- a/apps/student/src/main/java/com/instructure/student/activity/CallbackActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/CallbackActivity.kt
@@ -84,6 +84,7 @@ abstract class CallbackActivity : ParentActivity(), OnUnreadCountInvalidated, No
 
     abstract fun gotLaunchDefinitions(launchDefinitions: List<LaunchDefinition>?)
     abstract fun updateUnreadCount(unreadCount: Int)
+    abstract fun increaseUnreadCount(increaseBy: Int)
     abstract fun updateNotificationCount(notificationCount: Int)
     abstract fun initialCoreDataLoadingComplete()
 
@@ -264,6 +265,10 @@ abstract class CallbackActivity : ParentActivity(), OnUnreadCountInvalidated, No
         } catch {
 
         }
+    }
+
+    override fun updateUnreadCountOffline(increaseBy: Int) {
+        increaseUnreadCount(increaseBy)
     }
 
     override fun invalidateNotificationCount() {

--- a/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
@@ -1263,6 +1263,10 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
         updateBottomBarBadge(R.id.bottomNavigationInbox, unreadCount, R.plurals.a11y_inboxUnreadCount)
     }
 
+    override fun increaseUnreadCount(increaseBy: Int) {
+        updateUnreadCount(binding.bottomBar.getOrCreateBadge(R.id.bottomNavigationInbox).number + increaseBy)
+    }
+
     override fun updateNotificationCount(notificationCount: Int) {
         updateBottomBarBadge(R.id.bottomNavigationNotifications, notificationCount, R.plurals.a11y_notificationsUnreadCount)
     }

--- a/apps/teacher/src/main/java/com/instructure/teacher/activities/InitActivity.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/activities/InitActivity.kt
@@ -546,6 +546,10 @@ class InitActivity : BasePresenterActivity<InitActivityPresenter, InitActivityVi
         presenter?.updateUnreadCount()
     }
 
+    override fun updateUnreadCountOffline(increaseBy: Int) {
+        updateInboxUnreadCount(binding.bottomBar.getOrCreateBadge(R.id.tab_inbox).number + increaseBy)
+    }
+
     private fun updateBottomBarBadge(@IdRes menuItemId: Int, count: Int, @PluralsRes quantityContentDescription: Int? = null) = with(binding) {
         if (count > 0) {
             bottomBar.getOrCreateBadge(menuItemId).number = count

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/list/InboxFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/list/InboxFragment.kt
@@ -363,6 +363,7 @@ class InboxFragment : BaseCanvasFragment(), NavigationCallbacks, FragmentInterac
             is InboxAction.ConfirmDelete -> deleteSelected(action.count)
             is InboxAction.AvatarClickedCallback -> inboxRouter.avatarClicked(action.conversation, action.scope)
             InboxAction.DismissSnackbar -> confirmationSnackbar?.dismiss()
+            is InboxAction.UpdateUnreadCountOffline -> onUnreadCountInvalidated?.updateUnreadCountOffline(action.increaseBy)
         }
     }
 
@@ -476,4 +477,5 @@ class InboxFragment : BaseCanvasFragment(), NavigationCallbacks, FragmentInterac
 
 interface OnUnreadCountInvalidated {
     fun invalidateUnreadCount()
+    fun updateUnreadCountOffline(increaseBy: Int)
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/list/InboxViewData.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/list/InboxViewData.kt
@@ -55,6 +55,7 @@ sealed class InboxAction {
     object CreateNewMessage : InboxAction()
     object FailedToLoadNextPage : InboxAction()
     object UpdateUnreadCount : InboxAction()
+    data class UpdateUnreadCountOffline(val increaseBy: Int) : InboxAction()
     data class OpenContextFilterSelector(val canvasContexts: List<CanvasContext>) : InboxAction()
     object RefreshFailed : InboxAction()
     data class ConfirmDelete(val count: Int) : InboxAction()

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/list/InboxViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/list/InboxViewModel.kt
@@ -259,43 +259,48 @@ class InboxViewModel @Inject constructor(
 
     fun markAsReadSelected() {
         performBatchOperation("mark_as_read") { ids, progress ->
+            val unreadCountIncreasedBy = getUnreadCountDiff(ids, unread = false)
             if (scope == InboxApi.Scope.UNREAD) {
                 removeItemsAndSilentUpdate(ids, progress)
             } else {
                 updateItems(ids, unread = false)
             }
             _events.value = Event(InboxAction.ShowConfirmationSnackbar(resources.getString(R.string.inboxMarkAsReadConfirmation, ids.size)))
-            _events.value = Event(InboxAction.UpdateUnreadCount)
+            sendUpdateUnreadCountOfflineEvent(unreadCountIncreasedBy)
         }
     }
 
     fun markAsUnreadSelected() {
         performBatchOperation("mark_as_unread") { ids, progress ->
+            val unreadCountIncreasedBy = getUnreadCountDiff(ids, unread = true)
             if (scope == InboxApi.Scope.ARCHIVED) {
                 removeItemsAndSilentUpdate(ids, progress)
             } else {
                 updateItems(ids, unread = true)
             }
             _events.value = Event(InboxAction.ShowConfirmationSnackbar(resources.getString(R.string.inboxMarkAsUnreadConfirmation, ids.size)))
-            _events.value = Event(InboxAction.UpdateUnreadCount)
+            sendUpdateUnreadCountOfflineEvent(unreadCountIncreasedBy)
         }
     }
 
     fun deleteSelected() {
         performBatchOperation("destroy") { ids, progress ->
+            val unreadCountIncreasedBy = getUnreadCountDiff(ids, unread = false)
             removeItemsAndSilentUpdate(ids, progress)
             _events.value = Event(InboxAction.ShowConfirmationSnackbar(resources.getString(R.string.inboxDeletedConfirmation, ids.size)))
-            _events.value = Event(InboxAction.UpdateUnreadCount)
+            sendUpdateUnreadCountOfflineEvent(unreadCountIncreasedBy)
         }
     }
 
     fun archiveSelected() {
         performBatchOperation("archive") { ids, progress ->
+            var unreadCountIncreasedBy = 0
             if (scope != InboxApi.Scope.STARRED) {
+                unreadCountIncreasedBy = getUnreadCountDiff(ids, unread = false)
                 removeItemsAndSilentUpdate(ids, progress)
             }
             _events.value = Event(InboxAction.ShowConfirmationSnackbar(resources.getString(R.string.inboxArchivedConfirmation, ids.size)))
-            _events.value = Event(InboxAction.UpdateUnreadCount)
+            sendUpdateUnreadCountOfflineEvent(unreadCountIncreasedBy)
         }
     }
 
@@ -303,6 +308,12 @@ class InboxViewModel @Inject constructor(
         performBatchOperation("mark_as_read") { ids, progress ->
             removeItemsAndSilentUpdate(ids, progress)
             _events.value = Event(InboxAction.ShowConfirmationSnackbar(resources.getString(R.string.inboxUnarchivedConfirmation, ids.size)))
+        }
+    }
+
+    private fun sendUpdateUnreadCountOfflineEvent(unreadCountIncreasedBy: Int) {
+        if (unreadCountIncreasedBy != 0) {
+            _events.value = Event(InboxAction.UpdateUnreadCountOffline(unreadCountIncreasedBy))
         }
     }
 
@@ -557,5 +568,19 @@ class InboxViewModel @Inject constructor(
     fun confirmDelete() {
         val selectedCount = _itemViewModels.value?.count { it.selected } ?: 1
         _events.value = Event(InboxAction.ConfirmDelete(selectedCount))
+    }
+
+    private fun getUnreadCountDiff(ids: Set<Long>, unread: Boolean): Int {
+        var diff = 0
+        _itemViewModels.value?.forEach {
+            if (ids.contains(it.data.id)) {
+                if (unread && !it.data.unread) {
+                    diff++
+                } else if (!unread && it.data.unread) {
+                    diff--
+                }
+            }
+        }
+        return diff
     }
 }

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/inbox/list/InboxViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/inbox/list/InboxViewModelTest.kt
@@ -22,7 +22,6 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
-import androidx.lifecycle.Observer
 import com.instructure.canvasapi2.apis.InboxApi
 import com.instructure.canvasapi2.models.Conversation
 import com.instructure.canvasapi2.models.Course
@@ -224,9 +223,9 @@ class InboxViewModelTest {
         viewModel.itemViewModels.value!![0].onClick(View(context))
 
         val events = mutableListOf<Event<InboxAction>>()
-        viewModel.events.observeForever(Observer {
+        viewModel.events.observeForever {
             events.add(it)
-        })
+        }
 
         assertTrue(events.any { it.peekContent() == InboxAction.OpenConversation(conversation, InboxApi.Scope.INBOX) })
     }
@@ -241,9 +240,9 @@ class InboxViewModelTest {
         viewModel.itemViewModels.value!![0].onAvatarClick(View(context))
 
         val events = mutableListOf<Event<InboxAction>>()
-        viewModel.events.observeForever(Observer {
+        viewModel.events.observeForever {
             events.add(it)
-        })
+        }
 
         assertTrue(events.any { it.peekContent() == InboxAction.AvatarClickedCallback(conversation, InboxApi.Scope.INBOX) })
     }
@@ -318,6 +317,7 @@ class InboxViewModelTest {
         assertTrue(viewModel.itemViewModels.value!![0].data.unread)
         assertTrue(viewModel.itemViewModels.value!![1].data.unread)
         coVerify { inboxRepository.batchUpdateConversations(any(), eq("mark_as_unread")) }
+        assertEquals(InboxAction.UpdateUnreadCountOffline(2), viewModel.events.value!!.peekContent())
     }
 
     @Test
@@ -327,7 +327,6 @@ class InboxViewModelTest {
             DataResult.Success(listOf(Conversation(id = 1), Conversation(id = 2))), // We need an other call for the scope change
             DataResult.Success(emptyList())
         )
-        every { inboxEntryItemCreator.createInboxEntryItem(any(), any(), any(), any()) } answers { createItem(args[0] as Conversation, args[1], args[2], args[3], unread = true) }
 
         viewModel = createViewModel()
         viewModel.data.observe(lifecycleOwner) {}
@@ -338,6 +337,7 @@ class InboxViewModelTest {
 
         assertTrue(viewModel.itemViewModels.value!!.isEmpty())
         coVerify { inboxRepository.batchUpdateConversations(any(), eq("mark_as_unread")) }
+        assertEquals(InboxAction.UpdateUnreadCountOffline(2), viewModel.events.value!!.peekContent())
     }
 
     @Test
@@ -356,6 +356,7 @@ class InboxViewModelTest {
         assertFalse(viewModel.itemViewModels.value!![0].data.unread)
         assertFalse(viewModel.itemViewModels.value!![1].data.unread)
         coVerify { inboxRepository.batchUpdateConversations(any(), eq("mark_as_read")) }
+        assertEquals(InboxAction.UpdateUnreadCountOffline(-2), viewModel.events.value!!.peekContent())
     }
 
     @Test
@@ -376,6 +377,7 @@ class InboxViewModelTest {
 
         assertTrue(viewModel.itemViewModels.value!!.isEmpty())
         coVerify { inboxRepository.batchUpdateConversations(any(), eq("mark_as_read")) }
+        assertEquals(InboxAction.UpdateUnreadCountOffline(-2), viewModel.events.value!!.peekContent())
     }
 
     @Test
@@ -386,6 +388,11 @@ class InboxViewModelTest {
         )
 
         viewModel = createViewModel()
+        val events = mutableListOf<Event<InboxAction>>()
+        viewModel.events.observeForever {
+            events.add(it)
+        }
+
         viewModel.data.observe(lifecycleOwner) {}
         viewModel.itemViewModels.value!![0].onLongClick(View(context))
         viewModel.deleteSelected()
@@ -393,6 +400,33 @@ class InboxViewModelTest {
         assertEquals(1, viewModel.itemViewModels.value!!.size)
         assertEquals(2, viewModel.itemViewModels.value!![0].data.id)
         coVerify { inboxRepository.batchUpdateConversations(any(), eq("destroy")) }
+
+        assertFalse(events.any { it.peekContent() is InboxAction.UpdateUnreadCountOffline })
+    }
+
+    @Test
+    fun `Remove selected unread items from the list when deleted`() {
+        coEvery { inboxRepository.getConversations(any(), any(), any(), any()) }.returnsMany(
+            DataResult.Success(listOf(Conversation(id = 1), Conversation(id = 2))),
+            DataResult.Success(emptyList())
+        )
+        every { inboxEntryItemCreator.createInboxEntryItem(any(), any(), any(), any()) } answers { createItem(args[0] as Conversation, args[1], args[2], args[3], unread = true) }
+
+        viewModel = createViewModel()
+        val events = mutableListOf<Event<InboxAction>>()
+        viewModel.events.observeForever {
+            events.add(it)
+        }
+
+        viewModel.data.observe(lifecycleOwner) {}
+        viewModel.itemViewModels.value!![0].onLongClick(View(context))
+        viewModel.deleteSelected()
+
+        assertEquals(1, viewModel.itemViewModels.value!!.size)
+        assertEquals(2, viewModel.itemViewModels.value!![0].data.id)
+        coVerify { inboxRepository.batchUpdateConversations(any(), eq("destroy")) }
+
+        assertTrue(events.any { it.peekContent() == InboxAction.UpdateUnreadCountOffline(-1) })
     }
 
     @Test
@@ -401,8 +435,14 @@ class InboxViewModelTest {
             DataResult.Success(listOf(Conversation(id = 1), Conversation(id = 2))),
             DataResult.Success(emptyList())
         )
+        every { inboxEntryItemCreator.createInboxEntryItem(any(), any(), any(), any()) } answers { createItem(args[0] as Conversation, args[1], args[2], args[3], unread = true) }
 
         viewModel = createViewModel()
+        val events = mutableListOf<Event<InboxAction>>()
+        viewModel.events.observeForever {
+            events.add(it)
+        }
+
         viewModel.data.observe(lifecycleOwner) {}
         viewModel.itemViewModels.value!![1].onLongClick(View(context))
         viewModel.archiveSelected()
@@ -410,6 +450,7 @@ class InboxViewModelTest {
         assertEquals(1, viewModel.itemViewModels.value!!.size)
         assertEquals(1, viewModel.itemViewModels.value!![0].data.id)
         coVerify { inboxRepository.batchUpdateConversations(any(), eq("archive")) }
+        assertTrue(events.any { it.peekContent() == InboxAction.UpdateUnreadCountOffline(-1) })
     }
 
     @Test
@@ -679,9 +720,9 @@ class InboxViewModelTest {
 
         viewModel = createViewModel()
         val events = mutableListOf<Event<InboxAction>>()
-        viewModel.events.observeForever(Observer {
+        viewModel.events.observeForever {
             events.add(it)
-        })
+        }
         viewModel.data.observe(lifecycleOwner) {}
         viewModel.archiveConversation(1)
 
@@ -742,9 +783,9 @@ class InboxViewModelTest {
 
         viewModel = createViewModel()
         val events = mutableListOf<Event<InboxAction>>()
-        viewModel.events.observeForever(Observer {
+        viewModel.events.observeForever {
             events.add(it)
-        })
+        }
         viewModel.data.observe(lifecycleOwner) {}
         viewModel.scopeChanged(InboxApi.Scope.UNREAD)
         viewModel.markConversationAsRead(1)
@@ -806,9 +847,9 @@ class InboxViewModelTest {
 
         viewModel = createViewModel()
         val events = mutableListOf<Event<InboxAction>>()
-        viewModel.events.observeForever(Observer {
+        viewModel.events.observeForever {
             events.add(it)
-        })
+        }
         viewModel.data.observe(lifecycleOwner) {}
         viewModel.scopeChanged(InboxApi.Scope.ARCHIVED)
         viewModel.markConversationAsUnread(1)
@@ -853,9 +894,9 @@ class InboxViewModelTest {
 
         viewModel = createViewModel()
         val events = mutableListOf<Event<InboxAction>>()
-        viewModel.events.observeForever(Observer {
+        viewModel.events.observeForever {
             events.add(it)
-        })
+        }
         viewModel.data.observe(lifecycleOwner) {}
         viewModel.scopeChanged(InboxApi.Scope.STARRED)
         viewModel.unstarConversation(1)
@@ -898,9 +939,9 @@ class InboxViewModelTest {
 
         viewModel = createViewModel()
         val events = mutableListOf<Event<InboxAction>>()
-        viewModel.events.observeForever(Observer {
+        viewModel.events.observeForever {
             events.add(it)
-        })
+        }
         viewModel.data.observe(lifecycleOwner) {}
         viewModel.scopeChanged(InboxApi.Scope.STARRED)
         viewModel.unarchiveConversation(1)


### PR DESCRIPTION
Test plan: 
- Open Student or Teacher app
- Go to Inbox
- Select multiple items
- Press Unread/Read/Delete
- Unread count should be updated immediately

refs: MBL-18569
affects: Student, Teacher
release note: Inbox unread count badge is updated correctly

## Checklist

- [ ] Run E2E test suite
