### PR TITLE
[MBL-18657][All] Fixed status bar color on app start

### DIFF
--- a/apps/parent/src/main/res/values/themes.xml
+++ b/apps/parent/src/main/res/values/themes.xml
@@ -21,6 +21,7 @@
         <item name="colorAccent">@color/textDarkest</item>
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
+        <item name="android:statusBarColor">@color/darkStatusBarColor</item>
         <item name="android:windowBackground">@color/backgroundLightest</item>
         <item name="android:windowContentTransitions">true</item>
         <item name="android:windowAllowEnterTransitionOverlap">true</item>

--- a/apps/student/src/main/res/values/themes_canvastheme.xml
+++ b/apps/student/src/main/res/values/themes_canvastheme.xml
@@ -25,6 +25,7 @@
         <item name="colorAccent">@color/textDarkest</item>
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
+        <item name="android:statusBarColor">@color/darkStatusBarColor</item>
         <item name="android:windowBackground">@color/backgroundLightest</item>
         <item name="android:windowContentTransitions">true</item>
         <item name="android:windowAllowEnterTransitionOverlap">true</item>

--- a/libs/login-api-2/src/main/res/values/styles.xml
+++ b/libs/login-api-2/src/main/res/values/styles.xml
@@ -30,7 +30,7 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
-        <item name="android:statusBarColor">#FFFFFF</item>
+        <item name="android:statusBarColor">@color/darkStatusBarColor</item>
         <item name="android:fontFamily">@font/lato_font_family</item>
     </style>
 

--- a/libs/pandares/src/main/res/values/colors.xml
+++ b/libs/pandares/src/main/res/values/colors.xml
@@ -68,6 +68,7 @@
     <color name="backgroundDarkMode">#151D24</color>
     <color name="textOnColorDark">#273540</color>
     <color name="elevatedDarkColor">#242526</color>
+    <color name="darkStatusBarColor">#273540</color>
 
     <!-- We had to define custom colors for the switches because in dark mode the previously used light/medium didn't work, because one is a shade of blue -->
     <color name="switchThumbColor">#FFFFFF</color>


### PR DESCRIPTION
Test plan:
- Open all 3 apps in dark mode and light mode selected
- Status bar should be readable in all cases

refs: MBL-18657
affects: Student, Teacher, Parent
release note:

## Checklist

- [x] Tested in dark mode
- [x] Tested in light mode
