### PR TITLE
[MBL-18873][Parent] Fixed unpair student error handling

### DIFF
--- a/apps/parent/flank.yml
+++ b/apps/parent/flank.yml
@@ -6,7 +6,6 @@ gcloud:
   app: ./apps/parent/build/outputs/apk/qa/debug/parent-qa-debug.apk
   test: ./apps/parent/build/outputs/apk/androidTest/qa/debug/parent-qa-debug-androidTest.apk
   results-bucket: android-parent
-  local-result-dir: results
   auto-google-login: true
   use-orchestrator: true
   performance-metrics: false

--- a/apps/parent/flank.yml
+++ b/apps/parent/flank.yml
@@ -3,8 +3,8 @@ gcloud:
   # Use the next two lines to run locally
   #  app: ./build/intermediates/apk/qa/debug/parent-qa-debug.apk
   #  test: ./build/intermediates/apk/androidTest/qa/debug/parent-qa-debug-androidTest.apk
-  app: ./apps/parent/build/outputs/apk/qa/debug/parent-qa-debug.apk
-  test: ./apps/parent/build/outputs/apk/androidTest/qa/debug/parent-qa-debug-androidTest.apk
+  app: ./apps/parent/build/intermediates/apk/qa/debug/parent-qa-debug.apk
+  test: ./apps/parent/build/intermediates/apk/androidTest/qa/debug/parent-qa-debug-androidTest.apk
   results-bucket: android-parent
   auto-google-login: true
   use-orchestrator: true

--- a/apps/parent/flank.yml
+++ b/apps/parent/flank.yml
@@ -6,6 +6,7 @@ gcloud:
   app: ./apps/parent/build/outputs/apk/qa/debug/parent-qa-debug.apk
   test: ./apps/parent/build/outputs/apk/androidTest/qa/debug/parent-qa-debug-androidTest.apk
   results-bucket: android-parent
+  local-result-dir: results
   auto-google-login: true
   use-orchestrator: true
   performance-metrics: false

--- a/apps/parent/flank.yml
+++ b/apps/parent/flank.yml
@@ -3,8 +3,8 @@ gcloud:
   # Use the next two lines to run locally
   #  app: ./build/intermediates/apk/qa/debug/parent-qa-debug.apk
   #  test: ./build/intermediates/apk/androidTest/qa/debug/parent-qa-debug-androidTest.apk
-  app: ./apps/parent/build/intermediates/apk/qa/debug/parent-qa-debug.apk
-  test: ./apps/parent/build/intermediates/apk/androidTest/qa/debug/parent-qa-debug-androidTest.apk
+  app: ./apps/parent/build/outputs/apk/qa/debug/parent-qa-debug.apk
+  test: ./apps/parent/build/outputs/apk/androidTest/qa/debug/parent-qa-debug-androidTest.apk
   results-bucket: android-parent
   auto-google-login: true
   use-orchestrator: true

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/addstudent/AddStudentViewData.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/addstudent/AddStudentViewData.kt
@@ -28,10 +28,11 @@ data class AddStudentUiState(
 sealed class AddStudentViewModelAction {
     data object PairStudentSuccess : AddStudentViewModelAction()
     data object UnpairStudentSuccess : AddStudentViewModelAction()
+    data object UnpairStudentFailed : AddStudentViewModelAction()
 }
 
 sealed class AddStudentAction {
     data class UnpairStudent(val studentId: Long) : AddStudentAction()
     data class PairStudent(val pairingCode: String) : AddStudentAction()
-    object ResetError : AddStudentAction()
+    data object ResetError : AddStudentAction()
 }

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/addstudent/AddStudentViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/addstudent/AddStudentViewModel.kt
@@ -95,6 +95,7 @@ class AddStudentViewModel @Inject constructor(
                 _uiState.value = _uiState.value.copy(isLoading = false)
             } catch (e: Exception) {
                 crashlytics.recordException(e)
+                _events.emit(AddStudentViewModelAction.UnpairStudentFailed)
                 _uiState.value = _uiState.value.copy(isLoading = false)
             }
         }

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/settings/AlertSettingsFragment.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/settings/AlertSettingsFragment.kt
@@ -84,6 +84,10 @@ class AlertSettingsFragment : BaseCanvasFragment() {
                 requireActivity().onBackPressed()
             }
 
