### PR TITLE
[CLX-2897][Horizon] Show courses with no modules on Dashboard

### DIFF
--- a/libs/horizon/src/main/java/com/instructure/horizon/features/dashboard/DashboardScreen.kt
+++ b/libs/horizon/src/main/java/com/instructure/horizon/features/dashboard/DashboardScreen.kt
@@ -289,6 +289,8 @@ private fun DashboardCourseItem(
             Text(text = stringResource(R.string.dashboard_courseCompleted), style = HorizonTypography.h3)
             HorizonSpace(SpaceSize.SPACE_12)
             Text(text = stringResource(R.string.dashboard_courseCompletedDescription), style = HorizonTypography.p1)
+        } else if (!courseItem.hasModuleItems) {
+            Text(text = stringResource(R.string.dashboard_courseHasNoModules), style = HorizonTypography.p1)
         } else {
             Text(text = stringResource(R.string.dashboard_resumeLearning), style = HorizonTypography.h3)
             HorizonSpace(SpaceSize.SPACE_12)

--- a/libs/horizon/src/main/java/com/instructure/horizon/features/dashboard/DashboardUiState.kt
+++ b/libs/horizon/src/main/java/com/instructure/horizon/features/dashboard/DashboardUiState.kt
@@ -39,7 +39,8 @@ data class DashboardCourseUiState(
     val remainingTime: String? = null,
     val learningObjectType: LearningObjectType? = null,
     val dueDate: Date? = null,
-    val parentPrograms: List<DashboardCourseProgram> = emptyList()
+    val parentPrograms: List<DashboardCourseProgram> = emptyList(),
+    val hasModuleItems: Boolean = true,
 )
 
 data class DashboardCourseProgram(

--- a/libs/horizon/src/main/java/com/instructure/horizon/features/dashboard/DashboardViewModel.kt
+++ b/libs/horizon/src/main/java/com/instructure/horizon/features/dashboard/DashboardViewModel.kt
@@ -148,7 +148,13 @@ class DashboardViewModel @Inject constructor(
                 val nextModuleResult = modules.dataOrThrow.find { module -> module.id == nextModuleItemResult?.moduleId }
 
                 if (nextModuleItemResult == null || nextModuleResult == null) {
-                    return null
+                    return DashboardCourseUiState(
+                        courseId = dashboardCourse.course.courseId,
+                        courseName = dashboardCourse.course.courseName,
+                        courseProgress = dashboardCourse.course.progress,
+                        parentPrograms = parentPrograms,
+                        hasModuleItems = false
+                    )
                 }
                 createCourseUiState(dashboardCourse.course, nextModuleResult, nextModuleItemResult, parentPrograms)
             } else {

--- a/libs/horizon/src/main/res/values/strings.xml
+++ b/libs/horizon/src/main/res/values/strings.xml
@@ -353,4 +353,5 @@
     <string name="learn_failedToLoad">Failed to load programs and courses.</string>
     <string name="learn_failedToRefresh">Failed to refresh programs and courses.</string>
     <string name="tools_noLtiTools">There are no external tools for this course.</string>
+    <string name="dashboard_courseHasNoModules">Course has no modules</string>
 </resources>


### PR DESCRIPTION
Test plan: In the ticket

refs: CLX-2897
affects: Student
release note: none

## Checklist

- [x] Tested in light mode
