### PR TITLE
[MBL-18047][Teacher] Added option to navigate to module headers from links.

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ModuleListEffectHandler.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ModuleListEffectHandler.kt
@@ -62,7 +62,7 @@ class ModuleListEffectHandler(
                 effect.scrollToItemId
             )
 
-            is ModuleListEffect.ScrollToItem -> view?.scrollToItem(effect.moduleItemId)
+            is ModuleListEffect.ScrollToItem -> view?.scrollToItem(effect.moduleItemId, effect.scrollToHeaderItem)
             is ModuleListEffect.MarkModuleExpanded -> {
                 CollapsedModulesStore.markModuleCollapsed(effect.canvasContext, effect.moduleId, !effect.isExpanded)
             }

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ModuleListModels.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ModuleListModels.kt
@@ -76,7 +76,7 @@ sealed class ModuleListEffect {
         val scrollToItemId: Long?
     ) : ModuleListEffect()
 
-    data class ScrollToItem(val moduleItemId: Long) : ModuleListEffect()
+    data class ScrollToItem(val moduleItemId: Long, val scrollToHeaderItem: Boolean = false) : ModuleListEffect()
     data class MarkModuleExpanded(
         val canvasContext: CanvasContext,
         val moduleId: Long,

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ModuleListUpdate.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ModuleListUpdate.kt
@@ -70,11 +70,17 @@ class ModuleListUpdate : UpdateInit<ModuleListModel, ModuleListEvent, ModuleList
                 if (event.pageData.lastPageResult?.isSuccess == true) {
                     val newModules = event.pageData.lastPageResult.dataOrThrow
                     newModel = newModel.copy(modules = model.modules + newModules)
-                    if (model.scrollToItemId != null
-                        && newModules.any { module -> module.items.any { it.id == model.scrollToItemId } }
-                    ) {
-                        newModel = newModel.copy(scrollToItemId = null)
-                        effects += ModuleListEffect.ScrollToItem(model.scrollToItemId)
+                    if (model.scrollToItemId != null) {
+                        if (newModules.any { module -> module.items.any { it.id == model.scrollToItemId } }) {
+                            newModel = newModel.copy(scrollToItemId = null)
+                            effects += ModuleListEffect.ScrollToItem(model.scrollToItemId)
+                        } else if (newModules.any { it.id == model.scrollToItemId }) {
+                            newModel = newModel.copy(scrollToItemId = null)
+                            val idToScroll = newModules.first { it.id == model.scrollToItemId }.items.firstOrNull()?.id
+                            idToScroll?.let {
+                                effects += ModuleListEffect.ScrollToItem(it, true)
+                            }
+                        }
                     }
                 }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ui/ModuleListView.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/modules/list/ui/ModuleListView.kt
@@ -221,9 +221,12 @@ class ModuleListView(
         RouteMatcher.route(activity as FragmentActivity, route)
     }
 
-    fun scrollToItem(itemId: Long) {
+    fun scrollToItem(itemId: Long, scrollToModuleHeader: Boolean = false) {
         val itemPosition = adapter.getItemVisualPosition(itemId)
-        binding.recyclerView.scrollToPosition(itemPosition)
+        val scrollPosition = itemPosition - if (scrollToModuleHeader) 1 else 0
+        if (scrollPosition >= 0) {
+            binding.recyclerView.scrollToPosition(scrollPosition)
+        }
     }
 
     fun showConfirmationDialog(


### PR DESCRIPTION
I had to do this a bit hacky way, because of this legacy RecyclerView used here. There is no way that we can get the positions of the headers, so we just subtract one from the first item's position in it's group.

Test plan: In the ticket

refs: MBL-18047
affects: Teacher
release note: none

## Checklist

- [x] Tested in light mode
