### PR TITLE
Fix breaking inbox interaction test in landscape mode

### DIFF
--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/interaction/InboxListInteractionTest.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/interaction/InboxListInteractionTest.kt
@@ -245,7 +245,6 @@ abstract class InboxListInteractionTest : CanvasTest() {
     @TestMetaData(Priority.IMPORTANT, FeatureCategory.INBOX, TestCategory.INTERACTION)
     fun testInbox_swipeToReadUnread() {
         val data = createInitialData()
-        data.addConversations(userId = getLoggedInUser().id, messageBody = "Short body")
         val conversation = data.addConversation(
             senderId = getOtherUser().id,
             receiverIds = listOf(getLoggedInUser().id),


### PR DESCRIPTION
Fix breaking inbox interaction test in landscape mode conversations so the 'UNDO' message won't overlap the conversation).
