### PR TITLE
[MBL-18669][Student][Teacher] Terms of Use page 'Webpage not available'

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/features/legal/StudentLegalRouter.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/legal/StudentLegalRouter.kt
@@ -25,7 +25,7 @@ import com.instructure.student.activity.InternalWebViewActivity
 class StudentLegalRouter(private val context: Context) : LegalRouter {
     override fun routeToTermsOfService(html: String) {
         val intent = InternalWebViewActivity.createIntent(
-            context, "http://www.canvaslms.com/policies/terms-of-use", html, context.getString(
+            context, "https://www.canvaslms.com/policies/terms-of-use", html, context.getString(
                 R.string.termsOfUse
             ), false
         )

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/legal/TeacherLegalRouter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/legal/TeacherLegalRouter.kt
@@ -27,7 +27,7 @@ class TeacherLegalRouter(private val context: Context) : LegalRouter {
 
     override fun routeToTermsOfService(html: String) {
         val intent = InternalWebViewActivity.createIntent(
-            context, "http://www.canvaslms.com/policies/terms-of-use", html, context.getString(
+            context, "https://www.canvaslms.com/policies/terms-of-use", html, context.getString(
                 R.string.termsOfUse
             ), false
         )

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/legal/LegalDialogFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/legal/LegalDialogFragment.kt
@@ -23,6 +23,7 @@ import android.widget.ImageView
 import androidx.appcompat.app.AlertDialog
 import com.instructure.canvasapi2.managers.UserManager
 import com.instructure.canvasapi2.models.TermsOfService
+import com.instructure.canvasapi2.utils.APIHelper
 import com.instructure.canvasapi2.utils.weave.awaitApi
 import com.instructure.canvasapi2.utils.weave.catch
 import com.instructure.canvasapi2.utils.weave.tryWeave
@@ -34,6 +35,7 @@ import com.instructure.pandautils.utils.accessibilityClassName
 import com.instructure.pandautils.utils.descendants
 import com.instructure.pandautils.utils.onClickWithRequireNetwork
 import com.instructure.pandautils.utils.setVisible
+import com.instructure.pandautils.utils.showNoConnectionDialog
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Job
 import javax.inject.Inject
@@ -77,8 +79,12 @@ class LegalDialogFragment : BaseCanvasDialogFragment() {
         val dialog = builder.create()
 
         binding.termsOfUse.setOnClickListener {
-            legalRouter.routeToTermsOfService(html)
-            dialog.dismiss()
+            if (html.isBlank() && !APIHelper.hasNetworkConnection()) {
+                showNoConnectionDialog(requireContext())
+            } else {
+                legalRouter.routeToTermsOfService(html)
+                dialog.dismiss()
+            }
         }
 
         binding.termsOfUse.accessibilityClassName(Button::class.java.name)


### PR DESCRIPTION
Test plan: In the ticket. Actually it's quite hard to reproduce this in the Student because once you login the terms of use is requested and it will be cached, so it will open correctly. In the teacher we only request it on the LegalDialog, so you can test there. Just go offline after a new login and before opening the legal dialog.

refs: MBL-18669
affects: Student, Teacher
release note: none

## Checklist

- [x] Tested in light mode
