### PR TITLE
[CLX-2052][Horizon] Fixed unread filter for announcements.

### DIFF
--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/DiscussionAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/DiscussionAPI.kt
@@ -97,6 +97,9 @@ object DiscussionAPI {
         @PUT("{contextType}/{contextId}/discussion_topics/{topicId}/read")
         fun markDiscussionTopicRead(@Path("contextType") contextType: String, @Path("contextId") contextId: Long, @Path("topicId") topicId: Long): Call<Void>
 
+        @PUT("{contextType}/{contextId}/discussion_topics/{topicId}/read")
+        suspend fun markDiscussionTopicRead(@Path("contextType") contextType: String, @Path("contextId") contextId: Long, @Path("topicId") topicId: Long, @Tag params: RestParams): DataResult<Unit>
+
         @PUT("{contextType}/{contextId}/discussion_topics/{topicId}/entries/{entryId}/read")
         suspend fun markDiscussionTopicEntryRead(@Path("contextType") contextType: String, @Path("contextId") contextId: Long, @Path("topicId") topicId: Long, @Path("entryId") entryId: Long, @Tag params: RestParams): DataResult<Unit>
 

--- a/libs/horizon/src/main/java/com/instructure/horizon/features/inbox/compose/HorizonInboxComposeScreen.kt
+++ b/libs/horizon/src/main/java/com/instructure/horizon/features/inbox/compose/HorizonInboxComposeScreen.kt
@@ -56,6 +56,7 @@ import com.instructure.horizon.R
 import com.instructure.horizon.features.inbox.attachment.HorizonInboxAttachmentPicker
 import com.instructure.horizon.features.inbox.attachment.HorizonInboxAttachmentPickerUiState
 import com.instructure.horizon.features.inbox.list.HORIZON_INBOX_LIST_NEW_CONVERSATION_CREATED
+import com.instructure.horizon.features.inbox.list.HORIZON_REFRESH_INBOX_LIST
 import com.instructure.horizon.features.inbox.navigation.HorizonInboxRoute
 import com.instructure.horizon.horizonui.foundation.HorizonColors
 import com.instructure.horizon.horizonui.foundation.HorizonCornerRadius
@@ -393,8 +394,9 @@ private fun HorizonInboxComposeControlsSection(state: HorizonInboxComposeUiState
                         color = ButtonColor.Institution,
                         onClick = {
                             state.onSendConversation {
-                                listEntry?.savedStateHandle?.set(HORIZON_INBOX_LIST_NEW_CONVERSATION_CREATED,
-                                    true
+                                listEntry?.savedStateHandle?.set(
+                                    HORIZON_REFRESH_INBOX_LIST,
+                                    HORIZON_INBOX_LIST_NEW_CONVERSATION_CREATED
                                 )
                                 navController.popBackStack()
                             }

--- a/libs/horizon/src/main/java/com/instructure/horizon/features/inbox/details/HorizonInboxDetailsUiState.kt
+++ b/libs/horizon/src/main/java/com/instructure/horizon/features/inbox/details/HorizonInboxDetailsUiState.kt
@@ -30,6 +30,7 @@ data class HorizonInboxDetailsUiState(
     val items: List<HorizonInboxDetailsItem> = emptyList(),
     val replyState: HorizonInboxReplyState? = null,
     val bottomLayout: Boolean = false,
+    val announcementMarkedAsRead: Boolean = false,
 )
 
 data class HorizonInboxReplyState(

--- a/libs/horizon/src/main/java/com/instructure/horizon/features/inbox/list/HorizonInboxListScreen.kt
+++ b/libs/horizon/src/main/java/com/instructure/horizon/features/inbox/list/HorizonInboxListScreen.kt
@@ -87,7 +87,10 @@ import com.instructure.pandautils.utils.format
 import com.instructure.pandautils.utils.getActivityOrNull
 import java.util.Date
 
+const val HORIZON_REFRESH_INBOX_LIST = "horizon_refresh_inbox_list"
 const val HORIZON_INBOX_LIST_NEW_CONVERSATION_CREATED = "horizon_inbox_list_new_conversation_created"
+const val HORIZON_INBOX_LIST_ANNOUNCEMENT_READ = "horizon_inbox_list_announcement_read"
+
 @Composable
 fun HorizonInboxListScreen(
     state: HorizonInboxListUiState,
@@ -112,14 +115,16 @@ fun HorizonInboxListScreen(
 
     val listEntry = remember(navController.currentBackStackEntry) { navController.getBackStackEntry(HorizonInboxRoute.InboxList.route) }
     val savedStateHandle = listEntry.savedStateHandle
-    val refreshFlow = remember { savedStateHandle.getStateFlow(HORIZON_INBOX_LIST_NEW_CONVERSATION_CREATED, false) }
-    val shouldRefresh by refreshFlow.collectAsState()
+    val refreshFlow = remember { savedStateHandle.getStateFlow<String?>(HORIZON_REFRESH_INBOX_LIST, null) }
+    val refreshTrigger by refreshFlow.collectAsState()
     val snackbarMessage = stringResource(R.string.inboxListConversationCreatedMessage)
-    LaunchedEffect(shouldRefresh) {
-        if (shouldRefresh) {
+    LaunchedEffect(refreshTrigger) {
+        if (refreshTrigger != null) {
             state.loadingState.onRefresh()
-            state.showSnackbar(snackbarMessage)
-            savedStateHandle[HORIZON_INBOX_LIST_NEW_CONVERSATION_CREATED] = false
+            if (refreshTrigger == HORIZON_INBOX_LIST_NEW_CONVERSATION_CREATED) {
+                state.showSnackbar(snackbarMessage)
+            }
+            savedStateHandle[HORIZON_REFRESH_INBOX_LIST] = null
         }
     }
 

--- a/libs/horizon/src/main/java/com/instructure/horizon/features/inbox/list/HorizonInboxListViewModel.kt
+++ b/libs/horizon/src/main/java/com/instructure/horizon/features/inbox/list/HorizonInboxListViewModel.kt
@@ -123,7 +123,7 @@ class HorizonInboxListViewModel @Inject constructor(
                     ).orDefault()
                 }
         }
-        val accountAnnouncements = if (uiState.value.selectedScope == HorizonInboxScope.All || uiState.value.selectedScope == HorizonInboxScope.Announcements) {
+        val accountAnnouncements = if (uiState.value.selectedScope != HorizonInboxScope.Sent) {
              repository.getAccountAnnouncements(forceRefresh)
                  .filter {
                      uiState.value.selectedRecipients.isEmpty()
@@ -131,12 +131,13 @@ class HorizonInboxListViewModel @Inject constructor(
         } else {
             emptyList()
         }
-        val courseAnnouncements = if (uiState.value.selectedScope == HorizonInboxScope.All || uiState.value.selectedScope == HorizonInboxScope.Announcements) {
+        val courseAnnouncements = if (uiState.value.selectedScope != HorizonInboxScope.Sent) {
             repository.getCourseAnnouncements(forceRefresh)
                 .filter {
                     uiState.value.selectedRecipients.isEmpty()
-                            || listOf(it.second.author?.id?.toString()) == uiState.value.selectedRecipients.map { it.stringId }
+                            || listOf(it.second.author?.id?.toString()) == uiState.value.selectedRecipients.map { recipient -> recipient.stringId }
                 }
+                .filter { uiState.value.selectedScope != HorizonInboxScope.Unread || it.second.status == DiscussionTopicHeader.ReadState.UNREAD }
         } else {
             emptyList()
         }


### PR DESCRIPTION
Test plan: See ticket. I also fixed a different issue, where course announcements wouldn't change to read after opening them. There is no read status for global announcements.

refs: CLX-2052
affects: Student
release note: none

## Checklist

- [x] Tested in light mode
