### PR TITLE
[MBL-18914][Student][Teacher] The profile picture checkmark/X icons are hard to tap, and in landscape mode the checkmark can’t be tapped at all

### DIFF
--- a/libs/pandautils/src/main/AndroidManifest.xml
+++ b/libs/pandautils/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (C) 2017 - present Instructure, Inc.
   ~
   ~     Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,11 +21,11 @@
     <application>
         <activity
             android:name="com.instructure.pandautils.utils.AvatarCropActivity"
-            android:theme="@style/Theme.AppCompat.NoActionBar"/>
+            android:theme="@style/AvatarCropActivityTheme" />
 
         <!--Push Notifications-->
 
-        <receiver android:name=".receivers.PushDeleteReceiver"/>
+        <receiver android:name=".receivers.PushDeleteReceiver" />
 
     </application>
 

--- a/libs/pandautils/src/main/res/values/themes_canvasthemes.xml
+++ b/libs/pandautils/src/main/res/values/themes_canvasthemes.xml
@@ -104,4 +104,8 @@
         <item name="android:editTextStyle">@style/NoGifEditText</item>
         <item name="editTextStyle">@style/NoGifEditText</item>
     </style>
+
+    <style name="AvatarCropActivityTheme" parent="Theme.AppCompat.NoActionBar">
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
 </resources>


### PR DESCRIPTION
Test plan: see the ticket

refs: MBL-18914
affects: Student, Teacher
release note: Fixed a minor UI glitch on profile picture crop screen.