### PR TITLE
[MBL-19300][Teacher] Fix push notification routing to open correct student submission in SpeedGrader

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/speedgrader/SpeedGraderScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/speedgrader/SpeedGraderScreen.kt
@@ -70,10 +70,6 @@ fun SpeedGraderScreen(
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
 
-    val pagerState = rememberPagerState(
-        pageCount = { uiState.submissionIds.size },
-        initialPage = uiState.selectedItem
-    )
     val viewPagerEnabled by sharedViewModel.viewPagerEnabled.collectAsState(initial = true)
 
     val errorEvent by sharedViewModel.errorState.collectAsState(initial = null)
@@ -151,6 +147,11 @@ fun SpeedGraderScreen(
             }
 
             else -> {
+                val pagerState = rememberPagerState(
+                    pageCount = { uiState.submissionIds.size },
+                    initialPage = uiState.selectedItem
+                )
+
                 HorizontalPager(
                     modifier = Modifier.padding(padding),
                     state = pagerState,


### PR DESCRIPTION
Fixed an issue where tapping a push notification about a student comment would open SpeedGrader with the first submission instead of the corresponding student's submission.

Changes:
- Added submissionId parameter handling in SpeedGraderViewModel
- When submissionIds are empty, fetch all submissions and calculate selectedItem based on the provided submissionId
- Updated UI state to reflect the correct selected submission
- Added comprehensive unit tests for the new behavior

Test plan: Since push notifications only work in production, this can be tested using a deep link to open SpeedGrader with a specific submission ID. Verify that the correct student's submission is displayed (not the first one).

refs: MBL-19300
affects: Teacher
release note: Fixed an issue where tapping a push notification about a student comment would open SpeedGrader with the first submission instead of the corresponding student's submission.


## Checklist

- [ ] Tested in light mode
