### PR TITLE
[MBL-18662][Student] - Extend Smart Search E2E test with counter assertion

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/CourseBrowserE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/CourseBrowserE2ETest.kt
@@ -226,6 +226,12 @@ class CourseBrowserE2ETest : StudentComposeTest() {
         smartSearchPage.assertGroupHeaderDisplayed(SmartSearchContentType.ANNOUNCEMENT)
         smartSearchPage.assertGroupHeaderDisplayed(SmartSearchContentType.ASSIGNMENT)
 
+        Log.d(ASSERTION_TAG, "Assert that all the 4 groups has 1 item and it displays by the counter.")
+        smartSearchPage.assertGroupItemCount("1", SmartSearchContentType.WIKI_PAGE)
+        smartSearchPage.assertGroupItemCount("1", SmartSearchContentType.DISCUSSION_TOPIC)
+        smartSearchPage.assertGroupItemCount("1", SmartSearchContentType.ANNOUNCEMENT)
+        smartSearchPage.assertGroupItemCount("1", SmartSearchContentType.ASSIGNMENT)
+
         Log.d(ASSERTION_TAG, "Assert that all the types of result items are displayed on the Smart Search Result page.")
         smartSearchPage.assertItemDisplayed(testPage.title, "Page")
         smartSearchPage.assertItemDisplayed(testAnnouncement.title, "Announcement")

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/PickerSubmissionUploadInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/PickerSubmissionUploadInteractionTest.kt
@@ -44,14 +44,11 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import org.hamcrest.Matchers
 import org.hamcrest.core.AllOf
 import org.junit.Before
-import org.junit.FixMethodOrder
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runners.MethodSorters
 import java.io.File
 
 @HiltAndroidTest
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 class PickerSubmissionUploadInteractionTest : StudentTest() {
     override fun displaysPageObjects() = Unit
 
@@ -114,7 +111,7 @@ class PickerSubmissionUploadInteractionTest : StudentTest() {
 
     @Test
     @TestMetaData(Priority.IMPORTANT, FeatureCategory.SUBMISSIONS, TestCategory.INTERACTION)
-    fun test01Submit() {
+    fun testSubmit() {
         val data = goToSubmissionPicker()
 
         // Let's mock grabbing a file from our device

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/SmartSearchPage.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/SmartSearchPage.kt
@@ -18,6 +18,7 @@ package com.instructure.canvas.espresso.common.pages.compose
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasAnyChild
 import androidx.compose.ui.test.hasParent
 import androidx.compose.ui.test.hasTestTag
@@ -88,6 +89,7 @@ class SmartSearchPage(private val composeTestRule: ComposeTestRule) : BasePage()
         )
             .assertIsDisplayed()
             .performClick()
+        composeTestRule.waitForIdle()
     }
 
     fun clickOnFilters() {
@@ -105,6 +107,11 @@ class SmartSearchPage(private val composeTestRule: ComposeTestRule) : BasePage()
         composeTestRule.onNodeWithTag("${type.name.lowercase()}GroupHeader", useUnmergedTree = true)
             .assertIsDisplayed()
             .assertHasClickAction()
+    }
+
+    fun assertGroupItemCount(expectedCount: String, type: SmartSearchContentType) {
+        composeTestRule.onNode(hasTestTag("groupHeaderTitle") and hasAnyAncestor(hasTestTag("${type.name.lowercase()}GroupHeader")) and hasText("($expectedCount)", substring = true), useUnmergedTree = true)
+            .assertIsDisplayed()
     }
 
     fun assertGroupHeaderNotDisplayed(type: SmartSearchContentType) {

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/SmartSearchPreferencesPage.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/compose/SmartSearchPreferencesPage.kt
@@ -42,6 +42,7 @@ class SmartSearchPreferencesPage(private val composeTestRule: ComposeTestRule) {
     fun applyFilters() {
         composeTestRule.onNodeWithTag("navigationButton", useUnmergedTree = true)
             .performClick()
+        composeTestRule.waitForIdle()
     }
 
     fun toggleAll() {


### PR DESCRIPTION
Add assertion extension to SmartSearch E2E test for group counters.

refs: MBL-18662
affects: Student
release note:


- [x] Run E2E test suite
