### PR TITLE
[MBL-18680][Student] Quiz results for locked New Quizzes

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsUpdate.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/SubmissionDetailsUpdate.kt
@@ -171,7 +171,7 @@ class SubmissionDetailsUpdate : UpdateInit<SubmissionDetailsModel, SubmissionDet
             Assignment.SubmissionType.NONE.apiString in assignment?.submissionTypesRaw.orEmpty() -> SubmissionDetailsContentType.NoneContent
             Assignment.SubmissionType.ON_PAPER.apiString in assignment?.submissionTypesRaw.orEmpty() -> SubmissionDetailsContentType.OnPaperContent
             Assignment.SubmissionType.EXTERNAL_TOOL.apiString in assignment?.submissionTypesRaw.orEmpty() -> {
-                if (assignment?.isAllowedToSubmit == true)
+                if (assignment != null && (assignment.isAllowedToSubmit || submission?.workflowState != "unsubmitted"))
                     SubmissionDetailsContentType.ExternalToolContent(canvasContext, ltiTool, assignment.name.orEmpty(), assignment.ltiToolType())
                 else SubmissionDetailsContentType.LockedContent
             }

--- a/apps/student/src/test/java/com/instructure/student/test/assignment/details/submissionDetails/SubmissionDetailsUpdateTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/test/assignment/details/submissionDetails/SubmissionDetailsUpdateTest.kt
@@ -315,13 +315,25 @@ class SubmissionDetailsUpdateTest : Assert() {
     }
 
     @Test
-    fun `EXTERNAL_TOOL with locked assignment results in SubmissionDetailsContentType of LockedContent`() {
+    fun `EXTERNAL_TOOL with locked assignment results in SubmissionDetailsContentType of LockedContent without Submission`() {
+        verifyGetSubmissionContentType(
+            assignment.copy(
+                submissionTypesRaw = listOf(Assignment.SubmissionType.EXTERNAL_TOOL.apiString),
+                lockedForUser = true),
+            submission.copy(workflowState = "unsubmitted"),
+            SubmissionDetailsContentType.LockedContent,
+            ltiTool
+        )
+    }
+
+    @Test
+    fun `EXTERNAL_TOOL with locked assignment results in SubmissionDetailsContentType of ExternalToolContent with Submission`() {
         verifyGetSubmissionContentType(
             assignment.copy(
                 submissionTypesRaw = listOf(Assignment.SubmissionType.EXTERNAL_TOOL.apiString),
                 lockedForUser = true),
             submission,
-            SubmissionDetailsContentType.LockedContent,
+            SubmissionDetailsContentType.ExternalToolContent(course, ltiTool, assignment.name!!),
             ltiTool
         )
     }


### PR DESCRIPTION
Test plan: See ticket

refs: MBL-18680
affects: Student
release note: Quiz results can now be viewed for locked New Quizzes

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/6e026f30-0f03-4a4c-b20d-4bee9b2ba080" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/7c4c6504-01a5-4bac-9ebc-4a0a61ae3572" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Tested in light mode
