### PR TITLE
[MBL-19223][Teacher] SpeedGrader bottom sheet initial state

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/speedgrader/SpeedGraderSubmissionScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/speedgrader/SpeedGraderSubmissionScreen.kt
@@ -117,7 +117,8 @@ private fun SpeedGraderSubmissionContent(
             },
             bottomContent = {
                 bottomSheetContent(anchoredDraggableState)
-            }
+            },
+            initialAnchor = AnchorPoints.MIDDLE
         )
     }
 }


### PR DESCRIPTION
Test plan: Open speedgrader, the bottom sheet should start at half expanded.

refs: MBL-19223
affects: Teacher
release note: none
