### PR TITLE
[MBL-19379][Parent] Fixed discussion attachment not downloading.

### DIFF
--- a/apps/parent/src/main/java/com/instructure/parentapp/di/feature/AssignmentDetailsModule.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/di/feature/AssignmentDetailsModule.kt
@@ -29,6 +29,7 @@ import com.instructure.pandautils.features.assignments.details.AssignmentDetails
 import com.instructure.pandautils.features.assignments.details.AssignmentDetailsRouter
 import com.instructure.pandautils.features.assignments.details.AssignmentDetailsSubmissionHandler
 import com.instructure.pandautils.utils.ColorKeeper
+import com.instructure.pandautils.utils.FileDownloader
 import com.instructure.parentapp.features.assignment.details.ParentAssignmentDetailsBehaviour
 import com.instructure.parentapp.features.assignment.details.ParentAssignmentDetailsColorProvider
 import com.instructure.parentapp.features.assignment.details.ParentAssignmentDetailsRepository
@@ -50,9 +51,10 @@ class AssignmentDetailsFragmentModule {
         navigation: Navigation,
         parentPrefs: ParentPrefs,
         apiPrefs: ApiPrefs,
-        analytics: Analytics
+        analytics: Analytics,
+        fileDownloader: FileDownloader
     ): AssignmentDetailsRouter {
-        return ParentAssignmentDetailsRouter(navigation, parentPrefs, apiPrefs, analytics)
+        return ParentAssignmentDetailsRouter(navigation, parentPrefs, apiPrefs, analytics, fileDownloader)
     }
 
     @Provides

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/assignment/details/ParentAssignmentDetailsRouter.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/assignment/details/ParentAssignmentDetailsRouter.kt
@@ -17,11 +17,13 @@ package com.instructure.parentapp.features.assignment.details
 
 import androidx.fragment.app.FragmentActivity
 import com.instructure.canvasapi2.models.CanvasContext
+import com.instructure.canvasapi2.models.RemoteFile
 import com.instructure.canvasapi2.utils.Analytics
 import com.instructure.canvasapi2.utils.AnalyticsEventConstants
 import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.pandautils.features.assignments.details.AssignmentDetailsRouter
 import com.instructure.pandautils.features.inbox.utils.InboxComposeOptions
+import com.instructure.pandautils.utils.FileDownloader
 import com.instructure.parentapp.R
 import com.instructure.parentapp.util.ParentPrefs
 import com.instructure.parentapp.util.navigation.Navigation
@@ -30,7 +32,8 @@ class ParentAssignmentDetailsRouter(
     private val navigation: Navigation,
     private val parentPrefs: ParentPrefs,
     private val apiPrefs: ApiPrefs,
-    private val analytics: Analytics
+    private val analytics: Analytics,
+    private val fileDownloader: FileDownloader
 ) : AssignmentDetailsRouter() {
     override fun navigateToSendMessage(activity: FragmentActivity, options: InboxComposeOptions) {
         val route = navigation.inboxComposeRoute(options)
@@ -65,5 +68,13 @@ class ParentAssignmentDetailsRouter(
                 initialCookies = cookies
             )
         )
+    }
+
+    override fun navigateToDiscussionAttachmentScreen(
+        activity: FragmentActivity,
+        canvasContext: CanvasContext,
+        attachment: RemoteFile
+    ) {
+        fileDownloader.downloadFileToDevice(attachment.url, attachment.fileName, attachment.contentType)
     }
 }


### PR DESCRIPTION
Since the Parent app does not have a dedicated file download solution like the Student I just reused what we use in the Inbox. The file will be downloaded with a notification and clicking on it will open the file.

Test plan: In the ticket

refs: MBL-19379
affects: Parent
release note: Fixed a bug where discussion attachments couldn't be downloaded.

## Checklist

- [x] Tested in light mode
