### PR TITLE
SEC-13032-VERSION-BUMP-NETTY-CODEC-HTTP

### DIFF
--- a/automation/soseedygrpc/build.gradle
+++ b/automation/soseedygrpc/build.gradle
@@ -23,11 +23,11 @@ dependencies {
     compile project(':dataseedingapi')
 
     // https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22io.grpc%22%20a%3A%22grpc-netty%22
-    compile 'io.grpc:grpc-netty:1.12.0'
+    compile 'io.grpc:grpc-netty:1.61.1'
     compile Libs.KOTLIN_STD_LIB
 
     // https://mvnrepository.com/artifact/io.netty/netty-tcnative-boringssl-static
-    compile 'io.netty:netty-tcnative-boringssl-static:2.0.8.Final'
+    compile 'io.netty:netty-tcnative-boringssl-static:2.0.62.Final'
 
     testCompile Libs.JUNIT
 }


### PR DESCRIPTION
Vulnerable transitive dependency: netty-coded-http

Test plan:
- Check data seeding works fine
- Try the DataSeedingTest in the teacher app
- Verify that the server starts with SSL enabled and disabled fine

refs: SEC-13032
affects: Data seeding