### PR TITLE
[MBL-19203][Student] Push notification for teacher comment opens Assignment Details instead of Submission Details

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/assignments/details/AssignmentDetailsFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/assignments/details/AssignmentDetailsFragment.kt
@@ -93,6 +93,8 @@ class AssignmentDetailsFragment : BaseCanvasFragment(), FragmentInteractions, Bo
     @get:PageViewUrlParam(name = "courseId")
     val courseId by LongArg(key = Const.COURSE_ID, default = 0)
 
+    val submissionId by LongArg(key = Const.SUBMISSION_ID, default = -1)
+
     private var binding: FragmentAssignmentDetailsBinding? = null
     private val viewModel: AssignmentDetailsViewModel by viewModels()
 
@@ -432,7 +434,7 @@ class AssignmentDetailsFragment : BaseCanvasFragment(), FragmentInteractions, Bo
             if (route.paramsHash.containsKey(RouterParams.SUBMISSION_ID)) {
                 // Indicate that we want to route to the Submission Details page - this will give us a small backstack, allowing the user to hit back and go to Assignment Details instead
                 // of closing the app (in the case of when the app isn't running and the user hits a push notification that takes them to Submission Details)
-                route.arguments.putString(Const.SUBMISSION_ID, route.paramsHash[RouterParams.SUBMISSION_ID])
+                route.arguments.putLong(Const.SUBMISSION_ID, route.paramsHash[RouterParams.SUBMISSION_ID]?.toLong().orDefault())
             }
 
             if (route.paramsHash.containsKey(RouterParams.COURSE_ID)) {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/assignments/details/AssignmentDetailsViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/assignments/details/AssignmentDetailsViewModel.kt
@@ -114,6 +114,7 @@ class AssignmentDetailsViewModel @Inject constructor(
     private val _course = MutableLiveData(Course(id = courseId))
 
     private val assignmentId = savedStateHandle.get<Long>(Const.ASSIGNMENT_ID).orDefault()
+    private val submissionId = savedStateHandle.get<Long>(Const.SUBMISSION_ID)
 
     var bookmarker = Bookmarker(true, course.value).withParam(RouterParams.ASSIGNMENT_ID, assignmentId.toString())
 
@@ -231,6 +232,25 @@ class AssignmentDetailsViewModel @Inject constructor(
                 ) }
                 _data.postValue(getViewData(assignmentResult, hasDraft))
                 _state.postValue(ViewState.Success)
+
+                // Check if we need to auto-navigate to submission details from push notification
+                submissionId?.let { subId ->
+                    val submission = assignmentResult.submission
+                    if (submission != null
+                        && submission.id == subId
+                        && submission.submissionType != SubmissionType.NOT_GRADED.apiString
+                        && submission.submissionType != SubmissionType.ON_PAPER.apiString)
+                    {
+                        postAction(
+                            AssignmentDetailAction.NavigateToSubmissionScreen(
+                                isObserver,
+                                submission.attempt,
+                                assignmentResult.htmlUrl,
+                                isAssignmentEnhancementEnabled
+                            )
+                        )
+                    }
+                }
             } catch (ex: Exception) {
                 val errorString = if (ex is IllegalAccessException) {
                     resources.getString(R.string.assignmentNoLongerAvailable)

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/assignments/details/AssignmentDetailsViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/assignments/details/AssignmentDetailsViewModelTest.kt
@@ -112,6 +112,7 @@ class AssignmentDetailsViewModelTest {
 
         every { savedStateHandle.get<Long>(Const.COURSE_ID) } returns 0L
         every { savedStateHandle.get<Long>(Const.ASSIGNMENT_ID) } returns 0L
+        every { savedStateHandle.get<Long>(Const.SUBMISSION_ID) } returns 0L
 
         every { apiPrefs.user } returns User(id = 1)
         every { themePrefs.textButtonColor } returns 0
@@ -1007,5 +1008,117 @@ class AssignmentDetailsViewModelTest {
                 0
             )
         }
+    }
+
+    @Test
+    fun `loadData navigates to submission screen when submissionId is provided and matches`() {
+        val submissionId = 12345L
+        val course = Course(enrollments = mutableListOf(Enrollment(type = Enrollment.EnrollmentType.Student)))
+        coEvery { assignmentDetailsRepository.getCourseWithGrade(any(), any()) } returns course
+
+        val submission = Submission(id = submissionId, attempt = 2, submissionType = "online_text_entry")
+        val assignment = Assignment(id = 1L, htmlUrl = "https://assignment.url", submission = submission)
+        coEvery { assignmentDetailsRepository.getAssignment(any(), any(), any(), any()) } returns assignment
+        coEvery { assignmentDetailsRepository.isAssignmentEnhancementEnabled(any(), any()) } returns true
+
+        every { savedStateHandle.get<Long>(Const.SUBMISSION_ID) } returns submissionId
+
+        val viewModel = getViewModel()
+
+        val expected = AssignmentDetailAction.NavigateToSubmissionScreen(
+            isObserver = false,
+            selectedSubmissionAttempt = 2L,
+            assignmentUrl = "https://assignment.url",
+            isAssignmentEnhancementEnabled = true
+        )
+        assertEquals(expected, viewModel.events.value?.peekContent())
+    }
+
+    @Test
+    fun `loadData does not navigate when submissionId is not provided`() {
+        val course = Course(enrollments = mutableListOf(Enrollment(type = Enrollment.EnrollmentType.Student)))
+        coEvery { assignmentDetailsRepository.getCourseWithGrade(any(), any()) } returns course
+
+        val submission = Submission(id = 12345L, attempt = 2, submissionType = "online_text_entry")
+        val assignment = Assignment(id = 1L, htmlUrl = "https://assignment.url", submission = submission)
+        coEvery { assignmentDetailsRepository.getAssignment(any(), any(), any(), any()) } returns assignment
+        coEvery { assignmentDetailsRepository.isAssignmentEnhancementEnabled(any(), any()) } returns true
+
+        every { savedStateHandle.get<Long>(Const.SUBMISSION_ID) } returns null
+
+        val viewModel = getViewModel()
+
+        assertFalse(viewModel.events.value?.peekContent() is AssignmentDetailAction.NavigateToSubmissionScreen)
+    }
+
+    @Test
+    fun `loadData does not navigate when submissionId does not match`() {
+        val submissionId = 99999L
+        val course = Course(enrollments = mutableListOf(Enrollment(type = Enrollment.EnrollmentType.Student)))
+        coEvery { assignmentDetailsRepository.getCourseWithGrade(any(), any()) } returns course
+
+        val submission = Submission(id = 12345L, attempt = 2, submissionType = "online_text_entry")
+        val assignment = Assignment(id = 1L, htmlUrl = "https://assignment.url", submission = submission)
+        coEvery { assignmentDetailsRepository.getAssignment(any(), any(), any(), any()) } returns assignment
+        coEvery { assignmentDetailsRepository.isAssignmentEnhancementEnabled(any(), any()) } returns true
+
+        every { savedStateHandle.get<Long>(Const.SUBMISSION_ID) } returns submissionId
+
+        val viewModel = getViewModel()
+
+        assertFalse(viewModel.events.value?.peekContent() is AssignmentDetailAction.NavigateToSubmissionScreen)
+    }
+
+    @Test
+    fun `loadData does not navigate when submission is null`() {
+        val submissionId = 12345L
+        val course = Course(enrollments = mutableListOf(Enrollment(type = Enrollment.EnrollmentType.Student)))
+        coEvery { assignmentDetailsRepository.getCourseWithGrade(any(), any()) } returns course
+
+        val assignment = Assignment(id = 1L, htmlUrl = "https://assignment.url", submission = null)
+        coEvery { assignmentDetailsRepository.getAssignment(any(), any(), any(), any()) } returns assignment
+        coEvery { assignmentDetailsRepository.isAssignmentEnhancementEnabled(any(), any()) } returns true
+
+        every { savedStateHandle.get<Long>(Const.SUBMISSION_ID) } returns submissionId
+
+        val viewModel = getViewModel()
+
+        assertFalse(viewModel.events.value?.peekContent() is AssignmentDetailAction.NavigateToSubmissionScreen)
+    }
+
+    @Test
+    fun `loadData does not navigate when submission type is not_graded`() {
+        val submissionId = 12345L
+        val course = Course(enrollments = mutableListOf(Enrollment(type = Enrollment.EnrollmentType.Student)))
+        coEvery { assignmentDetailsRepository.getCourseWithGrade(any(), any()) } returns course
+
+        val submission = Submission(id = submissionId, attempt = 2, submissionType = "not_graded")
+        val assignment = Assignment(id = 1L, htmlUrl = "https://assignment.url", submission = submission)
+        coEvery { assignmentDetailsRepository.getAssignment(any(), any(), any(), any()) } returns assignment
+        coEvery { assignmentDetailsRepository.isAssignmentEnhancementEnabled(any(), any()) } returns true
+
+        every { savedStateHandle.get<Long>(Const.SUBMISSION_ID) } returns submissionId
+
+        val viewModel = getViewModel()
+
+        assertFalse(viewModel.events.value?.peekContent() is AssignmentDetailAction.NavigateToSubmissionScreen)
+    }
+
+    @Test
+    fun `loadData does not navigate when submission type is on_paper`() {
+        val submissionId = 12345L
+        val course = Course(enrollments = mutableListOf(Enrollment(type = Enrollment.EnrollmentType.Student)))
+        coEvery { assignmentDetailsRepository.getCourseWithGrade(any(), any()) } returns course
+
+        val submission = Submission(id = submissionId, attempt = 2, submissionType = "on_paper")
+        val assignment = Assignment(id = 1L, htmlUrl = "https://assignment.url", submission = submission)
+        coEvery { assignmentDetailsRepository.getAssignment(any(), any(), any(), any()) } returns assignment
+        coEvery { assignmentDetailsRepository.isAssignmentEnhancementEnabled(any(), any()) } returns true
+
+        every { savedStateHandle.get<Long>(Const.SUBMISSION_ID) } returns submissionId
+
+        val viewModel = getViewModel()
+
+        assertFalse(viewModel.events.value?.peekContent() is AssignmentDetailAction.NavigateToSubmissionScreen)
     }
 }


### PR DESCRIPTION
Test plan:  Since push notifications only work in production, this can be tested using a deep link to open the submission details with a specific submission ID. Verify that the correct student's submission is displayed (not the first one). I couldn't fix the attempt issue because the attempt number is not part of the push notification, older push notifications will still open the latest attempt but that is an edge case.

refs: MBL-19203
affects: Student
release note: Fixed an issue where submission comment push notifications wouldn't route to the submission.

## Checklist

- [x] Tested in light mode
