### PR TITLE
Restrict Add event from Calendars for Students App

### DIFF
--- a/apps/parent/src/main/java/com/instructure/parentapp/di/feature/CalendarModule.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/di/feature/CalendarModule.kt
@@ -22,6 +22,7 @@ import com.instructure.canvasapi2.apis.CourseAPI
 import com.instructure.canvasapi2.apis.FeaturesAPI
 import com.instructure.canvasapi2.apis.PlannerAPI
 import com.instructure.canvasapi2.utils.ApiPrefs
+import com.instructure.pandautils.features.calendar.CalendarBehavior
 import com.instructure.pandautils.features.calendar.CalendarRepository
 import com.instructure.pandautils.features.calendar.CalendarRouter
 import com.instructure.pandautils.room.calendar.daos.CalendarFilterDao
@@ -60,5 +61,10 @@ class CalendarViewModelModule {
         calendarFilterDao: CalendarFilterDao
     ): CalendarRepository {
         return ParentCalendarRepository(plannerApi, coursesApi, calendarEventsApi, apiPrefs, featuresApi, parentPrefs, calendarFilterDao)
+    }
+
+    @Provides
+    fun provideCalendarBehavior(): CalendarBehavior {
+        return object : CalendarBehavior {}
     }
 }

--- a/apps/student/src/main/java/com/instructure/student/di/feature/CalendarModule.kt
+++ b/apps/student/src/main/java/com/instructure/student/di/feature/CalendarModule.kt
@@ -22,9 +22,12 @@ import com.instructure.canvasapi2.apis.CourseAPI
 import com.instructure.canvasapi2.apis.GroupAPI
 import com.instructure.canvasapi2.apis.PlannerAPI
 import com.instructure.canvasapi2.utils.ApiPrefs
+import com.instructure.pandautils.features.calendar.CalendarBehavior
 import com.instructure.pandautils.features.calendar.CalendarRepository
 import com.instructure.pandautils.features.calendar.CalendarRouter
 import com.instructure.pandautils.room.calendar.daos.CalendarFilterDao
+import com.instructure.pandautils.utils.FeatureFlagProvider
+import com.instructure.student.features.calendar.StudentCalendarBehavior
 import com.instructure.student.features.calendar.StudentCalendarRepository
 import com.instructure.student.features.calendar.StudentCalendarRouter
 import dagger.Module
@@ -56,5 +59,12 @@ class CalendarViewModelModule {
         calendarFilterDao: CalendarFilterDao
     ): CalendarRepository {
         return StudentCalendarRepository(plannerApi, coursesApi, groupsApi, apiPrefs, calendarFilterDao)
+    }
+
+    @Provides
+    fun provideCalendarBehavior(
+        featureFlagProvider: FeatureFlagProvider
+    ): CalendarBehavior {
+        return StudentCalendarBehavior(featureFlagProvider)
     }
 }

--- a/apps/student/src/main/java/com/instructure/student/features/calendar/StudentCalendarBehavior.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/calendar/StudentCalendarBehavior.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.student.features.calendar
+
+import com.instructure.pandautils.features.calendar.CalendarBehavior
+import com.instructure.pandautils.utils.FeatureFlagProvider
+import javax.inject.Inject
+
+class StudentCalendarBehavior @Inject constructor(
+    private val featureFlagProvider: FeatureFlagProvider
+) : CalendarBehavior {
+    
+    override suspend fun shouldShowAddEventButton(): Boolean {
+        return try {
+            !featureFlagProvider.checkEnvironmentFeatureFlag("restrict_student_access")
+        } catch (e: Exception) {
+            true
+        }
+    }
+}

