### PR TITLE
[MBL-19190][Teacher] After sending a comment from the Comment Library, the input text still remains in the input field

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/speedgrader/grade/comments/SpeedGraderCommentsViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/speedgrader/grade/comments/SpeedGraderCommentsViewModel.kt
@@ -657,14 +657,13 @@ class SpeedGraderCommentsViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             if (_uiState.value.commentText.isNotEmpty()) {
                 val comment = _uiState.value.commentText
-                _uiState.update { state ->
-                    state.copy(
-                        commentText = ""
-                    )
-                }
 
                 val id = createPendingComment(comment)
                 sendComment(id, comment)
+
+                _uiState.update { state ->
+                    state.copy(commentText = "")
+                }
             }
         }
     }


### PR DESCRIPTION
Test plan: see the ticket

refs: MBL-19190
affects: Teacher
release note: none
