### PR TITLE
[MBL-18631][All] LTILaunchFragment crash

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/lti/LtiLaunchFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/lti/LtiLaunchFragment.kt
@@ -181,10 +181,12 @@ class LtiLaunchFragment : BaseCanvasFragment(), NavigationCallbacks {
 
             override fun routeInternallyCallback(url: String) {
                 // Handle return button in external tools. Links to course homepage should close the tool.
-                if (url == contextLink()) {
-                    ltiLaunchFragmentBehavior.closeLtiLaunchFragment(requireActivity())
-                } else {
-                    webViewRouter.routeInternally(url)
+                if (isAdded) {
+                    if (url == contextLink()) {
+                        ltiLaunchFragmentBehavior.closeLtiLaunchFragment(requireActivity())
+                    } else {
+                        webViewRouter.routeInternally(url)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Test plan: I couldn't reproduce the issue. It probably happens somewhere in the WebView routing when the user starts to load a page that would route but already closed the screen when loading finished.

refs: MBL-18631
affects: Student, Teacher, Parent
release note: none

## Checklist

- [ ] Tested in light mode
