### PR TITLE
[MBL-19363][All] Inbox messages can be sent from course participation courses in closed terms

### DIFF
--- a/libs/pandares/src/main/res/values/strings.xml
+++ b/libs/pandares/src/main/res/values/strings.xml
@@ -2153,4 +2153,5 @@
     <string name="additional_replies">Additional replies (%d)</string>
     <string name="a11y_discussion_checkpoints">Discussion Checkpoints</string>
     <string name="multipleDueDates">Multiple Due Dates</string>
+    <string name="courseConcludedError">Course concluded. Unable to send messages!</string>
 </resources>

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/compose/InboxComposeViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/compose/InboxComposeViewModel.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.work.WorkInfo
 import com.instructure.canvasapi2.models.CanvasContext
+import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.models.Recipient
 import com.instructure.canvasapi2.type.EnrollmentType
 import com.instructure.canvasapi2.utils.DataResult
@@ -47,6 +48,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.util.Date
 import java.util.EnumMap
 import java.util.UUID
 import javax.inject.Inject
@@ -532,12 +534,31 @@ class InboxComposeViewModel @Inject constructor(
         return inboxComposeRepository.getRecipients(searchQuery, contextId, forceRefresh)
     }
 
+    private fun canSendMessageInContext(canvasContext: CanvasContext): Boolean {
+        if (canvasContext !is Course) return true
+
+        val fullCourse = uiState.value.selectContextUiState.canvasContexts
+            .filterIsInstance<Course>()
+            .find { it.id == canvasContext.id }
+            ?: canvasContext
+
+        val now = Date()
+        return fullCourse.workflowState != Course.WorkflowState.COMPLETED &&
+                fullCourse.endDate?.before(now) != true &&
+                fullCourse.term?.endDate?.before(now) != true
+    }
+
     private fun createConversation() {
         uiState.value.selectContextUiState.selectedCanvasContext?.let { canvasContext ->
             viewModelScope.launch {
                 _uiState.update { uiState.value.copy(screenState = ScreenState.Loading) }
 
                 try {
+                    if (!canSendMessageInContext(canvasContext)) {
+                        sendScreenResult(context.getString(R.string.courseConcludedError))
+                        return@launch
+                    }
+
                     inboxComposeRepository.createConversation(
                         recipients = uiState.value.recipientPickerUiState.selectedRecipients,
                         subject = uiState.value.subject.text,
@@ -569,6 +590,11 @@ class InboxComposeViewModel @Inject constructor(
                 _uiState.update { uiState.value.copy(screenState = ScreenState.Loading) }
 
                 try {
+                    if (!canSendMessageInContext(canvasContext)) {
+                        sendScreenResult(context.getString(R.string.courseConcludedError))
+                        return@launch
+                    }
+
                     inboxComposeRepository.addMessage(
                         conversationId = uiState.value.previousMessages?.conversation?.id ?: 0,
                         recipients = uiState.value.recipientPickerUiState.selectedRecipients,

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/inbox/compose/InboxComposeViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/inbox/compose/InboxComposeViewModelTest.kt
@@ -900,6 +900,138 @@ class InboxComposeViewModelTest {
 
     // endregion
 
+    // region Concluded Course Validation
+
+    @Test
+    fun `Send message fails when course is concluded`() = runTest {
+        val concludedCourse = Course(id = 1, name = "Concluded Course", workflowState = Course.WorkflowState.COMPLETED)
+
+        coEvery { inboxComposeRepository.getCourses(any()) } returns DataResult.Success(listOf(concludedCourse))
+        coEvery { inboxComposeRepository.getGroups(any()) } returns DataResult.Success(emptyList())
+        coEvery { context.getString(R.string.courseConcludedError) } returns "This course has concluded. You can no longer send messages."
+
+        val viewmodel = getViewModel()
+
+        val events = mutableListOf<InboxComposeViewModelAction>()
+        backgroundScope.launch(testDispatcher) {
+            viewmodel.events.toList(events)
+        }
+
+        viewmodel.handleAction(ContextPickerActionHandler.ContextClicked(concludedCourse))
+        viewmodel.handleAction(InboxComposeActionHandler.AddRecipient(Recipient(stringId = "1")))
+        viewmodel.handleAction(InboxComposeActionHandler.SubjectChanged(TextFieldValue("Subject")))
+        viewmodel.handleAction(InboxComposeActionHandler.BodyChanged(TextFieldValue("Body")))
+        viewmodel.handleAction(InboxComposeActionHandler.SendClicked)
+
+        coVerify(exactly = 0) { inboxComposeRepository.createConversation(any(), any(), any(), any(), any(), any()) }
+        assertEquals(InboxComposeViewModelAction.ShowScreenResult("This course has concluded. You can no longer send messages."), events.last())
+    }
+
+    @Test
+    fun `Send message succeeds when course is active`() = runTest {
+        val activeCourse = Course(id = 1, name = "Active Course", workflowState = Course.WorkflowState.AVAILABLE)
+
+        coEvery { inboxComposeRepository.getCourses(any()) } returns DataResult.Success(listOf(activeCourse))
+        coEvery { inboxComposeRepository.getGroups(any()) } returns DataResult.Success(emptyList())
+        coEvery { inboxComposeRepository.createConversation(any(), any(), any(), any(), any(), any()) } returns DataResult.Success(mockk())
+
+        val viewmodel = getViewModel()
+
+        val events = mutableListOf<InboxComposeViewModelAction>()
+        backgroundScope.launch(testDispatcher) {
+            viewmodel.events.toList(events)
+        }
+
+        viewmodel.handleAction(ContextPickerActionHandler.ContextClicked(activeCourse))
+        viewmodel.handleAction(InboxComposeActionHandler.AddRecipient(Recipient(stringId = "1")))
+        viewmodel.handleAction(InboxComposeActionHandler.SubjectChanged(TextFieldValue("Subject")))
+        viewmodel.handleAction(InboxComposeActionHandler.BodyChanged(TextFieldValue("Body")))
+        viewmodel.handleAction(InboxComposeActionHandler.SendClicked)
+
+        coVerify(exactly = 1) { inboxComposeRepository.createConversation(any(), any(), any(), any(), any(), any()) }
+        assertEquals(3, events.size)
+        assertEquals(InboxComposeViewModelAction.UpdateParentFragment, events[0])
+        assertEquals(InboxComposeViewModelAction.ShowScreenResult(context.getString(R.string.messageSentSuccessfully)), events[1])
+        assertEquals(InboxComposeViewModelAction.NavigateBack, events[2])
+    }
+
+    @Test
+    fun `Reply message fails when course is concluded`() = runTest {
+        val concludedCourse = Course(id = 1, name = "Concluded Course", workflowState = Course.WorkflowState.COMPLETED)
+        val conversation = Conversation(id = 2)
+        val messages = listOf(Message(id = 2), Message(id = 3))
+
+        coEvery { inboxComposeRepository.getCourses(any()) } returns DataResult.Success(listOf(concludedCourse))
+        coEvery { inboxComposeRepository.getGroups(any()) } returns DataResult.Success(emptyList())
+        coEvery { context.getString(R.string.courseConcludedError) } returns "This course has concluded. You can no longer send messages."
+
+        val savedStateHandle = mockk<SavedStateHandle>(relaxed = true)
+        coEvery { savedStateHandle.get<InboxComposeOptions>(InboxComposeOptions.COMPOSE_PARAMETERS) } returns InboxComposeOptions(
+            mode = InboxComposeOptionsMode.REPLY,
+            previousMessages = InboxComposeOptionsPreviousMessages(conversation, messages),
+            defaultValues = InboxComposeOptionsDefaultValues(
+                contextCode = concludedCourse.contextId,
+                contextName = concludedCourse.name
+            )
+        )
+
+        val viewmodelWithReply = InboxComposeViewModel(savedStateHandle, context, mockk(relaxed = true), inboxComposeRepository, attachmentDao, featureFlagProvider, inboxComposeBehavior)
+
+        val events = mutableListOf<InboxComposeViewModelAction>()
+        backgroundScope.launch(testDispatcher) {
+            viewmodelWithReply.events.toList(events)
+        }
+
+        viewmodelWithReply.handleAction(ContextPickerActionHandler.ContextClicked(concludedCourse))
+        viewmodelWithReply.handleAction(InboxComposeActionHandler.AddRecipient(Recipient(stringId = "1")))
+        viewmodelWithReply.handleAction(InboxComposeActionHandler.BodyChanged(TextFieldValue("Reply Body")))
+        viewmodelWithReply.handleAction(InboxComposeActionHandler.SendClicked)
+
+        coVerify(exactly = 0) { inboxComposeRepository.addMessage(any(), any(), any(), any(), any(), any()) }
+        assertEquals(InboxComposeViewModelAction.ShowScreenResult("This course has concluded. You can no longer send messages."), events.last())
+    }
+
+    @Test
+    fun `Reply message succeeds when course is active`() = runTest {
+        val activeCourse = Course(id = 1, name = "Active Course", workflowState = Course.WorkflowState.AVAILABLE)
+        val conversation = Conversation(id = 2)
+        val messages = listOf(Message(id = 2), Message(id = 3))
+
+        coEvery { inboxComposeRepository.getCourses(any()) } returns DataResult.Success(listOf(activeCourse))
+        coEvery { inboxComposeRepository.getGroups(any()) } returns DataResult.Success(emptyList())
+        coEvery { inboxComposeRepository.addMessage(any(), any(), any(), any(), any(), any()) } returns DataResult.Success(mockk())
+
+        val savedStateHandle = mockk<SavedStateHandle>(relaxed = true)
+        coEvery { savedStateHandle.get<InboxComposeOptions>(InboxComposeOptions.COMPOSE_PARAMETERS) } returns InboxComposeOptions(
+            mode = InboxComposeOptionsMode.REPLY,
+            previousMessages = InboxComposeOptionsPreviousMessages(conversation, messages),
+            defaultValues = InboxComposeOptionsDefaultValues(
+                contextCode = activeCourse.contextId,
+                contextName = activeCourse.name
+            )
+        )
+
+        val viewmodelWithReply = InboxComposeViewModel(savedStateHandle, context, mockk(relaxed = true), inboxComposeRepository, attachmentDao, featureFlagProvider, inboxComposeBehavior)
+
+        val events = mutableListOf<InboxComposeViewModelAction>()
+        backgroundScope.launch(testDispatcher) {
+            viewmodelWithReply.events.toList(events)
+        }
+
+        viewmodelWithReply.handleAction(ContextPickerActionHandler.ContextClicked(activeCourse))
+        viewmodelWithReply.handleAction(InboxComposeActionHandler.AddRecipient(Recipient(stringId = "1")))
+        viewmodelWithReply.handleAction(InboxComposeActionHandler.BodyChanged(TextFieldValue("Reply Body")))
+        viewmodelWithReply.handleAction(InboxComposeActionHandler.SendClicked)
+
+        coVerify(exactly = 1) { inboxComposeRepository.addMessage(any(), any(), any(), any(), any(), any()) }
+        assertEquals(3, events.size)
+        assertEquals(InboxComposeViewModelAction.UpdateParentFragment, events[0])
+        assertEquals(InboxComposeViewModelAction.ShowScreenResult(context.getString(R.string.messageSentSuccessfully)), events[1])
+        assertEquals(InboxComposeViewModelAction.NavigateBack, events[2])
+    }
+
+    // endregion
+
     private fun getViewModel(fileDownloader: FileDownloader = mockk(relaxed = true)): InboxComposeViewModel {
         return InboxComposeViewModel(SavedStateHandle(), context, fileDownloader, inboxComposeRepository, attachmentDao, featureFlagProvider, inboxComposeBehavior)
     }


### PR DESCRIPTION
Test plan: see the ticket, also test forwarding message and parent app

refs: MBL-19363
affects: Student, Parent, Teacher
release note: Users are no longer able to send Inbox messages from courses that have been concluded or are part of a past term.
