### PR TITLE
[MBL-18938][Student][Teacher] - Unify 'Report a problem' dialog title

### DIFF
--- a/libs/login-api-2/src/main/res/values-en/strings.xml
+++ b/libs/login-api-2/src/main/res/values-en/strings.xml
@@ -73,7 +73,7 @@
     <string name="loginHint">Find your school or district</string>
 
     <!-- Error Report Dialog -->
-    <string name="errorReportAProblem">Report A Problem</string>
+    <string name="errorReportAProblem">Report a problem</string>
     <string name="errorReportSubject">Subject</string>
     <string name="errorReportDescription">Description</string>
     <string name="errorReportSend">Send</string>

--- a/libs/login-api-2/src/main/res/values/strings.xml
+++ b/libs/login-api-2/src/main/res/values/strings.xml
@@ -73,7 +73,7 @@
     <string name="loginHint">Find your school or district</string>
 
     <!-- Error Report Dialog -->
-    <string name="errorReportAProblem">Report A Problem</string>
+    <string name="errorReportAProblem">Report a problem</string>
     <string name="errorReportSubject">Subject</string>
     <string name="errorReportDescription">Description</string>
     <string name="errorReportSend">Send</string>

--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -706,7 +706,7 @@
     <string name="searchGuides">Search the Canvas Guides</string>
     <string name="canvasGuides">Canvas Guides</string>
     <string name="searchGuidesDetails">Find answers to common questions</string>
-    <string name="reportProblem">Report a Problem</string>
+    <string name="reportProblem">Report a problem</string>
     <string name="reportProblemDetails">If the app misbehaves, let us know</string>
     <string name="requestFeature">Request a Feature</string>
     <string name="requestFeatureDetails">Have an idea to improve the app?</string>


### PR DESCRIPTION
 Unify 'Report a problem' dialog title. (It was 'Report A Problem' in …Student and Teacher and we came to the conclusion with product that it should be 'Report a problem' in all 3 apps. Parent was already like this)

refs: MBL-18938
affects: Student, Teacher
release note: Report a problem dialog title unified to 'Report a problem'.
