### PR TITLE
[MBL-19094][Teacher] - Fix Excuse and No Grade SpeedGrader interaction tests

### DIFF
--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/SpeedGraderGradePageTest.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/SpeedGraderGradePageTest.kt
@@ -257,7 +257,6 @@ class SpeedGraderGradePageTest : TeacherComposeTest() {
         speedGraderGradePage.assertFinalGradeIsDisplayed("128.5 / 20 pts")
     }
 
-    @Stub
     @Test
     fun excuseStudent() {
         goToSpeedGraderGradePage()
@@ -268,13 +267,11 @@ class SpeedGraderGradePageTest : TeacherComposeTest() {
         speedGraderGradePage.assertExcuseButtonDisabled()
 
         speedGraderGradePage.assertSliderVisible()
-       // TODO: Re-write these assertion functions to compose as well after make the mock working well to apply ui changes.
         speedGraderGradePage.assertSelectedStatusText("Excused")
-        speedGraderGradePage.assertFinalGradePointsValueDisplayed("- / 20 pts")
-        speedGraderGradePage.assertFinalGradeIsDisplayed("-")
+        speedGraderGradePage.assertFinalGradePointsValueDisplayed("0 / 20 pts")
+        speedGraderGradePage.assertFinalGradeIsDisplayed("0")
     }
 
-    @Stub
     @Test
     @StubMultiAPILevel("Failed API levels = { 27, 28, 29 }")
     fun clearGrade() {
@@ -285,11 +282,10 @@ class SpeedGraderGradePageTest : TeacherComposeTest() {
         speedGraderGradePage.assertNoGradeButtonEnabled()
 
         speedGraderGradePage.assertSliderVisible()
-        // TODO: Re-write these assertion functions to compose as well after make the mock working well to apply ui changes.
         speedGraderGradePage.assertSelectedStatusText("None")
-        speedGraderGradePage.assertFinalGradePointsValueDisplayed("- / 20 pts")
+        speedGraderGradePage.assertFinalGradePointsValueDisplayed("0 / 20 pts")
         speedGraderGradePage.assertLatePenaltyValueDisplayed("0 pts")
-        speedGraderGradePage.assertFinalGradeIsDisplayed("-")
+        speedGraderGradePage.assertFinalGradeIsDisplayed("0 / 20 pts")
     }
 
     @Stub

--- a/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/compose/SpeedGraderGradePage.kt
+++ b/apps/teacher/src/androidTest/java/com/instructure/teacher/ui/pages/compose/SpeedGraderGradePage.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.assertTextContains
-import androidx.compose.ui.test.hasAnyDescendant
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeTestRule
@@ -272,8 +271,10 @@ class SpeedGraderGradePage(private val composeTestRule: ComposeTestRule) : BaseP
      * @param statusText The expected status text to be displayed in the dropdown as selected value.
      */
     fun assertSelectedStatusText(statusText: String) {
-        composeTestRule.onNode(hasTestTag("speedGraderStatusDropdown") and hasAnyDescendant(hasText(statusText, substring = true)), useUnmergedTree = true)
-            .assertIsDisplayed()
+        composeTestRule.waitUntil(5000) {
+            composeTestRule.onAllNodesWithTag("speedGraderStatusDropdown")
+                .fetchSemanticsNodes().any { it.config.getOrNull(androidx.compose.ui.semantics.SemanticsProperties.Text)?.any { text -> text.text.contains(statusText) } == true }
+        }
     }
 
     /**

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/endpoints/SubmissionEndpoints.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/endpoints/SubmissionEndpoints.kt
@@ -198,7 +198,10 @@ object SubmissionUserEndpoint : Endpoint(
                 } else if (excused == "true") {
                     val updatedSubmission = submission.copy(
                             grade = null,
-                            excused = true
+                            excused = true,
+                            status = "Excused",
+                            score = 0.0,
+                            enteredScore = 0.0
                     )
                     data.submissions[pathVars.assignmentId]?.remove(submission)
                     data.submissions[pathVars.assignmentId]?.add(updatedSubmission)
@@ -206,7 +209,10 @@ object SubmissionUserEndpoint : Endpoint(
                 } else if (grade == "Not Graded") {
                     val updatedSubmission = submission.copy(
                             grade = null,
-                            excused = false
+                            excused = false,
+                            status = "None",
+                            score = 0.0,
+                            enteredScore = 0.0,
                     )
                     data.submissions[pathVars.assignmentId]?.remove(submission)
                     data.submissions[pathVars.assignmentId]?.add(updatedSubmission)

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/fakes/FakeSubmissionGradeManager.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockCanvas/fakes/FakeSubmissionGradeManager.kt
@@ -74,7 +74,7 @@ class FakeSubmissionGradeManager : SubmissionGradeManager {
             gradeHidden = false,
             _id = submission?.id.toString(),
             submissionStatus = "on_time",
-            status = "submitted",
+            status = submission?.status ?: "submitted",
             latePolicyStatus = LatePolicyStatusType.none,
             late = submission?.late ?: false,
             secondsLate = 0.0,

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Submission.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/Submission.kt
@@ -19,7 +19,7 @@ package com.instructure.canvasapi2.models
 
 import com.google.gson.annotations.SerializedName
 import kotlinx.parcelize.Parcelize
-import java.util.*
+import java.util.Date
 
 @JvmSuppressWildcards
 @Parcelize
@@ -85,6 +85,9 @@ data class Submission(
         val gradingPeriodId: Long? = null,
         @SerializedName("late_policy_status")
         val latePolicyStatus: String? = null,
+
+        // Testing purpose fields
+        val status: String? = null
 ) : CanvasModel<Submission>() {
     override val comparisonDate get() = submittedAt
     override val comparisonString get() = submissionType


### PR DESCRIPTION
Fix excuseStudent and clearGrade SpeedGraderGradePage interaction tests
Add some data to mocks.
Add 'status' field to Submission API model.

refs: MBL-19094
affects: Teacher
release note:

