### PR TITLE
[MBL-19896][Student] Fix edge-to-edge Snackbar gap and offline indicator positioning

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
@@ -457,6 +457,23 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
     }
 
     private fun setupWindowInsets() = with(binding) {
+        // Consume navigation bar bottom inset at the CoordinatorLayout level so Snackbars
+        // shown inside it don't add extra bottom margin (the bottomBarContainer handles that space).
+        ViewCompat.setOnApplyWindowInsetsListener(fullScreenCoordinatorLayout) { view, insets ->
+            val navigationBars = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
+            val displayCutout = insets.getInsets(WindowInsetsCompat.Type.displayCutout())
+            WindowInsetsCompat.Builder(insets)
+                .setInsets(
+                    WindowInsetsCompat.Type.navigationBars(),
+                    Insets.of(navigationBars.left, navigationBars.top, navigationBars.right, 0)
+                )
+                .setInsets(
+                    WindowInsetsCompat.Type.displayCutout(),
+                    Insets.of(displayCutout.left, displayCutout.top, displayCutout.right, 0)
+                )
+                .build()
+        }
+
         ViewCompat.setOnApplyWindowInsetsListener(fullscreen) { view, insets ->
             val navigationBars = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
             val displayCutout = insets.getInsets(WindowInsetsCompat.Type.displayCutout())
@@ -473,10 +490,10 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
                 0
             )
 
-            // Consume horizontal insets so child ComposeViews don't apply them again
-            // Also consume bottom insets when offline indicator is visible
+            // Consume horizontal and bottom insets so child views don't apply them again.
+            // The bottomBarContainer handles the navigation bar bottom space, so we consume it here
+            // to prevent the CoordinatorLayout from double-counting it (e.g. for Snackbar positioning).
             val masquerading = ApiPrefs.isMasquerading
-            val consumeBottom = offlineIndicator.root.visibility == View.VISIBLE
             WindowInsetsCompat.Builder(insets)
                 .setInsets(
                     WindowInsetsCompat.Type.navigationBars(),
@@ -484,7 +501,7 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
                         0, // Consume left
                         if (masquerading) 0 else navigationBars.top,
                         0, // Consume right
-                        if (consumeBottom) 0 else navigationBars.bottom
+                        0  // Consume bottom — handled by bottomBarContainer
                     )
                 )
                 .setInsets(
@@ -505,7 +522,7 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
             val isLandscape = resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
 
             if (isLandscape) {
-                // In landscape, use both padding for content and margins to move the bar away from edges
+                // In landscape, apply left/right padding and margins to move the bar away from edges
                 val leftInset = maxOf(navigationBars.left, displayCutout.left)
                 val rightInset = maxOf(navigationBars.right, displayCutout.right)
 
@@ -516,13 +533,14 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
                     view.paddingBottom
                 )
 
-                view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                view.updateLayoutParams<LinearLayout.LayoutParams> {
                     this.leftMargin = leftInset
                     this.rightMargin = rightInset
-                    this.bottomMargin = navigationBars.bottom
+                    this.bottomMargin = 0
+                    height = 56.toPx + navigationBars.bottom
                 }
             } else {
-                // In portrait, only apply display cutout and bottom navigation bar
+                // In portrait, extend the height to draw behind the Android navigation bar (edge-to-edge)
                 view.setPadding(
                     displayCutout.left,
                     view.paddingTop,
@@ -530,10 +548,11 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
                     view.paddingBottom
                 )
 
-                view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                view.updateLayoutParams<LinearLayout.LayoutParams> {
                     this.leftMargin = 0
                     this.rightMargin = 0
-                    this.bottomMargin = navigationBars.bottom
+                    this.bottomMargin = 0
+                    height = 56.toPx + navigationBars.bottom
                 }
             }
 
@@ -544,14 +563,6 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
             layoutParams?.bottomMargin = if (bottomBarContainer.isVisible) 0 else navigationBars.bottom
             offlineIndicator.root.layoutParams = layoutParams
 
-            insets
-        }
-
-        ViewCompat.setOnApplyWindowInsetsListener(bottomBarContainer) { view, insets ->
-            val navigationBars = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
-            bottomBarContainer.updateLayoutParams<LinearLayout.LayoutParams> {
-                height = 56.toPx + navigationBars.bottom
-            }
             insets
         }
 