--- a/apps/student/src/main/java/com/instructure/student/features/calendar/StudentCalendarBehavior.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/calendar/StudentCalendarBehavior.kt
@@ -26,7 +26,7 @@ class StudentCalendarBehavior @Inject constructor(
     
     override suspend fun shouldShowAddEventButton(): Boolean {
         return try {
-            !featureFlagProvider.checkEnvironmentFeatureFlag("restrict_student_access")
+            !featureFlagProvider.checkRestrictStudentAccessFlag()
         } catch (e: Exception) {
             true
         }

--- a/apps/student/src/test/java/com/instructure/student/features/calendar/StudentCalendarBehaviorTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/features/calendar/StudentCalendarBehaviorTest.kt
@@ -31,7 +31,7 @@ class StudentCalendarBehaviorTest {
 
     @Test
     fun `shouldShowAddEventButton returns false when restrict_student_access flag is enabled`() = runTest {
-        coEvery { featureFlagProvider.checkEnvironmentFeatureFlag("restrict_student_access") } returns true
+        coEvery { featureFlagProvider.checkRestrictStudentAccessFlag() } returns true
 
         val result = behavior.shouldShowAddEventButton()
 
@@ -40,7 +40,7 @@ class StudentCalendarBehaviorTest {
 
     @Test
     fun `shouldShowAddEventButton returns true when restrict_student_access flag is disabled`() = runTest {
-        coEvery { featureFlagProvider.checkEnvironmentFeatureFlag("restrict_student_access") } returns false
+        coEvery { featureFlagProvider.checkRestrictStudentAccessFlag() } returns false
 
         val result = behavior.shouldShowAddEventButton()
 
@@ -49,7 +49,7 @@ class StudentCalendarBehaviorTest {
 
     @Test
     fun `shouldShowAddEventButton returns true when flag check throws exception`() = runTest {
-        coEvery { featureFlagProvider.checkEnvironmentFeatureFlag("restrict_student_access") } throws RuntimeException("Network error")
+        coEvery { featureFlagProvider.checkRestrictStudentAccessFlag() } throws RuntimeException("Network error")
 
         val result = behavior.shouldShowAddEventButton()
 

--- a/apps/student/src/test/java/com/instructure/student/features/calendar/StudentCalendarBehaviorTest.kt
+++ b/apps/student/src/test/java/com/instructure/student/features/calendar/StudentCalendarBehaviorTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.instructure.student.features.calendar
+
+import com.instructure.pandautils.utils.FeatureFlagProvider
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StudentCalendarBehaviorTest {
+
+    private val featureFlagProvider: FeatureFlagProvider = mockk()
+    private val behavior = StudentCalendarBehavior(featureFlagProvider)
+
+    @Test
+    fun `shouldShowAddEventButton returns false when restrict_student_access flag is enabled`() = runTest {
+        coEvery { featureFlagProvider.checkEnvironmentFeatureFlag("restrict_student_access") } returns true
+
+        val result = behavior.shouldShowAddEventButton()
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `shouldShowAddEventButton returns true when restrict_student_access flag is disabled`() = runTest {
+        coEvery { featureFlagProvider.checkEnvironmentFeatureFlag("restrict_student_access") } returns false
+
+        val result = behavior.shouldShowAddEventButton()
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `shouldShowAddEventButton returns true when flag check throws exception`() = runTest {
+        coEvery { featureFlagProvider.checkEnvironmentFeatureFlag("restrict_student_access") } throws RuntimeException("Network error")
+
+        val result = behavior.shouldShowAddEventButton()
+
+        assertTrue(result)
+    }
+}

--- a/apps/teacher/src/main/java/com/instructure/teacher/di/CalendarModule.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/di/CalendarModule.kt
@@ -22,6 +22,7 @@ import com.instructure.canvasapi2.apis.CourseAPI
 import com.instructure.canvasapi2.apis.FeaturesAPI
 import com.instructure.canvasapi2.apis.PlannerAPI
 import com.instructure.canvasapi2.utils.ApiPrefs
+import com.instructure.pandautils.features.calendar.CalendarBehavior
 import com.instructure.pandautils.features.calendar.CalendarRepository
 import com.instructure.pandautils.features.calendar.CalendarRouter
 import com.instructure.pandautils.room.calendar.daos.CalendarFilterDao
@@ -56,6 +57,11 @@ class CalendarModule {
             calendarFilterDao: CalendarFilterDao
         ): CalendarRepository {
             return TeacherCalendarRepository(plannerApi, coursesApi, calendarEventsApi, apiPrefs, featuresApi, calendarFilterDao)
+        }
+
+        @Provides
+        fun provideCalendarBehavior(): CalendarBehavior {
+            return object : CalendarBehavior {}
         }
     }
 }

--- a/libs/pandautils/src/androidTest/java/com/instructure/pandautils/compose/features/calendar/CalendarScreenTest.kt
+++ b/libs/pandautils/src/androidTest/java/com/instructure/pandautils/compose/features/calendar/CalendarScreenTest.kt
@@ -306,4 +306,72 @@ class CalendarScreenTest {
         val snackbarText = composeTestRule.onNode(hasText("Snackbar message").and(hasAnyAncestor(hasTestTag("snackbarHost"))))
         snackbarText.assertIsDisplayed()
     }
+
+    @Test
+    fun addEventButtonIsHiddenWhenShowAddEventButtonIsFalse() {
+        composeTestRule.setContent {
+            AndroidThreeTen.init(LocalContext.current)
+            stateMapper = CalendarStateMapper(Clock.systemDefaultZone())
+            val selectedDate = LocalDate.now().plusDays(1)
+            CalendarScreen(
+                title = "Calendar",
+                calendarScreenUiState = CalendarScreenUiState(
+                    calendarUiState = CalendarUiState(
+                        selectedDate, true, stateMapper.createHeaderUiState(
+                            selectedDate, null
+                        ), stateMapper.createBodyUiState(true, selectedDate)
+                    ),
+                    showAddEventButton = false
+                ),
+                false,
+                showToolbar = true,
+                actionHandler = {},
+                navigationActionClick = {},
+            )
+        }
+
+        val fab = composeTestRule.onNode(hasContentDescription("Add new calendar item"))
+        fab.performClick()
+        composeTestRule.waitForIdle()
+        
+        val addToDoItem = composeTestRule.onNode((hasText("Add To Do")))
+        addToDoItem.assertIsDisplayed()
+        
+        val addEventItem = composeTestRule.onNode((hasText("Add Event")))
+        addEventItem.assertIsNotDisplayed()
+    }
+
+    @Test
+    fun addEventButtonIsShownWhenShowAddEventButtonIsTrue() {
+        composeTestRule.setContent {
+            AndroidThreeTen.init(LocalContext.current)
+            stateMapper = CalendarStateMapper(Clock.systemDefaultZone())
+            val selectedDate = LocalDate.now().plusDays(1)
+            CalendarScreen(
+                title = "Calendar",
+                calendarScreenUiState = CalendarScreenUiState(
+                    calendarUiState = CalendarUiState(
+                        selectedDate, true, stateMapper.createHeaderUiState(
+                            selectedDate, null
+                        ), stateMapper.createBodyUiState(true, selectedDate)
+                    ),
+                    showAddEventButton = true
+                ),
+                false,
+                showToolbar = true,
+                actionHandler = {},
+                navigationActionClick = {},
+            )
+        }
+
+        val fab = composeTestRule.onNode(hasContentDescription("Add new calendar item"))
+        fab.performClick()
+        composeTestRule.waitForIdle()
+        
+        val addToDoItem = composeTestRule.onNode((hasText("Add To Do")))
+        addToDoItem.assertIsDisplayed()
+        
+        val addEventItem = composeTestRule.onNode((hasText("Add Event")))
+        addEventItem.assertIsDisplayed()
+    }
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/CalendarBehavior.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/CalendarBehavior.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2025 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package com.instructure.pandautils.features.calendar
+
+interface CalendarBehavior {
+    suspend fun shouldShowAddEventButton(): Boolean = true
+}

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/CalendarScreenUiState.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/CalendarScreenUiState.kt
@@ -25,7 +25,8 @@ import java.util.Locale
 data class CalendarScreenUiState(
     val calendarUiState: CalendarUiState,
     val calendarEventsUiState: CalendarEventsUiState = CalendarEventsUiState(),
-    val snackbarMessage: String? = null
+    val snackbarMessage: String? = null,
+    val showAddEventButton: Boolean = true
 )
 
 data class CalendarUiState(

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/CalendarViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/CalendarViewModel.kt
@@ -65,6 +65,7 @@ class CalendarViewModel @Inject constructor(
     private val calendarPrefs: CalendarPrefs,
     private val calendarStateMapper: CalendarStateMapper,
     private val calendarSharedEvents: CalendarSharedEvents,
+    private val calendarBehavior: CalendarBehavior,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -97,6 +98,14 @@ class CalendarViewModel @Inject constructor(
 
     init {
         loadVisibleMonths()
+        initializeCalendarBehavior()
+    }
+    
+    private fun initializeCalendarBehavior() {
+        viewModelScope.launch {
+            val shouldShowAddEventButton = calendarBehavior.shouldShowAddEventButton()
+            _uiState.update { it.copy(showAddEventButton = shouldShowAddEventButton) }
+        }
     }
 
     private suspend fun loadFilters(filtersFromDb: CalendarFilterEntity?) {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/composables/CalendarScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/composables/CalendarScreen.kt
@@ -188,7 +188,7 @@ fun CalendarScreen(
                         )
                     },
                     expanded = fabExpandedState,
-                    expandedItems = listOf(
+                    expandedItems = listOfNotNull(
                         {
                             ExpandableFabItem(
                                 icon = painterResource(id = R.drawable.ic_todo),
@@ -201,18 +201,20 @@ fun CalendarScreen(
                                     .semantics { traversalIndex = 1f }
                             )
                         },
-                        {
-                            ExpandableFabItem(
-                                icon = painterResource(id = R.drawable.ic_calendar_month_24),
-                                text = stringResource(id = R.string.calendarAddEvent),
-                                modifier = Modifier
-                                    .clickable {
-                                        fabExpandedState.value = false
-                                        actionHandler(CalendarAction.AddEventTapped)
-                                    }
-                                    .semantics { traversalIndex = 2f }
-                            )
-                        }
+                        if (calendarScreenUiState.showAddEventButton) {
+                            {
+                                ExpandableFabItem(
+                                    icon = painterResource(id = R.drawable.ic_calendar_month_24),
+                                    text = stringResource(id = R.string.calendarAddEvent),
+                                    modifier = Modifier
+                                        .clickable {
+                                            fabExpandedState.value = false
+                                            actionHandler(CalendarAction.AddEventTapped)
+                                        }
+                                        .semantics { traversalIndex = 2f }
+                                )
+                            }
+                        } else null
                     )
                 )
             }

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/calendar/CalendarBehaviorTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/calendar/CalendarBehaviorTest.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2025 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package com.instructure.pandautils.features.calendar
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CalendarBehaviorTest {
+
+    @Test
+    fun `default implementation returns true for shouldShowAddEventButton`() = runTest {
+        val behavior = object : CalendarBehavior {}
+
+        val result = behavior.shouldShowAddEventButton()
+
+        assertTrue(result)
+    }
+}

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/calendar/CalendarViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/calendar/CalendarViewModelTest.kt
@@ -67,6 +67,7 @@ class CalendarViewModelTest {
     private val calendarPrefs: CalendarPrefs = mockk(relaxed = true)
     private val calendarStateMapper: CalendarStateMapper = mockk(relaxed = true)
     private val calendarSharedEvents: CalendarSharedEvents = mockk(relaxed = true)
+    private val calendarBehavior: CalendarBehavior = mockk(relaxed = true)
     private val savedStateHandle: SavedStateHandle = mockk(relaxed = true)
 
     private lateinit var viewModel: CalendarViewModel
@@ -135,6 +136,8 @@ class CalendarViewModelTest {
             "1",
             filters = setOf("course_1", "course_2", "group_3", "group_4", "user_5")
         )
+
+        coEvery { calendarBehavior.shouldShowAddEventButton() } returns true
 
         every { savedStateHandle.get<Any>(any()) } returns null
     }
@@ -1240,8 +1243,31 @@ class CalendarViewModelTest {
         )
     }
 
+    @Test
+    fun `showAddEventButton is true when behavior allows it`() = runTest {
+        coEvery { calendarBehavior.shouldShowAddEventButton() } returns true
+        initViewModel()
+
+        assertTrue(viewModel.uiState.value.showAddEventButton)
+    }
+
+    @Test
+    fun `showAddEventButton is false when behavior restricts it`() = runTest {
+        coEvery { calendarBehavior.shouldShowAddEventButton() } returns false
+        initViewModel()
+
+        assertFalse(viewModel.uiState.value.showAddEventButton)
+    }
+
+    @Test
+    fun `behavior shouldShowAddEventButton is called during initialization`() = runTest {
+        initViewModel()
+
+        coVerify { calendarBehavior.shouldShowAddEventButton() }
+    }
+
     private fun initViewModel() {
-        viewModel = CalendarViewModel(context, calendarRepository, apiPrefs, clock, calendarPrefs, calendarStateMapper, calendarSharedEvents, savedStateHandle)
+        viewModel = CalendarViewModel(context, calendarRepository, apiPrefs, clock, calendarPrefs, calendarStateMapper, calendarSharedEvents, calendarBehavior, savedStateHandle)
     }
 
     private fun createPlannerItem(


### PR DESCRIPTION
Test plan:

refs: PFS-25692, PFS-25742
affects: Students App
release note: None

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [ ] Run E2E test suite
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] A11y checked
- [ ] Approve from product
