### PR TITLE
[MBL-19299][Student][Parent] Excused assignments show missing tag

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/AssignmentExtensions.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/AssignmentExtensions.kt
@@ -17,7 +17,6 @@
 
 package com.instructure.pandautils.utils
 
-import android.content.Context
 import android.content.res.Resources
 import com.instructure.canvasapi2.CustomGradeStatusesQuery
 import com.instructure.canvasapi2.models.Assignment
@@ -207,6 +206,7 @@ fun Assignment.getSubAssignmentSubmissionGrade(
 private fun mapSubmissionStateLabel(
     customGradeStatusId: Long?,
     customStatuses: List<CustomGradeStatusesQuery.Node>,
+    excused: Boolean,
     late: Boolean,
     missing: Boolean,
     graded: Boolean,
@@ -218,6 +218,7 @@ private fun mapSubmissionStateLabel(
     }
 
     return when {
+        excused -> SubmissionStateLabel.Excused
         matchedCustomStatus != null -> SubmissionStateLabel.Custom(
             R.drawable.ic_flag,
             R.color.textInfo,
@@ -238,6 +239,7 @@ fun Assignment.getSubmissionStateLabel(
 ) = mapSubmissionStateLabel(
     submission?.customGradeStatusId,
     customStatuses,
+    submission?.excused.orDefault(),
     submission?.late.orDefault(),
     isMissing(),
     isGraded().orDefault(),
@@ -251,6 +253,7 @@ fun Assignment.getSubAssignmentSubmissionStateLabel(
 ) = mapSubmissionStateLabel(
     submission?.customGradeStatusId,
     customStatuses,
+    submission?.excused.orDefault(),
     submission?.late.orDefault(),
     submission?.missing.orDefault(),
     !submission?.grade.isNullOrEmpty(),

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/assignments/details/AssignmentDetailsViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/assignments/details/AssignmentDetailsViewModelTest.kt
@@ -298,9 +298,9 @@ class AssignmentDetailsViewModelTest {
     fun `Missing submission`() {
         val expectedLabelText = "Missing"
         val expectedTint = R.color.textDanger
-        val expectedIcon = R.drawable.ic_no
+        val expectedIcon = R.drawable.ic_unpublish
 
-        every { resources.getString(R.string.missingAssignment) } returns expectedLabelText
+        every { resources.getString(R.string.missingSubmissionLabel) } returns expectedLabelText
 
         val course = Course(enrollments = mutableListOf(Enrollment(type = Enrollment.EnrollmentType.Student)))
         coEvery { assignmentDetailsRepository.getCourseWithGrade(any(), any()) } returns course
@@ -322,8 +322,8 @@ class AssignmentDetailsViewModelTest {
     @Test
     fun `Not submitted submission`() {
         val expectedLabelText = "Not submitted"
-        val expectedTint = R.color.textDark
-        val expectedIcon = R.drawable.ic_no
+        val expectedTint = R.color.backgroundDark
+        val expectedIcon = R.drawable.ic_unpublish
 
         every { resources.getString(R.string.notSubmitted) } returns expectedLabelText
 
@@ -373,7 +373,7 @@ class AssignmentDetailsViewModelTest {
     fun `Submitted submission`() {
         val expectedLabelText = "Submitted"
         val expectedTint = R.color.textSuccess
-        val expectedIcon = R.drawable.ic_complete_solid
+        val expectedIcon = R.drawable.ic_complete
 
         every { resources.getString(R.string.submitted) } returns expectedLabelText
 


### PR DESCRIPTION
Test plan: on assignment list Excused assignments should have Excused status, also on Assignment Details the same status should be shown as on the list.

refs: MBL-19299
affects: Student, Parent
release note: Excused assignments now consistently show an 'Excused' status in both the assignment list and assignment details.

## Checklist

- [ ] Run E2E test suite
