### PR TITLE
[MBL-19358][Teacher] Scrolling in New Quiz submissions is not smooth

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/speedgrader/content/SpeedGraderContentScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/speedgrader/content/SpeedGraderContentScreen.kt
@@ -157,7 +157,11 @@ private fun SpeedGraderContentScreen(
                         arguments = route.bundle,
                         modifier = Modifier
                             .fillMaxSize()
-                            .conditional(content is PdfContent || content is DiscussionContent) {
+                            .conditional(
+                                content is PdfContent ||
+                                        content is DiscussionContent ||
+                                        content is ExternalToolContent
+                            ) {
                                 pointerInput(Unit) {
                                     awaitPointerEventScope {
                                         while (true) {


### PR DESCRIPTION
Test plan: Verify scrolling in SpeedGrader with a New Quizzes assignment. Confirm that swiping between students is only possible on the header and the bottom sheet.

refs: MBL-19358
affects: Teacher
release note: Fixed a scrolling issue in SpeedGrader when grading New Quizzes assignments.