### PR TITLE
[MBL-18587][Parent] In the Filter Tray of an assignment the "Grading Period" and "Sort" text does not meet contrast requirements

### DIFF
--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/GradeCellStateTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/GradeCellStateTest.kt
@@ -199,7 +199,7 @@ class GradeCellStateTest : Assert() {
             score = 0.0
         )
         val expected = baseGradedState.copy(
-            accentColor = 0xFF6A7883.toInt(),
+            accentColor = 0xFF66717C.toInt(),
             graphPercent = 1.0f,
             showIncompleteIcon = true,
             grade = "Incomplete",

--- a/libs/pandares/src/main/res/values/colors.xml
+++ b/libs/pandares/src/main/res/values/colors.xml
@@ -18,10 +18,10 @@
 <resources>
 
     <!-- InstUI colors - We should use these colors to build standard UI elements -->
-    <color name="ash">#6A7883</color>
+    <color name="ash">#66717C</color>
     <color name="backgroundMasquerade">#BF32A4</color>
     <color name="backgroundDanger">#E62429</color>
-    <color name="backgroundDark">#6A7883</color>
+    <color name="backgroundDark">#66717C</color>
     <color name="backgroundDarkest">#273540</color>
     <color name="backgroundGrouped">#FFFFFF</color>
     <color name="backgroundGroupedCell">#FFFFFF</color>
@@ -35,7 +35,7 @@
     <color name="barney">#BF32A4</color>
     <color name="borderMasquerade">#BF32A4</color>
     <color name="borderDanger">#E62429</color>
-    <color name="borderDark">#6A7883</color>
+    <color name="borderDark">#66717C</color>
     <color name="borderDarkest">#273540</color>
     <color name="borderInfo">#2B7ABC</color>
     <color name="borderLight">#F2F4F4</color>
@@ -52,7 +52,7 @@
     <color name="shamrock">#03893D</color>
     <color name="textMasquerade">#BF32A4</color>
     <color name="textDanger">#E62429</color>
-    <color name="textDark">#6A7883</color>
+    <color name="textDark">#66717C</color>
     <color name="textDarkest">#273540</color>
     <color name="textPlaceholder">#9EA6AD</color>
     <color name="textInfo">#2B7ABC</color>


### PR DESCRIPTION
Test plan: in the ticket

refs: MBL-18587
affects: Parent
release note: none