--- a/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
@@ -457,29 +457,10 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
     }
 
     private fun setupWindowInsets() = with(binding) {
-        // Consume navigation bar bottom inset at the CoordinatorLayout level so Snackbars
-        // shown inside it don't add extra bottom margin (the bottomBarContainer handles that space).
-        ViewCompat.setOnApplyWindowInsetsListener(fullScreenCoordinatorLayout) { view, insets ->
-            val navigationBars = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
-            val displayCutout = insets.getInsets(WindowInsetsCompat.Type.displayCutout())
-            WindowInsetsCompat.Builder(insets)
-                .setInsets(
-                    WindowInsetsCompat.Type.navigationBars(),
-                    Insets.of(navigationBars.left, navigationBars.top, navigationBars.right, 0)
-                )
-                .setInsets(
-                    WindowInsetsCompat.Type.displayCutout(),
-                    Insets.of(displayCutout.left, displayCutout.top, displayCutout.right, 0)
-                )
-                .build()
-        }
-
         ViewCompat.setOnApplyWindowInsetsListener(fullscreen) { view, insets ->
             val navigationBars = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
             val displayCutout = insets.getInsets(WindowInsetsCompat.Type.displayCutout())
 
-            // Apply both navigation bar and display cutout insets
-            // This ensures content is not hidden behind the navigation bar OR the hole punch camera
             val leftPadding = maxOf(navigationBars.left, displayCutout.left)
             val rightPadding = maxOf(navigationBars.right, displayCutout.right)
 
@@ -490,10 +471,10 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
                 0
             )
 
-            // Consume horizontal and bottom insets so child views don't apply them again.
-            // The bottomBarContainer handles the navigation bar bottom space, so we consume it here
-            // to prevent the CoordinatorLayout from double-counting it (e.g. for Snackbar positioning).
             val masquerading = ApiPrefs.isMasquerading
+            // When the offline indicator is visible it sits between the content area and the bottom bar,
+            // so child screens must not add extra bottom padding — that would create a gap above it.
+            val consumeBottom = offlineIndicator.root.isVisible
             WindowInsetsCompat.Builder(insets)
                 .setInsets(
                     WindowInsetsCompat.Type.navigationBars(),
@@ -501,7 +482,7 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
                         0, // Consume left
                         if (masquerading) 0 else navigationBars.top,
                         0, // Consume right
-                        0  // Consume bottom — handled by bottomBarContainer
+                        if (consumeBottom) 0 else navigationBars.bottom
                     )
                 )
                 .setInsets(

--- a/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/NavigationActivity.kt
@@ -134,7 +134,6 @@ import com.instructure.pandautils.utils.postSticky
 import com.instructure.pandautils.utils.setGone
 import com.instructure.pandautils.utils.setVisible
 import com.instructure.pandautils.utils.setupAsBackButton
-import com.instructure.pandautils.utils.toPx
 import com.instructure.pandautils.utils.toast
 import com.instructure.student.R
 import com.instructure.student.databinding.ActivityNavigationBinding
@@ -475,6 +474,25 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
             // When the offline indicator is visible it sits between the content area and the bottom bar,
             // so child screens must not add extra bottom padding — that would create a gap above it.
             val consumeBottom = offlineIndicator.root.isVisible
+
+            // The IME inset is measured from the screen bottom, but the fullscreen CoordinatorLayout
+            // ends above the views below it (offline indicator, divider, bottom bar). Subtract their
+            // combined height so child screens only pad by the amount the keyboard actually overlaps
+            // the content area — otherwise a blank gap appears above the keyboard.
+            //
+            // Siblings of fullScreenCoordinatorLayout (bottomBarContainer, offlineIndicator) receive
+            // raw system insets independently — the modifications returned by fullscreen's listener
+            // do not propagate to them. So bottomBarContainer always sets offlineIndicator.bottomMargin
+            // = navigationBars.bottom when the bottom bar is hidden. We mirror that logic here so that
+            // heightBelowContent accounts for the offline indicator's nav-bar clearance margin.
+            val ime = insets.getInsets(WindowInsetsCompat.Type.ime())
+            val expectedBottomBarHeight = if (bottomBarContainer.isVisible) (bottomBarContainer.minimumHeight + navigationBars.bottom) else 0
+            val expectedOfflineMargin = if (bottomBarContainer.isVisible) 0 else navigationBars.bottom
+            val heightBelowContent = expectedBottomBarHeight +
+                (if (bottomBarDivider.isVisible) bottomBarDivider.height else 0) +
+                (if (offlineIndicator.root.isVisible) offlineIndicator.root.height + expectedOfflineMargin else 0)
+            val adjustedImeBottom = maxOf(0, ime.bottom - heightBelowContent)
+
             WindowInsetsCompat.Builder(insets)
                 .setInsets(
                     WindowInsetsCompat.Type.navigationBars(),
@@ -493,6 +511,10 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
                         0, // Consume right
                         displayCutout.bottom
                     )
+                )
+                .setInsets(
+                    WindowInsetsCompat.Type.ime(),
+                    Insets.of(0, 0, 0, adjustedImeBottom)
                 )
                 .build()
         }
