### PR TITLE
[MBL-19098][Teacher] Fixed crash on quiz details

### DIFF
--- a/apps/teacher/src/main/java/com/instructure/teacher/fragments/QuizDetailsFragment.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/fragments/QuizDetailsFragment.kt
@@ -158,7 +158,7 @@ class QuizDetailsFragment : BasePresenterFragment<
                 R.id.menu_speedGrader -> {
                     val bundle = SpeedGraderFragment.makeBundle(
                         courseId = course.id,
-                        assignmentId = quiz.id
+                        assignmentId = quiz.assignmentId
                     )
                     RouteMatcher.route(requireActivity(), Route(bundle, RouteContext.SPEED_GRADER))
                 }


### PR DESCRIPTION
Test plan: Open quiz details, press SpeedGrader button, app should not crash

refs: MBL-19098
affects: Teacher
release note:

