### PR TITLE
Create Compose WebView for url loading.

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/compose/composables/ComposeCanvasWebView.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/compose/composables/ComposeCanvasWebView.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2025 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package com.instructure.pandautils.compose.composables
+
+import android.webkit.WebView
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.os.bundleOf
+import com.instructure.pandautils.views.CanvasWebView
+
+data class ComposeWebViewCallbacks(
+    val openMedia: (String, String, String) -> Unit = { _, _, _ -> },
+    val onPageFinished: (WebView, String) -> Unit = { _, _ -> },
+    val onPageStarted: (WebView, String) -> Unit = { _, _ -> },
+    val canRouteInternally: (String) -> Boolean = { _ -> false },
+    val routeInternally: (String) -> Unit = { _ -> },
+    val onReceivedError: (WebView, Int, String, String) -> Unit = { _, _, _, _ -> },
+)
+
+data class ComposeEmbeddedWebViewCallbacks(
+    val shouldLaunchInternalWebViewFragment: (String) -> Boolean = { _ -> false },
+    val launchInternalWebViewFragment: (String) -> Unit = { _ -> }
+)
+
+@Composable
+fun ComposeCanvasWebView(
+    url: String,
+    modifier: Modifier = Modifier,
+    webViewCallbacks: ComposeWebViewCallbacks = ComposeWebViewCallbacks(),
+    embeddedWebViewCallbacks: ComposeEmbeddedWebViewCallbacks = ComposeEmbeddedWebViewCallbacks(),
+    applyOnWebView: (CanvasWebView.() -> Unit)? = null
+) {
+    val webViewState = rememberSaveable { bundleOf() }
+
+    if (LocalInspectionMode.current) {
+        Text(text = url)
+    } else {
+        AndroidView(
+            factory = {
+                CanvasWebView(it).apply {
+                    canvasWebViewClientCallback = object : CanvasWebView.CanvasWebViewClientCallback {
+                        override fun openMediaFromWebView(mime: String, url: String, filename: String) =
+                            webViewCallbacks.openMedia(mime, url, filename)
+
+                        override fun onPageFinishedCallback(webView: WebView, url: String) = webViewCallbacks.onPageFinished(webView, url)
+
+                        override fun onPageStartedCallback(webView: WebView, url: String) = webViewCallbacks.onPageStarted(webView, url)
+
+                        override fun canRouteInternallyDelegate(url: String): Boolean = webViewCallbacks.canRouteInternally(url)
+
+                        override fun routeInternallyCallback(url: String) = webViewCallbacks.routeInternally(url)
+
+                        override fun onReceivedErrorCallback(webView: WebView, errorCode: Int, description: String, failingUrl: String) =
+                            webViewCallbacks.onReceivedError(webView, errorCode, description, failingUrl)
+                    }
+                    canvasEmbeddedWebViewCallback = object : CanvasWebView.CanvasEmbeddedWebViewCallback {
+                        override fun launchInternalWebViewFragment(url: String) =
+                            embeddedWebViewCallbacks.launchInternalWebViewFragment(url)
+
+                        override fun shouldLaunchInternalWebViewFragment(url: String): Boolean =
+                            embeddedWebViewCallbacks.shouldLaunchInternalWebViewFragment(url)
+                    }
+
+                    applyOnWebView?.let { applyOnWebView -> applyOnWebView() }
+                }
+            },
+            update = {
+                if (webViewState.isEmpty) {
+                    it.loadUrl(url)
+                } else {
+                    it.restoreState(webViewState)
+                }
+            },
+            onRelease = {
+                it.saveState(webViewState)
+            },
+            modifier = modifier.fillMaxSize()
+        )
+    }
+}

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/views/CanvasWebView.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/views/CanvasWebView.kt
@@ -92,6 +92,7 @@ class CanvasWebView @JvmOverloads constructor(
         fun onPageFinishedCallback(webView: WebView, url: String)
         fun routeInternallyCallback(url: String)
         fun canRouteInternallyDelegate(url: String): Boolean
+        fun onReceivedErrorCallback(webView: WebView, errorCode: Int, description: String, failingUrl: String) = Unit
 
     }
 
@@ -459,6 +460,8 @@ class CanvasWebView @JvmOverloads constructor(
             super.onReceivedError(view, errorCode, description, failingUrl)
             if (failingUrl.startsWith("file://")) {
                 view.loadUrl(failingUrl.replaceFirst("file://".toRegex(), "https://"), Utils.referer)
+            } else {
+                canvasWebViewClientCallback?.onReceivedErrorCallback(view, errorCode, description, failingUrl)
             }
         }
     }


### PR DESCRIPTION
This is just an implementation of the CanvasWebView that can be used in Jetpack Compose. Don't need to test anything, since this is currently not used anywhere, only in the Horizon UI, but should be also merged to master.

Note: We could add the same callbacks for the ComposeCanvasWebViewWrapper as well, it can be beneficial to simplify things, but I didn't want to do that now, because it would need some existing production code to change.