### PR TITLE
[MBL-18842][Parent] Filter icon displays as 'empty' even though there is a filter selected but it's default

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/grades/gradepreferences/GradePreferencesUiState.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/grades/gradepreferences/GradePreferencesUiState.kt
@@ -32,7 +32,7 @@ data class GradePreferencesUiState(
     val sortBy: SortBy = SortBy.DUE_DATE
 ) {
     val isDefault: Boolean
-        get() = selectedGradingPeriod == defaultGradingPeriod && sortBy == SortBy.DUE_DATE
+        get() = selectedGradingPeriod == defaultGradingPeriod
 }
 
 enum class SortBy(@StringRes val titleRes: Int) {


### PR DESCRIPTION
Test plan: in the ticket (comment)

refs: MBL-18842
affects: Parent
release note: Updated grades filter icon behaviour.

## Checklist

- [x] Tested in dark mode
