### PR TITLE
[MBL-18748][Parent] FileDownloader.downloadFileToDevice permission error

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/FileDownloader.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/FileDownloader.kt
@@ -18,6 +18,7 @@ package com.instructure.pandautils.utils
 import android.app.DownloadManager
 import android.content.Context
 import android.net.Uri
+import android.os.Build
 import android.os.Environment
 import android.webkit.CookieManager
 import com.instructure.canvasapi2.models.Attachment
@@ -51,7 +52,12 @@ class FileDownloader(
             .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
             .setTitle(filename)
             .setMimeType(contentType)
-            .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, "$filename")
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, filename)
+        } else {
+            request.setDestinationInExternalFilesDir(context, Environment.DIRECTORY_DOWNLOADS, filename)
+        }
 
         if (cookie?.isNotEmpty().orDefault()) {
             request.addRequestHeader("Cookie", cookie)


### PR DESCRIPTION
Test plan: test file downloader on Android 9, Android 10 and Android 11+, it should work in all cases. (It can be tested downloading a file from Inbox or Announcement Details.)

refs: MBL-18748
affects: Parent
release note: none
