### PR TITLE
[MBL-18747][Parent] CourseDetailsScreen crash fix

### DIFF
--- a/apps/parent/src/main/java/com/instructure/parentapp/features/courses/details/CourseDetailsScreen.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/courses/details/CourseDetailsScreen.kt
@@ -132,7 +132,9 @@ private fun CourseDetailsScreenContent(
 
     LaunchedEffect(pagerState) {
         snapshotFlow { pagerState.currentPage }.collect { page ->
-            actionHandler(CourseDetailsAction.CurrentTabChanged(uiState.tabs[page]))
+            uiState.tabs.getOrNull(page)?.let {
+                actionHandler(CourseDetailsAction.CurrentTabChanged(it))
+            }
         }
     }
 


### PR DESCRIPTION
Test plan: test if course details screen compose message has the correct subject by tab 

refs: MBL-18747
affects: Parent
release note: none
