### PR TITLE
[MBL-18840][All] Always fetch inbox signature from network

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/list/InboxRepository.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/list/InboxRepository.kt
@@ -123,6 +123,6 @@ abstract class InboxRepository(
     suspend fun getInboxSignature() {
         // We are just prefetching the signature settings here
         featuresApi.getAccountSettingsFeatures(RestParams())
-        inboxSettingsManager.getInboxSignatureSettings()
+        inboxSettingsManager.getInboxSignatureSettings(true)
     }
 }

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/inbox/list/InboxRepositoryTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/inbox/list/InboxRepositoryTest.kt
@@ -35,7 +35,6 @@ import com.instructure.canvasapi2.utils.Failure
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import junit.framework.Assert
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -204,6 +203,6 @@ class InboxRepositoryTest {
         inboxRepository.getInboxSignature()
 
         coVerify { featuresApi.getAccountSettingsFeatures(any()) }
-        coVerify { inboxSettingsManager.getInboxSignatureSettings() }
+        coVerify { inboxSettingsManager.getInboxSignatureSettings(true) }
     }
 }


### PR DESCRIPTION
test plan: See ticket.

refs: MBL-18840
affects: Student, Teacher, Parent
release note: Fixed a bug where the wrong inbox signature would load in some cases.