### PR TITLE
Hide bottom divider when bottomnavbar is not visible

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
@@ -50,8 +50,6 @@ import com.airbnb.lottie.LottieAnimationView
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.instructure.canvasapi2.CanvasRestAdapter
-import com.instructure.canvasapi2.apis.OAuthAPI
-import com.instructure.canvasapi2.builders.RestParams
 import com.instructure.canvasapi2.managers.GroupManager
 import com.instructure.canvasapi2.managers.UserManager
 import com.instructure.canvasapi2.models.CanvasContext
@@ -322,7 +320,7 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
              from external sources. */
             val visible = isBottomNavFragment(it) || supportFragmentManager.backStackEntryCount <= 1
             binding.bottomBar.setVisible(visible)
-            binding.divider.setVisible(visible)
+            binding.bottomBarDivider.setVisible(visible)
         }
     }
 
@@ -451,7 +449,7 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
         currentFragment?.let {
             val visible = isBottomNavFragment(it) || supportFragmentManager.backStackEntryCount <= 1
             binding.bottomBar.setVisible(visible)
-            binding.divider.setVisible(visible)
+            binding.bottomBarDivider.setVisible(visible)
         }
     }
 

--- a/apps/student/src/main/res/layout/activity_navigation.xml
+++ b/apps/student/src/main/res/layout/activity_navigation.xml
@@ -52,11 +52,10 @@
             android:visibility="gone" />
 
         <View
-            android:id="@+id/divider"
+            android:id="@+id/bottomBarDivider"
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:background="@color/backgroundLight"
-            app:layout_constraintTop_toTopOf="parent" />
+            android:background="@color/backgroundLight" />
 
         <com.google.android.material.bottomnavigation.BottomNavigationView
             android:id="@+id/bottomBar"


### PR DESCRIPTION
affects: Student
release note: Removed unnecessary bottom divider.