### PR TITLE
[MBL-18918][Student] Offline: 'Terms of Use' link should pop-up 'No Internet Connection' dalog instead of 'Webpage not available.'

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/legal/LegalDialogFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/legal/LegalDialogFragment.kt
@@ -77,7 +77,7 @@ class LegalDialogFragment : BaseCanvasDialogFragment() {
 
         val dialog = builder.create()
 
-        binding.termsOfUse.setOnClickListener {
+        binding.termsOfUse.onClickWithRequireNetwork {
             if (html.isBlank() && !APIHelper.hasNetworkConnection()) {
                 showNoConnectionDialog(requireContext())
             } else {


### PR DESCRIPTION
Test plan: in the ticket

refs: MBL-18918
affects: Student
release note: Showing 'No Internet Connection' dialog when clicking terms of use offline.
