### PR TITLE
[MBL-18910][Student] Bookmarking the Front Page of a course doesn’t work — clicking the button has no effect

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/features/pages/details/PageDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/pages/details/PageDetailsFragment.kt
@@ -305,6 +305,7 @@ class PageDetailsFragment : InternalWebviewFragment(), Bookmarkable {
     override val bookmark: Bookmarker
         get() = Bookmarker(true, canvasContext)
             .withParam(RouterParams.PAGE_ID, if (Page.FRONT_PAGE_NAME == pageName) Page.FRONT_PAGE_NAME else pageName!!)
+            .withUrl(page.htmlUrl)
 
     private fun openEditPage(page: Page) {
         if (APIHelper.hasNetworkConnection()) {


### PR DESCRIPTION
Test plan: test bookmarking frontpage opened from course home, also test when opened from pages

refs: MBL-18910
affects: Student
release note: Fixed an issue where Frontpage could not be Bookmarked.
