### PR TITLE
[MBL-18681][All] Compose message exit confirmation

### DIFF
--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/interaction/InboxComposeInteractionTest.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/interaction/InboxComposeInteractionTest.kt
@@ -317,10 +317,22 @@ abstract class InboxComposeInteractionTest : CanvasComposeTest() {
     }
 
     @Test
-    fun assertAlertDialogPopsOnExit() {
+    fun assertAlertDialogNotPopsOnExitWithoutModification() {
         val data = initData()
         goToInboxCompose(data)
         composeTestRule.waitForIdle()
+
+        inboxComposePage.pressBackButton()
+        inboxPage.assertInboxEmpty()
+    }
+
+    @Test
+    fun assertAlertDialogPopsOnExitWithModification() {
+        val data = initData()
+        goToInboxCompose(data)
+        composeTestRule.waitForIdle()
+
+        inboxComposePage.typeBody("Test Body")
 
         inboxComposePage.pressBackButton()
         inboxComposePage.assertAlertDialog()

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/compose/InboxComposeFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/compose/InboxComposeFragment.kt
@@ -143,7 +143,7 @@ class InboxComposeFragment : BaseCanvasFragment(), FragmentInteractions, FileUpl
 
     override fun onHandleBackPressed(): Boolean {
         val uiState = viewModel.uiState.value
-        if (!uiState.enableCustomBackHandler) return false
+        if (shouldAllowExit()) return false
 
         when (uiState.screenOption) {
             is InboxComposeScreenOptions.None -> {
@@ -171,7 +171,7 @@ class InboxComposeFragment : BaseCanvasFragment(), FragmentInteractions, FileUpl
 
     // For Teacher BottomSheetDialog handling
     fun shouldAllowExit(): Boolean {
-        return !viewModel.uiState.value.enableCustomBackHandler
+        return !viewModel.uiState.value.enableCustomBackHandler || !viewModel.composeContentHasChanged()
     }
 
     fun handleExit() {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/compose/InboxComposeViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/compose/InboxComposeViewModel.kt
@@ -175,6 +175,7 @@ class InboxComposeViewModel @Inject constructor(
                                 )
                             )
                         }
+                        initialState = initialState.copy(recipientPickerUiState = uiState.value.recipientPickerUiState)
                     }
                 }
             }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/compose/InboxComposeViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/compose/InboxComposeViewModel.kt
@@ -67,6 +67,7 @@ class InboxComposeViewModel @Inject constructor(
     val events = _events.receiveAsFlow()
 
     private val options = savedStateHandle.get<InboxComposeOptions>(InboxComposeOptions.COMPOSE_PARAMETERS)
+    private var initialState: InboxComposeUiState
 
     private val debouncedInnerSearch = debounce<String>(waitMs = 200, coroutineScope = viewModelScope) { searchQuery ->
         val contextId = uiState.value.selectContextUiState.selectedCanvasContext?.contextId ?: return@debounce
@@ -98,7 +99,19 @@ class InboxComposeViewModel @Inject constructor(
         if (options != null) {
             initFromOptions(options)
         }
+        initialState = uiState.value
         loadSignature()
+    }
+
+    fun composeContentHasChanged(): Boolean {
+        return uiState.value.let {
+            it.selectContextUiState.selectedCanvasContext != initialState.selectContextUiState.selectedCanvasContext ||
+            it.recipientPickerUiState.selectedRecipients != initialState.recipientPickerUiState.selectedRecipients ||
+            it.sendIndividual != initialState.sendIndividual ||
+            it.subject.text != initialState.subject.text ||
+            it.body.text != initialState.body.text ||
+            it.attachments != initialState.attachments
+        }
     }
 
     private fun initFromOptions(options: InboxComposeOptions?) {
@@ -419,6 +432,7 @@ class InboxComposeViewModel @Inject constructor(
                 _uiState.update { it.copy(
                     body = TextFieldValue(it.body.text.plus(signatureFooter))
                 ) }
+                initialState = initialState.copy(body = TextFieldValue(uiState.value.body.text))
             }
         }
     }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/compose/composables/InboxComposeScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/compose/composables/InboxComposeScreen.kt
@@ -112,7 +112,7 @@ fun InboxComposeScreen(
             topBar = {
                 CanvasAppBar(
                     title = title,
-                    navigationActionClick = { actionHandler(InboxComposeActionHandler.CancelDismissDialog(true)) },
+                    navigationActionClick = { actionHandler(InboxComposeActionHandler.Close) },
                     actions = {
                         if (uiState.screenState == ScreenState.Loading) {
                             Loading(

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/inbox/compose/InboxComposeViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/inbox/compose/InboxComposeViewModelTest.kt
@@ -357,6 +357,36 @@ class InboxComposeViewModelTest {
     }
 
     @Test
+    fun `Check if Compose content had been changed`() {
+        val viewModel = getViewModel()
+        assertEquals(false, viewModel.composeContentHasChanged())
+
+        viewModel.handleAction(InboxComposeActionHandler.SubjectChanged(TextFieldValue("Subject")))
+        assertEquals(true, viewModel.composeContentHasChanged())
+        viewModel.handleAction(InboxComposeActionHandler.SubjectChanged(TextFieldValue("")))
+        assertEquals(false, viewModel.composeContentHasChanged())
+
+        viewModel.handleAction(InboxComposeActionHandler.BodyChanged(TextFieldValue("Body")))
+        assertEquals(true, viewModel.composeContentHasChanged())
+        viewModel.handleAction(InboxComposeActionHandler.BodyChanged(TextFieldValue("")))
+        assertEquals(false, viewModel.composeContentHasChanged())
+
+        viewModel.handleAction(InboxComposeActionHandler.SendIndividualChanged(true))
+        assertEquals(true, viewModel.composeContentHasChanged())
+        viewModel.handleAction(InboxComposeActionHandler.SendIndividualChanged(false))
+        assertEquals(false, viewModel.composeContentHasChanged())
+
+        val recipient = Recipient(stringId = "1")
+        viewModel.handleAction(InboxComposeActionHandler.AddRecipient(recipient))
+        assertEquals(true, viewModel.composeContentHasChanged())
+        viewModel.handleAction(InboxComposeActionHandler.RemoveRecipient(recipient))
+        assertEquals(false, viewModel.composeContentHasChanged())
+
+        viewModel.handleAction(ContextPickerActionHandler.ContextClicked(Course()))
+        assertEquals(true, viewModel.composeContentHasChanged())
+    }
+
+    @Test
     fun `Attachment selector dialog opens`() = runTest {
         val viewmodel = getViewModel()
 


### PR DESCRIPTION
Test plan: See ticket

refs: MBL-18681
affects: Student, Teacher, Parent
release note: The inbox compose message exit confirmation is now only displayed after changes have been made.

## Checklist

- [x] Tested in dark mode
- [x] Tested in light mode