### PR TITLE
[MBL-18830][All] Set min SDK version to 28

### DIFF
--- a/apps/buildSrc/src/main/java/GlobalDependencies.kt
+++ b/apps/buildSrc/src/main/java/GlobalDependencies.kt
@@ -3,7 +3,7 @@
 object Versions {
     /* SDK Versions */
     const val COMPILE_SDK = 35
-    const val MIN_SDK = 26
+    const val MIN_SDK = 28
     const val TARGET_SDK = 35
 
     /* Build/tooling */


### PR DESCRIPTION
Test plan: 

refs: MBL-18830
affects: Student, Parent, Teacher
release note: Updated min sdk version to 28.
