### PR TITLE
[MBL-18790][Student] Only return enrollments for the current user in offline mode.

### DIFF
--- a/libs/pandautils/src/androidTest/java/com/instructure/pandautils/room/offline/daos/EnrollmentDaoTest.kt
+++ b/libs/pandautils/src/androidTest/java/com/instructure/pandautils/room/offline/daos/EnrollmentDaoTest.kt
@@ -21,10 +21,15 @@ import android.database.sqlite.SQLiteConstraintException
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.instructure.canvasapi2.models.*
+import com.instructure.canvasapi2.models.Course
+import com.instructure.canvasapi2.models.Enrollment
+import com.instructure.canvasapi2.models.Section
+import com.instructure.canvasapi2.models.User
 import com.instructure.pandautils.room.offline.OfflineDatabase
-import com.instructure.pandautils.room.offline.entities.*
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import com.instructure.pandautils.room.offline.entities.CourseEntity
+import com.instructure.pandautils.room.offline.entities.EnrollmentEntity
+import com.instructure.pandautils.room.offline.entities.SectionEntity
+import com.instructure.pandautils.room.offline.entities.UserEntity
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -279,5 +284,23 @@ class EnrollmentDaoTest {
         val result = enrollmentDao.findByUserId(4L)
 
         Assert.assertEquals(expected, result)
+    }
+
+    @Test
+    fun testFindByCourseIdAndUserId() = runTest {
+        val entities = listOf(
+            EnrollmentEntity(Enrollment(id = 1, userId = 1, role = Enrollment.EnrollmentType.Observer), 1, 1, 1),
+            EnrollmentEntity(Enrollment(id = 2, userId = 2, role = Enrollment.EnrollmentType.Student), 1, 1, 1),
+            EnrollmentEntity(Enrollment(id = 3, userId = 3, role = Enrollment.EnrollmentType.Teacher), 2, 1, 1),
+        )
+        entities.forEach {
+            enrollmentDao.insert(it)
+        }
+
+        val expected = entities[1]
+
+        val result = enrollmentDao.findByCourseIdAndUserId(1L, 2L)
+
+        Assert.assertEquals(expected, result.first())
     }
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/di/OfflineModule.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/di/OfflineModule.kt
@@ -307,7 +307,8 @@ class OfflineModule {
         sectionDao: SectionDao,
         tabDao: TabDao,
         enrollmentFacade: EnrollmentFacade,
-        courseSettingsDao: CourseSettingsDao
+        courseSettingsDao: CourseSettingsDao,
+        apiPrefs: ApiPrefs
     ): CourseFacade {
         return CourseFacade(
             termDao,
@@ -317,7 +318,8 @@ class OfflineModule {
             sectionDao,
             tabDao,
             enrollmentFacade,
-            courseSettingsDao
+            courseSettingsDao,
+            apiPrefs
         )
     }
 

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/room/offline/daos/EnrollmentDao.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/room/offline/daos/EnrollmentDao.kt
@@ -38,6 +38,9 @@ interface EnrollmentDao {
     @Query("SELECT * FROM EnrollmentEntity WHERE courseId = :courseId")
     suspend fun findByCourseId(courseId: Long): List<EnrollmentEntity>
 
+    @Query("SELECT * FROM EnrollmentEntity WHERE courseId = :courseId AND userId = :userId")
+    suspend fun findByCourseIdAndUserId(courseId: Long, userId: Long): List<EnrollmentEntity>
+
     @Query("SELECT * FROM EnrollmentEntity")
     suspend fun findAll(): List<EnrollmentEntity>
 

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/room/offline/facade/EnrollmentFacade.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/room/offline/facade/EnrollmentFacade.kt
@@ -17,8 +17,6 @@
 
 package com.instructure.pandautils.room.offline.facade
 
-import com.instructure.canvasapi2.apis.UserAPI
-import com.instructure.canvasapi2.builders.RestParams
 import com.instructure.canvasapi2.models.Enrollment
 import com.instructure.pandautils.room.offline.daos.EnrollmentDao
 import com.instructure.pandautils.room.offline.daos.GradesDao
@@ -57,6 +55,21 @@ class EnrollmentFacade(
 
     suspend fun getEnrollmentsByCourseId(id: Long): List<Enrollment> {
         val enrollmentEntities = enrollmentDao.findByCourseId(id)
+        return enrollmentEntities.map { enrollmentEntity ->
+            val gradesEntity = gradesDao.findByEnrollmentId(enrollmentEntity.id)
+            val observedUserEntity = enrollmentEntity.observedUserId?.let { userDao.findById(it) }
+            val userEntity = userDao.findById(enrollmentEntity.userId)
+
+            enrollmentEntity.toApiModel(
+                grades = gradesEntity?.toApiModel(),
+                observedUser = observedUserEntity?.toApiModel(),
+                user = userEntity?.toApiModel()
+            )
+        }
+    }
+
+    suspend fun getEnrollmentsForUserByCourseId(courseId: Long, userId: Long): List<Enrollment> {
+        val enrollmentEntities = enrollmentDao.findByCourseIdAndUserId(courseId, userId)
         return enrollmentEntities.map { enrollmentEntity ->
             val gradesEntity = gradesDao.findByEnrollmentId(enrollmentEntity.id)
             val observedUserEntity = enrollmentEntity.observedUserId?.let { userDao.findById(it) }

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/room/offline/facade/EnrollmentFacadeTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/room/offline/facade/EnrollmentFacadeTest.kt
@@ -29,8 +29,8 @@ import com.instructure.pandautils.room.offline.entities.UserEntity
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert
 import org.junit.Test
 
 class EnrollmentFacadeTest {
@@ -69,10 +69,10 @@ class EnrollmentFacadeTest {
 
         val result = facade.getEnrollmentsByCourseId(courseId)
 
-        Assert.assertEquals(grades, result.first().grades)
-        Assert.assertEquals(user, result.first().observedUser)
-        Assert.assertEquals(user, result.first().user)
-        Assert.assertEquals(enrollment, result.first())
+        assertEquals(grades, result.first().grades)
+        assertEquals(user, result.first().observedUser)
+        assertEquals(user, result.first().user)
+        assertEquals(enrollment, result.first())
     }
 
     @Test
@@ -90,11 +90,11 @@ class EnrollmentFacadeTest {
 
         val result = facade.getAllEnrollments()
 
-        Assert.assertEquals(1, result.size)
-        Assert.assertEquals(grades, result.first().grades)
-        Assert.assertEquals(user, result.first().observedUser)
-        Assert.assertEquals(user, result.first().user)
-        Assert.assertEquals(enrollment, result.first())
+        assertEquals(1, result.size)
+        assertEquals(grades, result.first().grades)
+        assertEquals(user, result.first().observedUser)
+        assertEquals(user, result.first().user)
+        assertEquals(enrollment, result.first())
     }
 
     @Test
@@ -121,10 +121,32 @@ class EnrollmentFacadeTest {
 
         val result = facade.getEnrollmentsByGradingPeriodId(gradingPeriodId)
 
-        Assert.assertEquals(1, result.size)
-        Assert.assertEquals(grades, result.first().grades)
-        Assert.assertEquals(user, result.first().observedUser)
-        Assert.assertEquals(user, result.first().user)
-        Assert.assertEquals(enrollment, result.first())
+        assertEquals(1, result.size)
+        assertEquals(grades, result.first().grades)
+        assertEquals(user, result.first().observedUser)
+        assertEquals(user, result.first().user)
+        assertEquals(enrollment, result.first())
+    }
+
+    @Test
+    fun `Calling getEnrollmentsForUserByCourseId should return enrollments by user id and course id`() = runTest {
+        val courseId = 1L
+        val userId = 2L
+        val grades = Grades(htmlUrl = "htmlUrl")
+        val user = User(id = userId, name = "User")
+        val enrollment = Enrollment(id = 1L, courseId = courseId, userId = userId, user = user, grades = grades, courseSectionId = 1L)
+
+        coEvery { enrollmentDao.findByCourseIdAndUserId(courseId, userId) } returns listOf(enrollment).map {
+            EnrollmentEntity(it, courseId, null, observedUserId = null)
+        }
+        coEvery { gradesDao.findByEnrollmentId(enrollment.id) } returns GradesEntity(grades, enrollment.id)
+        coEvery { userDao.findById(any()) } returns UserEntity(user)
+
+        val result = facade.getEnrollmentsForUserByCourseId(courseId, userId)
+
+        assertEquals(1, result.size)
+        assertEquals(grades, result.first().grades)
+        assertEquals(user, result.first().user)
+        assertEquals(enrollment, result.first())
     }
 }


### PR DESCRIPTION
test plan: See ticket.

refs: MBL-18790
affects: Student
release note: Fixed a bug where the total grades would display incorrectly in offline mode.
