### PR TITLE
[MBL-18753][Parent] Grading Period filter complaints

### DIFF
--- a/apps/parent/src/main/java/com/instructure/parentapp/features/grades/ParentGradesRepository.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/grades/ParentGradesRepository.kt
@@ -29,6 +29,7 @@ import com.instructure.canvasapi2.models.Enrollment
 import com.instructure.canvasapi2.models.GradingPeriod
 import com.instructure.canvasapi2.utils.depaginate
 import com.instructure.pandautils.features.grades.GradesRepository
+import com.instructure.pandautils.features.grades.gradepreferences.SortBy
 import com.instructure.pandautils.utils.orDefault
 import com.instructure.parentapp.util.ParentPrefs
 
@@ -36,7 +37,7 @@ import com.instructure.parentapp.util.ParentPrefs
 class ParentGradesRepository(
     private val assignmentApi: AssignmentAPI.AssignmentInterface,
     private val courseApi: CourseAPI.CoursesInterface,
-    parentPrefs: ParentPrefs
+    private val parentPrefs: ParentPrefs
 ) : GradesRepository {
 
     override val studentId = parentPrefs.currentStudent?.id.orDefault()
@@ -84,5 +85,15 @@ class ParentGradesRepository(
             enrollment,
             firstEnrollment == null && gradingPeriodId == null
         )
+    }
+
+    override fun getSortBy(): SortBy? {
+        return parentPrefs.gradesSortBy?.let {
+            SortBy.valueOf(it)
+        }
+    }
+
+    override fun setSortBy(sortBy: SortBy) {
+        parentPrefs.gradesSortBy = sortBy.name
     }
 }

--- a/apps/parent/src/main/java/com/instructure/parentapp/util/ParentPrefs.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/util/ParentPrefs.kt
@@ -20,6 +20,7 @@ package com.instructure.parentapp.util
 import com.instructure.canvasapi2.models.User
 import com.instructure.canvasapi2.utils.BooleanPref
 import com.instructure.canvasapi2.utils.GsonPref
+import com.instructure.canvasapi2.utils.NStringPref
 import com.instructure.canvasapi2.utils.PrefManager
 import kotlin.reflect.KMutableProperty0
 
@@ -28,6 +29,10 @@ object ParentPrefs : PrefManager("parentSP") {
 
     var currentStudent: User? by GsonPref(User::class.java, null, "current_student", false)
     var hasMigrated: Boolean by BooleanPref(false, "has_migrated_data_from_old_app")
+    var gradesSortBy: String? by NStringPref(null, "grades_sort_by")
 
-    override fun keepBaseProps(): List<KMutableProperty0<out Any?>> = listOf(::hasMigrated)
+    override fun keepBaseProps(): List<KMutableProperty0<out Any?>> = listOf(
+        ::hasMigrated,
+        ::gradesSortBy
+    )
 }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/ModelExtensions.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/ModelExtensions.kt
@@ -25,6 +25,7 @@ import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.Attachment
 import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.models.Enrollment
+import com.instructure.canvasapi2.models.GradingPeriod
 import com.instructure.canvasapi2.models.GradingSchemeRow
 import com.instructure.canvasapi2.models.MediaComment
 import com.instructure.canvasapi2.models.ModuleItem
