### PR TITLE
[MBL-18786][Student] Fix Pages enabled tabs routing.

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/router/EnabledTabs.kt
+++ b/apps/student/src/main/java/com/instructure/student/router/EnabledTabs.kt
@@ -28,6 +28,8 @@ class EnabledTabsImpl: EnabledTabs {
             pathSegments.last() == "grades" -> true
             pathSegments.last() == "discussion_topics" -> true
             pathSegments.any { it.contains("external_tools") } -> true
+            pathSegments.last() == "wiki" -> tabs.any { it.tabId == Tab.PAGES_ID }
+            pathSegments.last() == "pages" -> tabs.any { it.tabId == Tab.PAGES_ID }
             pathSegments.last() == Tab.SYLLABUS_ID -> tabs.any { relativePath == it.htmlUrl }
             pathSegments.size == 3 -> tabs.any { relativePath == it.htmlUrl }
             else -> true

--- a/apps/student/src/test/java/com/instructure/student/router/EnabledTabsTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/router/EnabledTabsTest.kt
@@ -285,4 +285,38 @@ class EnabledTabsTest {
         val result = enabledTabs.isPathTabNotEnabled(route)
         assertFalse(result)
     }
+
+    @Test
+    fun `routing to pages with wiki url`() = runTest {
+        coEvery { courseApi.getFirstPageCourses(any()) } returns DataResult.Success(
+            listOf(
+                Course(id = 1, tabs = listOf(Tab(tabId = Tab.PAGES_ID, htmlUrl = "/courses/1/pages"))),
+            )
+        )
+
+        enabledTabs.initTabs()
+
+        val route = Route(uri = mockUri)
+        every { mockUri.path } returns "http://www.google.com/courses/1/wiki"
+        every { mockUri.pathSegments } returns listOf("courses", "1", "wiki")
+        val result = enabledTabs.isPathTabNotEnabled(route)
+        assertFalse(result)
+    }
+
+    @Test
+    fun `routing to wiki with pages url`() = runTest {
+        coEvery { courseApi.getFirstPageCourses(any()) } returns DataResult.Success(
+            listOf(
+                Course(id = 1, tabs = listOf(Tab(tabId = Tab.PAGES_ID, htmlUrl = "/courses/1/wiki"))),
+            )
+        )
+
+        enabledTabs.initTabs()
+
+        val route = Route(uri = mockUri)
+        every { mockUri.path } returns "http://www.google.com/courses/1/pages"
+        every { mockUri.pathSegments } returns listOf("courses", "1", "pages")
+        val result = enabledTabs.isPathTabNotEnabled(route)
+        assertFalse(result)
+    }
 }


### PR DESCRIPTION
Test plan: See ticket. Should work with 'wiki' and 'pages'

refs: MBL-18786
affects: Student
release note: Fixed a bug where navigating to Pages did not work in some cases.
