### PR TITLE
[MBL-19220][Teacher] Show no-attempt comments only for the first attempt

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/speedgrader/grade/comments/SpeedGraderCommentsViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/speedgrader/grade/comments/SpeedGraderCommentsViewModel.kt
@@ -119,7 +119,7 @@ class SpeedGraderCommentsViewModel @Inject constructor(
         subscribeToFileUploadEvents()
         val isAnonymousGrading = response.data.submission?.assignment?.anonymousGrading ?: false
         fetchedComments = response.comments
-            .filter { it.attempt.toLong() == selectedAttemptId || !assignmentEnhancementsEnabled }
+            .filter { (it.attempt.toLong() == 0L && selectedAttemptId == 1L) || it.attempt.toLong() == selectedAttemptId || !assignmentEnhancementsEnabled }
             .map { node ->
                 node.let {
                     val isOwnComment = apiPrefs.user?.id?.toString() == it.author?._id

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/speedgrader/grade/comments/SpeedGraderCommentsViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/speedgrader/grade/comments/SpeedGraderCommentsViewModelTest.kt
@@ -303,4 +303,73 @@ class SpeedGraderCommentsViewModelTest {
         assert(!viewModel.uiState.value.showAttachmentTypeDialog)
         assert(viewModel.uiState.value.fileSelectorDialogData == null)
     }
+
+    @Test
+    fun `comments for no attempt is shown for the first attempt`() = runTest {
+        coEvery { repository.getCourseFeatures(any()) } returns listOf("assignments_2_student")
+        val attemptFlow = MutableStateFlow(1L)
+        coEvery { selectedAttemptHolder.selectedAttemptIdFlowFor(any()) } returns attemptFlow
+        coEvery { repository.getSubmissionComments(any(), any(), any()) } returns mockk {
+            every { data.submission } returns null
+            every { comments } returns listOf(
+                SubmissionCommentsQuery.Node1(
+                    comment = "Comment for no attempt",
+                    author = SubmissionCommentsQuery.Author(
+                        _id = "1",
+                        name = "Author",
+                        avatarUrl = "avatarUrl",
+                        email = "email@asd.com",
+                        pronouns = "they/them"
+                    ),
+                    mediaObject = null,
+                    createdAt = java.util.Date(),
+                    canReply = true,
+                    draft = false,
+                    attempt = 0,
+                    read = true,
+                    attachments = null,
+                    mediaCommentId = null
+                )
+            )
+        }
+
+        createViewModel()
+        Thread.sleep(100)
+
+        assertEquals(1, viewModel.uiState.value.comments.size)
+    }
+
+    @Test
+    fun `comments for no attempt don't show for non first attempt`() = runTest {
+        coEvery { repository.getCourseFeatures(any()) } returns listOf("assignments_2_student")
+        val attemptFlow = MutableStateFlow(2L)
+        coEvery { selectedAttemptHolder.selectedAttemptIdFlowFor(any()) } returns attemptFlow
+        coEvery { repository.getSubmissionComments(any(), any(), any()) } returns mockk {
+            every { data.submission } returns null
+            every { comments } returns listOf(
+                SubmissionCommentsQuery.Node1(
+                    comment = "Comment for no attempt",
+                    author = SubmissionCommentsQuery.Author(
+                        _id = "1",
+                        name = "Author",
+                        avatarUrl = "avatarUrl",
+                        email = "email@asd.com",
+                        pronouns = "they/them"
+                    ),
+                    mediaObject = null,
+                    createdAt = java.util.Date(),
+                    canReply = true,
+                    draft = false,
+                    attempt = 0,
+                    read = true,
+                    attachments = null,
+                    mediaCommentId = null
+                )
+            )
+        }
+
+        createViewModel()
+        Thread.sleep(100)
+        assertEquals(0, viewModel.uiState.value.comments.size)
+    }
 }


### PR DESCRIPTION
Test plan: Add a comment with no attempt on a submission.
  - The comment should be visible in SG when viewing the first attempt.
  - The comment should not be visible in SG when viewing any other attempt.

refs: MBL-19220
affects: Teacher
release note: none