+            is AddStudentViewModelAction.UnpairStudentFailed -> {
+                viewModel.handleAction(AlertSettingsAction.UnpairStudentFailed)
+            }
+
             else -> {}
         }
     }

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/settings/AlertSettingsUiState.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/settings/AlertSettingsUiState.kt
@@ -38,7 +38,7 @@ sealed class AlertSettingsAction {
     data class CreateThreshold(val alertType: AlertType, val threshold: String?) : AlertSettingsAction()
     data class DeleteThreshold(val alertType: AlertType) : AlertSettingsAction()
     data class UnpairStudent(val studentId: Long) : AlertSettingsAction()
-
+    data object UnpairStudentFailed : AlertSettingsAction()
     data object ReloadAlertSettings : AlertSettingsAction()
 }
 

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/settings/AlertSettingsViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/alerts/settings/AlertSettingsViewModel.kt
@@ -65,7 +65,7 @@ class AlertSettingsViewModel @Inject constructor(
         }
     }
 
-    private fun handleAction(alertSettingsAction: AlertSettingsAction) {
+    fun handleAction(alertSettingsAction: AlertSettingsAction) {
         viewModelScope.launch {
             when (alertSettingsAction) {
                 is AlertSettingsAction.CreateThreshold -> {
@@ -111,29 +111,29 @@ class AlertSettingsViewModel @Inject constructor(
                     _uiState.update {
                         it.copy(isLoading = true)
                     }
-                    try {
-                        _events.send(
-                            AlertSettingsViewModelAction.UnpairStudent(
-                                alertSettingsAction.studentId
-                            )
+                    _events.send(
+                        AlertSettingsViewModelAction.UnpairStudent(
+                            alertSettingsAction.studentId
                         )
-                    } catch (e: Exception) {
-                        crashlytics.recordException(e)
-                        e.printStackTrace()
-                        _uiState.update {
-                            it.copy(isLoading = false)
-                        }
-                        _events.send(AlertSettingsViewModelAction.ShowSnackbar(
-                            message = R.string.generalUnexpectedError,
-                            actionCallback = {
-                                handleAction(alertSettingsAction)
-                            }
-                        ))
-                    }
+                    )
                 }
 
                 is AlertSettingsAction.ReloadAlertSettings -> {
                     loadAlertThresholds(true)
+                }
+
+                is AlertSettingsAction.UnpairStudentFailed -> {
+                    _uiState.update {
+                        it.copy(isLoading = false)
+                    }
+                    _events.send(
+                        AlertSettingsViewModelAction.ShowSnackbar(
+                            message = R.string.generalUnexpectedError,
+                            actionCallback = {
+                                handleAction(AlertSettingsAction.UnpairStudent(student.id))
+                            }
+                        )
+                    )
                 }
             }
         }
@@ -170,5 +170,4 @@ class AlertSettingsViewModel @Inject constructor(
     private suspend fun deleteAlertThreshold(thresholdId: Long) {
         repository.deleteAlertThreshold(thresholdId)
     }
-
 }

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/dashboard/DashboardFragment.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/dashboard/DashboardFragment.kt
@@ -177,7 +177,7 @@ class DashboardFragment : BaseCanvasFragment(), NavigationCallbacks {
                 context?.let { announceAccessibilityText(it, getString(R.string.unpairStudentSuccessfull)) }
             }
 
-            else -> {}
+            is AddStudentViewModelAction.UnpairStudentFailed -> {}
         }
     }
 

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/dashboard/DashboardFragment.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/dashboard/DashboardFragment.kt
@@ -171,10 +171,13 @@ class DashboardFragment : BaseCanvasFragment(), NavigationCallbacks {
                 viewModel.reloadData()
                 context?.let { announceAccessibilityText(it, getString(R.string.addStudentSuccessfull)) }
             }
+
             is AddStudentViewModelAction.UnpairStudentSuccess -> {
                 viewModel.reloadData()
                 context?.let { announceAccessibilityText(it, getString(R.string.unpairStudentSuccessfull)) }
             }
+
+            else -> {}
         }
     }
 

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/managestudents/ManageStudentsFragment.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/managestudents/ManageStudentsFragment.kt
@@ -94,7 +94,7 @@ class ManageStudentsFragment : BaseCanvasFragment() {
                 context?.let { announceAccessibilityText(it, getString(R.string.unpairStudentSuccessfull)) }
             }
 
