### PR TITLE
[MBL-19103][Teacher] Expand comments

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/speedgrader/grade/SpeedGraderGradeScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/speedgrader/grade/SpeedGraderGradeScreen.kt
@@ -39,6 +39,7 @@ fun SpeedGraderGradeScreen() {
     val speedGraderRubricUiState by speedGraderRubricViewModel.uiState.collectAsState()
     var commentsExpanded by rememberSaveable { mutableStateOf(false) }
     var commentsPressed by rememberSaveable { mutableStateOf(false) }
+    var commentsFixed by rememberSaveable { mutableStateOf(false) }
 
     Column(
         modifier = Modifier
@@ -46,15 +47,19 @@ fun SpeedGraderGradeScreen() {
             .verticalScroll(rememberScrollState())
     ) {
         val showRubric = speedGraderRubricUiState.loading || speedGraderRubricUiState.criterions.isNotEmpty()
+        commentsFixed = speedGraderRubricUiState.criterions.isEmpty()
         if (!commentsPressed) {
             commentsExpanded = speedGraderRubricUiState.criterions.isEmpty()
         }
         SpeedGraderGradingScreen()
         SpeedGraderCommentsScreen(
             expanded = commentsExpanded,
+            fixed = commentsFixed,
             onExpandToggle = {
-                commentsExpanded = !commentsExpanded
-                commentsPressed = true
+                if (!commentsFixed) {
+                    commentsExpanded = !commentsExpanded
+                    commentsPressed = true
+                }
             }
         )
         if (showRubric) {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/speedgrader/grade/SpeedGraderGradeScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/speedgrader/grade/SpeedGraderGradeScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -37,7 +37,8 @@ import com.instructure.pandautils.features.speedgrader.grade.rubric.SpeedGraderR
 fun SpeedGraderGradeScreen() {
     val speedGraderRubricViewModel = hiltViewModel<SpeedGraderRubricViewModel>()
     val speedGraderRubricUiState by speedGraderRubricViewModel.uiState.collectAsState()
-    var commentsExpanded by remember { mutableStateOf(false) }
+    var commentsExpanded by rememberSaveable { mutableStateOf(false) }
+    var commentsPressed by rememberSaveable { mutableStateOf(false) }
 
     Column(
         modifier = Modifier
@@ -45,10 +46,16 @@ fun SpeedGraderGradeScreen() {
             .verticalScroll(rememberScrollState())
     ) {
         val showRubric = speedGraderRubricUiState.loading || speedGraderRubricUiState.criterions.isNotEmpty()
+        if (!commentsPressed) {
+            commentsExpanded = speedGraderRubricUiState.criterions.isEmpty()
+        }
         SpeedGraderGradingScreen()
         SpeedGraderCommentsScreen(
             expanded = commentsExpanded,
-            onExpandToggle = { commentsExpanded = !commentsExpanded }
+            onExpandToggle = {
+                commentsExpanded = !commentsExpanded
+                commentsPressed = true
+            }
         )
         if (showRubric) {
             SpeedGraderRubricContent(uiState = speedGraderRubricUiState)

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/speedgrader/grade/comments/SpeedGraderCommentsScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/speedgrader/grade/comments/SpeedGraderCommentsScreen.kt
@@ -56,6 +56,7 @@ import com.instructure.pandautils.compose.composables.CanvasDivider
 @Composable
 fun SpeedGraderCommentsScreen(
     expanded: Boolean,
+    fixed: Boolean = false,
     onExpandToggle: () -> Unit
 ) {
     val viewModel: SpeedGraderCommentsViewModel = hiltViewModel()
@@ -105,7 +106,7 @@ fun SpeedGraderCommentsScreen(
                     color = LocalCourseColor.current,
                     modifier = Modifier.size(24.dp)
                 )
-            } else {
+            } else if (!fixed) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_arrow_down),
                     tint = colorResource(id = R.color.textDarkest),


### PR DESCRIPTION
Test plan: 
- Open an assignment in SpeedGrader which has no rubrics, comments should be expanded, and not collapsable
- Open an assignment in SpeedGrader which has rubrics, comments should collapsed, and can be expanded

refs: MBL-19103
affects: Teacher
release note:

