### PR TITLE
Add missing pendoAccessToken to open source data

### DIFF
--- a/open_source_data/parent/private.properties
+++ b/open_source_data/parent/private.properties
@@ -10,3 +10,5 @@ roboTestUsername=1
 heapProductionId=1
 heapStagingId=1
 
+# Pendo
+pendoAccessToken=1

--- a/open_source_data/student/private.properties
+++ b/open_source_data/student/private.properties
@@ -15,3 +15,6 @@ pronounTestStudentPassword=2
 # Student User for Push Notifications
 pushNotificationsTestStudent=3
 pushNotificationsTestStudentPassword=4
+
+# Pendo
+pendoAccessToken=1

--- a/open_source_data/teacher/private.properties
+++ b/open_source_data/teacher/private.properties
@@ -22,3 +22,6 @@ pronounTestTeacherPassword=2
 # Teacher User for Push Notifications
 pushNotificationsTestTeacher=3
 pushNotificationsTestTeacherPassword=4
+
+# Pendo
+pendoAccessToken=1


### PR DESCRIPTION
## Summary
Fixes open source builds by adding the missing `pendoAccessToken` property to open_source_data configuration files.

## Problem
The build.gradle files for student, teacher, and parent apps reference `pendoAccessToken` property, but this property was not defined in the open_source_data configuration. This causes builds to fail for open source contributors.

## Solution
Added `pendoAccessToken=1` (dummy value) to:
- `open_source_data/student/private.properties`
- `open_source_data/teacher/private.properties`
- `open_source_data/parent/private.properties`

## Testing
- Open source build should now complete successfully after running `./open_source.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>