### PR TITLE
[MBL-18705][Student] Fix Module items continuously reload

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/features/modules/list/ModuleListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/modules/list/ModuleListFragment.kt
@@ -36,7 +36,13 @@ import com.instructure.interactions.router.RouterParams
 import com.instructure.pandautils.analytics.SCREEN_VIEW_MODULE_LIST
 import com.instructure.pandautils.analytics.ScreenView
 import com.instructure.pandautils.binding.viewBinding
-import com.instructure.pandautils.utils.*
+import com.instructure.pandautils.utils.Const
+import com.instructure.pandautils.utils.ParcelableArg
+import com.instructure.pandautils.utils.ViewStyler
+import com.instructure.pandautils.utils.isTablet
+import com.instructure.pandautils.utils.makeBundle
+import com.instructure.pandautils.utils.setVisible
+import com.instructure.pandautils.utils.setupAsBackButton
 import com.instructure.student.R
 import com.instructure.student.databinding.FragmentModuleListBinding
 import com.instructure.student.databinding.PandaRecyclerRefreshLayoutBinding
@@ -162,7 +168,7 @@ class ModuleListFragment : ParentFragment(), Bookmarkable {
                 // Remove all the subheaders and stuff.
                 val groups = recyclerAdapter?.groups ?: arrayListOf()
 
-                val moduleItemsArray = groups.indices.mapTo(ArrayList()) { recyclerAdapter?.getItems(groups[it]) ?: arrayListOf() }
+                val moduleItemsArray = groups.indices.mapTo(ArrayList()) { recyclerAdapter?.getItems(groups[it]) }
                 val moduleHelper = ModuleProgressionUtility.prepareModulesForCourseProgression(
                     requireContext(), moduleItem.id, groups, moduleItemsArray
                 )

--- a/apps/student/src/main/java/com/instructure/student/features/modules/progression/CourseModuleProgressionFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/modules/progression/CourseModuleProgressionFragment.kt
@@ -82,7 +82,6 @@ import com.instructure.student.fragment.ParentFragment
 import com.instructure.student.router.RouteMatcher
 import com.instructure.student.util.Const
 import com.instructure.student.util.CourseModulesStore
-import com.pspdfkit.internal.utilities.toArrayList
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -746,12 +745,12 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
                    else -> sequenceItems[0].current
                 }
                 val moduleItems = repository.getAllModuleItems(canvasContext, current!!.moduleId, true)
-                val unfilteredItems = ArrayList<ArrayList<ModuleItem>>(1).apply { add(ArrayList(moduleItems)) }
+                val unfilteredItems = ArrayList<ArrayList<ModuleItem>?>(1).apply { add(ArrayList(moduleItems)) }
                 modules = ArrayList<ModuleObject>(1).apply { moduleItemSequence.modules!!.firstOrNull { it.id == current?.moduleId }?.let { add(it) } }
                 val moduleHelper = ModuleProgressionUtility.prepareModulesForCourseProgression(requireContext(), current!!.id, modules, unfilteredItems)
                 groupPos = moduleHelper.newGroupPosition
                 childPos = moduleHelper.newChildPosition
