### PR TITLE
[MBL-18623][Parent] Fixed undo mechanism in alerts.

### DIFF
--- a/apps/parent/src/test/java/com/instructure/parentapp/features/alerts/list/AlertsViewModelTest.kt
+++ b/apps/parent/src/test/java/com/instructure/parentapp/features/alerts/list/AlertsViewModelTest.kt
@@ -511,6 +511,81 @@ class AlertsViewModelTest {
     }
 
     @Test
+    fun `Undo dismissal with unread state resets alert as read`() = runTest {
+        val student = User(1L)
+        every { student.studentColor } returns 1
+
+        val alerts = listOf(
+            Alert(
+                id = 1,
+                actionDate = Date.from(
+                    Instant.parse("2024-01-03T00:00:00Z")
+                ),
+                title = "Alert 1",
+                workflowState = AlertWorkflowState.UNREAD,
+                alertType = AlertType.ASSIGNMENT_MISSING,
+                htmlUrl = "https://example.com/alert1",
+                contextId = 1L,
+                contextType = "Course",
+                lockedForUser = false,
+                observerAlertThresholdId = 1L,
+                observerId = 1L,
+                userId = 2L
+            )
+        )
+
+        coEvery { repository.getAlertsForStudent(student.id, any()) } returns alerts
+        coEvery { repository.updateAlertWorkflow(any(), any()) } returns mockk()
+
+        createViewModel()
+        selectedStudentFlow.emit(student)
+
+        val expected = AlertsUiState(
+            isLoading = false,
+            isError = false,
+            alerts = alerts.map {
+                AlertsItemUiState(
+                    alertId = it.id,
+                    contextId = it.contextId,
+                    title = it.title,
+                    alertType = it.alertType,
+                    date = it.actionDate,
+                    observerAlertThreshold = null,
+                    lockedForUser = it.lockedForUser,
+                    unread = true,
+                    htmlUrl = it.htmlUrl
+                )
+            }.sortedByDescending { it.date },
+            studentColor = 1
+        )
+
+        assertEquals(expected, viewModel.uiState.value)
+
+        viewModel.handleAction(AlertsAction.DismissAlert(1L))
+        assertEquals(emptyList<AlertsItemUiState>(), viewModel.uiState.value.alerts)
+
+        val events = mutableListOf<AlertsViewModelAction>()
+
+        backgroundScope.launch(testDispatcher) {
+            viewModel.events.toList(events)
+        }
+
+        assertEquals(
+            R.string.alertDismissMessage,
+            (events.last() as AlertsViewModelAction.ShowSnackbar).message
+        )
+        assertEquals(
+            R.string.alertDismissAction,
+            (events.last() as AlertsViewModelAction.ShowSnackbar).action
+        )
+
+        (events.last() as AlertsViewModelAction.ShowSnackbar).actionCallback?.invoke()
+
+        assertEquals(expected.copy(alerts = listOf(expected.alerts.first().copy(unread = false))), viewModel.uiState.value)
+        coVerify { repository.updateAlertWorkflow(1L, AlertWorkflowState.READ) }
+    }
+
+    @Test
     fun `Undo does not reset event on error`() = runTest {
         val student = User(1L)
         every { student.studentColor } returns 1


### PR DESCRIPTION
Test plan: In the ticket. As we discussed on the Android meeting, undoing dismissed alerts will always mark the alerts as read.

refs: MBL-18623
affects: Parent
release note: none

## Checklist

- [x] Tested in light mode
