### PR TITLE
[MBL-18668][Parent] Cannot open Gmail mailing app when clicking email link on Terms of Use page

### DIFF
--- a/apps/parent/src/main/AndroidManifest.xml
+++ b/apps/parent/src/main/AndroidManifest.xml
@@ -187,4 +187,16 @@
 
     </application>
 
+    <queries>
+        <intent>
+            <action android:name="android.media.action.IMAGE_CAPTURE" />
+        </intent>
+        <intent>
+            <action android:name="android.media.action.VIDEO_CAPTURE" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:mimeType="*/*" />
+        </intent>
+    </queries>
 </manifest>


### PR DESCRIPTION
Test plan: only test the email link, there was an other issue that got fixed on the release branch, the url-s are not gonna work until the release branch is merged back

refs: MBL-18668
affects: Parent
release note: none
