### PR TITLE
[MBL-18929][All] Inbox signautre loads previous user signature if composing message with any FAB button

### DIFF
--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/QLClientConfig.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/QLClientConfig.kt
@@ -33,6 +33,7 @@ import com.instructure.canvasapi2.type.GraphQLID
 import com.instructure.canvasapi2.type.URL
 import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.canvasapi2.utils.ContextKeeper
+import com.instructure.canvasapi2.utils.Logger
 import com.instructure.canvasapi2.utils.toApiString
 import com.instructure.canvasapi2.utils.toDate
 import okhttp3.OkHttpClient
@@ -134,6 +135,15 @@ open class QLClientConfig {
             // Since we handle errors with exceptions, we keep the compat call of execute because the new doesn't throw exceptions
             val result = config.buildClient().mutation(mutation).executeV3()
             return result
+        }
+
+        fun clearCacheDirectory(): Boolean {
+            return try {
+                cacheFile.deleteRecursively()
+            } catch (e: Exception) {
+                Logger.e("Could not delete cache $e")
+                false
+            }
         }
     }
 }

--- a/libs/login-api-2/src/main/java/com/instructure/loginapi/login/tasks/LogoutTask.kt
+++ b/libs/login-api-2/src/main/java/com/instructure/loginapi/login/tasks/LogoutTask.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import com.instructure.canvasapi2.CanvasRestAdapter
+import com.instructure.canvasapi2.QLClientConfig
 import com.instructure.canvasapi2.builders.RestBuilder
 import com.instructure.canvasapi2.managers.CommunicationChannelsManager
 import com.instructure.canvasapi2.managers.OAuthManager
@@ -104,6 +105,7 @@ abstract class LogoutTask(
                 // Clear caches
                 CanvasRestAdapter.okHttpClient.cache?.evictAll()
                 RestBuilder.clearCacheDirectory()
+                QLClientConfig.clearCacheDirectory()
                 Utils.getAttachmentsDirectory(ContextKeeper.appContext).deleteRecursively()
                 File(ContextKeeper.appContext.filesDir, "cache").deleteRecursively()
 

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/list/InboxRepository.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/list/InboxRepository.kt
@@ -123,6 +123,6 @@ abstract class InboxRepository(
     suspend fun getInboxSignature() {
         // We are just prefetching the signature settings here
         featuresApi.getAccountSettingsFeatures(RestParams())
-        inboxSettingsManager.getInboxSignatureSettings(true)
+        inboxSettingsManager.getInboxSignatureSettings()
     }
 }

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/inbox/list/InboxRepositoryTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/inbox/list/InboxRepositoryTest.kt
@@ -203,6 +203,6 @@ class InboxRepositoryTest {
         inboxRepository.getInboxSignature()
 
         coVerify { featuresApi.getAccountSettingsFeatures(any()) }
-        coVerify { inboxSettingsManager.getInboxSignatureSettings(true) }
+        coVerify { inboxSettingsManager.getInboxSignatureSettings() }
     }
 }


### PR DESCRIPTION
Test plan: Test all cases, even what already worked since I came up with a complete different solution.

refs: MBL-18929
affects: Student, Parent, Teacher
release note: Fixed a caching issue related to inbox signature.
