### PR TITLE
[MBL-19390][Teacher] Letter Grade assignments can’t be marked as Excused after a grade is entered

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/speedgrader/grade/grading/SpeedGraderGradingScreen.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/speedgrader/grade/grading/SpeedGraderGradingScreen.kt
@@ -456,7 +456,7 @@ private fun LetterGradeGradingTypeInput(uiState: SpeedGraderGradingUiState) {
     }
 
     LaunchedEffect(selectedGrade) {
-        if (selectedGrade != uiState.enteredGrade) {
+        if (selectedGrade != uiState.enteredGrade && uiState.letterGrades.any { it.name == selectedGrade }) {
             uiState.onPercentageChange(
                 uiState.letterGrades
                     .find { it.name == selectedGrade }


### PR DESCRIPTION
Test plan: see the ticket

refs: MBL-19390
affects: Teacher
release note: Fixed an issue that occurred when attempting to excuse a letter grade assignment.