@@ -518,7 +540,7 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
                     this.leftMargin = leftInset
                     this.rightMargin = rightInset
                     this.bottomMargin = 0
-                    height = 56.toPx + navigationBars.bottom
+                    height = view.minimumHeight + navigationBars.bottom
                 }
             } else {
                 // In portrait, extend the height to draw behind the Android navigation bar (edge-to-edge)
@@ -533,7 +555,7 @@ class NavigationActivity : BaseRouterActivity(), Navigation, MasqueradingDialog.
                     this.leftMargin = 0
                     this.rightMargin = 0
                     this.bottomMargin = 0
-                    height = 56.toPx + navigationBars.bottom
+                    height = view.minimumHeight + navigationBars.bottom
                 }
             }
 

--- a/apps/student/src/main/java/com/instructure/student/features/dashboard/edit/StudentEditDashboardRouter.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/dashboard/edit/StudentEditDashboardRouter.kt
@@ -16,14 +16,32 @@
 
 package com.instructure.student.features.dashboard.edit
 
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
+import com.google.android.material.snackbar.Snackbar
 import com.instructure.canvasapi2.models.CanvasContext
 import com.instructure.pandautils.features.dashboard.edit.EditDashboardRouter
+import com.instructure.pandautils.utils.EdgeToEdgeHelper
 import com.instructure.student.features.coursebrowser.CourseBrowserFragment
 import com.instructure.student.router.RouteMatcher
 
 class StudentEditDashboardRouter(private val activity: FragmentActivity) : EditDashboardRouter {
     override fun routeCourse(canvasContext: CanvasContext?) {
         RouteMatcher.route(activity, CourseBrowserFragment.makeRoute(canvasContext))
+    }
+
+    override fun showSnackbar(fragment: Fragment, resId: Int) {
+        val view = fragment.view ?: return
+        val snackbar = Snackbar.make(view, resId, Snackbar.LENGTH_LONG)
+        if (EdgeToEdgeHelper.isEdgeToEdgeEnforced()) {
+            // In Student app the Snackbar anchors to fullScreenCoordinatorLayout, which is already
+            // positioned above the bottom bar. Consuming the navigation bar insets prevents the
+            // Snackbar from adding an extra bottom margin that would double-count the nav bar space.
+            ViewCompat.setOnApplyWindowInsetsListener(snackbar.view) { _, _ -> WindowInsetsCompat.CONSUMED }
+        }
+        snackbar.show()
+        view.announceForAccessibility(fragment.requireContext().getString(resId))
     }
 }

--- a/apps/student/src/main/res/layout/activity_navigation.xml
+++ b/apps/student/src/main/res/layout/activity_navigation.xml
@@ -61,6 +61,7 @@
             android:id="@+id/bottomBarContainer"
             android:layout_width="match_parent"
             android:layout_height="56dp"
+            android:minHeight="56dp"
             android:background="@color/backgroundLightestElevated">
 
             <com.google.android.material.bottomnavigation.BottomNavigationView

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/dashboard/edit/EditDashboardFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/dashboard/edit/EditDashboardFragment.kt
@@ -25,9 +25,6 @@ import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import com.google.android.material.snackbar.Snackbar
 import com.instructure.canvasapi2.utils.pageview.PageView
 import com.instructure.interactions.router.Route
 import com.instructure.pandautils.R
