### PR TITLE
[MBL-18645][All]Removed code where we skip the values-en string folder.

### DIFF
--- a/translations/import.rb
+++ b/translations/import.rb
@@ -92,10 +92,6 @@ Dir.glob("#{import_dir}/*/") do |src_dir|
       language = language.gsub('sv+instk12', 'sv+SE+instk12')
     end
 
-    if language.eql? 'en'
-      puts "Skipping redundant 'en' resource"
-      next
-    end
     project = File.basename(file, '.*')
     res_dir = resource_dirs[project]
     if res_dir.nil?


### PR DESCRIPTION
Test plan: I am not sure how we can test this now since we just updated the translations, but we can test this later when there are new translations available.

refs: MBL-18645
affects: -
release note: -