### PR TITLE
[MBL-18776][Teacher] Last assignment "assign to" cannot be deleted

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/DueDatesFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/DueDatesFragment.kt
@@ -86,9 +86,9 @@ class DueDatesFragment : BaseSyncFragment<DueDateGroup, DueDatesPresenter, DueDa
         ViewStyler.themeToolbarColored(requireActivity(), toolbar, mCourse.color, requireContext().getColor(R.color.textLightest))
     }
 
-    override fun showMenu(assignment: Assignment) {
-        binding.toolbar.setupMenu(R.menu.menu_edit_generic) {
-            if(APIHelper.hasNetworkConnection()) {
+    override fun showMenu(assignment: Assignment) = with(binding) {
+        toolbar.setupMenu(R.menu.menu_edit_generic) {
+            if (APIHelper.hasNetworkConnection()) {
                 when {
                     assignment.submissionTypesRaw.contains(Assignment.SubmissionType.ONLINE_QUIZ.apiString) -> {
                         val args = EditQuizDetailsFragment.makeBundle(assignment.quizId)
@@ -109,6 +109,7 @@ class DueDatesFragment : BaseSyncFragment<DueDateGroup, DueDatesPresenter, DueDa
                 NoInternetConnectionDialog.show(requireFragmentManager())
             }
         }
+        ViewStyler.themeToolbarColored(requireActivity(), toolbar, mCourse.color, requireContext().getColor(R.color.textLightest))
     }
 
     override fun onPresenterPrepared(presenter: DueDatesPresenter) {

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/EditAssignmentDetailsFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/EditAssignmentDetailsFragment.kt
@@ -383,7 +383,7 @@ class EditAssignmentDetailsFragment : BaseFragment() {
                 }
             }
 
-            v.setupOverride(index, dueDateGroup, editDateGroups.size > 1, assignees, datePickerOnClick, timePickerOnClick, removeOverrideClick) {
+            v.setupOverride(index, dueDateGroup, true, assignees, datePickerOnClick, timePickerOnClick, removeOverrideClick) {
                 val args = AssigneeListFragment.makeBundle(
                         editDateGroups,
                         index,
@@ -481,7 +481,7 @@ class EditAssignmentDetailsFragment : BaseFragment() {
                 saveButton?.setGone()
                 savingProgressBar.announceForAccessibility(getString(R.string.saving))
                 savingProgressBar.setVisible()
-                assignment = awaitApi { AssignmentManager.editAssignment(assignment.courseId, assignment.id, postData, it, false) }
+                assignment = awaitApi { AssignmentManager.editAssignment(assignment.courseId, assignment.id, postData, it, true) }
                 AssignmentUpdatedEvent(assignment.id).post() // Post bus event
                 toast(R.string.successfully_updated_assignment) // let the user know the assignment was saved
                 editAssignmentName.hideKeyboard() // close the keyboard

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/EditQuizDetailsFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/EditQuizDetailsFragment.kt
@@ -407,7 +407,7 @@ class EditQuizDetailsFragment : BasePresenterFragment<
                     }
                 }
 
-                v.setupOverride(index, dueDateGroup, mEditDateGroups.size > 1, assignees, datePickerOnClick, timePickerOnClick, removeOverrideClick) {
+                v.setupOverride(index, dueDateGroup, true, assignees, datePickerOnClick, timePickerOnClick, removeOverrideClick) {
                     val args = AssigneeListFragment.makeBundle(
                             mEditDateGroups,
                             index,
@@ -463,11 +463,18 @@ class EditQuizDetailsFragment : BasePresenterFragment<
      */
     private fun assembleAssignmentPostData(): AssignmentPostBody {
         return AssignmentPostBody().apply {
+            val assignment = presenter.mAssignment
+            name = assignment.name
+            description = assignment.description
+            pointsPossible = assignment.pointsPossible
+            gradingType = assignment.gradingType
+            submissionTypes = assignment.submissionTypesRaw
+
             setGroupedDueDates(presenter.mEditDateGroups)
             notifyOfUpdate = false
 
-            // Only set the published flag if we can unpublish/publish the assignment
-            if (presenter.mAssignment.unpublishable) published = mIsPublished
+            // only set the published flag if we can unpublish/publish the assignment
+            published = if (assignment.unpublishable) mIsPublished else assignment.published
         }
     }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/EditQuizDetailsFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/EditQuizDetailsFragment.kt
@@ -463,18 +463,8 @@ class EditQuizDetailsFragment : BasePresenterFragment<
      */
     private fun assembleAssignmentPostData(): AssignmentPostBody {
         return AssignmentPostBody().apply {
-            val assignment = presenter.mAssignment
-            name = assignment.name
-            description = assignment.description
-            pointsPossible = assignment.pointsPossible
-            gradingType = assignment.gradingType
-            submissionTypes = assignment.submissionTypesRaw
-
             setGroupedDueDates(presenter.mEditDateGroups)
             notifyOfUpdate = false
-
-            // only set the published flag if we can unpublish/publish the assignment
-            published = if (assignment.unpublishable) mIsPublished else assignment.published
         }
     }
 

--- a/apps/teacher/src/main/java/com/instructure/teacher/presenters/EditQuizDetailsPresenter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/presenters/EditQuizDetailsPresenter.kt
@@ -16,17 +16,26 @@
  */
 package com.instructure.teacher.presenters
 
-import com.instructure.canvasapi2.managers.*
-import com.instructure.canvasapi2.models.*
+import com.instructure.canvasapi2.managers.AssignmentManager
+import com.instructure.canvasapi2.managers.GroupCategoriesManager
+import com.instructure.canvasapi2.managers.QuizManager
+import com.instructure.canvasapi2.managers.SectionManager
+import com.instructure.canvasapi2.managers.UserManager
+import com.instructure.canvasapi2.models.Assignment
+import com.instructure.canvasapi2.models.CanvasContext
+import com.instructure.canvasapi2.models.Group
+import com.instructure.canvasapi2.models.Quiz
+import com.instructure.canvasapi2.models.Section
+import com.instructure.canvasapi2.models.User
 import com.instructure.canvasapi2.models.postmodels.AssignmentPostBody
 import com.instructure.canvasapi2.models.postmodels.QuizPostBody
 import com.instructure.canvasapi2.utils.weave.awaitApi
 import com.instructure.canvasapi2.utils.weave.weave
+import com.instructure.pandautils.blueprint.FragmentPresenter
 import com.instructure.teacher.events.QuizUpdatedEvent
 import com.instructure.teacher.events.post
 import com.instructure.teacher.models.DueDateGroup
 import com.instructure.teacher.viewinterface.EditQuizDetailsView
-import com.instructure.pandautils.blueprint.FragmentPresenter
 import kotlinx.coroutines.Job
 
 class EditQuizDetailsPresenter(var mQuiz: Quiz, var mAssignment: Assignment, val canvasContext: CanvasContext) : FragmentPresenter<EditQuizDetailsView>() {
@@ -98,7 +107,7 @@ class EditQuizDetailsPresenter(var mQuiz: Quiz, var mAssignment: Assignment, val
 
                 if (mQuiz.assignmentId != 0L) {
                     // This quiz has an assignment - update the overrides on the assignment
-                    mAssignment = awaitApi { AssignmentManager.editAssignmentAllowNullValues(canvasContext.id, mQuiz.assignmentId, assignmentPostData, it) }
+                    mAssignment = awaitApi { AssignmentManager.editAssignment(canvasContext.id, mQuiz.assignmentId, assignmentPostData, it, true) }
                 }
 
                 QuizUpdatedEvent(mQuiz.id).post() // Post bus event

--- a/apps/teacher/src/main/java/com/instructure/teacher/presenters/EditQuizDetailsPresenter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/presenters/EditQuizDetailsPresenter.kt
@@ -35,6 +35,7 @@ import com.instructure.pandautils.blueprint.FragmentPresenter
 import com.instructure.teacher.events.QuizUpdatedEvent
 import com.instructure.teacher.events.post
 import com.instructure.teacher.models.DueDateGroup
+import com.instructure.teacher.utils.toQuizAssignmentPostBody
 import com.instructure.teacher.viewinterface.EditQuizDetailsView
 import kotlinx.coroutines.Job
 
@@ -107,7 +108,8 @@ class EditQuizDetailsPresenter(var mQuiz: Quiz, var mAssignment: Assignment, val
 
                 if (mQuiz.assignmentId != 0L) {
                     // This quiz has an assignment - update the overrides on the assignment
-                    mAssignment = awaitApi { AssignmentManager.editAssignment(canvasContext.id, mQuiz.assignmentId, assignmentPostData, it, true) }
+                    assignmentPostData.published = mQuiz.published
+                    mAssignment = awaitApi { AssignmentManager.editQuizAssignment(canvasContext.id, mQuiz.assignmentId, assignmentPostData.toQuizAssignmentPostBody(), it) }
                 }
 
                 QuizUpdatedEvent(mQuiz.id).post() // Post bus event

--- a/apps/teacher/src/main/java/com/instructure/teacher/utils/AssignmentExtensions.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/utils/AssignmentExtensions.kt
@@ -25,6 +25,7 @@ import com.instructure.canvasapi2.models.AssignmentOverride
 import com.instructure.canvasapi2.models.Submission
 import com.instructure.canvasapi2.models.postmodels.AssignmentPostBody
 import com.instructure.canvasapi2.models.postmodels.OverrideBody
+import com.instructure.canvasapi2.models.postmodels.QuizAssignmentPostBody
 import com.instructure.canvasapi2.type.SubmissionGradingStatus
 import com.instructure.canvasapi2.type.SubmissionType
 import com.instructure.canvasapi2.utils.NumberHelper
@@ -44,7 +45,6 @@ import com.instructure.pandautils.utils.getContentDescriptionForMinusGradeString
 import com.instructure.teacher.R
 import com.instructure.teacher.models.CoreDates
 import com.instructure.teacher.models.DueDateGroup
-import java.util.ArrayList
 import java.util.Calendar
 
 fun List<SubmissionType>?.getAssignmentIcon() = when {
@@ -354,3 +354,7 @@ fun getResForSubmission(submissionStatus: String?): Pair<Int, Int> {
         else -> Pair(-1, -1)
     }
 }
+
+fun AssignmentPostBody.toQuizAssignmentPostBody() = QuizAssignmentPostBody(
+    dueAt, notifyOfUpdate, unlockAt, lockAt, published, assignmentOverrides, isOnlyVisibleToOverrides
+)

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/AssignmentAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/AssignmentAPI.kt
@@ -20,11 +20,24 @@ package com.instructure.canvasapi2.apis
 import com.instructure.canvasapi2.StatusCallback
 import com.instructure.canvasapi2.builders.RestBuilder
 import com.instructure.canvasapi2.builders.RestParams
-import com.instructure.canvasapi2.models.*
+import com.instructure.canvasapi2.models.Assignment
+import com.instructure.canvasapi2.models.AssignmentGroup
+import com.instructure.canvasapi2.models.GradeableStudent
+import com.instructure.canvasapi2.models.LTITool
+import com.instructure.canvasapi2.models.ObserveeAssignment
+import com.instructure.canvasapi2.models.ObserveeAssignmentGroup
+import com.instructure.canvasapi2.models.Submission
 import com.instructure.canvasapi2.models.postmodels.AssignmentPostBodyWrapper
+import com.instructure.canvasapi2.models.postmodels.QuizAssignmentPostBodyWrapper
 import com.instructure.canvasapi2.utils.DataResult
 import retrofit2.Call
-import retrofit2.http.*
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.PUT
+import retrofit2.http.Path
+import retrofit2.http.Query
+import retrofit2.http.Tag
+import retrofit2.http.Url
 
 
 object AssignmentAPI {
@@ -129,6 +142,13 @@ object AssignmentAPI {
                 @Path("assignmentId") assignmentId: Long,
                 @Body body: AssignmentPostBodyWrapper): Call<Assignment>
 
+        @PUT("courses/{courseId}/assignments/{assignmentId}")
+        fun editQuizAssignment(
+            @Path("courseId") courseId: Long,
+            @Path("assignmentId") assignmentId: Long,
+            @Body body: QuizAssignmentPostBodyWrapper
+        ): Call<Assignment>
+
         @GET("courses/{courseId}/assignments/{assignmentId}/gradeable_students")
         fun getFirstPageGradeableStudentsForAssignment(@Path("courseId") courseId: Long, @Path("assignmentId") assignmentId: Long): Call<List<GradeableStudent>>
 
@@ -210,8 +230,8 @@ object AssignmentAPI {
         }
     }
 
-    fun editAssignmentAllowNullValues(courseId: Long, assignmentId: Long, body: AssignmentPostBodyWrapper, adapter: RestBuilder, callback: StatusCallback<Assignment>, params: RestParams) {
-        callback.addCall(adapter.build(AssignmentInterface::class.java, params).editAssignment(courseId, assignmentId, body)).enqueue(callback)
+    fun editQuizAssignment(courseId: Long, assignmentId: Long, body: QuizAssignmentPostBodyWrapper, adapter: RestBuilder, callback: StatusCallback<Assignment>, params: RestParams) {
+        callback.addCall(adapter.buildSerializeNulls(AssignmentInterface::class.java, params).editQuizAssignment(courseId, assignmentId, body)).enqueue(callback)
     }
 
     fun getFirstPageGradeableStudentsForAssignment(courseId: Long, assignmentId: Long, adapter: RestBuilder, callback: StatusCallback<List<GradeableStudent>>) {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/AssignmentManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/AssignmentManager.kt
@@ -20,9 +20,16 @@ import com.instructure.canvasapi2.StatusCallback
 import com.instructure.canvasapi2.apis.AssignmentAPI
 import com.instructure.canvasapi2.builders.RestBuilder
 import com.instructure.canvasapi2.builders.RestParams
-import com.instructure.canvasapi2.models.*
+import com.instructure.canvasapi2.models.Assignment
+import com.instructure.canvasapi2.models.AssignmentGroup
+import com.instructure.canvasapi2.models.GradeableStudent
+import com.instructure.canvasapi2.models.LTITool
+import com.instructure.canvasapi2.models.ObserveeAssignment
+import com.instructure.canvasapi2.models.Submission
 import com.instructure.canvasapi2.models.postmodels.AssignmentPostBody
 import com.instructure.canvasapi2.models.postmodels.AssignmentPostBodyWrapper
+import com.instructure.canvasapi2.models.postmodels.QuizAssignmentPostBody
+import com.instructure.canvasapi2.models.postmodels.QuizAssignmentPostBodyWrapper
 import com.instructure.canvasapi2.utils.ExhaustiveListCallback
 import com.instructure.canvasapi2.utils.weave.apiAsync
 
@@ -158,18 +165,18 @@ object AssignmentManager {
         AssignmentAPI.editAssignment(courseId, assignmentId, bodyWrapper, adapter, callback, params, serializeNulls)
     }
 
-    fun editAssignmentAllowNullValues(
+    fun editQuizAssignment(
         courseId: Long,
         assignmentId: Long,
-        body: AssignmentPostBody,
+        body: QuizAssignmentPostBody,
         callback: StatusCallback<Assignment>
     ) {
         val adapter = RestBuilder(callback)
         val params = RestParams()
 
-        val bodyWrapper = AssignmentPostBodyWrapper()
+        val bodyWrapper = QuizAssignmentPostBodyWrapper()
         bodyWrapper.assignment = body
-        AssignmentAPI.editAssignmentAllowNullValues(courseId, assignmentId, bodyWrapper, adapter, callback, params)
+        AssignmentAPI.editQuizAssignment(courseId, assignmentId, bodyWrapper, adapter, callback, params)
     }
 
     fun getAllGradeableStudentsForAssignment(

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/postmodels/AssignmentPostBody.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/postmodels/AssignmentPostBody.kt
@@ -17,7 +17,7 @@
 package com.instructure.canvasapi2.models.postmodels
 
 import com.google.gson.annotations.SerializedName
-import java.util.*
+import java.util.Date
 
 /**
  * Editing an assignment requires us to use a GSON serializer that serializes null. Because of this, we need to
@@ -65,26 +65,46 @@ class AssignmentPostBody {
 class OverrideBody {
     @SerializedName("assignment_id")
     var assignmentId: Long? = null
-    
+
     @SerializedName("due_at")
     var dueAt: Date? = null
-    
+
     @SerializedName("unlock_at")
     var unlockAt: Date? = null
-    
+
     @SerializedName("lock_at")
     var lockAt: Date? = null
-    
+
     @SerializedName("student_ids")
     var studentIds: LongArray? = null
-    
+
     @SerializedName("course_section_id")
     var courseSectionId: Long? = null
-    
+
     @SerializedName("group_id")
     var groupId: Long? = null
 }
 
 class AssignmentPostBodyWrapper {
     var assignment: AssignmentPostBody? = null
+}
+
+data class QuizAssignmentPostBody(
+    @SerializedName("due_at")
+    val dueAt: String? = null,
+    @SerializedName("notify_of_update")
+    val notifyOfUpdate: Boolean? = null,
+    @SerializedName("unlock_at")
+    val unlockAt: String? = null,
+    @SerializedName("lock_at")
+    val lockAt: String? = null,
+    val published: Boolean? = null,
+    @SerializedName("assignment_overrides")
+    val assignmentOverrides: List<OverrideBody>? = null,
+    @SerializedName("only_visible_to_overrides")
+    val isOnlyVisibleToOverrides: Boolean? = null
+)
+
+class QuizAssignmentPostBodyWrapper {
+    var assignment: QuizAssignmentPostBody? = null
 }


### PR DESCRIPTION
Test plan: test edit assignment and quiz, I had to make some modification saving quiz details, it should be tested exhaustively

refs: MBL-18776
affects: Teacher
release note: It's possible now to remove even the last 'Assign To' block on Edit Assignment screen.

## Checklist

- [ ] Run E2E test suite