-            else -> {}
+            is AddStudentViewModelAction.UnpairStudentFailed -> {}
         }
     }
 

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/managestudents/ManageStudentsFragment.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/managestudents/ManageStudentsFragment.kt
@@ -93,6 +93,8 @@ class ManageStudentsFragment : BaseCanvasFragment() {
                 viewModel.handleAction(ManageStudentsAction.Refresh)
                 context?.let { announceAccessibilityText(it, getString(R.string.unpairStudentSuccessfull)) }
             }
+
+            else -> {}
         }
     }
 

--- a/apps/parent/src/test/java/com/instructure/parentapp/features/addstudent/AddStudentViewModelTest.kt
+++ b/apps/parent/src/test/java/com/instructure/parentapp/features/addstudent/AddStudentViewModelTest.kt
@@ -144,4 +144,20 @@ class AddStudentViewModelTest {
 
         assert(events.last() is AddStudentViewModelAction.UnpairStudentSuccess)
     }
+
+    @Test
+    fun `unpairStudent should emit UnpairStudentFailed on error`() = runTest {
+        coEvery { repository.unpairStudent(any()) } throws Exception("Unpair failed")
+
+        val events = mutableListOf<AddStudentViewModelAction>()
+        backgroundScope.launch(testDispatcher) {
+            viewModel.events.toList(events)
+        }
+
+        viewModel.uiState.value.actionHandler(AddStudentAction.UnpairStudent(1))
+
+        events.addAll(viewModel.events.replayCache)
+
+        assert(events.last() is AddStudentViewModelAction.UnpairStudentFailed)
+    }
 }

--- a/apps/parent/src/test/java/com/instructure/parentapp/features/alerts/settings/AlertSettingsViewModelTest.kt
+++ b/apps/parent/src/test/java/com/instructure/parentapp/features/alerts/settings/AlertSettingsViewModelTest.kt
@@ -28,6 +28,7 @@ import com.instructure.canvasapi2.models.ThresholdWorkflowState
 import com.instructure.canvasapi2.models.User
 import com.instructure.pandautils.utils.ColorKeeper
 import com.instructure.pandautils.utils.ThemedColor
+import com.instructure.parentapp.R
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -214,7 +215,7 @@ class AlertSettingsViewModelTest {
     }
 
     @Test
-    fun `deleteThreshold error`() = runTest{
+    fun `deleteThreshold error`() = runTest {
         val alertType = AlertType.ASSIGNMENT_GRADE_HIGH
 
         coEvery { repository.loadAlertThresholds(any()) } returns listOf(
@@ -259,7 +260,23 @@ class AlertSettingsViewModelTest {
         assertEquals(expected, events.last())
     }
 
+    @Test
+    fun `unpair student fails`() = runTest {
+        createViewModel()
 
+        viewModel.handleAction(AlertSettingsAction.UnpairStudentFailed)
+
+        val events = mutableListOf<AlertSettingsViewModelAction>()
+        backgroundScope.launch(testDispatcher) {
+            viewModel.events.toList(events)
+        }
+
+        val event = events.last() as AlertSettingsViewModelAction.ShowSnackbar
+        assertEquals(R.string.generalUnexpectedError, event.message)
+
+        event.actionCallback.invoke()
+        assertEquals(AlertSettingsViewModelAction.UnpairStudent(1L), events.last())
+    }
 
     private fun createViewModel() {
         viewModel = AlertSettingsViewModel(savedStateHandle, repository, crashlytics)


### PR DESCRIPTION
Test plan: test removing a student, mock an api error with proxy, see the error snackbar, then retry it without the api error.

refs: MBL-18873
affects: Parent
release note: Fixed error handling when unpairing a student fails.

