### PR TITLE
[MBL-18913][Student] If there are no quizzes, the page keeps loading instead of showing a “No quizzes yet” page

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/features/quiz/list/QuizListRecyclerAdapter.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/quiz/list/QuizListRecyclerAdapter.kt
@@ -99,9 +99,9 @@ class QuizListRecyclerAdapter(
         lifecycleScope.tryLaunch {
             settings = repository.loadCourseSettings(canvasContext.id, isRefresh)
             quizzes = repository.loadQuizzes(canvasContext.type.apiString, canvasContext.id, isRefresh)
+            isAllPagesLoaded = true
             populateData()
             onCallbackFinished(ApiType.API)
-            isAllPagesLoaded = true
         } catch {
             context.toast(R.string.errorOccurred)
         }


### PR DESCRIPTION
Test plan: see the ticket

refs: MBL-18913
affects: Student
release note: Showing empty view if there are no quizzes for the course.