@@ -211,4 +212,9 @@ fun convertPercentScoreToLetterGrade(percentScore: Double, gradingScheme: List<G
 
 fun convertPercentToPointBased(percentScore: Double, scalingFactor: Double): String {
     return String.format("%.2f / %.2f", scalingFactor * (percentScore / 100.0), scalingFactor)
+}
+
+fun List<GradingPeriod>.getCurrentGradingPeriod(): GradingPeriod? {
+    val currentDate = Date()
+    return this.firstOrNull { it.startDate?.toDate()?.before(currentDate) == true && it.endDate?.toDate()?.after(currentDate) == true }
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/grades/GradesRepository.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/grades/GradesRepository.kt
@@ -22,6 +22,7 @@ import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.models.CourseGrade
 import com.instructure.canvasapi2.models.Enrollment
 import com.instructure.canvasapi2.models.GradingPeriod
+import com.instructure.pandautils.features.grades.gradepreferences.SortBy
 
 
 interface GradesRepository {
@@ -32,4 +33,6 @@ interface GradesRepository {
     suspend fun loadEnrollments(courseId: Long, gradingPeriodId: Long?, forceRefresh: Boolean): List<Enrollment>
     suspend fun loadCourse(courseId: Long, forceRefresh: Boolean): Course
     fun getCourseGrade(course: Course, studentId: Long, enrollments: List<Enrollment>, gradingPeriodId: Long?): CourseGrade?
+    fun getSortBy(): SortBy?
+    fun setSortBy(sortBy: SortBy)
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/grades/GradesViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/grades/GradesViewModel.kt
@@ -26,6 +26,7 @@ import com.instructure.canvasapi2.models.AssignmentGroup
 import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.models.CourseGrade
 import com.instructure.canvasapi2.utils.DateHelper
+import com.instructure.canvasapi2.utils.getCurrentGradingPeriod
 import com.instructure.canvasapi2.utils.toDate
 import com.instructure.canvasapi2.utils.weave.catch
 import com.instructure.canvasapi2.utils.weave.tryLaunch
@@ -70,10 +71,13 @@ class GradesViewModel @Inject constructor(
     private var courseGrade: CourseGrade? = null
 
     init {
-        loadGrades(false)
+        loadGrades(
+            forceRefresh = false,
+            initialize = true
+        )
     }
 
-    private fun loadGrades(forceRefresh: Boolean) {
+    private fun loadGrades(forceRefresh: Boolean, initialize: Boolean = false) {
         viewModelScope.tryLaunch {
             _uiState.update {
                 it.copy(
@@ -90,13 +94,24 @@ class GradesViewModel @Inject constructor(
             val course = repository.loadCourse(courseId, forceRefresh)
             this@GradesViewModel.course = course
             val gradingPeriods = repository.loadGradingPeriods(courseId, forceRefresh)
-            val selectedGradingPeriodId = _uiState.value.gradePreferencesUiState.selectedGradingPeriod?.id
-            val assignmentGroups = repository.loadAssignmentGroups(courseId, selectedGradingPeriodId, forceRefresh).filterHiddenAssignments()
-            val enrollments = repository.loadEnrollments(courseId, selectedGradingPeriodId, forceRefresh)
+            val currentGradingPeriod = gradingPeriods.getCurrentGradingPeriod()
 
-            courseGrade = repository.getCourseGrade(course, repository.studentId, enrollments, selectedGradingPeriodId)
+            var selectedGradingPeriod = _uiState.value.gradePreferencesUiState.selectedGradingPeriod
+            var sortBy = _uiState.value.gradePreferencesUiState.sortBy
 
-            val items = when (_uiState.value.gradePreferencesUiState.sortBy) {
+            if (initialize) {
+                selectedGradingPeriod = currentGradingPeriod
+                sortBy = repository.getSortBy() ?: sortBy
+            } else {
+                repository.setSortBy(_uiState.value.gradePreferencesUiState.sortBy)
+            }
+
+            val assignmentGroups = repository.loadAssignmentGroups(courseId, selectedGradingPeriod?.id, forceRefresh).filterHiddenAssignments()
+            val enrollments = repository.loadEnrollments(courseId, selectedGradingPeriod?.id, forceRefresh)
+
+            courseGrade = repository.getCourseGrade(course, repository.studentId, enrollments, selectedGradingPeriod?.id)
+
+            val items = when (sortBy) {
                 SortBy.GROUP -> groupByAssignmentGroup(assignmentGroups)
                 SortBy.DUE_DATE -> groupByDueDate(assignmentGroups)
             }.filter {
@@ -110,7 +125,10 @@ class GradesViewModel @Inject constructor(
                     isRefreshing = false,
                     gradePreferencesUiState = it.gradePreferencesUiState.copy(
                         courseName = course.name,
-                        gradingPeriods = gradingPeriods
+                        gradingPeriods = gradingPeriods,
+                        defaultGradingPeriod = currentGradingPeriod,
+                        selectedGradingPeriod = selectedGradingPeriod,
+                        sortBy = sortBy
                     ),
                     gradeText = gradeFormatter.getGradeString(course, courseGrade, !it.onlyGradedAssignmentsSwitchEnabled),
                     isGradeLocked = courseGrade?.isLocked.orDefault()

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/grades/gradepreferences/GradePreferencesUiState.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/grades/gradepreferences/GradePreferencesUiState.kt
@@ -27,11 +27,12 @@ data class GradePreferencesUiState(
     val canvasContextColor: Int = android.graphics.Color.BLACK,
     val courseName: String = "",
     val gradingPeriods: List<GradingPeriod> = emptyList(),
+    val defaultGradingPeriod: GradingPeriod? = null,
     val selectedGradingPeriod: GradingPeriod? = null,
     val sortBy: SortBy = SortBy.DUE_DATE
 ) {
     val isDefault: Boolean
-        get() = selectedGradingPeriod == null && sortBy == SortBy.DUE_DATE
+        get() = selectedGradingPeriod == defaultGradingPeriod && sortBy == SortBy.DUE_DATE
 }
 
 enum class SortBy(@StringRes val titleRes: Int) {


### PR DESCRIPTION
Test plan: grades by default should be filtered by the current grading period (if theres no current then All Periods), should be grouped by Due Date by default, but should be saved when changed

refs: MBL-18753
affects: Parent
release note: In the Grades Filter, the default grading period is now set to the current one, and the sorting preference is saved.

## Checklist

- [x] Approve from product
