### PR TITLE
[CLX-2234][Horizon] Disable Widgets and shortcuts in the Horizon experience

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/features/login/StudentLoginNavigation.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/login/StudentLoginNavigation.kt
@@ -16,7 +16,9 @@
  */
 package com.instructure.student.features.login
 
+import android.content.ComponentName
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.webkit.CookieManager
 import androidx.fragment.app.FragmentActivity
 import com.instructure.canvasapi2.utils.ApiPrefs
@@ -30,6 +32,10 @@ import com.instructure.pandautils.room.offline.DatabaseProvider
 import com.instructure.pandautils.services.PushNotificationRegistrationWorker
 import com.instructure.student.activity.NavigationActivity
 import com.instructure.student.tasks.StudentLogoutTask
+import com.instructure.student.widget.NotificationWidgetProvider
+import com.instructure.student.widget.grades.list.GradesWidgetReceiver
+import com.instructure.student.widget.grades.singleGrade.SingleGradeWidgetReceiver
+import com.instructure.student.widget.todo.ToDoWidgetReceiver
 
 class StudentLoginNavigation(
     private val activity: FragmentActivity,
@@ -49,6 +55,7 @@ class StudentLoginNavigation(
 
         return when (experience) {
             Experience.Career -> {
+                disableWidgets(activity)
                 val intent = Intent(activity, HorizonActivity::class.java)
                 activity.intent?.extras?.let { extras ->
                     intent.putExtras(extras)
@@ -56,6 +63,7 @@ class StudentLoginNavigation(
                 intent
             }
             is Experience.Academic -> {
+                enableWidgets(activity)
                 val intent = Intent(activity, NavigationActivity.startActivityClass)
                 activity.intent?.extras?.let { extras ->
                     intent.putExtras(extras)
@@ -64,5 +72,28 @@ class StudentLoginNavigation(
                 intent
             }
         }
+    }
+
+    private fun disableWidgets(activity: FragmentActivity) {
+        changeWidgetAvailability(activity, false, ToDoWidgetReceiver::class.java)
+        changeWidgetAvailability(activity, false, SingleGradeWidgetReceiver::class.java)
+        changeWidgetAvailability(activity, false, GradesWidgetReceiver::class.java)
+        changeWidgetAvailability(activity, false, NotificationWidgetProvider::class.java)
+    }
+
+    private fun enableWidgets(activity: FragmentActivity) {
+        changeWidgetAvailability(activity, true, ToDoWidgetReceiver::class.java)
+        changeWidgetAvailability(activity, true, SingleGradeWidgetReceiver::class.java)
+        changeWidgetAvailability(activity, true, GradesWidgetReceiver::class.java)
+        changeWidgetAvailability(activity, true, NotificationWidgetProvider::class.java)
+    }
+
+    private fun changeWidgetAvailability(activity: FragmentActivity, enabled: Boolean, widgetClass: Class<*>) {
+        val componentName = ComponentName(activity, widgetClass)
+        activity.packageManager.setComponentEnabledSetting(
+            componentName,
+            if (enabled) PackageManager.COMPONENT_ENABLED_STATE_ENABLED else PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+            PackageManager.DONT_KILL_APP
+        )
     }
 }

--- a/libs/horizon/src/main/java/com/instructure/horizon/HorizonActivity.kt
+++ b/libs/horizon/src/main/java/com/instructure/horizon/HorizonActivity.kt
@@ -15,6 +15,7 @@
  */
 package com.instructure.horizon
 
+import android.content.pm.ShortcutManager
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.compose.ui.platform.LocalContext
@@ -38,6 +39,8 @@ class HorizonActivity : BaseCanvasActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val manager = getSystemService(ShortcutManager::class.java)
+        manager?.removeAllDynamicShortcuts()
         setContent {
             val activity = LocalContext.current.getActivityOrNull()
             if (activity != null) ViewStyler.setStatusBarColor(activity, ContextCompat.getColor(activity, R.color.surface_pagePrimary))


### PR DESCRIPTION
Test plan: Check if widgets and dymamic shortcuts (the ones from the launcher icon) is disabled when a Career user logs in and check if those are enabled again when an Academic user logs in. I couldn't remove the Bookmarks shortcut dynamically, but it doesn't break the Horizon experience.

refs: CLX-2234
affects: Student
release note: none

## Checklist

- [x] Tested in light mode