@@ -110,12 +107,7 @@ class EditDashboardFragment : BaseCanvasFragment() {
                 editDashboardRouter.routeCourse(action.canvasContext)
             }
             is EditDashboardItemAction.ShowSnackBar -> {
-                val snackbar = Snackbar.make(requireView(), action.res, Snackbar.LENGTH_LONG)
-                // The CoordinatorLayout is already positioned above the bottom bar, so the Snackbar
-                // must not apply navigationBars.bottom as extra margin (it would double-count the space).
-                ViewCompat.setOnApplyWindowInsetsListener(snackbar.view) { _, _ -> WindowInsetsCompat.CONSUMED }
-                snackbar.show()
-                view?.announceForAccessibility(requireContext().getString(action.res))
+                editDashboardRouter.showSnackbar(this, action.res)
             }
             else -> {}
         }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/dashboard/edit/EditDashboardFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/dashboard/edit/EditDashboardFragment.kt
@@ -25,6 +25,8 @@ import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import com.google.android.material.snackbar.Snackbar
 import com.instructure.canvasapi2.utils.pageview.PageView
 import com.instructure.interactions.router.Route
@@ -108,7 +110,11 @@ class EditDashboardFragment : BaseCanvasFragment() {
                 editDashboardRouter.routeCourse(action.canvasContext)
             }
             is EditDashboardItemAction.ShowSnackBar -> {
-                Snackbar.make(requireView(), action.res, Snackbar.LENGTH_LONG).show()
+                val snackbar = Snackbar.make(requireView(), action.res, Snackbar.LENGTH_LONG)
+                // The CoordinatorLayout is already positioned above the bottom bar, so the Snackbar
+                // must not apply navigationBars.bottom as extra margin (it would double-count the space).
+                ViewCompat.setOnApplyWindowInsetsListener(snackbar.view) { _, _ -> WindowInsetsCompat.CONSUMED }
+                snackbar.show()
                 view?.announceForAccessibility(requireContext().getString(action.res))
             }
             else -> {}

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/dashboard/edit/EditDashboardRouter.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/dashboard/edit/EditDashboardRouter.kt
@@ -16,8 +16,16 @@
 
 package com.instructure.pandautils.features.dashboard.edit
 
+import androidx.fragment.app.Fragment
+import com.google.android.material.snackbar.Snackbar
 import com.instructure.canvasapi2.models.CanvasContext
 
 interface EditDashboardRouter {
     fun routeCourse(canvasContext: CanvasContext?)
+
+    fun showSnackbar(fragment: Fragment, resId: Int) {
+        val view = fragment.view ?: return
+        Snackbar.make(view, resId, Snackbar.LENGTH_LONG).show()
+        view.announceForAccessibility(fragment.requireContext().getString(resId))
+    }
 }


### PR DESCRIPTION
Test plan:
1. Build and run the Student app on Android 15+ (edge-to-edge is enforced)
2. Go offline and open the All Courses page (Edit Dashboard)
3. Try to mark/unmark a course as favourite — verify the Snackbar appears just above the offline indicator banner with no extra gap below it
4. Verify the offline indicator banner is not hidden behind the Android navigation bar
5. Navigate into a course (CourseBrowserFragment) while offline — verify the offline indicator is still visible above the navigation bar
6. Rotate to landscape — verify no gap appears below the bottom navigation bar
7. Rotate back to portrait — verify the bottom navigation bar extends behind the Android navigation bar with no visible shelf/gap

> ⚠️ **Smoke test required:** This change touches core window insets handling in `NavigationActivity` and `EditDashboardFragment`. A quick smoke test across the main flows (Dashboard, Courses, Inbox, Calendar, Notifications) is strongly recommended to catch any unexpected regressions.

refs: MBL-19896
affects: Student
release note: Fixed a gap appearing between the Snackbar and the Android navigation bar on the All Courses page in offline mode, and fixed the offline indicator being hidden behind the navigation bar on secondary screens.

- [x] Follow-up e2e test ticket created or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] Test in landscape mode and/or tablet
- [ ] A11y checked
- [ ] Approve from product