### PR TITLE
[MBL-18952][Student] - Refactor and extend DashboardE2E test to test that we don't show the grades by default

### DIFF
--- a/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/DashboardE2ETest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/e2e/DashboardE2ETest.kt
@@ -146,11 +146,9 @@ class DashboardE2ETest : StudentTest() {
         Log.d(STEP_TAG, "Navigate back to Dashboard Page.")
         Espresso.pressBack()
 
-        Log.d(ASSERTION_TAG, "Assert that both of the courses, '${course1.name}' and '${course2.name}', and their grades are displayed properly.")
+        Log.d(ASSERTION_TAG, "Assert that both of the courses, '${course1.name}' and '${course2.name}'.")
         dashboardPage.assertDisplaysCourse(course1)
         dashboardPage.assertDisplaysCourse(course2)
-        dashboardPage.assertCourseGrade(course1.name, "N/A")
-        dashboardPage.assertCourseGrade(course2.name, "N/A")
 
         Log.d(STEP_TAG, "Click on 'Edit nickname' menu of '${course1.name}' course.")
         dashboardPage.clickCourseOverflowMenu(course1.name, "Edit nickname")
@@ -179,12 +177,9 @@ class DashboardE2ETest : StudentTest() {
         Log.d(ASSERTION_TAG, "Assert that '${group.name}' groups is displayed and the '${data.coursesList[0]}' is displayed as the corresponding course name of the group.")
         dashboardPage.assertDisplaysGroup(group, data.coursesList[0])
 
-        Log.d(STEP_TAG, "Toggle OFF 'Show Grades' and navigate back to Dashboard Page.")
-        leftSideNavigationDrawerPage.setShowGrades(false)
-
-        Log.d(ASSERTION_TAG, "Assert that the grades does not displayed on both of the courses' cards.")
-        dashboardPage.assertCourseGradeNotDisplayed(course1.name, "N/A")
-        dashboardPage.assertCourseGradeNotDisplayed(course2.name, "N/A")
+        Log.d(ASSERTION_TAG, "Assert that the grades does not displayed on both of the courses' cards by default.")
+        dashboardPage.assertCourseGradeNotDisplayed(course1.name, "N/A", false)
+        dashboardPage.assertCourseGradeNotDisplayed(course2.name, "N/A", false)
 
         Log.d(STEP_TAG, "Toggle ON 'Show Grades' and navigate back to Dashboard Page.")
         leftSideNavigationDrawerPage.setShowGrades(true)
@@ -192,6 +187,13 @@ class DashboardE2ETest : StudentTest() {
         Log.d(ASSERTION_TAG, "Assert that the grades are displayed on both of the courses' cards.")
         dashboardPage.assertCourseGrade(course1.name, "N/A")
         dashboardPage.assertCourseGrade(course2.name, "N/A")
+
+        Log.d(STEP_TAG, "Toggle OFF 'Show Grades' and navigate back to Dashboard Page.")
+        leftSideNavigationDrawerPage.setShowGrades(false)
+
+        Log.d(ASSERTION_TAG, "Assert that the grades does not displayed on both of the courses' cards by default.")
+        dashboardPage.assertCourseGradeNotDisplayed(course1.name, "N/A")
+        dashboardPage.assertCourseGradeNotDisplayed(course2.name, "N/A")
 
         Log.d(STEP_TAG, "Click on 'All Courses' button.")
         dashboardPage.openAllCoursesPage()

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DashboardPage.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/pages/DashboardPage.kt
@@ -371,11 +371,11 @@ class DashboardPage : BasePage(R.id.dashboardPage) {
         onView(matcher).scrollTo().assertDisplayed()
     }
 
-    fun assertCourseGradeNotDisplayed(courseName: String, courseGrade: String) {
+    fun assertCourseGradeNotDisplayed(courseName: String, courseGrade: String, hasText: Boolean = true) {
         val siblingMatcher = allOf(withId(R.id.textContainer), withDescendant(withId(R.id.titleTextView) + withText(courseName)))
-        val matcher = allOf(withId(R.id.gradeLayout), withDescendant(withId(R.id.gradeTextView) + withText(courseGrade)), hasSibling(siblingMatcher))
-
-        onView(matcher).check(matches(Matchers.not(isDisplayed())))
+        val matcher: Matcher<View> = if(hasText) allOf(withId(R.id.gradeLayout), withDescendant(withId(R.id.gradeTextView) + withText(courseGrade)), hasSibling(siblingMatcher))
+        else allOf(withId(R.id.gradeLayout), withDescendant(withId(R.id.gradeTextView)), hasSibling(siblingMatcher))
+        onView(matcher).check(matches(anyOf(withEffectiveVisibility(Visibility.GONE), Matchers.not(isDisplayed()))))
     }
 
     fun assertDashboardNotificationDisplayed(title: String, subTitle: String) {


### PR DESCRIPTION
Refactor and extend DashboardE2E test to test that we don't show the grades by default any more.

refs: MBL-18952
affects: Student
release note:


- [ ] Run E2E test suite