-                items = moduleHelper.strippedModuleItems.map { it.toArrayList() }.toArrayList()
+                items = moduleHelper.strippedModuleItems
             } else {
                 binding.progressBar.setGone()
                 val moduleItemAsset = ModuleItemAsset.fromAssetType(assetType) ?: ModuleItemAsset.MODULE_ITEM

--- a/apps/student/src/main/java/com/instructure/student/features/modules/progression/CourseModuleProgressionFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/modules/progression/CourseModuleProgressionFragment.kt
@@ -346,6 +346,8 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
                 // Update the module item locally, needed to unlock modules as the user ViewPages through them
                 getCurrentModuleItem(currentPos)?.completionRequirement?.completed = true
 
+                setupNextModule(getModuleItemGroup(currentPos))
+
                 // Update the module state to indicate in the list that the module is completed
                 val module = modules.find { it.id == moduleItem.moduleId } ?: return@tryWeave
                 val isModuleCompleted = items.flatten().filter { it.moduleId == moduleItem.moduleId }.all { it.completionRequirement?.completed.orDefault() }
@@ -786,11 +788,9 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
         private const val NAVIGATED_FROM_MODULES = "navigated_from_modules"
 
 
-        //we don't want to add subheaders or external tools into the list. subheaders don't do anything and we
-        //don't support external tools.
+        //we don't want to add external tools into the list. we don't support external tools.
         fun shouldAddModuleItem(context: Context, moduleItem: ModuleItem): Boolean = when (moduleItem.type) {
             "UnlockRequirements" -> false
-            "SubHeader" -> false
             else -> !moduleItem.title.equals(context.getString(R.string.loading), ignoreCase = true)
         }
 

--- a/apps/student/src/main/java/com/instructure/student/features/modules/progression/CourseModuleProgressionFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/modules/progression/CourseModuleProgressionFragment.kt
@@ -346,8 +346,6 @@ class CourseModuleProgressionFragment : ParentFragment(), Bookmarkable {
                 // Update the module item locally, needed to unlock modules as the user ViewPages through them
                 getCurrentModuleItem(currentPos)?.completionRequirement?.completed = true
 
-                setupNextModule(getModuleItemGroup(currentPos))
-
                 // Update the module state to indicate in the list that the module is completed
                 val module = modules.find { it.id == moduleItem.moduleId } ?: return@tryWeave
                 val isModuleCompleted = items.flatten().filter { it.moduleId == moduleItem.moduleId }.all { it.completionRequirement?.completed.orDefault() }

--- a/apps/student/src/main/java/com/instructure/student/features/modules/util/ModuleProgressionUtility.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/modules/util/ModuleProgressionUtility.kt
@@ -26,7 +26,7 @@ object ModuleProgressionUtility {
         context: Context,
         moduleItemId: Long,
         modules: ArrayList<ModuleObject>,
-        moduleItems: ArrayList<ArrayList<ModuleItem>>
+        moduleItems: ArrayList<ArrayList<ModuleItem>?>
     ): ModuleHelper {
         // We want to give CourseModuleProgressionFragment an arrayList without SubHeaders and ExternalTool moduleItems.
         // We currently don't display them and there isn't a good way to just skip over them during the progression.
@@ -34,12 +34,18 @@ object ModuleProgressionUtility {
         // checks/math to account for skipping over sub-headers and external tools.
 
         // Remove all the subHeaders and external tools items from the children list. We won't display them in module progression
-        val headerlessItems = ArrayList<ArrayList<ModuleItem>>()
+        val headerlessItems = ArrayList<ArrayList<ModuleItem>?>()
         for (i in modules.indices) {
+            val moduleGroup = moduleItems[i]
+            if (moduleGroup == null) {
+                headerlessItems.add(null)
+                continue
+            }
             headerlessItems.add(ArrayList())
-            for (k in moduleItems[i].indices) {
-                if (shouldAddModuleItem(context, moduleItems[i][k])) {
-                    headerlessItems[i].add(moduleItems[i][k])
+            for (k in moduleGroup.indices) {
+                val moduleItem = moduleGroup[k]
+                if (shouldAddModuleItem(context, moduleItem)) {
+                    headerlessItems[i]?.add(moduleItem)
                 }
             }
         }
@@ -50,8 +56,9 @@ object ModuleProgressionUtility {
         var newGroupPos = 0
         var newChildPos = 0
         for (i in headerlessItems.indices) {
-            for (k in headerlessItems[i].indices) {
-                if (moduleItemId == headerlessItems[i][k].id) {
+            val moduleGroup = headerlessItems[i] ?: continue
+            for (k in moduleGroup.indices) {
+                if (moduleItemId == moduleGroup[k].id) {
                     newGroupPos = i
                     newChildPos = k
                     break
@@ -62,7 +69,7 @@ object ModuleProgressionUtility {
     }
 
     data class ModuleHelper(
-        var strippedModuleItems: ArrayList<ArrayList<ModuleItem>>,
+        var strippedModuleItems: ArrayList<ArrayList<ModuleItem>?>,
         var newGroupPosition: Int = 0,
         var newChildPosition: Int = 0
     )

--- a/apps/student/src/main/java/com/instructure/student/util/CourseModulesStore.kt
+++ b/apps/student/src/main/java/com/instructure/student/util/CourseModulesStore.kt
@@ -19,10 +19,9 @@ package com.instructure.student.util
 
 import com.instructure.canvasapi2.models.ModuleItem
 import com.instructure.canvasapi2.models.ModuleObject
-import java.util.ArrayList
 
 object CourseModulesStore {
 
-    var moduleListItems: ArrayList<ArrayList<ModuleItem>>? = null
+    var moduleListItems: ArrayList<ArrayList<ModuleItem>?>? = null
     var moduleObjects: ArrayList<ModuleObject>? = null
 }


### PR DESCRIPTION
Test plan: See ticket

Reason of the bug:
Previously empty list meant that the module's items hadn't been initialised. If a module had only a sub header which is not handled as valid module item the app got into an infinite loop as the list of module items was always empty.
Solution for the bug:
Differentiate uninitialised modules and empty modules with null values.

refs: MBL-18705
affects: Student
release note: none

## Checklist

- [x] Tested in light mode
