### PR TITLE
[MBL-18810][Student] - Fix login interaction test on tablet

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/LoginInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/LoginInteractionTest.kt
@@ -17,9 +17,9 @@ package com.instructure.student.ui.interaction
 
 import com.instructure.canvas.espresso.FeatureCategory
 import com.instructure.canvas.espresso.Priority
-import com.instructure.canvas.espresso.StubTablet
 import com.instructure.canvas.espresso.TestCategory
 import com.instructure.canvas.espresso.TestMetaData
+import com.instructure.student.R
 import com.instructure.student.ui.utils.StudentTest
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Test
@@ -29,13 +29,15 @@ class LoginInteractionTest : StudentTest() {
 
     override fun displaysPageObjects() = Unit // Not used for interaction tests
 
-    @StubTablet
     @Test
     @TestMetaData(Priority.MANDATORY, FeatureCategory.LOGIN, TestCategory.INTERACTION)
     fun testLogin_canFindSchool() {
         loginLandingPage.clickFindMySchoolButton()
         loginFindSchoolPage.assertPageObjects()
-        loginFindSchoolPage.assertHintText()
+
+        if(isTabletDevice()) loginFindSchoolPage.assertHintText(R.string.schoolInstructureCom)
+        else loginFindSchoolPage.assertHintText(R.string.loginHint)
+
         loginFindSchoolPage.enterDomain("harv")
         loginFindSchoolPage.assertSchoolSearchResults("City Harvest Church (Singapore)")
     }

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/LoginFindSchoolPage.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/LoginFindSchoolPage.kt
@@ -77,9 +77,9 @@ class LoginFindSchoolPage: BasePage() {
      * Assert that the schoolText school is displayed in the results.
      * @param schoolText The school to assert.
      */
-    fun assertHintText() {
+    fun assertHintText(schoolText: Int) {
         val hintText = getHintText(withId(R.id.domainInput))
-        assertEquals(hintText, getStringFromResource(R.string.loginHint))
+        assertEquals(hintText, getStringFromResource(schoolText))
     }
 }
 


### PR DESCRIPTION
Fix login interaction test to assert correct hint text for tablet devices.

refs: MBL-18810
affects: Student
release note: