### PR TITLE
[MBL-19271][Teacher] Fix syllabus embedded images not displaying in Edit Syllabus page

### DIFF
--- a/libs/rceditor/src/main/java/instructure/rceditor/RCETextEditor.kt
+++ b/libs/rceditor/src/main/java/instructure/rceditor/RCETextEditor.kt
@@ -24,6 +24,7 @@ import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
+import android.webkit.CookieManager
 import android.webkit.ValueCallback
 import android.webkit.WebView
 import androidx.annotation.RestrictTo
@@ -37,6 +38,8 @@ class RCETextEditor @JvmOverloads constructor(
     init {
         setEditorBackgroundColor(context.getColor(R.color.rce_backgroundColor))
         setEditorFontColor(context.getColor(R.color.rce_defaultTextColor))
+        CookieManager.getInstance().setAcceptCookie(true)
+        CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
     }
 
     var disallowInterceptTouchEvents: Boolean = true


### PR DESCRIPTION
test plan:
- Open Teacher app
- Navigate to a course with a syllabus containing embedded images
- Tap "Edit" on the syllabus page
- Verify that embedded images display correctly in the editor

refs: MBL-19271
affects: Teacher
release note: Fixed an issue where embedded images in syllabus content would not display when editing the syllabus

🤖 Generated with [Claude Code](https://claude.com/claude-code)
