### PR TITLE
[MBL-19958][Student] Migrate dashboard course widget to GraphQL

### DIFF
--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -90,11 +90,13 @@ task assembleAllApps() {
 
 apply from: '../gradle/jacoco.gradle'
 
-configurations.all{
-    resolutionStrategy {
-        eachDependency { details ->
-            if ('org.jacoco' == details.requested.group) {
-                details.useVersion "0.8.7"
+configurations.configureEach {
+    if (canBeResolved) {
+        resolutionStrategy {
+            eachDependency { details ->
+                if ('org.jacoco' == details.requested.group) {
+                    details.useVersion "0.8.7"
+                }
             }
         }
     }

--- a/apps/buildSrc/src/main/java/MergePrivateData.kt
+++ b/apps/buildSrc/src/main/java/MergePrivateData.kt
@@ -20,7 +20,7 @@ object PrivateData {
         val dataDir = File(baseDir, dataDirName).canonicalFile
 
         println("")
-        println("============= MERGE PRIVATE FILES: ${dataDirName.toUpperCase()} ".padEnd(PRINT_PAD_SIZE, '='))
+        println("============= MERGE PRIVATE FILES: ${dataDirName.uppercase()} ".padEnd(PRINT_PAD_SIZE, '='))
 
         /* Confirm dir exists */
         if (!dataDir.exists() || !dataDir.isDirectory) {

--- a/apps/parent/build.gradle
+++ b/apps/parent/build.gradle
@@ -26,9 +26,9 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.compose'
 }
 
-configurations {
-    all*.exclude group: 'commons-logging', module: 'commons-logging'
-    all*.exclude group: 'org.apache.httpcomponents', module: 'httpclient'
+configurations.configureEach {
+    exclude group: 'commons-logging', module: 'commons-logging'
+    exclude group: 'org.apache.httpcomponents', module: 'httpclient'
 }
 
 def coverageEnabled = project.hasProperty('coverage')
@@ -123,17 +123,19 @@ android {
         }
     }
 
-    configurations.all {
-        resolutionStrategy.force 'com.google.code.findbugs:jsr305:1.3.9'
-        /*
-        Resolves dependency versions across test and production APKs, specifically, transitive
-        dependencies. This is required since Espresso internally has a dependency on support-annotations.
-        https://github.com/googlecodelabs/android-testing/blob/57852eaf7df88ddaf828eca879a407f2249d5348/app/build.gradle#L86
-        */
-        resolutionStrategy.force Libs.ANDROIDX_ANNOTATION
+    configurations.configureEach {
+        if (canBeResolved) {
+            resolutionStrategy.force 'com.google.code.findbugs:jsr305:1.3.9'
+            /*
+            Resolves dependency versions across test and production APKs, specifically, transitive
+            dependencies. This is required since Espresso internally has a dependency on support-annotations.
+            https://github.com/googlecodelabs/android-testing/blob/57852eaf7df88ddaf828eca879a407f2249d5348/app/build.gradle#L86
+            */
+            resolutionStrategy.force Libs.ANDROIDX_ANNOTATION
 
-        resolutionStrategy.force Libs.KOTLIN_COROUTINES_CORE
-        resolutionStrategy.force Libs.KOTLIN_STD_LIB
+            resolutionStrategy.force Libs.KOTLIN_COROUTINES_CORE
+            resolutionStrategy.force Libs.KOTLIN_STD_LIB
+        }
     }
 
     configurations.implementation.dependencies.each { compileDependency ->

--- a/apps/settings.gradle
+++ b/apps/settings.gradle
@@ -23,7 +23,6 @@ include ':canvas-api-2'
 include ':dataseedingapi'
 include ':espresso'
 include ':interactions'
-include ":jazzyviewpager"
 include ':login-api-2'
 include ':pandautils'
 include ':rceditor'
@@ -37,7 +36,6 @@ project(':canvas-api-2').projectDir = new File(rootProject.projectDir, '/../libs
 project(':dataseedingapi').projectDir = new File(rootProject.projectDir, '/../automation/dataseedingapi')
 project(':espresso').projectDir = new File(rootProject.projectDir, '/../automation/espresso')
 project(':interactions').projectDir = new File(rootProject.projectDir, '/../libs/interactions')
-project(':jazzyviewpager').projectDir = new File(rootProject.projectDir, '/../libs/jazzyviewpager')
 project(':login-api-2').projectDir = new File(rootProject.projectDir, '/../libs/login-api-2')
 project(':pandautils').projectDir = new File(rootProject.projectDir, '/../libs/pandautils')
 project(':rceditor').projectDir = new File(rootProject.projectDir, '/../libs/rceditor')

--- a/apps/student/build.gradle
+++ b/apps/student/build.gradle
@@ -25,9 +25,9 @@ apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 def updatePriority = 2
 def coverageEnabled = project.hasProperty('coverage')
 
-configurations {
-    all*.exclude group: 'commons-logging', module: 'commons-logging'
-    all*.exclude group: 'org.apache.httpcomponents', module: 'httpclient'
+configurations.configureEach {
+    exclude group: 'commons-logging', module: 'commons-logging'
+    exclude group: 'org.apache.httpcomponents', module: 'httpclient'
 }
 
 android {
@@ -166,17 +166,19 @@ android {
     testOptions.unitTests.includeAndroidResources = true
     testOptions.animationsDisabled = true
 
-    configurations.all {
-        resolutionStrategy.force 'com.google.code.findbugs:jsr305:1.3.9'
-        /*
-        Resolves dependency versions across test and production APKs, specifically, transitive
-        dependencies. This is required since Espresso internally has a dependency on support-annotations.
-        https://github.com/googlecodelabs/android-testing/blob/57852eaf7df88ddaf828eca879a407f2249d5348/app/build.gradle#L86
-        */
-        resolutionStrategy.force Libs.ANDROIDX_ANNOTATION
+    configurations.configureEach {
+        if (canBeResolved) {
+            resolutionStrategy.force 'com.google.code.findbugs:jsr305:1.3.9'
+            /*
+            Resolves dependency versions across test and production APKs, specifically, transitive
+            dependencies. This is required since Espresso internally has a dependency on support-annotations.
+            https://github.com/googlecodelabs/android-testing/blob/57852eaf7df88ddaf828eca879a407f2249d5348/app/build.gradle#L86
+            */
+            resolutionStrategy.force Libs.ANDROIDX_ANNOTATION
 
-        resolutionStrategy.force Libs.KOTLIN_COROUTINES_CORE
-        resolutionStrategy.force Libs.KOTLIN_STD_LIB
+            resolutionStrategy.force Libs.KOTLIN_COROUTINES_CORE
+            resolutionStrategy.force Libs.KOTLIN_STD_LIB
+        }
     }
 
     /*

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/StudentInboxComposeInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/StudentInboxComposeInteractionTest.kt
@@ -27,6 +27,7 @@ import com.instructure.canvas.espresso.mockcanvas.addCoursePermissions
 import com.instructure.canvas.espresso.mockcanvas.addRecipientsToCourse
 import com.instructure.canvas.espresso.mockcanvas.fakes.FakeAssignmentDetailsManager
 import com.instructure.canvas.espresso.mockcanvas.fakes.FakeCommentLibraryManager
+import com.instructure.canvas.espresso.mockcanvas.fakes.FakeDashboardCoursesManager
 import com.instructure.canvas.espresso.mockcanvas.fakes.FakeInboxSettingsManager
 import com.instructure.canvas.espresso.mockcanvas.fakes.FakePostPolicyManager
 import com.instructure.canvas.espresso.mockcanvas.fakes.FakeRecentGradedSubmissionsManager
@@ -42,6 +43,7 @@ import com.instructure.canvasapi2.managers.InboxSettingsManager
 import com.instructure.canvasapi2.managers.PostPolicyManager
 import com.instructure.canvasapi2.managers.SubmissionRubricManager
 import com.instructure.canvasapi2.managers.graphql.AssignmentDetailsManager
+import com.instructure.canvasapi2.managers.graphql.DashboardCoursesManager
 import com.instructure.canvasapi2.managers.graphql.RecentGradedSubmissionsManager
 import com.instructure.canvasapi2.managers.graphql.SubmissionCommentsManager
 import com.instructure.canvasapi2.managers.graphql.SubmissionContentManager
@@ -110,6 +112,10 @@ class StudentInboxComposeInteractionTest: InboxComposeInteractionTest() {
     @BindValue
     @JvmField
     val recentGradedSubmissionsManager: RecentGradedSubmissionsManager = FakeRecentGradedSubmissionsManager()
+
+    @BindValue
+    @JvmField
+    val dashboardCoursesManager: DashboardCoursesManager = FakeDashboardCoursesManager()
 
     override fun goToInboxCompose(data: MockCanvas) {
         val parent = data.parents.first()

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/StudentInboxSignatureInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/StudentInboxSignatureInteractionTest.kt
@@ -23,6 +23,7 @@ import com.instructure.canvas.espresso.common.interaction.InboxSignatureInteract
 import com.instructure.canvas.espresso.mockcanvas.MockCanvas
 import com.instructure.canvas.espresso.mockcanvas.fakes.FakeAssignmentDetailsManager
 import com.instructure.canvas.espresso.mockcanvas.fakes.FakeCommentLibraryManager
+import com.instructure.canvas.espresso.mockcanvas.fakes.FakeDashboardCoursesManager
 import com.instructure.canvas.espresso.mockcanvas.fakes.FakeInboxSettingsManager
 import com.instructure.canvas.espresso.mockcanvas.fakes.FakePostPolicyManager
 import com.instructure.canvas.espresso.mockcanvas.fakes.FakeRecentGradedSubmissionsManager
@@ -38,6 +39,7 @@ import com.instructure.canvasapi2.managers.InboxSettingsManager
 import com.instructure.canvasapi2.managers.PostPolicyManager
 import com.instructure.canvasapi2.managers.SubmissionRubricManager
 import com.instructure.canvasapi2.managers.graphql.AssignmentDetailsManager
+import com.instructure.canvasapi2.managers.graphql.DashboardCoursesManager
 import com.instructure.canvasapi2.managers.graphql.RecentGradedSubmissionsManager
 import com.instructure.canvasapi2.managers.graphql.SubmissionCommentsManager
 import com.instructure.canvasapi2.managers.graphql.SubmissionContentManager
@@ -96,6 +98,10 @@ class StudentInboxSignatureInteractionTest : InboxSignatureInteractionTest() {
     @BindValue
     @JvmField
     val recentGradedSubmissionsManager: RecentGradedSubmissionsManager = FakeRecentGradedSubmissionsManager()
+
+    @BindValue
+    @JvmField
+    val dashboardCoursesManager: DashboardCoursesManager = FakeDashboardCoursesManager()
 
     private val leftSideNavigationDrawerPage = LeftSideNavigationDrawerPage()
 

--- a/apps/teacher/build.gradle
+++ b/apps/teacher/build.gradle
@@ -156,13 +156,15 @@ android {
         }
     }
 
-    configurations.all {
-        resolutionStrategy {
-            force 'android.arch.lifecycle:runtime:1.0.3'
+    configurations.configureEach {
+        if (canBeResolved) {
+            resolutionStrategy {
+                force 'android.arch.lifecycle:runtime:1.0.3'
 
-            force Libs.KOTLIN_COROUTINES_CORE
+                force Libs.KOTLIN_COROUTINES_CORE
 
-            force Libs.KOTLIN_STD_LIB
+                force Libs.KOTLIN_STD_LIB
+            }
         }
     }
 

--- a/automation/dataseedingapi/build.gradle
+++ b/automation/dataseedingapi/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'java'
 apply plugin: 'kotlin'
 apply plugin: 'com.apollographql.apollo'
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
 
 buildscript {
     repositories {

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockcanvas/fakes/FakeDashboardCoursesManager.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockcanvas/fakes/FakeDashboardCoursesManager.kt
@@ -37,6 +37,7 @@ class FakeDashboardCoursesManager : DashboardCoursesManager {
 
     override suspend fun getCourseAnnouncements(
         courseId: Long,
+        cursor: String?,
         forceNetwork: Boolean
     ): CourseAnnouncementsQuery.Data {
         return CourseAnnouncementsQuery.Data(course = null)

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockcanvas/fakes/FakeDashboardCoursesManager.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockcanvas/fakes/FakeDashboardCoursesManager.kt
@@ -38,7 +38,7 @@ class FakeDashboardCoursesManager : DashboardCoursesManager {
     override suspend fun getCourseAnnouncements(
         courseId: Long,
         forceNetwork: Boolean
-    ): List<CourseAnnouncementsQuery.Node1?> {
-        return emptyList()
+    ): CourseAnnouncementsQuery.Data {
+        return CourseAnnouncementsQuery.Data(course = null)
     }
 }

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockcanvas/fakes/FakeDashboardCoursesManager.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockcanvas/fakes/FakeDashboardCoursesManager.kt
@@ -15,6 +15,7 @@
  */
 package com.instructure.canvas.espresso.mockcanvas.fakes
 
+import com.instructure.canvasapi2.CourseAnnouncementsQuery
 import com.instructure.canvasapi2.DashboardCoursesQuery
 import com.instructure.canvasapi2.DashboardSingleCourseQuery
 import com.instructure.canvasapi2.managers.graphql.DashboardCoursesManager
@@ -32,5 +33,12 @@ class FakeDashboardCoursesManager : DashboardCoursesManager {
         forceNetwork: Boolean
     ): DashboardSingleCourseQuery.Data {
         return DashboardSingleCourseQuery.Data(course = null)
+    }
+
+    override suspend fun getCourseAnnouncements(
+        courseId: Long,
+        forceNetwork: Boolean
+    ): List<CourseAnnouncementsQuery.Node1?> {
+        return emptyList()
     }
 }

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockcanvas/fakes/FakeDashboardCoursesManager.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/mockcanvas/fakes/FakeDashboardCoursesManager.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package com.instructure.canvas.espresso.mockcanvas.fakes
+
+import com.instructure.canvasapi2.DashboardCoursesQuery
+import com.instructure.canvasapi2.DashboardSingleCourseQuery
+import com.instructure.canvasapi2.managers.graphql.DashboardCoursesManager
+
+class FakeDashboardCoursesManager : DashboardCoursesManager {
+
+    override suspend fun getDashboardCourses(
+        forceNetwork: Boolean
+    ): DashboardCoursesQuery.Data {
+        return DashboardCoursesQuery.Data(allCourses = emptyList())
+    }
+
+    override suspend fun getSingleCourse(
+        courseId: Long,
+        forceNetwork: Boolean
+    ): DashboardSingleCourseQuery.Data {
+        return DashboardSingleCourseQuery.Data(course = null)
+    }
+}

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -186,11 +186,11 @@ task jacocoFullReport(type: JacocoReport, group: 'Coverage reports') {
     reports {
         html {
             required = true
-            destination file('build/reports/jacoco/html')
+            outputLocation = file('build/reports/jacoco/html')
         }
         csv {
             required = true
-            destination file('build/reports/jacoco/jacocoFullReport.csv')
+            outputLocation = file('build/reports/jacoco/jacocoFullReport.csv')
         }
     }
 }
@@ -218,11 +218,11 @@ task jacocoFullCombinedReport(type: JacocoReport, group: 'Coverage reports') {
     reports {
         html {
             required = true
-            destination file('build/reports/jacoco/html')
+            outputLocation = file('build/reports/jacoco/html')
         }
         csv {
             required = true
-            destination file('build/reports/jacoco/jacocoFullCombinedReport.csv')
+            outputLocation = file('build/reports/jacoco/jacocoFullCombinedReport.csv')
         }
     }
 }

--- a/libs/annotations/build.gradle
+++ b/libs/annotations/build.gradle
@@ -82,8 +82,10 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
-    configurations.all {
-        resolutionStrategy.force 'com.getkeepsafe.relinker:relinker:1.4.3'
+    configurations.configureEach {
+        if (canBeResolved) {
+            resolutionStrategy.force 'com.getkeepsafe.relinker:relinker:1.4.3'
+        }
     }
 }
 

--- a/libs/canvas-api-2/src/main/graphql/com/instructure/canvasapi2/CourseAnnouncementsQuery.graphql
+++ b/libs/canvas-api-2/src/main/graphql/com/instructure/canvasapi2/CourseAnnouncementsQuery.graphql
@@ -14,26 +14,26 @@
 #     limitations under the License.
 #
 
-query DashboardSingleCourseQuery($courseId: ID!) {
+query CourseAnnouncementsQuery($courseId: ID!, $cursor: String) {
     course: legacyNode(_id: $courseId, type: Course) {
         ... on Course {
             _id
-            name
-            courseCode
-            imageUrl
-            dashboardCard {
-                isFavorited
-                position
-                color
-                image
-            }
-            enrollmentsConnection(first: 1) {
+            announcements: discussionsConnection(
+                first: 20
+                after: $cursor
+                filter: { isAnnouncement: true }
+            ) {
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
                 nodes {
                     _id
-                    type
-                    grades {
-                        currentGrade
-                        currentScore
+                    title
+                    message
+                    postedAt
+                    participant {
+                        read
                     }
                 }
             }

--- a/libs/canvas-api-2/src/main/graphql/com/instructure/canvasapi2/CourseAnnouncementsQuery.graphql
+++ b/libs/canvas-api-2/src/main/graphql/com/instructure/canvasapi2/CourseAnnouncementsQuery.graphql
@@ -35,6 +35,9 @@ query CourseAnnouncementsQuery($courseId: ID!, $pageSize: Int!, $cursor: String)
                     participant {
                         read
                     }
+                    entryCounts {
+                        unreadCount
+                    }
                 }
             }
         }

--- a/libs/canvas-api-2/src/main/graphql/com/instructure/canvasapi2/CourseAnnouncementsQuery.graphql
+++ b/libs/canvas-api-2/src/main/graphql/com/instructure/canvasapi2/CourseAnnouncementsQuery.graphql
@@ -14,12 +14,12 @@
 #     limitations under the License.
 #
 
-query CourseAnnouncementsQuery($courseId: ID!, $cursor: String) {
+query CourseAnnouncementsQuery($courseId: ID!, $pageSize: Int!, $cursor: String) {
     course: legacyNode(_id: $courseId, type: Course) {
         ... on Course {
             _id
             announcements: discussionsConnection(
-                first: 20
+                first: $pageSize
                 after: $cursor
                 filter: { isAnnouncement: true }
             ) {

--- a/libs/canvas-api-2/src/main/graphql/com/instructure/canvasapi2/DashboardCoursesQuery.graphql
+++ b/libs/canvas-api-2/src/main/graphql/com/instructure/canvasapi2/DashboardCoursesQuery.graphql
@@ -1,0 +1,58 @@
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+#
+
+query DashboardCoursesQuery($announcementCursor: String) {
+    allCourses {
+        _id
+        name
+        courseCode
+        imageUrl
+        dashboardCard {
+            isFavorited
+            position
+            color
+            image
+        }
+        enrollmentsConnection(first: 1) {
+            nodes {
+                _id
+                type
+                grades {
+                    currentGrade
+                    currentScore
+                }
+            }
+        }
+        announcements: discussionsConnection(
+            after: $announcementCursor
+            filter: { isAnnouncement: true }
+        ) {
+            pageInfo {
+                hasNextPage
+                endCursor
+            }
+            nodes {
+                _id
+                title
+                message
+                postedAt
+                participant {
+                    read
+                }
+            }
+        }
+    }
+}

--- a/libs/canvas-api-2/src/main/graphql/com/instructure/canvasapi2/DashboardCoursesQuery.graphql
+++ b/libs/canvas-api-2/src/main/graphql/com/instructure/canvasapi2/DashboardCoursesQuery.graphql
@@ -14,7 +14,7 @@
 #     limitations under the License.
 #
 
-query DashboardCoursesQuery($announcementCursor: String) {
+query DashboardCoursesQuery {
     allCourses {
         _id
         name
@@ -37,7 +37,7 @@ query DashboardCoursesQuery($announcementCursor: String) {
             }
         }
         announcements: discussionsConnection(
-            after: $announcementCursor
+            first: 20
             filter: { isAnnouncement: true }
         ) {
             pageInfo {

--- a/libs/canvas-api-2/src/main/graphql/com/instructure/canvasapi2/DashboardCoursesQuery.graphql
+++ b/libs/canvas-api-2/src/main/graphql/com/instructure/canvasapi2/DashboardCoursesQuery.graphql
@@ -52,6 +52,9 @@ query DashboardCoursesQuery($pageSize: Int!) {
                 participant {
                     read
                 }
+                entryCounts {
+                    unreadCount
+                }
             }
         }
     }

--- a/libs/canvas-api-2/src/main/graphql/com/instructure/canvasapi2/DashboardCoursesQuery.graphql
+++ b/libs/canvas-api-2/src/main/graphql/com/instructure/canvasapi2/DashboardCoursesQuery.graphql
@@ -14,7 +14,7 @@
 #     limitations under the License.
 #
 
-query DashboardCoursesQuery {
+query DashboardCoursesQuery($pageSize: Int!) {
     allCourses {
         _id
         name
@@ -37,7 +37,7 @@ query DashboardCoursesQuery {
             }
         }
         announcements: discussionsConnection(
-            first: 20
+            first: $pageSize
             filter: { isAnnouncement: true }
         ) {
             pageInfo {

--- a/libs/canvas-api-2/src/main/graphql/com/instructure/canvasapi2/DashboardSingleCourseQuery.graphql
+++ b/libs/canvas-api-2/src/main/graphql/com/instructure/canvasapi2/DashboardSingleCourseQuery.graphql
@@ -1,0 +1,55 @@
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+#
+
+query DashboardSingleCourseQuery($courseId: ID!) {
+    course: legacyNode(_id: $courseId, type: Course) {
+        ... on Course {
+            _id
+            name
+            courseCode
+            imageUrl
+            dashboardCard {
+                isFavorited
+                position
+                color
+                image
+            }
+            enrollmentsConnection(first: 1) {
+                nodes {
+                    _id
+                    type
+                    grades {
+                        currentGrade
+                        currentScore
+                    }
+                }
+            }
+            announcements: discussionsConnection(
+                filter: { isAnnouncement: true }
+            ) {
+                nodes {
+                    _id
+                    title
+                    message
+                    postedAt
+                    participant {
+                        read
+                    }
+                }
+            }
+        }
+    }
+}

--- a/libs/canvas-api-2/src/main/graphql/com/instructure/canvasapi2/schema.json
+++ b/libs/canvas-api-2/src/main/graphql/com/instructure/canvasapi2/schema.json
@@ -11,6 +11,381 @@
       "types": [
         {
           "kind": "OBJECT",
+          "name": "AIGradeCriterionResult",
+          "description": null,
+          "fields": [
+            {
+              "name": "comments",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rating",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AIGradeRating",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AIGradeRating",
+          "description": null,
+          "fields": [
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rating",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "reasoning",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AIGradeResult",
+          "description": null,
+          "fields": [
+            {
+              "name": "_id",
+              "description": "legacy canvas id",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "attempt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "errorMessage",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gradeData",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "AIGradeCriterionResult",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gradingAttempts",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "LegacyIDInterface",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "AcceptEnrollmentInvitationInput",
+          "description": "Autogenerated input type of AcceptEnrollmentInvitation",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "enrollmentUuid",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AcceptEnrollmentInvitationPayload",
+          "description": "Autogenerated return type of AcceptEnrollmentInvitation.",
+          "fields": [
+            {
+              "name": "enrollment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Enrollment",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "errors",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ValidationError",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "success",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
           "name": "Account",
           "description": null,
           "fields": [
@@ -116,6 +491,18 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "careerLearningLibraryOnly",
+                  "description": "Whether or not to include or exclude Canvas Career learning library only courses",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null,
@@ -449,6 +836,18 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "id",
+                  "description": "Filter by rubric ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -589,6 +988,22 @@
                 "kind": "OBJECT",
                 "name": "AccountConnection",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "workflowState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -896,6 +1311,223 @@
         },
         {
           "kind": "OBJECT",
+          "name": "AccountNotification",
+          "description": null,
+          "fields": [
+            {
+              "name": "_id",
+              "description": "legacy canvas id",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "accountId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "accountName",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "endAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "icon",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "message",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "notificationType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "siteAdmin",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subject",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "LegacyIDInterface",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Timestamped",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
           "name": "ActivityStream",
           "description": "An activity stream",
           "fields": [
@@ -1152,6 +1784,438 @@
         },
         {
           "kind": "OBJECT",
+          "name": "AllocationError",
+          "description": "An error that occurred while processing an allocation rule",
+          "fields": [
+            {
+              "name": "assignmentId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "attribute",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "attributeId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "message",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AllocationRule",
+          "description": null,
+          "fields": [
+            {
+              "name": "_id",
+              "description": "legacy canvas id",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "appliesToAssessor",
+              "description": "Boolean indicating if this rule applies to the assessor (true) or assessee (false)",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assessee",
+              "description": "The user who will be receiving the peer review",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assessor",
+              "description": "The user who will be doing the peer review",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assignmentId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "courseId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mustReview",
+              "description": "Boolean indicating if the assessor must review the assessee",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "reviewPermitted",
+              "description": "Boolean indicating if the assessor is permitted to review the assessee",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "workflowState",
+              "description": "The current state of the allocation rule",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "LegacyIDInterface",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Timestamped",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AllocationRuleConnection",
+          "description": "The connection type for AllocationRule.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AllocationRuleEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of nodes.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AllocationRule",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AllocationRuleEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AllocationRule",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "AllocationRulesFilterInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "searchTerm",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "ENUM",
+          "name": "AllowProvisionalGradingType",
+          "description": "Indicates whether a submission requires a provisional grade",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "not_applicable",
+              "description": "Assignment does not use moderated grading or grades are already published",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "not_allowed",
+              "description": "User is not allowed to provide a provisional grade",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "allowed",
+              "description": "User can provide a provisional grade",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
           "name": "AnonymousStudentIdentity",
           "description": "An anonymous student identity",
           "fields": [
@@ -1366,6 +2430,50 @@
               "deprecationReason": null
             },
             {
+              "name": "rubricAssessment",
+              "description": "Assessor's rubric assessment for the submission being peer reviewed",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "RubricAssessment",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submission",
+              "description": "The submission being peer reviewed",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Submission",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submissionComments",
+              "description": "Assessor's comments for the submission being peer reviewed",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "SubmissionComment",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "updatedAt",
               "description": null,
               "args": [],
@@ -1507,6 +2615,90 @@
           "isOneOf": false
         },
         {
+          "kind": "INTERFACE",
+          "name": "AssignedDates",
+          "description": "Contains standardized date hash information for objects with date overrides",
+          "fields": [
+            {
+              "name": "assignedToDates",
+              "description": "Standardized date hash visible to current user",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "DateHash",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Assignment",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Checkpoint",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Discussion",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "PeerReviewSubAssignment",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Quiz",
+              "ofType": null
+            }
+          ],
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "AssignedStudentsFilter",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "searchTerm",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "OBJECT",
           "name": "Assignment",
           "description": null,
@@ -1528,6 +2720,18 @@
               "deprecationReason": null
             },
             {
+              "name": "allocationRules",
+              "description": "Allocation rules if peer review is enabled",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AssignmentAllocationRules",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "allowGoogleDocsSubmission",
               "description": null,
               "args": [],
@@ -1535,6 +2739,22 @@
                 "kind": "SCALAR",
                 "name": "Boolean",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "allowProvisionalGrading",
+              "description": "Whether the current user can provide a provisional grade for this assignment",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AllowProvisionalGradingType",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1640,6 +2860,136 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "AssessmentRequest",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assessmentRequestsForUser",
+              "description": "Assessment requests for a specific user where they are the assessor (peer reviewer)",
+              "args": [
+                {
+                  "name": "userId",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AssessmentRequest",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assignedStudents",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "filter",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AssignedStudentsFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "UserConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assignedToDates",
+              "description": "Standardized date hash visible to current user",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "DateHash",
                     "ofType": null
                   }
                 }
@@ -1806,7 +3156,103 @@
               "deprecationReason": null
             },
             {
+              "name": "assignmentType",
+              "description": "Discriminator indicating the actual type of this assignment",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AssignmentTypeEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assignmentVisibility",
+              "description": "Returns empty array if visible to everyone",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "autoGradeAssignmentErrors",
+              "description": "Errors related to the assignment",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use autoGradeEligibility instead"
+            },
+            {
+              "name": "autoGradeAssignmentIssues",
+              "description": "Issues related to the assignment",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "EligibilityIssue",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use autoGradeEligibility instead"
+            },
+            {
+              "name": "autoGradeEligibility",
+              "description": "Eligibility for auto-grading",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AutoGradeEligibility",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "canDuplicate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canManageAssignTo",
               "description": null,
               "args": [],
               "type": {
@@ -1843,7 +3289,7 @@
             },
             {
               "name": "checkpoints",
-              "description": null,
+              "description": "A list of checkpoints (also known as sub_assignments) that are associated with this assignment",
               "args": [],
               "type": {
                 "kind": "LIST",
@@ -2027,12 +3473,85 @@
               "deprecationReason": null
             },
             {
+              "name": "graded",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "gradedSubmissionsExist",
               "description": "If true, the assignment has at least one graded submission",
               "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "graderIdentitiesConnection",
+              "description": "Grader identities if moderated assignment",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "GraderIdentityConnection",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -2051,6 +3570,18 @@
               "deprecationReason": null
             },
             {
+              "name": "gradesPublishedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "gradingPeriodId",
               "description": null,
               "args": [],
@@ -2063,12 +3594,36 @@
               "deprecationReason": null
             },
             {
+              "name": "gradingRole",
+              "description": "The grading role of the current user for this assignment. Returns null if the user does not have sufficient grading permissions.",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "GradingRole",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "gradingStandard",
               "description": null,
               "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "GradingStandard",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gradingStandardId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -2232,8 +3787,40 @@
               "deprecationReason": null
             },
             {
-              "name": "hasSubAssignments",
+              "name": "hasPlagiarismTool",
+              "description": "Indicates if the assignment has LTI 2.0 plagiarism detection tool configured",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasRubric",
               "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasSubAssignments",
+              "description": "Boolean: returns true if the assignment is checkpointed. A checkpointed assignment has checkpoints ( also known as sub_assignments)",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -2329,12 +3916,16 @@
             },
             {
               "name": "isNewQuiz",
-              "description": null,
+              "description": "Assignment is connected to a New Quiz",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -2377,6 +3968,67 @@
               "deprecationReason": null
             },
             {
+              "name": "ltiAssetProcessorsConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "LtiAssetProcessorConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "moderatedGrading",
               "description": null,
               "args": [],
@@ -2396,6 +4048,26 @@
                 "kind": "SCALAR",
                 "name": "Boolean",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "moduleItems",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ModuleItem",
+                    "ofType": null
+                  }
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -2421,8 +4093,20 @@
               "deprecationReason": null
             },
             {
-              "name": "mySubAssignmentSubmissionsConnection",
+              "name": "muted",
               "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mySubAssignmentSubmissionsConnection",
+              "description": "submissions for sub-assignments belonging to the current user",
               "args": [
                 {
                   "name": "after",
@@ -2506,6 +4190,18 @@
               "deprecationReason": null
             },
             {
+              "name": "newQuizzesAnonymousParticipants",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "nonDigitalSubmission",
               "description": null,
               "args": [],
@@ -2552,6 +4248,42 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "parentAssignment",
+              "description": "The parent assignment (only for PeerReviewSubAssignment)",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Assignment",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "parentAssignmentId",
+              "description": "The parent assignment ID (only for PeerReviewSubAssignment)",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "peerReviewSubAssignment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PeerReviewSubAssignment",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -2625,6 +4357,22 @@
                 "kind": "SCALAR",
                 "name": "Boolean",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "provisionalGradingLocked",
+              "description": "Indicates if the user is locked out of provisional grading for this assignment.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -2733,6 +4481,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "scheduledPost",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ScheduledPost",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -2920,6 +4680,22 @@
               "deprecationReason": null
             },
             {
+              "name": "suppressAssignment",
+              "description": "internal use",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "timeZoneEdited",
               "description": null,
               "args": [],
@@ -2962,18 +4738,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "type",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -3049,6 +4813,11 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
+              "name": "AssignedDates",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
               "name": "LegacyIDInterface",
               "ofType": null
             },
@@ -3068,6 +4837,117 @@
               "ofType": null
             }
           ],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AssignmentAllocationRules",
+          "description": "Allocation rules for peer review assignments",
+          "fields": [
+            {
+              "name": "count",
+              "description": "Total count of allocation rules (filtered if search is applied)",
+              "args": [
+                {
+                  "name": "filter",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AllocationRulesFilterInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rulesConnection",
+              "description": "Paginated list of allocation rules",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "filter",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AllocationRulesFilterInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AllocationRuleConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": null,
           "specifiedByURL": null,
@@ -3161,6 +5041,26 @@
               "deprecationReason": null
             },
             {
+              "name": "assetProcessors",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "LtiAssetProcessorCreateOrUpdate",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "assignmentGroupId",
               "description": null,
               "type": {
@@ -3206,7 +5106,7 @@
             },
             {
               "name": "forCheckpoints",
-              "description": null,
+              "description": "if true, this assignment is a parent assignment for checkpoints. cannot set points_possible, due_at, lock_at, or unlock_at",
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
@@ -3326,6 +5226,30 @@
             },
             {
               "name": "postToSis",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "secureParams",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "suppressAssignment",
               "description": null,
               "type": {
                 "kind": "SCALAR",
@@ -3469,6 +5393,26 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "submissionTypes",
+              "description": "only return assignments for the given submission types. Defaults to\nall.\n",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "SubmissionType",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": null,
@@ -3564,9 +5508,13 @@
                 }
               ],
               "type": {
-                "kind": "OBJECT",
-                "name": "AssignmentConnection",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AssignmentConnection",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -4088,12 +6036,36 @@
               "deprecationReason": null
             },
             {
+              "name": "allDayDate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "assignment",
               "description": null,
               "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "Assignment",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assignmentId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -4533,6 +6505,18 @@
           "fields": null,
           "inputFields": [
             {
+              "name": "acrossSections",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "anonymousReviews",
               "description": null,
               "type": {
@@ -4594,6 +6578,18 @@
             },
             {
               "name": "intraReviews",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submissionRequired",
               "description": null,
               "type": {
                 "kind": "SCALAR",
@@ -4891,6 +6887,31 @@
           "isOneOf": false
         },
         {
+          "kind": "ENUM",
+          "name": "AssignmentTypeEnum",
+          "description": "Assignment subtypes for filtering queries and discriminating response types",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "ASSIGNMENT",
+              "description": "Standard assignment",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PEER_REVIEW_SUB_ASSIGNMENT",
+              "description": "Peer review sub-assignment",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "INPUT_OBJECT",
           "name": "AssignmentUpdate",
           "description": null,
@@ -4908,6 +6929,26 @@
                   "ofType": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assetProcessors",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "LtiAssetProcessorCreateOrUpdate",
                     "ofType": null
                   }
                 }
@@ -4962,7 +7003,7 @@
             },
             {
               "name": "forCheckpoints",
-              "description": null,
+              "description": "if true, this assignment is a parent assignment for checkpoints. cannot set points_possible, due_at, lock_at, or unlock_at",
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
@@ -5093,6 +7134,30 @@
               "deprecationReason": null
             },
             {
+              "name": "secureParams",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "suppressAssignment",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "unlockAt",
               "description": null,
               "type": {
@@ -5194,9 +7259,13 @@
                 }
               ],
               "type": {
-                "kind": "OBJECT",
-                "name": "AssignmentConnection",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AssignmentConnection",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -5217,6 +7286,691 @@
               "ofType": null
             }
           ],
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AuditEvent",
+          "description": null,
+          "fields": [
+            {
+              "name": "_id",
+              "description": "legacy canvas id",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eventType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuditEventType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "externalTool",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AuditEventExternalTool",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "payload",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "JSON",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quiz",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AuditEventQuiz",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "user",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AuditEventUser",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "LegacyIDInterface",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Timestamped",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AuditEventConnection",
+          "description": "The connection type for AuditEvent.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AuditEventEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of nodes.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AuditEvent",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AuditEventEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AuditEvent",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AuditEventExternalTool",
+          "description": null,
+          "fields": [
+            {
+              "name": "_id",
+              "description": "legacy canvas id",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "role",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuditEventRole",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "LegacyIDInterface",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AuditEventQuiz",
+          "description": null,
+          "fields": [
+            {
+              "name": "_id",
+              "description": "legacy canvas id",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "role",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuditEventRole",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "LegacyIDInterface",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "ENUM",
+          "name": "AuditEventRole",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "student",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "final_grader",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "admin",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "grader",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "ENUM",
+          "name": "AuditEventType",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "assignment_created",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assignment_updated",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "docviewer_area_created",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "docviewer_area_deleted",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "docviewer_area_updated",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "docviewer_comment_created",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "docviewer_comment_deleted",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "docviewer_comment_updated",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "docviewer_free_draw_created",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "docviewer_free_draw_deleted",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "docviewer_free_draw_updated",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "docviewer_free_text_created",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "docviewer_free_text_deleted",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "docviewer_free_text_updated",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "docviewer_highlight_created",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "docviewer_highlight_deleted",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "docviewer_highlight_updated",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "docviewer_point_created",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "docviewer_point_deleted",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "docviewer_point_updated",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "docviewer_strikeout_created",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "docviewer_strikeout_deleted",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "docviewer_strikeout_updated",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "grades_posted",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "provisional_grade_created",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "provisional_grade_selected",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "provisional_grade_updated",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rubric_created",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rubric_deleted",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rubric_updated",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submission_comment_created",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submission_comment_deleted",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submission_comment_updated",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submission_updated",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AuditEventUser",
+          "description": null,
+          "fields": [
+            {
+              "name": "_id",
+              "description": "legacy canvas id",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "role",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuditEventRole",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "LegacyIDInterface",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null,
           "specifiedByURL": null,
           "isOneOf": false
         },
@@ -5335,6 +8089,158 @@
           "isOneOf": false
         },
         {
+          "kind": "OBJECT",
+          "name": "AutoGradeEligibility",
+          "description": null,
+          "fields": [
+            {
+              "name": "issues",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "AutoGradeIssue",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AutoGradeIssue",
+          "description": null,
+          "fields": [
+            {
+              "name": "message",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "AutoGradeSubmissionInput",
+          "description": "Autogenerated input type of AutoGradeSubmission",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "submissionId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AutoGradeSubmissionPayload",
+          "description": "Autogenerated return type of AutoGradeSubmission.",
+          "fields": [
+            {
+              "name": "error",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "errors",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ValidationError",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "progress",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Progress",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "ENUM",
           "name": "AutoLeaderPolicy",
           "description": "Determines if/how a leader is chosen for each group",
@@ -5401,6 +8307,26 @@
           "name": "Checkpoint",
           "description": null,
           "fields": [
+            {
+              "name": "assignedToDates",
+              "description": "Standardized date hash visible to current user",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "DateHash",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "assignmentOverrides",
               "description": null,
@@ -5599,7 +8525,13 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "AssignedDates",
+              "ofType": null
+            }
+          ],
           "enumValues": null,
           "possibleTypes": null,
           "specifiedByURL": null,
@@ -5647,6 +8579,18 @@
                   "name": "ID",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assignmentId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -5802,14 +8746,14 @@
             },
             {
               "name": "pageInfo",
-              "description": "Information to aid in pagination.",
+              "description": null,
               "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "PageInfo",
+                  "name": "TotalCountPageInfo",
                   "ofType": null
                 }
               },
@@ -7380,9 +10324,13 @@
                 }
               ],
               "type": {
-                "kind": "OBJECT",
-                "name": "AssignmentGroupConnection",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AssignmentGroupConnection",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -7514,9 +10462,13 @@
                 }
               ],
               "type": {
-                "kind": "OBJECT",
-                "name": "AssignmentConnection",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AssignmentConnection",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -7589,6 +10541,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "careerLearningLibraryOnly",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -7851,7 +10815,7 @@
             },
             {
               "name": "externalToolsConnection",
-              "description": null,
+              "description": "returns a list of external tools.\n",
               "args": [
                 {
                   "name": "after",
@@ -7996,6 +10960,67 @@
               "deprecationReason": null
             },
             {
+              "name": "foldersConnection",
+              "description": "Folders for this course.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "FolderConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "gradeStatuses",
               "description": null,
               "args": [],
@@ -8073,9 +11098,13 @@
                 }
               ],
               "type": {
-                "kind": "OBJECT",
-                "name": "GradingPeriodConnection",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "GradingPeriodConnection",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -8284,18 +11313,6 @@
               "deprecationReason": null
             },
             {
-              "name": "horizonCourse",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "id",
               "description": null,
               "args": [],
@@ -8318,6 +11335,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "URL",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "moduleProgressionStatistics",
+              "description": "Returns module progression statistics for the current user",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ModuleProgressionStatistics",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -8369,6 +11398,18 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "filter",
+                  "description": "Filter modules by various criteria",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ModuleFilterInput",
                     "ofType": null
                   },
                   "defaultValue": null,
@@ -8685,6 +11726,18 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "id",
+                  "description": "Filter by rubric ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -8761,8 +11814,24 @@
                 }
               ],
               "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SectionConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "settings",
+              "description": "Settings for the course",
+              "args": [],
+              "type": {
                 "kind": "OBJECT",
-                "name": "SectionConnection",
+                "name": "CourseSettings",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -8792,6 +11861,31 @@
                   "name": "CourseWorkflowState",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submissionStatistics",
+              "description": "Returns submission-related statistics for the current user",
+              "args": [
+                {
+                  "name": "observedUserId",
+                  "description": "Optional observed user ID for observer statistics",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SubmissionStatistics",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -9028,11 +12122,80 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CourseUsersSortInputType",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
                 "kind": "OBJECT",
                 "name": "UserConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "usersConnectionCount",
+              "description": null,
+              "args": [
+                {
+                  "name": "filter",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CourseUsersFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CourseUsersSortInputType",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "userIds",
+                  "description": "Only include users with the given ids.\n\n**This field is deprecated, use `filter: {userIds}` instead.**\n",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -9058,12 +12221,7 @@
             },
             {
               "kind": "INTERFACE",
-              "name": "FilesConnectionInterface",
-              "ofType": null
-            },
-            {
-              "kind": "INTERFACE",
-              "name": "DiscussionsConnectionInterface",
+              "name": "ExternalToolsConnectionInterface",
               "ofType": null
             },
             {
@@ -9079,16 +12237,6 @@
             {
               "kind": "INTERFACE",
               "name": "Node",
-              "ofType": null
-            },
-            {
-              "kind": "INTERFACE",
-              "name": "PagesConnectionInterface",
-              "ofType": null
-            },
-            {
-              "kind": "INTERFACE",
-              "name": "QuizzesConnectionInterface",
               "ofType": null
             },
             {
@@ -10096,31 +13244,420 @@
           "isOneOf": false
         },
         {
+          "kind": "OBJECT",
+          "name": "CourseSettings",
+          "description": "Settings for a course",
+          "fields": [
+            {
+              "name": "allowFinalGradeOverride",
+              "description": "Whether the course allows final grade override",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "allowStudentAnonymousDiscussionTopics",
+              "description": "Whether the course allows students to create anonymous discussion topics",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "allowStudentDiscussionEditing",
+              "description": "Whether the course allows students to edit their discussion posts",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "allowStudentDiscussionReporting",
+              "description": "Whether the course allows students to report discussion posts",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "allowStudentDiscussionTopics",
+              "description": "Whether the course allows students to create discussion topics",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "allowStudentForumAttachments",
+              "description": "Whether the course allows students to attach files to discussion posts",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "allowStudentOrganizedGroups",
+              "description": "Whether the course allows student organized groups",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bannerImageId",
+              "description": "ID of the course banner image",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bannerImageUrl",
+              "description": "URL to the course banner image",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "conditionalRelease",
+              "description": "Whether the course has conditional release enabled",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "courseColor",
+              "description": "Color for the course",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "defaultDueTime",
+              "description": "Default due time for the course",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "filterSpeedGraderByStudentGroup",
+              "description": "Whether the course filters SpeedGrader by student group",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "friendlyName",
+              "description": "Friendly name for the course",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gradePassbackSetting",
+              "description": "Grade passback setting for the course",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gradingStandardEnabled",
+              "description": "Whether the course has a grading standard enabled",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gradingStandardId",
+              "description": "ID of the grading standard, if enabled",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hideDistributionGraphs",
+              "description": "Whether the course hides grade distribution graphs from students",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hideFinalGrades",
+              "description": "Whether the course hides final grades from students",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hideSectionsOnCourseUsersPage",
+              "description": "Whether the course hides sections on the course users page",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "homePageAnnouncementLimit",
+              "description": "Maximum number of announcements to show on the home page",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "homeroomCourse",
+              "description": "Whether the course is a homeroom course",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "imageId",
+              "description": "ID of the course image",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "imageUrl",
+              "description": "URL to the course image",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lockAllAnnouncements",
+              "description": "Whether the course locks all announcements",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "restrictQuantitativeData",
+              "description": "How the course restricts quantitative data for students",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "restrictStudentFutureView",
+              "description": "Whether the course restricts students from viewing future courses",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "restrictStudentPastView",
+              "description": "Whether the course restricts students from viewing past courses",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "showAnnouncementsOnHomePage",
+              "description": "Whether the course shows announcements on the home page",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "showStudentOnlyModuleId",
+              "description": "ID of the module that should only be shown to students",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "showTeacherOnlyModuleId",
+              "description": "ID of the module that should only be shown to teachers",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "syllabusCourseSummary",
+              "description": "Whether the course shows the syllabus course summary",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "usageRightsRequired",
+              "description": "Whether the course requires usage rights for uploaded files",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "INPUT_OBJECT",
           "name": "CourseUsersFilter",
           "description": null,
           "fields": null,
           "inputFields": [
-            {
-              "name": "userIds",
-              "description": "only include users with the given ids",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
             {
               "name": "enrollmentRoleIds",
               "description": "Only return users with the specified enrollment role ids",
@@ -10204,10 +13741,176 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "userIds",
+              "description": "only include users with the given ids",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "ENUM",
+          "name": "CourseUsersSortDirectionType",
+          "description": "Order direction for results",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "ENUM",
+          "name": "CourseUsersSortFieldType",
+          "description": "Sort field for results",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "name",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sis_id",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "login_id",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "total_activity_time",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "last_activity_at",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "section_name",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "role",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "CourseUsersSortInputType",
+          "description": "Specify sort field and direction for results",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "direction",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "CourseUsersSortDirectionType",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "field",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CourseUsersSortFieldType",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "ENUM",
+          "name": "CourseWorkSubmissionsOrderField",
+          "description": "Fields to order course work submissions by",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "graded_at",
+              "description": "Order by graded date",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "due_at",
+              "description": "Order by due date",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null,
           "specifiedByURL": null,
           "isOneOf": false
@@ -10325,6 +14028,204 @@
                 "kind": "OBJECT",
                 "name": "AccountDomainLookup",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "errors",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ValidationError",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "CreateAllocationRuleInput",
+          "description": "Autogenerated input type of CreateAllocationRule",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "appliesToAssessor",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": "true",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assesseeIds",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assessorIds",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mustReview",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": "true",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "reciprocal",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": "false",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "reviewPermitted",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": "true",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assignmentId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CreateAllocationRulePayload",
+          "description": "Autogenerated return type of CreateAllocationRule.",
+          "fields": [
+            {
+              "name": "allocationErrors",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AllocationError",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "allocationRules",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AllocationRule",
+                    "ofType": null
+                  }
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -10477,7 +14378,7 @@
             },
             {
               "name": "forCheckpoints",
-              "description": null,
+              "description": "if true, this assignment is a parent assignment for checkpoints. cannot set points_possible, due_at, lock_at, or unlock_at",
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
@@ -10696,6 +14597,18 @@
               "deprecationReason": null
             },
             {
+              "name": "suppressAssignment",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "unlockAt",
               "description": null,
               "type": {
@@ -10734,6 +14647,18 @@
                   "name": "String",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "secureParams",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -10797,6 +14722,18 @@
           "description": "Autogenerated input type of CreateCommentBankItem",
           "fields": null,
           "inputFields": [
+            {
+              "name": "assignmentId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "comment",
               "description": null,
@@ -11091,132 +15028,6 @@
                     "ofType": null
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "errors",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "ValidationError",
-                    "ofType": null
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null,
-          "specifiedByURL": null,
-          "isOneOf": false
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "CreateDiscussionEntryDraftInput",
-          "description": "Autogenerated input type of CreateDiscussionEntryDraft",
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "discussionEntryId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "discussionTopicId",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "fileId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "message",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "parentId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null,
-          "specifiedByURL": null,
-          "isOneOf": false
-        },
-        {
-          "kind": "OBJECT",
-          "name": "CreateDiscussionEntryDraftPayload",
-          "description": "Autogenerated return type of CreateDiscussionEntryDraft.",
-          "fields": [
-            {
-              "name": "discussionEntryDraft",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "DiscussionEntryDraft",
-                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -13583,6 +17394,18 @@
               "deprecationReason": null
             },
             {
+              "name": "icon",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": null,
               "args": [],
@@ -13761,6 +17584,152 @@
           "isOneOf": false
         },
         {
+          "kind": "OBJECT",
+          "name": "DateHash",
+          "description": "Standardized date hash from backend assigned_to_dates field",
+          "fields": [
+            {
+              "name": "base",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dueAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lockAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "peerReviewDates",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PeerReviewDates",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "set",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "DateHashSet",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "unlockAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DateHashSet",
+          "description": "Set information for a date hash entry",
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "SCALAR",
           "name": "DateTime",
           "description": "an ISO8601 formatted time string",
@@ -13851,6 +17820,84 @@
                 "kind": "SCALAR",
                 "name": "ID",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "errors",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ValidationError",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "DeleteAllocationRuleInput",
+          "description": "Autogenerated input type of DeleteAllocationRule",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "ruleId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DeleteAllocationRulePayload",
+          "description": "Autogenerated return type of DeleteAllocationRule.",
+          "fields": [
+            {
+              "name": "allocationRuleId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -15003,6 +19050,26 @@
               "deprecationReason": null
             },
             {
+              "name": "assignedToDates",
+              "description": "Standardized date hash visible to current user",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "DateHash",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "assignment",
               "description": null,
               "args": [],
@@ -15100,7 +19167,31 @@
               "deprecationReason": null
             },
             {
+              "name": "canDuplicate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "canGroup",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canManageAssignTo",
               "description": null,
               "args": [],
               "type": {
@@ -15145,7 +19236,7 @@
             },
             {
               "name": "checkpoints",
-              "description": null,
+              "description": "a list of checkpoints(also known as sub_assignments) that belong to this discussion",
               "args": [],
               "type": {
                 "kind": "LIST",
@@ -15364,18 +19455,6 @@
                   "deprecationReason": null
                 },
                 {
-                  "name": "sortOrder",
-                  "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "DiscussionSortOrderType",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
                   "name": "unreadBefore",
                   "description": null,
                   "type": {
@@ -15403,67 +19482,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "DiscussionEntryConnection",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "discussionEntryDraftsConnection",
-              "description": null,
-              "args": [
-                {
-                  "name": "after",
-                  "description": "Returns the elements in the list that come after the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "before",
-                  "description": "Returns the elements in the list that come before the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "first",
-                  "description": "Returns the first _n_ elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "last",
-                  "description": "Returns the last _n_ elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "DiscussionEntryDraftConnection",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -15665,6 +19683,18 @@
             },
             {
               "name": "expandedLocked",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "graded",
               "description": null,
               "args": [],
               "type": {
@@ -15981,6 +20011,26 @@
               "deprecationReason": null
             },
             {
+              "name": "pinnedEntries",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "DiscussionEntry",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "podcastEnabled",
               "description": null,
               "args": [],
@@ -16248,6 +20298,99 @@
               "deprecationReason": null
             },
             {
+              "name": "submissionsConnection",
+              "description": "submissions for this assignment",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "filter",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "SubmissionSearchFilterInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "SubmissionSearchOrder",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SubmissionConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "subscribed",
               "description": null,
               "args": [],
@@ -16411,6 +20554,11 @@
           ],
           "inputFields": null,
           "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "AssignedDates",
+              "ofType": null
+            },
             {
               "kind": "INTERFACE",
               "name": "LegacyIDInterface",
@@ -17268,6 +21416,30 @@
               "deprecationReason": null
             },
             {
+              "name": "pinType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "DiscussionEntryPinningType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pinnedBy",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "previewMessage",
               "description": null,
               "args": [],
@@ -17560,268 +21732,6 @@
         },
         {
           "kind": "OBJECT",
-          "name": "DiscussionEntryDraft",
-          "description": null,
-          "fields": [
-            {
-              "name": "_id",
-              "description": "legacy canvas id",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "attachment",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "File",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "createdAt",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "discussionEntryId",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "discussionTopicId",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "message",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "parentId",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "rootEntryId",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "updatedAt",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "LegacyIDInterface",
-              "ofType": null
-            },
-            {
-              "kind": "INTERFACE",
-              "name": "Timestamped",
-              "ofType": null
-            }
-          ],
-          "enumValues": null,
-          "possibleTypes": null,
-          "specifiedByURL": null,
-          "isOneOf": false
-        },
-        {
-          "kind": "OBJECT",
-          "name": "DiscussionEntryDraftConnection",
-          "description": "The connection type for DiscussionEntryDraft.",
-          "fields": [
-            {
-              "name": "edges",
-              "description": "A list of edges.",
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "DiscussionEntryDraftEdge",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "nodes",
-              "description": "A list of nodes.",
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "DiscussionEntryDraft",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "pageInfo",
-              "description": "Information to aid in pagination.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "PageInfo",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null,
-          "specifiedByURL": null,
-          "isOneOf": false
-        },
-        {
-          "kind": "OBJECT",
-          "name": "DiscussionEntryDraftEdge",
-          "description": "An edge in a connection.",
-          "fields": [
-            {
-              "name": "cursor",
-              "description": "A cursor for use in pagination.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "node",
-              "description": "The item at the end of the edge.",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "DiscussionEntryDraft",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null,
-          "specifiedByURL": null,
-          "isOneOf": false
-        },
-        {
-          "kind": "OBJECT",
           "name": "DiscussionEntryEdge",
           "description": "An edge in a connection.",
           "fields": [
@@ -17971,6 +21881,37 @@
           "isOneOf": false
         },
         {
+          "kind": "ENUM",
+          "name": "DiscussionEntryPinningType",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "thread",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "reply",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "none",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "OBJECT",
           "name": "DiscussionEntryReportTypeCounts",
           "description": null,
@@ -18113,6 +22054,22 @@
               "deprecationReason": null
             },
             {
+              "name": "messageIntro",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "updatedAt",
               "description": null,
               "args": [],
@@ -18188,6 +22145,18 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "isAnnouncement",
+              "description": "only return discussions that are announcements (true) or\nregular discussions (false). If not provided, returns both.\n",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": null,
@@ -18239,7 +22208,35 @@
           "description": null,
           "fields": [
             {
+              "name": "discussionTopic",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Discussion",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "expanded",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasUnreadPinnedEntry",
               "description": null,
               "args": [],
               "type": {
@@ -18267,6 +22264,62 @@
               "deprecationReason": null
             },
             {
+              "name": "posted",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "preferredLanguage",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "PreferredLanguageType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "read",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "showPinnedEntries",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "sortOrder",
               "description": null,
               "args": [],
@@ -18277,10 +22330,189 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "summaryEnabled",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "workflowState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DiscussionParticipantConnection",
+          "description": "The connection type for DiscussionParticipant.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "DiscussionParticipantEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of nodes.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "DiscussionParticipant",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TotalCountPageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DiscussionParticipantEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "DiscussionParticipant",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "DiscussionParticipantFilter",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "isAnnouncement",
+              "description": "only return participants for discussions that are announcements (true) or\nregular discussions (false). If not provided, returns both.\n",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "courseId",
+              "description": "only return participants for discussions in the specified course\n",
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "readState",
+              "description": "only return participants with specific read state: 'read', 'unread', or 'all' (default)\n",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null,
           "specifiedByURL": null,
@@ -18566,6 +22798,18 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "viewGroupPages",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -18786,6 +23030,68 @@
           "isOneOf": false
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "DismissAccountNotificationInput",
+          "description": "Autogenerated input type of DismissAccountNotification",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "notificationId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DismissAccountNotificationPayload",
+          "description": "Autogenerated return type of DismissAccountNotification.",
+          "fields": [
+            {
+              "name": "errors",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ValidationError",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "ENUM",
           "name": "DraftableSubmissionType",
           "description": "Types of submissions that can have a submission draft",
@@ -18825,6 +23131,76 @@
             },
             {
               "name": "student_annotation",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EligibilityIssue",
+          "description": null,
+          "fields": [
+            {
+              "name": "level",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "EligibilityIssueLevel",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "message",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "ENUM",
+          "name": "EligibilityIssueLevel",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "error",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "warning",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -18936,6 +23312,34 @@
               "deprecationReason": null
             },
             {
+              "name": "endAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "enrollmentState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "EnrollmentWorkflowState",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "grades",
               "description": null,
               "args": [
@@ -18989,6 +23393,18 @@
               "deprecationReason": null
             },
             {
+              "name": "invitationSentAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "lastActivityAt",
               "description": null,
               "args": [],
@@ -19007,6 +23423,30 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "role",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "EnrollmentRole",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "roleLabel",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -19043,6 +23483,30 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sisSectionId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -19115,6 +23579,30 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "userId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uuid",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -19179,14 +23667,14 @@
             },
             {
               "name": "pageInfo",
-              "description": "Information to aid in pagination.",
+              "description": null,
               "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "PageInfo",
+                  "name": "TotalCountPageInfo",
                   "ofType": null
                 }
               },
@@ -19307,9 +23795,66 @@
               "defaultValue": "null",
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "userIds",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": "[]",
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EnrollmentRole",
+          "description": null,
+          "fields": [
+            {
+              "name": "_id",
+              "description": "legacy canvas id",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": null,
           "specifiedByURL": null,
@@ -19420,6 +23965,103 @@
           "isOneOf": false
         },
         {
+          "kind": "ENUM",
+          "name": "EnrollmentsSortDirectionType",
+          "description": "Order direction for enrollments",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "ENUM",
+          "name": "EnrollmentsSortFieldType",
+          "description": "Sort field for enrollments",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "role",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "section_name",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "last_activity_at",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "EnrollmentsSortInputType",
+          "description": "Specify sort field and direction for enrollments",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "direction",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "EnrollmentsSortDirectionType",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "field",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "EnrollmentsSortFieldType",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "OBJECT",
           "name": "EntryParticipant",
           "description": null,
@@ -19506,6 +24148,30 @@
               "deprecationReason": null
             },
             {
+              "name": "canDuplicate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canManageAssignTo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "canUnpublish",
               "description": "Whether the module item can be unpublished",
               "args": [],
@@ -19542,17 +24208,25 @@
               "deprecationReason": null
             },
             {
-              "name": "isLockedByMasterCourse",
+              "name": "domain",
               "description": null,
               "args": [],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "graded",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -19569,6 +24243,35 @@
                   "name": "Boolean",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "labelFor",
+              "description": null,
+              "args": [
+                {
+                  "name": "placement",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "ExternalToolPlacement",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -19598,9 +24301,29 @@
               "description": null,
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "placements",
+              "description": "Placements for the external tool",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Placements",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -19619,7 +24342,7 @@
             },
             {
               "name": "published",
-              "description": "Whether the module item is published",
+              "description": null,
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -19712,6 +24435,11 @@
             {
               "kind": "INTERFACE",
               "name": "ModuleItemInterface",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "PlacementsInterface",
               "ofType": null
             },
             {
@@ -19834,11 +24562,11 @@
           "fields": null,
           "inputFields": [
             {
-              "name": "state",
+              "name": "placement",
               "description": null,
               "type": {
                 "kind": "ENUM",
-                "name": "ExternalToolState",
+                "name": "ExternalToolPlacement",
                 "ofType": null
               },
               "defaultValue": "null",
@@ -19846,11 +24574,31 @@
               "deprecationReason": null
             },
             {
-              "name": "placement",
+              "name": "placementList",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "ExternalToolPlacement",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": "null",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "state",
               "description": null,
               "type": {
                 "kind": "ENUM",
-                "name": "ExternalToolPlacement",
+                "name": "ExternalToolState",
                 "ofType": null
               },
               "defaultValue": "null",
@@ -19874,6 +24622,24 @@
           "enumValues": [
             {
               "name": "homework_submission",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ActivityAssetProcessor",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "link_selection",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "resource_selection",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -20067,6 +24833,98 @@
           "isOneOf": false
         },
         {
+          "kind": "INTERFACE",
+          "name": "ExternalToolsConnectionInterface",
+          "description": null,
+          "fields": [
+            {
+              "name": "externalToolsConnection",
+              "description": "returns a list of external tools.\n",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "filter",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ExternalToolFilterInput",
+                    "ofType": null
+                  },
+                  "defaultValue": "{}",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ExternalToolConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Course",
+              "ofType": null
+            }
+          ],
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "OBJECT",
           "name": "ExternalUrl",
           "description": null,
@@ -20083,6 +24941,30 @@
                   "name": "ID",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canDuplicate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canManageAssignTo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -20112,17 +24994,13 @@
               "deprecationReason": null
             },
             {
-              "name": "isLockedByMasterCourse",
+              "name": "graded",
               "description": null,
               "args": [],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -20293,6 +25171,30 @@
               "deprecationReason": null
             },
             {
+              "name": "canDuplicate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canManageAssignTo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "canUnpublish",
               "description": "Whether the module item can be unpublished",
               "args": [],
@@ -20341,6 +25243,42 @@
               "deprecationReason": null
             },
             {
+              "name": "fileState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "folder",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Folder",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "graded",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": null,
               "args": [],
@@ -20373,17 +25311,25 @@
               "deprecationReason": null
             },
             {
-              "name": "isLockedByMasterCourse",
+              "name": "lockAt",
               "description": null,
               "args": [],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locked",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -20518,24 +25464,12 @@
               "deprecationReason": null
             },
             {
-              "name": "title",
+              "name": "unlockAt",
               "description": null,
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "type",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -20572,6 +25506,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "UsageRights",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "viewedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -20862,6 +25808,461 @@
           "isOneOf": false
         },
         {
+          "kind": "OBJECT",
+          "name": "Folder",
+          "description": null,
+          "fields": [
+            {
+              "name": "_id",
+              "description": "legacy canvas id",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canUpload",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "contextId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "contextType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currentlyLocked",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "files",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "File",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "filesCount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "foldersCount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fullName",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hidden",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lockAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locked",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "parentFolder",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Folder",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "parentFolderId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "position",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rootFolder",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subFolders",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Folder",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "unlockAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "LegacyIDInterface",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Timestamped",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FolderConnection",
+          "description": "The connection type for Folder.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "FolderEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of nodes.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Folder",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FolderEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Folder",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "ENUM",
           "name": "GradeState",
           "description": null,
@@ -20882,6 +26283,169 @@
               "deprecationReason": null
             }
           ],
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "GraderIdentity",
+          "description": "Represents a grader's identity in a moderated grading context.",
+          "fields": [
+            {
+              "name": "anonymousId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "The name of the grader, which may be anonymized in certain contexts.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "position",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "GraderIdentityConnection",
+          "description": "The connection type for GraderIdentity.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "GraderIdentityEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of nodes.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "GraderIdentity",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "GraderIdentityEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "GraderIdentity",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
           "possibleTypes": null,
           "specifiedByURL": null,
           "isOneOf": false
@@ -20982,6 +26546,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "GradingPeriod",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "htmlUrl",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "URL",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -21728,6 +27304,37 @@
           "isOneOf": false
         },
         {
+          "kind": "ENUM",
+          "name": "GradingRole",
+          "description": "The grading role of the current user for this assignment",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "moderator",
+              "description": "User is a moderator for the assignment",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "provisional_grader",
+              "description": "User is a provisional grader for the assignment",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "grader",
+              "description": "User is a standard grader for the assignment",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "OBJECT",
           "name": "GradingStandard",
           "description": null,
@@ -22098,6 +27705,18 @@
               "deprecationReason": null
             },
             {
+              "name": "groupCategory",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "GroupSet",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": null,
               "args": [],
@@ -22247,6 +27866,22 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "state",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "GroupState",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -22423,6 +28058,22 @@
                 "kind": "SCALAR",
                 "name": "DateTime",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "group",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Group",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -22826,6 +28477,22 @@
               "deprecationReason": null
             },
             {
+              "name": "singleTag",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "sisId",
               "description": null,
               "args": [],
@@ -22979,6 +28646,31 @@
           "inputFields": null,
           "interfaces": [],
           "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "ENUM",
+          "name": "GroupState",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "available",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deleted",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null,
           "specifiedByURL": null,
           "isOneOf": false
@@ -23625,6 +29317,238 @@
           "isOneOf": false
         },
         {
+          "kind": "OBJECT",
+          "name": "InstructorEnrollmentInfo",
+          "description": null,
+          "fields": [
+            {
+              "name": "course",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Course",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "enrollmentState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "role",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "EnrollmentRole",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "InstructorWithEnrollments",
+          "description": null,
+          "fields": [
+            {
+              "name": "enrollments",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "InstructorEnrollmentInfo",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "user",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "User",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "InstructorWithEnrollmentsConnection",
+          "description": "The connection type for InstructorWithEnrollments.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "InstructorWithEnrollmentsEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of nodes.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "InstructorWithEnrollments",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TotalCountPageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "InstructorWithEnrollmentsEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "InstructorWithEnrollments",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "SCALAR",
           "name": "Int",
           "description": "Represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
@@ -23805,6 +29729,31 @@
             },
             {
               "name": "none",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "ENUM",
+          "name": "LearnerDashboardTabType",
+          "description": "Available tabs on the learner dashboard",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "dashboard",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "courses",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -24765,6 +30714,11 @@
           "possibleTypes": [
             {
               "kind": "OBJECT",
+              "name": "AIGradeResult",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "Account",
               "ofType": null
             },
@@ -24780,6 +30734,16 @@
             },
             {
               "kind": "OBJECT",
+              "name": "AccountNotification",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "AllocationRule",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "AssessmentRequest",
               "ofType": null
             },
@@ -24791,6 +30755,26 @@
             {
               "kind": "OBJECT",
               "name": "AssignmentGroup",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "AuditEvent",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "AuditEventExternalTool",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "AuditEventQuiz",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "AuditEventUser",
               "ofType": null
             },
             {
@@ -24830,11 +30814,6 @@
             },
             {
               "kind": "OBJECT",
-              "name": "DiscussionEntryDraft",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
               "name": "DiscussionEntryVersion",
               "ofType": null
             },
@@ -24851,6 +30830,11 @@
             {
               "kind": "OBJECT",
               "name": "File",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Folder",
               "ofType": null
             },
             {
@@ -24895,6 +30879,21 @@
             },
             {
               "kind": "OBJECT",
+              "name": "LtiAsset",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "LtiAssetProcessor",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "LtiAssetReport",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "MediaTrack",
               "ofType": null
             },
@@ -24911,6 +30910,11 @@
             {
               "kind": "OBJECT",
               "name": "ModuleItem",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "ModuleProgression",
               "ofType": null
             },
             {
@@ -24945,6 +30949,11 @@
             },
             {
               "kind": "OBJECT",
+              "name": "PeerReviewSubAssignment",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "PostPolicy",
               "ofType": null
             },
@@ -24960,7 +30969,17 @@
             },
             {
               "kind": "OBJECT",
+              "name": "ProvisionalGrade",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "Quiz",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "QuizSubmission",
               "ofType": null
             },
             {
@@ -24986,6 +31005,11 @@
             {
               "kind": "OBJECT",
               "name": "RubricRating",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "ScheduledPost",
               "ofType": null
             },
             {
@@ -25156,6 +31180,1103 @@
               "ofType": null
             }
           ],
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "LtiAsset",
+          "description": null,
+          "fields": [
+            {
+              "name": "_id",
+              "description": "legacy canvas id",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "attachmentId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "attachmentName",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "discussionEntryVersion",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "DiscussionEntryVersion",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submissionAttempt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submissionId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "LegacyIDInterface",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "LtiAssetProcessor",
+          "description": null,
+          "fields": [
+            {
+              "name": "_id",
+              "description": "legacy canvas id",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "externalTool",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ExternalTool",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iconOrToolIconUrl",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iframe",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "LtiAssetProcessorIframe",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "text",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "window",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "LtiAssetProcessorWindowSettings",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "LegacyIDInterface",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "LtiAssetProcessorConnection",
+          "description": "The connection type for LtiAssetProcessor.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "LtiAssetProcessorEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of nodes.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "LtiAssetProcessor",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "LtiAssetProcessorCreateOrUpdate",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "existingId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "newContentItem",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "LtiAssetProcessorDto",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "LtiAssetProcessorDto",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "contextExternalToolId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "custom",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "StringMap",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "icon",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "LtiContentItemIcon",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iframe",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "LtiContentItemIframe",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "report",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "LtiAssetProcessorReportSettings",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "text",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "thumbnail",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "LtiContentItemIcon",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "window",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "LtiAssetProcessorWindowSettingsInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "LtiAssetProcessorEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "LtiAssetProcessor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "LtiAssetProcessorIframe",
+          "description": null,
+          "fields": [
+            {
+              "name": "height",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "width",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "LtiAssetProcessorReportSettings",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "custom",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "StringMap",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "LtiAssetProcessorWindowSettings",
+          "description": null,
+          "fields": [
+            {
+              "name": "height",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "targetName",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "width",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "windowFeatures",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "LtiAssetProcessorWindowSettingsInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "height",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "targetName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "width",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "windowFeatures",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "LtiAssetReport",
+          "description": null,
+          "fields": [
+            {
+              "name": "_id",
+              "description": "legacy canvas id",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "asset",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "LtiAsset",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "comment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "errorCode",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "indicationAlt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "indicationColor",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "launchUrlPath",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "priority",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "processingProgress",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "processorId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "reportType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "resubmitAvailable",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "result",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "resultTruncated",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "LegacyIDInterface",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "LtiAssetReportConnection",
+          "description": "The connection type for LtiAssetReport.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "LtiAssetReportEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of nodes.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "LtiAssetReport",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "LtiAssetReportEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "LtiAssetReport",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "LtiContentItemIcon",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "height",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "width",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "LtiContentItemIframe",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "height",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "width",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
           "specifiedByURL": null,
           "isOneOf": false
         },
@@ -25547,6 +32668,22 @@
               "deprecationReason": null
             },
             {
+              "name": "asr",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "content",
               "description": null,
               "args": [],
@@ -25609,6 +32746,22 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "workflowState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "MediaTrackWorkflowState",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -25620,6 +32773,37 @@
             }
           ],
           "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "ENUM",
+          "name": "MediaTrackWorkflowState",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "ready",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "failed",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "processing",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null,
           "specifiedByURL": null,
           "isOneOf": false
@@ -26178,6 +33362,18 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "sisId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -26325,6 +33521,18 @@
               "deprecationReason": null
             },
             {
+              "name": "finalGraderAnonymousId",
+              "description": "The anonymous ID of the final grader",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "graderCommentsVisibleToGraders",
               "description": "Boolean indicating if provisional graders' comments are visible to other provisional graders.",
               "args": [],
@@ -26446,13 +33654,17 @@
               "deprecationReason": null
             },
             {
-              "name": "estimatedDuration",
+              "name": "hasActiveOverrides",
               "description": null,
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "ISO8601Duration",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -26488,6 +33700,95 @@
                     "name": "ModuleItem",
                     "ofType": null
                   }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "moduleItemsConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "filter",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ModuleItemFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ModuleItemConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "moduleItemsTotalCount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,
@@ -26538,7 +33839,31 @@
               "deprecationReason": null
             },
             {
+              "name": "progression",
+              "description": "The current user's progression through the module",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ModuleProgression",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "published",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "requireSequentialProgress",
               "description": null,
               "args": [],
               "type": {
@@ -26556,6 +33881,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submissionStatistics",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ModuleStatistics",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -26674,6 +34011,43 @@
           "inputFields": null,
           "interfaces": [],
           "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "ENUM",
+          "name": "ModuleCompletionStatus",
+          "description": "Filter options for module completion status",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "COMPLETED",
+              "description": "Modules marked as completed",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INCOMPLETE",
+              "description": "Modules not yet completed (includes locked, unlocked, started)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NOT_STARTED",
+              "description": "Modules that are unlocked but not started",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "IN_PROGRESS",
+              "description": "Modules that are started but not completed",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null,
           "specifiedByURL": null,
           "isOneOf": false
@@ -26802,6 +34176,30 @@
               "deprecationReason": null
             },
             {
+              "name": "canDuplicate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canManageAssignTo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "canUnpublish",
               "description": "Whether the module item can be unpublished",
               "args": [],
@@ -26820,6 +34218,30 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "domain",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "graded",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -26958,6 +34380,43 @@
           "isOneOf": false
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "ModuleFilterInput",
+          "description": "Input type for filtering modules in a course",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "completionStatus",
+              "description": "Filter modules by completion status",
+              "type": {
+                "kind": "ENUM",
+                "name": "ModuleCompletionStatus",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "userId",
+              "description": "Filter by specific user's progress (requires permission). Defaults to current user if not specified.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "OBJECT",
           "name": "ModuleItem",
           "description": null,
@@ -27015,18 +34474,6 @@
               "deprecationReason": null
             },
             {
-              "name": "estimatedDuration",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "ISO8601Duration",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "id",
               "description": null,
               "args": [],
@@ -27055,12 +34502,24 @@
               "deprecationReason": null
             },
             {
-              "name": "indent",
-              "description": null,
+              "name": "masterCourseRestrictions",
+              "description": "Restrictions from master courses for this module item",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "Int",
+                "kind": "OBJECT",
+                "name": "ModuleItemMasterCourseRestriction",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "masteryPaths",
+              "description": "Mastery path information for this module item",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ModuleItemMasteryPathInfo",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -27073,6 +34532,30 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Module",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "moduleItemUrl",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "URL",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "newTab",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -27152,6 +34635,18 @@
               "deprecationReason": null
             },
             {
+              "name": "position",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "previous",
               "description": null,
               "args": [],
@@ -27219,6 +34714,30 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "ModuleItemConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "published",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -27375,13 +34894,98 @@
           "isOneOf": false
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "ModuleItemFilter",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "contentType",
+              "description": "Filter by content type (Assignment, WikiPage, etc.)",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "published",
+              "description": "Filter by published status",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "searchTerm",
+              "description": "Filter by title or content",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "INTERFACE",
           "name": "ModuleItemInterface",
           "description": "An item that can be in context modules",
           "fields": [
             {
+              "name": "canDuplicate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canManageAssignTo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "canUnpublish",
               "description": "Whether the module item can be unpublished",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "graded",
+              "description": null,
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -27517,6 +35121,11 @@
             },
             {
               "kind": "OBJECT",
+              "name": "PeerReviewSubAssignment",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "Quiz",
               "ofType": null
             },
@@ -27526,6 +35135,164 @@
               "ofType": null
             }
           ],
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ModuleItemMasterCourseRestriction",
+          "description": "Restrictions for a module item defined in a blueprint course",
+          "fields": [
+            {
+              "name": "all",
+              "description": "Whether all aspects are restricted",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "availabilityDates",
+              "description": "Whether availability dates are restricted",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "content",
+              "description": "Whether content is restricted",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dueDates",
+              "description": "Whether due dates are restricted",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "points",
+              "description": "Whether points are restricted",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "settings",
+              "description": "Whether settings are restricted",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ModuleItemMasteryPathInfo",
+          "description": "Mastery path information for a module item",
+          "fields": [
+            {
+              "name": "assignmentSetCount",
+              "description": "Number of assignment sets that can be selected",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "awaitingChoice",
+              "description": "Whether the next assignment set can be chosen",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "chooseUrl",
+              "description": "URL to expose next assignment set choice",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locked",
+              "description": "Indicates locked content",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "stillProcessing",
+              "description": "Indicates mastery path handler in-flight",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
           "specifiedByURL": null,
           "isOneOf": false
         },
@@ -27596,6 +35363,138 @@
           "description": null,
           "fields": [
             {
+              "name": "_id",
+              "description": "legacy canvas id",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "collapsed",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "completed",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "completedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "contextModule",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Module",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "current",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currentPosition",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "evaluatedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "incompleteItemsConnection",
               "description": "Items are ordered by position",
               "args": [
@@ -27661,6 +35560,42 @@
               "deprecationReason": null
             },
             {
+              "name": "incompleteRequirements",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Requirement",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locked",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "module",
               "description": null,
               "args": [],
@@ -27675,10 +35610,118 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "requirementsMet",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Requirement",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "started",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "unlocked",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "user",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "workflowState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "LegacyIDInterface",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Timestamped",
+              "ofType": null
+            }
+          ],
           "enumValues": null,
           "possibleTypes": null,
           "specifiedByURL": null,
@@ -27774,6 +35817,124 @@
                 "kind": "OBJECT",
                 "name": "ModuleProgression",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ModuleProgressionStatistics",
+          "description": null,
+          "fields": [
+            {
+              "name": "completedModulesCount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "inProgressModulesCount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lockedModulesCount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalModulesCount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ModuleStatistics",
+          "description": null,
+          "fields": [
+            {
+              "name": "latestDueAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "missingAssignmentCount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -27902,6 +36063,35 @@
           "description": null,
           "fields": [
             {
+              "name": "acceptEnrollmentInvitation",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for AcceptEnrollmentInvitation",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "AcceptEnrollmentInvitationInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AcceptEnrollmentInvitationPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "addConversationMessage",
               "description": null,
               "args": [
@@ -27931,6 +36121,35 @@
               "deprecationReason": null
             },
             {
+              "name": "autoGradeSubmission",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for AutoGradeSubmission",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "AutoGradeSubmissionInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AutoGradeSubmissionPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "createAccountDomainLookup",
               "description": null,
               "args": [
@@ -27954,6 +36173,35 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "CreateAccountDomainLookupPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createAllocationRule",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for CreateAllocationRule",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "CreateAllocationRuleInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CreateAllocationRulePayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -28070,35 +36318,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "CreateDiscussionEntryPayload",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "createDiscussionEntryDraft",
-              "description": null,
-              "args": [
-                {
-                  "name": "input",
-                  "description": "Parameters for CreateDiscussionEntryDraft",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "CreateDiscussionEntryDraftInput",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "CreateDiscussionEntryDraftPayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -28511,6 +36730,35 @@
               "deprecationReason": null
             },
             {
+              "name": "deleteAllocationRule",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for DeleteAllocationRule",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "DeleteAllocationRuleInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "DeleteAllocationRulePayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "deleteCommentBankItem",
               "description": null,
               "args": [
@@ -28888,6 +37136,35 @@
               "deprecationReason": null
             },
             {
+              "name": "dismissAccountNotification",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for DismissAccountNotification",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "DismissAccountNotificationInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "DismissAccountNotificationPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "hideAssignmentGrades",
               "description": null,
               "args": [
@@ -29114,6 +37391,151 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "PostDraftSubmissionCommentPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rejectEnrollmentInvitation",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for RejectEnrollmentInvitation",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "RejectEnrollmentInvitationInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "RejectEnrollmentInvitationPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "reorderModuleItems",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for ReorderModuleItems",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "ReorderModuleItemsInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ReorderModuleItemsPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "restoreDeletedDiscussionEntry",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for RestoreDeletedDiscussionEntry",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "RestoreDeletedDiscussionEntryInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "RestoreDeletedDiscussionEntryPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "saveRubricAssessment",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for SaveRubricAssessment",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "SaveRubricAssessmentInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SaveRubricAssessmentPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "selectProvisionalGrade",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for SelectProvisionalGrade",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "SelectProvisionalGradeInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SelectProvisionalGradePayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -29381,6 +37803,35 @@
               "deprecationReason": null
             },
             {
+              "name": "updateAllocationRule",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for UpdateAllocationRule",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "UpdateAllocationRuleInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "UpdateAllocationRulePayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "updateAssignment",
               "description": null,
               "args": [
@@ -29555,35 +38006,6 @@
               "deprecationReason": null
             },
             {
-              "name": "updateDiscussionExpanded",
-              "description": null,
-              "args": [
-                {
-                  "name": "input",
-                  "description": "Parameters for UpdateDiscussionExpanded",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "UpdateDiscussionExpandedInput",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "UpdateDiscussionExpandedPayload",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "updateDiscussionReadState",
               "description": null,
               "args": [
@@ -29607,35 +38029,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "UpdateDiscussionReadStatePayload",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "updateDiscussionSortOrder",
-              "description": null,
-              "args": [
-                {
-                  "name": "input",
-                  "description": "Parameters for UpdateDiscussionSortOrder",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "UpdateDiscussionSortOrderInput",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "UpdateDiscussionSortOrderPayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -29700,18 +38093,18 @@
               "deprecationReason": null
             },
             {
-              "name": "updateGradebookGroupFilter",
+              "name": "updateDiscussionTopicParticipant",
               "description": null,
               "args": [
                 {
                   "name": "input",
-                  "description": "Parameters for UpdateGradebookGroupFilter",
+                  "description": "Parameters for UpdateDiscussionTopicParticipant",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "UpdateGradebookGroupFilterInput",
+                      "name": "UpdateDiscussionTopicParticipantInput",
                       "ofType": null
                     }
                   },
@@ -29722,7 +38115,7 @@
               ],
               "type": {
                 "kind": "OBJECT",
-                "name": "UpdateGradebookGroupFilterPayload",
+                "name": "UpdateDiscussionTopicParticipantPayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -29781,6 +38174,35 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "UpdateInternalSettingPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updateLearnerDashboardTabSelection",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for UpdateLearnerDashboardTabSelection",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "UpdateLearnerDashboardTabSelectionInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "UpdateLearnerDashboardTabSelectionPayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -30251,6 +38673,64 @@
               "deprecationReason": null
             },
             {
+              "name": "updateWidgetDashboardConfig",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for UpdateWidgetDashboardConfig",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "UpdateWidgetDashboardConfigInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "UpdateWidgetDashboardConfigPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updateWidgetDashboardLayout",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for UpdateWidgetDashboardLayout",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "UpdateWidgetDashboardLayoutInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "UpdateWidgetDashboardLayoutPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "upsertCustomGradeStatus",
               "description": null,
               "args": [
@@ -30560,6 +39040,16 @@
             },
             {
               "kind": "OBJECT",
+              "name": "AccountNotification",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "AllocationRule",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "Assignment",
               "ofType": null
             },
@@ -30616,6 +39106,11 @@
             {
               "kind": "OBJECT",
               "name": "File",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Folder",
               "ofType": null
             },
             {
@@ -30685,6 +39180,11 @@
             },
             {
               "kind": "OBJECT",
+              "name": "ModuleProgression",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "Notification",
               "ofType": null
             },
@@ -30711,6 +39211,11 @@
             {
               "kind": "OBJECT",
               "name": "Page",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "PeerReviewSubAssignment",
               "ofType": null
             },
             {
@@ -30782,6 +39287,12 @@
               "deprecationReason": null
             },
             {
+              "name": "AllocationRule",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "Assignment",
               "description": null,
               "isDeprecated": false,
@@ -30825,6 +39336,12 @@
             },
             {
               "name": "File",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Folder",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -30884,6 +39401,12 @@
               "deprecationReason": null
             },
             {
+              "name": "ModuleProgression",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "OutcomeCalculationMethod",
               "description": null,
               "isDeprecated": false,
@@ -30897,6 +39420,12 @@
             },
             {
               "name": "Page",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PeerReviewSubAssignment",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -30921,6 +39450,12 @@
             },
             {
               "name": "Section",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SubAssignment",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -32349,6 +40884,22 @@
               "deprecationReason": null
             },
             {
+              "name": "masteryPoints",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "proficiencyRatingsConnection",
               "description": null,
               "args": [
@@ -32402,9 +40953,13 @@
                 }
               ],
               "type": {
-                "kind": "OBJECT",
-                "name": "ProficiencyRatingConnection",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProficiencyRatingConnection",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -32527,6 +41082,30 @@
               "deprecationReason": null
             },
             {
+              "name": "canDuplicate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canManageAssignTo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "canUnpublish",
               "description": "Whether the module item can be unpublished",
               "args": [],
@@ -32545,6 +41124,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "graded",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -32633,6 +41224,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "todoDate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -33042,9 +41645,2267 @@
         },
         {
           "kind": "OBJECT",
+          "name": "PeerReviewDates",
+          "description": "Peer review dates for an assignment date hash entry",
+          "fields": [
+            {
+              "name": "dueAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lockAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "unlockAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PeerReviewStatus",
+          "description": "Peer review status for a student on an assignment",
+          "fields": [
+            {
+              "name": "completedReviewsCount",
+              "description": "Number of peer reviews the student has completed",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mustReviewCount",
+              "description": "Number of peer reviews the student has been allocated",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PeerReviewSubAssignment",
+          "description": null,
+          "fields": [
+            {
+              "name": "_id",
+              "description": "legacy canvas id",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "allocationRules",
+              "description": "Allocation rules if peer review is enabled",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AssignmentAllocationRules",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "allowGoogleDocsSubmission",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "allowProvisionalGrading",
+              "description": "Whether the current user can provide a provisional grade for this assignment",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AllowProvisionalGradingType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "allowedAttempts",
+              "description": "The number of submission attempts a student can make for this assignment. null implies unlimited.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "allowedExtensions",
+              "description": "permitted uploaded file extensions (e.g. ['doc', 'xls', 'txt'])",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "anonymizeStudents",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "anonymousGrading",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "anonymousInstructorAnnotations",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "anonymousStudentIdentities",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AnonymousStudentIdentity",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assessmentRequestsForCurrentUser",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AssessmentRequest",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assessmentRequestsForUser",
+              "description": "Assessment requests for a specific user where they are the assessor (peer reviewer)",
+              "args": [
+                {
+                  "name": "userId",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AssessmentRequest",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assignedStudents",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "filter",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AssignedStudentsFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "UserConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assignedToDates",
+              "description": "Standardized date hash visible to current user",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "DateHash",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assignmentGroup",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AssignmentGroup",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assignmentGroupId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assignmentOverrides",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AssignmentOverrideConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assignmentTargetConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AssignmentTargetSortOrder",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AssignmentOverrideConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assignmentType",
+              "description": "Discriminator indicating the actual type of this assignment",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AssignmentTypeEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assignmentVisibility",
+              "description": "Returns empty array if visible to everyone",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "autoGradeAssignmentErrors",
+              "description": "Errors related to the assignment",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use autoGradeEligibility instead"
+            },
+            {
+              "name": "autoGradeAssignmentIssues",
+              "description": "Issues related to the assignment",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "EligibilityIssue",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use autoGradeEligibility instead"
+            },
+            {
+              "name": "autoGradeEligibility",
+              "description": "Eligibility for auto-grading",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AutoGradeEligibility",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canDuplicate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canManageAssignTo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canUnpublish",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canUpdateRubricSelfAssessment",
+              "description": "specifies that the current user can update the rubric self-assessment.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "checkpoints",
+              "description": "A list of checkpoints (also known as sub_assignments) that are associated with this assignment",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Checkpoint",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "course",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Course",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "courseId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "discussion",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Discussion",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dueAt",
+              "description": "when this assignment is due",
+              "args": [
+                {
+                  "name": "applyOverrides",
+                  "description": "When true, return the overridden dates.\n\nNot all roles have permission to view un-overridden dates (in which\ncase the overridden dates will be returned)\n",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "true",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dueDateRequired",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "expectsExternalSubmission",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "expectsSubmission",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gradeAsGroup",
+              "description": "specifies that students are being graded as a group (as opposed to being graded individually).",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gradeByQuestionEnabled",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gradeGroupStudentsIndividually",
+              "description": "If this is a group assignment, boolean flag indicating whether or not students will be graded individually.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "graded",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gradedSubmissionsExist",
+              "description": "If true, the assignment has at least one graded submission",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "graderIdentitiesConnection",
+              "description": "Grader identities if moderated assignment",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "GraderIdentityConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gradesPublished",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gradesPublishedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gradingPeriodId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gradingRole",
+              "description": "The grading role of the current user for this assignment. Returns null if the user does not have sufficient grading permissions.",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "GradingRole",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gradingStandard",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "GradingStandard",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gradingStandardId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gradingType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "GradingType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "groupCategoryId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "groupSet",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "GroupSet",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "groupSubmissionsConnection",
+              "description": "returns submissions grouped to one submission object per group",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "filter",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "SubmissionSearchFilterInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "SubmissionSearchOrder",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SubmissionConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasGroupCategory",
+              "description": "specifies that this assignment is a group assignment",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasMultipleDueDates",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasPlagiarismTool",
+              "description": "Indicates if the assignment has LTI 2.0 plagiarism detection tool configured",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasRubric",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasSubAssignments",
+              "description": "Boolean: returns true if the assignment is checkpointed. A checkpointed assignment has checkpoints ( also known as sub_assignments)",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasSubmittedSubmissions",
+              "description": "If true, the assignment has been submitted to by at least one student",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "htmlUrl",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "URL",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "importantDates",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "inClosedGradingPeriod",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isLockedByMasterCourse",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isNewQuiz",
+              "description": "Assignment is connected to a New Quiz",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lockAt",
+              "description": "the lock date (assignment is locked after this date)",
+              "args": [
+                {
+                  "name": "applyOverrides",
+                  "description": "When true, return the overridden dates.\n\nNot all roles have permission to view un-overridden dates (in which\ncase the overridden dates will be returned)\n",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "true",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lockInfo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "LockInfo",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ltiAssetProcessorsConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "LtiAssetProcessorConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "moderatedGrading",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ModeratedGrading",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "moderatedGradingEnabled",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "moduleItems",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ModuleItem",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "modules",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Module",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "muted",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mySubAssignmentSubmissionsConnection",
+              "description": "submissions for sub-assignments belonging to the current user",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SubmissionConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "needsGradingCount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "newQuizzesAnonymousParticipants",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nonDigitalSubmission",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "omitFromFinalGrade",
+              "description": "If true, the assignment will be omitted from the student's final grade",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "onlyVisibleToOverrides",
+              "description": "specifies that this assignment is only assigned to students for whom an\n       `AssignmentOverride` applies.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "originalityReportVisibility",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "parentAssignment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Assignment",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "parentAssignmentId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "peerReviewSubAssignment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PeerReviewSubAssignment",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "peerReviews",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PeerReviews",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pointsPossible",
+              "description": "the assignment is out of this many points",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "position",
+              "description": "determines the order this assignment is displayed in in its assignment group",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "postManually",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "postPolicy",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PostPolicy",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "postToSis",
+              "description": "present if Sync Grades to SIS feature is enabled",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "provisionalGradingLocked",
+              "description": "Indicates if the user is locked out of provisional grading for this assignment.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "published",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quiz",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Quiz",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "restrictQuantitativeData",
+              "description": "Is the current user restricted from viewing quantitative data",
+              "args": [
+                {
+                  "name": "checkExtraPermissions",
+                  "description": "Check extra permissions in RQD method",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rubric",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Rubric",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rubricAssessment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AssignmentRubricAssessment",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rubricAssociation",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "RubricAssociation",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rubricSelfAssessmentEnabled",
+              "description": "specifies that students can self-assess using the assignment rubric.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rubricUpdateUrl",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "scheduledPost",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ScheduledPost",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "scoreStatistic",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AssignmentScoreStatistic",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sisId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "state",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AssignmentState",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submissionTypes",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "SubmissionType",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submissionsConnection",
+              "description": "submissions for this assignment",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "filter",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "SubmissionSearchFilterInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "SubmissionSearchOrder",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SubmissionConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submissionsDownloads",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "supportsGradeByQuestion",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "suppressAssignment",
+              "description": "internal use",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "timeZoneEdited",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalGradedSubmissions",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalSubmissions",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "unlockAt",
+              "description": "the unlock date (assignment is unlocked after this date)",
+              "args": [
+                {
+                  "name": "applyOverrides",
+                  "description": "When true, return the overridden dates.\n\nNot all roles have permission to view un-overridden dates (in which\ncase the overridden dates will be returned)\n",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "true",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "visibleToEveryone",
+              "description": "specifies all other variables that can determine visiblity.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "AssignedDates",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "LegacyIDInterface",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "ModuleItemInterface",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Timestamped",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
           "name": "PeerReviews",
           "description": "Settings for Peer Reviews on an Assignment",
           "fields": [
+            {
+              "name": "acrossSections",
+              "description": "Boolean indicating if peer reviews can be assigned across different sections",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "anonymousReviews",
               "description": "Boolean representing whether or not peer reviews are anonymous",
@@ -33116,12 +43977,245 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "pointsPossible",
+              "description": "Points possible for the peer review sub-assignment",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submissionRequired",
+              "description": "Boolean indicating if students must submit their assignment before they can do peer reviews",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
           "enumValues": null,
           "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Placement",
+          "description": null,
+          "fields": [
+            {
+              "name": "title",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Placements",
+          "description": "A placement for an external tool in Canvas",
+          "fields": [
+            {
+              "name": "assignmentSelection",
+              "description": "Placement for assignment selection",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Placement",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "courseAssignmentsMenu",
+              "description": "Placement for course assignments menu",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Placement",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "editorButton",
+              "description": "Placement for editor button",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Placement",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "linkSelection",
+              "description": "Placement for link selection",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Placement",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "moduleIndexMenuModal",
+              "description": "Placement for module index menu modal",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Placement",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "moduleMenuModal",
+              "description": "Placement for module menu modal",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Placement",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "resourceSelection",
+              "description": "Placement for resource selection",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Placement",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "PlacementsInterface",
+          "description": "Interface for placements",
+          "fields": [
+            {
+              "name": "placements",
+              "description": "Placements for the external tool",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Placements",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "ExternalTool",
+              "ofType": null
+            }
+          ],
           "specifiedByURL": null,
           "isOneOf": false
         },
@@ -33722,6 +44816,79 @@
           "isOneOf": false
         },
         {
+          "kind": "ENUM",
+          "name": "PreferredLanguageType",
+          "description": "The preferred language for the translation, currently supporting only Cedar languages.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "CA",
+              "description": "Catalan",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ZH_HANS",
+              "description": "Chinese (Simplified)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NL",
+              "description": "Dutch",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "EN",
+              "description": "English",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FR",
+              "description": "French",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DE",
+              "description": "German",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PT_BR",
+              "description": "Portuguese (Brazil)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "RU",
+              "description": "Russian",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ES",
+              "description": "Spanish",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SV",
+              "description": "Swedish",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "OBJECT",
           "name": "ProficiencyRating",
           "description": "Customized proficiency rating",
@@ -33787,9 +44954,13 @@
               "description": null,
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -34185,6 +45356,211 @@
         },
         {
           "kind": "OBJECT",
+          "name": "ProvisionalGrade",
+          "description": null,
+          "fields": [
+            {
+              "name": "_id",
+              "description": "legacy canvas id",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "final",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "grade",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "score",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "scorerAnonymousId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "selected",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "LegacyIDInterface",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProvisionalGradeConnection",
+          "description": "The connection type for ProvisionalGrade.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProvisionalGradeEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of nodes.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProvisionalGrade",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProvisionalGradeEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProvisionalGrade",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
           "name": "Query",
           "description": null,
           "fields": [
@@ -34226,6 +45602,43 @@
               "deprecationReason": null
             },
             {
+              "name": "accountNotifications",
+              "description": "Account notifications for the current user",
+              "args": [
+                {
+                  "name": "accountId",
+                  "description": "Account ID to fetch notifications for",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "AccountNotification",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "allCourses",
               "description": "All courses viewable by the current user",
               "args": [],
@@ -34258,6 +45671,26 @@
                     "ofType": null
                   },
                   "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "includeTypes",
+                  "description": "Types of assignments to include. Defaults to [ASSIGNMENT] for backward compatibility. Note: This parameter is ignored when using sisId lookup.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "AssignmentTypeEnum",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": "[ASSIGNMENT]",
                   "isDeprecated": false,
                   "deprecationReason": null
                 },
@@ -34363,6 +45796,250 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Course",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "courseInstructorsConnection",
+              "description": "Paginated instructors with their enrollments across multiple courses",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "courseIds",
+                  "description": "Course IDs to get instructors for",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "SCALAR",
+                          "name": "ID",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "enrollmentTypes",
+                  "description": "Filter by enrollment types (TeacherEnrollment, TaEnrollment)",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "observedUserId",
+                  "description": "ID of the observed user",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "InstructorWithEnrollmentsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "courses",
+              "description": "Courses by IDs that are viewable by the current user",
+              "args": [
+                {
+                  "name": "ids",
+                  "description": "graphql or legacy course IDs",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "sisIds",
+                  "description": "ids from the original SIS system",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Course",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "enrollmentInvitations",
+              "description": "Pending enrollment invitations for the current user",
+              "args": [
+                {
+                  "name": "includeEnrollmentUuid",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Enrollment",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "folder",
+              "description": "Folder",
+              "args": [
+                {
+                  "name": "id",
+                  "description": "a graphql or legacy id",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Folder",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -34657,6 +46334,35 @@
               "deprecationReason": null
             },
             {
+              "name": "peerReviewSubAssignment",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": "a graphql or legacy id",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PeerReviewSubAssignment",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "rubric",
               "description": "Rubric",
               "args": [
@@ -34829,6 +46535,50 @@
               "deprecationReason": null
             },
             {
+              "name": "assignedToDates",
+              "description": "Standardized date hash visible to current user",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "DateHash",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canDuplicate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canManageAssignTo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "canUnpublish",
               "description": "Whether the module item can be unpublished",
               "args": [],
@@ -34847,6 +46597,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "graded",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -34929,6 +46691,115 @@
               "deprecationReason": null
             },
             {
+              "name": "quizType",
+              "description": "The type of quiz: 'quiz' for regular quizzes, 'assignment' for LTI quiz assignments",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submissionsConnection",
+              "description": "submissions for this quiz's assignment",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "filter",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "SubmissionSearchFilterInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "SubmissionSearchOrder",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SubmissionConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "title",
               "description": null,
               "args": [],
@@ -34967,6 +46838,11 @@
           ],
           "inputFields": null,
           "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "AssignedDates",
+              "ofType": null
+            },
             {
               "kind": "INTERFACE",
               "name": "LegacyIDInterface",
@@ -35165,6 +47041,320 @@
                   "name": "String",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "QuizSubmission",
+          "description": null,
+          "fields": [
+            {
+              "name": "_id",
+              "description": "legacy canvas id",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "attempt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "extraAttempts",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "extraTime",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "finishedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fudgePoints",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "keptScore",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "manuallyScored",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quizPointsPossible",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quizVersion",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "score",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "workflowState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "LegacyIDInterface",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Timestamped",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "QuizSubmissionConnection",
+          "description": "The connection type for QuizSubmission.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "QuizSubmissionEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of nodes.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "QuizSubmission",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "QuizSubmissionEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "QuizSubmission",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -35442,6 +47632,246 @@
           "isOneOf": false
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "RejectEnrollmentInvitationInput",
+          "description": "Autogenerated input type of RejectEnrollmentInvitation",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "enrollmentUuid",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RejectEnrollmentInvitationPayload",
+          "description": "Autogenerated return type of RejectEnrollmentInvitation.",
+          "fields": [
+            {
+              "name": "enrollment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Enrollment",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "errors",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ValidationError",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "success",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ReorderModuleItemsInput",
+          "description": "Autogenerated input type of ReorderModuleItems",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "courseId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "itemIds",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "moduleId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oldModuleId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "targetPosition",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ReorderModuleItemsPayload",
+          "description": "Autogenerated return type of ReorderModuleItems.",
+          "fields": [
+            {
+              "name": "errors",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ValidationError",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "module",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Module",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oldModule",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Module",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "ENUM",
           "name": "ReportType",
           "description": null,
@@ -35468,6 +47898,161 @@
               "deprecationReason": null
             }
           ],
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Requirement",
+          "description": null,
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "minPercentage",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "minScore",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "score",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "RestoreDeletedDiscussionEntryInput",
+          "description": "Autogenerated input type of RestoreDeletedDiscussionEntry",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "discussionEntryId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RestoreDeletedDiscussionEntryPayload",
+          "description": "Autogenerated return type of RestoreDeletedDiscussionEntry.",
+          "fields": [
+            {
+              "name": "discussionEntry",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "DiscussionEntry",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "errors",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ValidationError",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
           "possibleTypes": null,
           "specifiedByURL": null,
           "isOneOf": false
@@ -35503,6 +48088,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canUpdateRubric",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
                   "ofType": null
                 }
               },
@@ -35809,6 +48410,22 @@
                 "kind": "OBJECT",
                 "name": "User",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isCurrentUser",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -36137,6 +48754,38 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "associationId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "associationType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },
@@ -36590,6 +49239,255 @@
           "isOneOf": false
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "SaveRubricAssessmentInput",
+          "description": "Autogenerated input type of SaveRubricAssessment",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "assessmentDetails",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "JSON",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "final",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": "false",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gradedAnonymously",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "provisional",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": "false",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rubricAssessmentId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rubricAssociationId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submissionId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SaveRubricAssessmentPayload",
+          "description": "Autogenerated return type of SaveRubricAssessment.",
+          "fields": [
+            {
+              "name": "errors",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ValidationError",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rubricAssessment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "RubricAssessment",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rubricAssociation",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "RubricAssociation",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submission",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Submission",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ScheduledPost",
+          "description": "A ScheduledPost represents an assignment grade and/or comment posting that is scheduled to be published at a\nspecific time.\n",
+          "fields": [
+            {
+              "name": "_id",
+              "description": "legacy canvas id",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "postCommentsAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "postGradesAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "LegacyIDInterface",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "OBJECT",
           "name": "Section",
           "description": null,
@@ -36694,6 +49592,39 @@
                     "kind": "SCALAR",
                     "name": "ID",
                     "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gradesPresent",
+              "description": null,
+              "args": [
+                {
+                  "name": "assignmentId",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
                   },
                   "defaultValue": null,
                   "isDeprecated": false,
@@ -36972,6 +49903,96 @@
           "isOneOf": false
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "SelectProvisionalGradeInput",
+          "description": "Autogenerated input type of SelectProvisionalGrade",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "assignmentId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "provisionalGradeId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SelectProvisionalGradePayload",
+          "description": "Autogenerated return type of SelectProvisionalGrade.",
+          "fields": [
+            {
+              "name": "errors",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ValidationError",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "provisionalGrade",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProvisionalGrade",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "ENUM",
           "name": "SelfSignupPolicy",
           "description": "Determines if/how a student may join a group. A student can belong to\nonly one group per group set at a time.\n",
@@ -37019,6 +50040,30 @@
                   "name": "ID",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "postCommentsAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "postGradesAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -38294,6 +51339,18 @@
           "isOneOf": false
         },
         {
+          "kind": "SCALAR",
+          "name": "StringMap",
+          "description": "A hash with string keys and string values",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "OBJECT",
           "name": "StudentSummaryAnalytics",
           "description": "basic information about a students activity in a course",
@@ -38364,12 +51421,12 @@
               "deprecationReason": null
             },
             {
-              "name": "customGradeStatusId",
+              "name": "cachedDueDate",
               "description": null,
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "ID",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -38382,6 +51439,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deductedPoints",
+              "description": "how many points are being deducted due to late policy",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -38437,6 +51506,42 @@
             },
             {
               "name": "gradeMatchesCurrentSubmission",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "late",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "latePolicyStatus",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "LatePolicyStatusType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "missing",
               "description": null,
               "args": [],
               "type": {
@@ -38522,6 +51627,18 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "submittedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -38537,8 +51654,44 @@
           "description": null,
           "fields": [
             {
+              "name": "canDuplicate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canManageAssignTo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "canUnpublish",
               "description": "Whether the module item can be unpublished",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "graded",
+              "description": null,
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -38668,6 +51821,18 @@
               "deprecationReason": null
             },
             {
+              "name": "aiGradeResult",
+              "description": "The AI grading result for the current submission attempt, if any.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AIGradeResult",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "anonymousId",
               "description": null,
               "args": [],
@@ -38704,9 +51869,13 @@
               "description": null,
               "args": [],
               "type": {
-                "kind": "OBJECT",
-                "name": "Assignment",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Assignment",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -38774,6 +51943,131 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "auditEventsConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AuditEventConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "autoGradeEligibility",
+              "description": "Eligibility for auto-grading",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AutoGradeEligibility",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "autoGradeResultPresent",
+              "description": "Indicates whether an auto-grading result exists for the submission.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "autoGradeSubmissionErrors",
+              "description": "Errors related to the submission",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use autoGradeEligibility instead"
+            },
+            {
+              "name": "autoGradeSubmissionIssues",
+              "description": "Issues related to the submission",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "EligibilityIssue",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use autoGradeEligibility instead"
             },
             {
               "name": "body",
@@ -38886,12 +52180,40 @@
                   "defaultValue": "false",
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "includeDraftsFromOthers",
+                  "description": "When true and include_draft_comments is true, draft comments from other teachers will be included.\nOnly applies to users with grading permissions (teachers, TAs, etc).\nWhen false, only the current user's draft comments are included.\nStudents never see draft comments from others regardless of this setting.\n",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "includeProvisionalComments",
+                  "description": "When true, provisional comments that the current user has permission to see will be returned.\nThe Moderator has permission to see all provisional comments.\nProvisional Graders can see each other's comments if \"Graders can view each other's comments\" is enabled.\nOtherwise, Provisional Graders can only see their own comments.\nStudents cannot see provisional comments.\n",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
-                "kind": "OBJECT",
-                "name": "SubmissionCommentConnection",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SubmissionCommentConnection",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -39182,6 +52504,22 @@
               "deprecationReason": null
             },
             {
+              "name": "hasOriginalityReport",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "hasPostableComments",
               "description": null,
               "args": [],
@@ -39193,6 +52531,34 @@
                   "name": "Boolean",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasProvisionalGradeByCurrentUser",
+              "description": "Whether the current user has provided a provisional grade with a non-null score for this submission",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasSubAssignmentSubmissions",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -39278,6 +52644,79 @@
               "deprecationReason": null
             },
             {
+              "name": "ltiAssetReportsConnection",
+              "description": "Lti Asset Reports with active processors, with assets preloaded",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "latest",
+                  "description": "When true, returns only the asset reports of the latest submission attempt (as students would see them)",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "LtiAssetReportConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "mediaObject",
               "description": null,
               "args": [],
@@ -39348,6 +52787,67 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "provisionalGradesConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProvisionalGradeConnection",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -39479,9 +52979,13 @@
                 }
               ],
               "type": {
-                "kind": "OBJECT",
-                "name": "RubricAssessmentConnection",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "RubricAssessmentConnection",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -39716,8 +53220,73 @@
                 }
               ],
               "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SubmissionHistoryConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submissionQuizHistoriesConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
                 "kind": "OBJECT",
-                "name": "SubmissionHistoryConnection",
+                "name": "QuizSubmissionConnection",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -39844,6 +53413,26 @@
               "deprecationReason": null
             },
             {
+              "name": "vericiteData",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "VericiteData",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "wordCount",
               "description": null,
               "args": [],
@@ -39922,15 +53511,19 @@
               "description": null,
               "args": [],
               "type": {
-                "kind": "LIST",
+                "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "NON_NULL",
+                  "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "OBJECT",
-                    "name": "File",
-                    "ofType": null
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "File",
+                      "ofType": null
+                    }
                   }
                 }
               },
@@ -39960,6 +53553,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "authorVisibleName",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -40086,6 +53691,38 @@
               "deprecationReason": null
             },
             {
+              "name": "provisional",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "publishable",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "read",
               "description": null,
               "args": [],
@@ -40187,14 +53824,14 @@
             },
             {
               "name": "pageInfo",
-              "description": "Information to aid in pagination.",
+              "description": null,
               "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "PageInfo",
+                  "name": "TotalCountPageInfo",
                   "ofType": null
                 }
               },
@@ -40291,10 +53928,49 @@
               "defaultValue": "false",
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "status",
+              "description": "Filter comments by status type.\n- ALL: Returns all comments visible to the current user (published + drafts based on permissions)\nWhen set, includeDraftComments, includeDraftsFromOthers and includeProvisionalComments will be ignored.\n",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "SubmissionCommentStatusType",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": "null",
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "ENUM",
+          "name": "SubmissionCommentStatusType",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "ALL",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null,
           "specifiedByURL": null,
           "isOneOf": false
@@ -40363,14 +54039,14 @@
             },
             {
               "name": "pageInfo",
-              "description": "Information to aid in pagination.",
+              "description": null,
               "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "PageInfo",
+                  "name": "TotalCountPageInfo",
                   "ofType": null
                 }
               },
@@ -40777,6 +54453,18 @@
               "deprecationReason": null
             },
             {
+              "name": "includePeerReviewSubmissions",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": "false",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "submittedSince",
               "description": null,
               "type": {
@@ -40850,6 +54538,18 @@
           "description": null,
           "fields": [
             {
+              "name": "aiGradeResult",
+              "description": "The AI grading result for the current submission attempt, if any.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AIGradeResult",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "anonymousId",
               "description": null,
               "args": [],
@@ -40886,9 +54586,13 @@
               "description": null,
               "args": [],
               "type": {
-                "kind": "OBJECT",
-                "name": "Assignment",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Assignment",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -40951,6 +54655,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "autoGradeResultPresent",
+              "description": "Indicates whether an auto-grading result exists for the submission.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
                   "ofType": null
                 }
               },
@@ -41068,12 +54788,40 @@
                   "defaultValue": "false",
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "includeDraftsFromOthers",
+                  "description": "When true and include_draft_comments is true, draft comments from other teachers will be included.\nOnly applies to users with grading permissions (teachers, TAs, etc).\nWhen false, only the current user's draft comments are included.\nStudents never see draft comments from others regardless of this setting.\n",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "includeProvisionalComments",
+                  "description": "When true, provisional comments that the current user has permission to see will be returned.\nThe Moderator has permission to see all provisional comments.\nProvisional Graders can see each other's comments if \"Graders can view each other's comments\" is enabled.\nOtherwise, Provisional Graders can only see their own comments.\nStudents cannot see provisional comments.\n",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
-                "kind": "OBJECT",
-                "name": "SubmissionCommentConnection",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SubmissionCommentConnection",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -41291,6 +55039,22 @@
               "deprecationReason": null
             },
             {
+              "name": "hasOriginalityReport",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "hasPostableComments",
               "description": null,
               "args": [],
@@ -41302,6 +55066,34 @@
                   "name": "Boolean",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasProvisionalGradeByCurrentUser",
+              "description": "Whether the current user has provided a provisional grade with a non-null score for this submission",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasSubAssignmentSubmissions",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -41576,9 +55368,13 @@
                 }
               ],
               "type": {
-                "kind": "OBJECT",
-                "name": "RubricAssessmentConnection",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "RubricAssessmentConnection",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -41815,6 +55611,26 @@
                 "kind": "OBJECT",
                 "name": "User",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vericiteData",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "VericiteData",
+                    "ofType": null
+                  }
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -42067,6 +55883,18 @@
           "description": "Types for submission or submission history",
           "fields": [
             {
+              "name": "aiGradeResult",
+              "description": "The AI grading result for the current submission attempt, if any.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AIGradeResult",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "anonymousId",
               "description": null,
               "args": [],
@@ -42103,9 +55931,13 @@
               "description": null,
               "args": [],
               "type": {
-                "kind": "OBJECT",
-                "name": "Assignment",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Assignment",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -42168,6 +56000,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "autoGradeResultPresent",
+              "description": "Indicates whether an auto-grading result exists for the submission.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
                   "ofType": null
                 }
               },
@@ -42285,12 +56133,40 @@
                   "defaultValue": "false",
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "includeDraftsFromOthers",
+                  "description": "When true and include_draft_comments is true, draft comments from other teachers will be included.\nOnly applies to users with grading permissions (teachers, TAs, etc).\nWhen false, only the current user's draft comments are included.\nStudents never see draft comments from others regardless of this setting.\n",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "includeProvisionalComments",
+                  "description": "When true, provisional comments that the current user has permission to see will be returned.\nThe Moderator has permission to see all provisional comments.\nProvisional Graders can see each other's comments if \"Graders can view each other's comments\" is enabled.\nOtherwise, Provisional Graders can only see their own comments.\nStudents cannot see provisional comments.\n",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
-                "kind": "OBJECT",
-                "name": "SubmissionCommentConnection",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SubmissionCommentConnection",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -42496,6 +56372,22 @@
               "deprecationReason": null
             },
             {
+              "name": "hasOriginalityReport",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "hasPostableComments",
               "description": null,
               "args": [],
@@ -42507,6 +56399,34 @@
                   "name": "Boolean",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasProvisionalGradeByCurrentUser",
+              "description": "Whether the current user has provided a provisional grade with a non-null score for this submission",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasSubAssignmentSubmissions",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -42765,9 +56685,13 @@
                 }
               ],
               "type": {
-                "kind": "OBJECT",
-                "name": "RubricAssessmentConnection",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "RubricAssessmentConnection",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -42997,6 +56921,26 @@
               "deprecationReason": null
             },
             {
+              "name": "vericiteData",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "VericiteData",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "wordCount",
               "description": null,
               "args": [],
@@ -43094,6 +57038,31 @@
           "isOneOf": false
         },
         {
+          "kind": "ENUM",
+          "name": "SubmissionPostingStatus",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "hideable",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "postable",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "INPUT_OBJECT",
           "name": "SubmissionRubricAssessmentFilterInput",
           "description": null,
@@ -43101,13 +57070,37 @@
           "inputFields": [
             {
               "name": "forAttempt",
-              "description": "What submission attempt the rubric assessment should be returned for. If not\nspecified, it will return the rubric assessment for the current submisssion\nor submission history.\n",
+              "description": "What submission attempt the rubric assessment should be returned for. If not\nspecified, it will return the rubric assessment for the current submission\nor submission history.\n",
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
                 "ofType": null
               },
               "defaultValue": "null",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "forAllAttempts",
+              "description": "it will return all rubric assessments for the current submission\nor submission history.\n",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": "null",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "includeProvisionalAssessments",
+              "description": "When true, provisional rubric assessments that the current user has permission to see will be returned.\nThe Moderator has permission to see all provisional rubric assessments.\nProvisional Graders only have permission to view their own provisional rubric assessments.\nDefault behavior is to omit provisional assessments entirely.\n",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": "false",
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -43257,6 +57250,18 @@
               "deprecationReason": null
             },
             {
+              "name": "postingStatus",
+              "description": "Filter submissions by their posting status. Valid values: postable, hideable.\nIgnored if the current user cannot manage or view all grades for the assignment.\n",
+              "type": {
+                "kind": "ENUM",
+                "name": "SubmissionPostingStatus",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "userSearch",
               "description": "The partial name or full ID of the users to match and return in the\nresults list. Must be at least 3 characters.\nQueries by administrative users will search on SIS ID, login ID, name, or email\naddress; non-administrative queries will only be compared against name.\n",
               "type": {
@@ -43271,6 +57276,18 @@
             {
               "name": "userId",
               "description": "Return only submissions related to the given user_id\nThere is no character restriction on this field\n",
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "userRepresentativeId",
+              "description": "Return only submissions related to group representative for the user_id\nThere is no character restriction on this field\n",
               "type": {
                 "kind": "SCALAR",
                 "name": "ID",
@@ -43350,7 +57367,7 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "SubmissionSearchOrder",
-          "description": "Specify a sort for the results",
+          "description": "Specify a sort for the results. The 'direction' argument is ignored for 'random' sorts. For sorts of boolean fields, 'true' comes before 'false' for ascending sorts.",
           "fields": null,
           "inputFields": [
             {
@@ -43397,13 +57414,49 @@
           "interfaces": null,
           "enumValues": [
             {
+              "name": "group_name",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "username",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
+              "name": "username_first_last",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "test_student",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "needs_grading",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "random",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "score",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submission_status",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -43469,6 +57522,235 @@
           "isOneOf": false
         },
         {
+          "kind": "OBJECT",
+          "name": "SubmissionStatistics",
+          "description": null,
+          "fields": [
+            {
+              "name": "missingSubmissionsCount",
+              "description": null,
+              "args": [
+                {
+                  "name": "onlyCurrentGradingPeriod",
+                  "description": "Only count missing submissions from current grading period (default: true)",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "true",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submissionsDueCount",
+              "description": null,
+              "args": [
+                {
+                  "name": "endDate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601DateTime",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "startDate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601DateTime",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submissionsDueThisWeekCount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submissionsOverdueCount",
+              "description": null,
+              "args": [
+                {
+                  "name": "endDate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601DateTime",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "startDate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601DateTime",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submissionsSubmittedCount",
+              "description": null,
+              "args": [
+                {
+                  "name": "endDate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601DateTime",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "startDate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601DateTime",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submittedAndGradedCount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submittedNotGradedCount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submittedSubmissionsCount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "ENUM",
           "name": "SubmissionStatusTagType",
           "description": null,
@@ -43525,6 +57807,12 @@
           "inputFields": null,
           "interfaces": null,
           "enumValues": [
+            {
+              "name": "ams",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "attendance",
               "description": null,
@@ -43593,6 +57881,12 @@
             },
             {
               "name": "online_url",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "peer_review",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -43992,6 +58286,16 @@
             },
             {
               "kind": "OBJECT",
+              "name": "AccountNotification",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "AllocationRule",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "AssessmentRequest",
               "ofType": null
             },
@@ -44008,6 +58312,11 @@
             {
               "kind": "OBJECT",
               "name": "AssignmentOverride",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "AuditEvent",
               "ofType": null
             },
             {
@@ -44042,11 +58351,6 @@
             },
             {
               "kind": "OBJECT",
-              "name": "DiscussionEntryDraft",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
               "name": "DiscussionEntryVersion",
               "ofType": null
             },
@@ -44068,6 +58372,11 @@
             {
               "kind": "OBJECT",
               "name": "File",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Folder",
               "ofType": null
             },
             {
@@ -44122,6 +58431,11 @@
             },
             {
               "kind": "OBJECT",
+              "name": "ModuleProgression",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "Notification",
               "ofType": null
             },
@@ -44147,12 +58461,22 @@
             },
             {
               "kind": "OBJECT",
+              "name": "PeerReviewSubAssignment",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "Progress",
               "ofType": null
             },
             {
               "kind": "OBJECT",
               "name": "Quiz",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "QuizSubmission",
               "ofType": null
             },
             {
@@ -44185,6 +58509,87 @@
           "isOneOf": false
         },
         {
+          "kind": "OBJECT",
+          "name": "TotalCountPageInfo",
+          "description": "Information about pagination in a connection.",
+          "fields": [
+            {
+              "name": "endCursor",
+              "description": "When paginating forwards, the cursor to continue.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasNextPage",
+              "description": "When paginating forwards, are there more items?",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasPreviousPage",
+              "description": "When paginating backwards, are there more items?",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startCursor",
+              "description": "When paginating backwards, the cursor to continue.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "Total number of items in the connection, ignoring pagination.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "UNION",
           "name": "TurnitinContext",
           "description": null,
@@ -44212,6 +58617,22 @@
           "name": "TurnitinData",
           "description": null,
           "fields": [
+            {
+              "name": "assetString",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "reportUrl",
               "description": null,
@@ -44408,6 +58829,204 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "UpdateAllocationRuleInput",
+          "description": "Autogenerated input type of UpdateAllocationRule",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "appliesToAssessor",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": "true",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assesseeIds",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assessorIds",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mustReview",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": "true",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "reciprocal",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": "false",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "reviewPermitted",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": "true",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ruleId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "UpdateAllocationRulePayload",
+          "description": "Autogenerated return type of UpdateAllocationRule.",
+          "fields": [
+            {
+              "name": "allocationErrors",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AllocationError",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "allocationRules",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AllocationRule",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "errors",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ValidationError",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "UpdateAssignmentInput",
           "description": "Autogenerated input type of UpdateAssignment",
           "fields": null,
@@ -44526,7 +59145,7 @@
             },
             {
               "name": "forCheckpoints",
-              "description": null,
+              "description": "if true, this assignment is a parent assignment for checkpoints. cannot set points_possible, due_at, lock_at, or unlock_at",
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
@@ -44739,6 +59358,18 @@
                     "ofType": null
                   }
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "suppressAssignment",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -45205,6 +59836,18 @@
               "deprecationReason": null
             },
             {
+              "name": "pinType",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "DiscussionEntryPinningType",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "quotedEntryId",
               "description": null,
               "type": {
@@ -45408,100 +60051,6 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "UpdateDiscussionExpandedInput",
-          "description": "Autogenerated input type of UpdateDiscussionExpanded",
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "discussionTopicId",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "expanded",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null,
-          "specifiedByURL": null,
-          "isOneOf": false
-        },
-        {
-          "kind": "OBJECT",
-          "name": "UpdateDiscussionExpandedPayload",
-          "description": "Autogenerated return type of UpdateDiscussionExpanded.",
-          "fields": [
-            {
-              "name": "discussionTopic",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Discussion",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "errors",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "ValidationError",
-                    "ofType": null
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null,
-          "specifiedByURL": null,
-          "isOneOf": false
-        },
-        {
-          "kind": "INPUT_OBJECT",
           "name": "UpdateDiscussionReadStateInput",
           "description": "Autogenerated input type of UpdateDiscussionReadState",
           "fields": null,
@@ -45549,100 +60098,6 @@
           "kind": "OBJECT",
           "name": "UpdateDiscussionReadStatePayload",
           "description": "Autogenerated return type of UpdateDiscussionReadState.",
-          "fields": [
-            {
-              "name": "discussionTopic",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Discussion",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "errors",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "ValidationError",
-                    "ofType": null
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null,
-          "specifiedByURL": null,
-          "isOneOf": false
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "UpdateDiscussionSortOrderInput",
-          "description": "Autogenerated input type of UpdateDiscussionSortOrder",
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "discussionTopicId",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "sortOrder",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "DiscussionSortOrderType",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null,
-          "specifiedByURL": null,
-          "isOneOf": false
-        },
-        {
-          "kind": "OBJECT",
-          "name": "UpdateDiscussionSortOrderPayload",
-          "description": "Autogenerated return type of UpdateDiscussionSortOrder.",
           "fields": [
             {
               "name": "discussionTopic",
@@ -46164,6 +60619,156 @@
           "isOneOf": false
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "UpdateDiscussionTopicParticipantInput",
+          "description": "Autogenerated input type of UpdateDiscussionTopicParticipant",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "discussionTopicId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "expanded",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasUnreadPinnedEntry",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "preferredLanguage",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "PreferredLanguageType",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "showPinnedEntries",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sortOrder",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "DiscussionSortOrderType",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "summaryEnabled",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "UpdateDiscussionTopicParticipantPayload",
+          "description": "Autogenerated return type of UpdateDiscussionTopicParticipant.",
+          "fields": [
+            {
+              "name": "discussionTopic",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Discussion",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "errors",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ValidationError",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "OBJECT",
           "name": "UpdateDiscussionTopicPayload",
           "description": "Autogenerated return type of UpdateDiscussionTopic.",
@@ -46402,6 +61007,84 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "InternalSetting",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "UpdateLearnerDashboardTabSelectionInput",
+          "description": "Autogenerated input type of UpdateLearnerDashboardTabSelection",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "tab",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "LearnerDashboardTabType",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "UpdateLearnerDashboardTabSelectionPayload",
+          "description": "Autogenerated return type of UpdateLearnerDashboardTabSelection.",
+          "fields": [
+            {
+              "name": "errors",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ValidationError",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tab",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "LearnerDashboardTabType",
                   "ofType": null
                 }
               },
@@ -48186,6 +62869,182 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "UpdateWidgetDashboardConfigInput",
+          "description": "Autogenerated input type of UpdateWidgetDashboardConfig",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "filters",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "JSON",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "widgetId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "UpdateWidgetDashboardConfigPayload",
+          "description": "Autogenerated return type of UpdateWidgetDashboardConfig.",
+          "fields": [
+            {
+              "name": "errors",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ValidationError",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "filters",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "JSON",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "widgetId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "UpdateWidgetDashboardLayoutInput",
+          "description": "Autogenerated input type of UpdateWidgetDashboardLayout",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "layout",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "UpdateWidgetDashboardLayoutPayload",
+          "description": "Autogenerated return type of UpdateWidgetDashboardLayout.",
+          "fields": [
+            {
+              "name": "errors",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ValidationError",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "layout",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "UpsertCustomGradeStatusInput",
           "description": "Autogenerated input type of UpsertCustomGradeStatus",
           "fields": null,
@@ -48603,11 +63462,23 @@
                   "deprecationReason": null
                 },
                 {
-                  "name": "limit",
+                  "name": "assignmentId",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "courseId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
                     "ofType": null
                   },
                   "defaultValue": null,
@@ -48706,6 +63577,18 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "showHorizonConversations",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -48794,12 +63677,343 @@
               "deprecationReason": null
             },
             {
+              "name": "courseWorkSubmissionsConnection",
+              "description": "All actionable submissions for the current user across enrolled courses, for course work widget",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "courseFilter",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "endDate",
+                  "description": "End date for due date range filter",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601DateTime",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "includeNoDueDate",
+                  "description": "Include assignments with no due date",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "includeOverdue",
+                  "description": "Include overdue assignments",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "observedUserId",
+                  "description": "ID of the observed user",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "onlyCurrentGradingPeriod",
+                  "description": "Only include missing submissions from current grading period (default: true)",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "true",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "onlySubmitted",
+                  "description": "Show only submitted assignments",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "Field to order results by",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CourseWorkSubmissionsOrderField",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "startDate",
+                  "description": "Start date for due date range filter",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601DateTime",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SubmissionConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "createdAt",
               "description": null,
               "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "differentiationTagsConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "courseId",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "GroupMembershipConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "discussionParticipantsConnection",
+              "description": "All discussion topic participants for the user, optionally filtered by announcement status",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "filter",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "DiscussionParticipantFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "observedUserId",
+                  "description": "ID of the observed user",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "DiscussionParticipantConnection",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -48837,6 +64051,18 @@
               "name": "enrollments",
               "description": null,
               "args": [
+                {
+                  "name": "careerLearningLibraryOnly",
+                  "description": "Whether or not to only filter for or exclude Canvas Career learning library only courses",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
                 {
                   "name": "courseId",
                   "description": "only return enrollments for this course",
@@ -48904,6 +64130,18 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "sort",
+                  "description": "The sort field and direction for the results. Secondary sort is by section name",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "EnrollmentsSortInputType",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -48922,6 +64160,187 @@
                     }
                   }
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "enrollmentsConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "courseId",
+                  "description": "only return enrollments for this course",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "courseIds",
+                  "description": "only return enrollments for these courses",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "currentOnly",
+                  "description": "Whether or not to restrict results to `active` enrollments in `available` courses",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "enrollmentTypes",
+                  "description": "Filter by enrollment types (e.g., TeacherEnrollment, TaEnrollment)",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "EnrollmentType",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "excludeConcluded",
+                  "description": "Whether or not to exclude `completed` enrollments",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "horizonCourses",
+                  "description": "Whether or not to include or exclude Canvas Career courses",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": "The fields to order the results by",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "sort",
+                  "description": "The sort field and direction for the results. Secondary sort is by section name",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "EnrollmentsSortInputType",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "EnrollmentConnection",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -49073,6 +64492,55 @@
               "deprecationReason": null
             },
             {
+              "name": "firstName",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "groupMemberships",
+              "description": null,
+              "args": [
+                {
+                  "name": "filter",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "UserGroupMembershipsFilterInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "GroupMembership",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "groups",
               "description": "**NOTE**: this only returns groups for the currently logged-in user.\n",
               "args": [],
@@ -49190,6 +64658,18 @@
               "deprecationReason": null
             },
             {
+              "name": "lastName",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "loginId",
               "description": null,
               "args": [],
@@ -49278,6 +64758,18 @@
                   "name": "Boolean",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "peerReviewStatus",
+              "description": "Peer review status for assignments where peer reviews are enabled",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PeerReviewStatus",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -49630,6 +65122,18 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "widgetDashboardConfig",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -49694,14 +65198,14 @@
             },
             {
               "name": "pageInfo",
-              "description": "Information to aid in pagination.",
+              "description": null,
               "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "PageInfo",
+                  "name": "TotalCountPageInfo",
                   "ofType": null
                 }
               },
@@ -49758,6 +65262,79 @@
           "isOneOf": false
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "UserGroupMembershipsFilterInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "groupCourseId",
+              "description": "Only return group memberships in the specified group course ids",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "groupState",
+              "description": "Only return group memberships with the specified group workflow states",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "GroupState",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "state",
+              "description": "Only return group memberships with the specified workflow states",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "GroupMembershipState",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
           "kind": "OBJECT",
           "name": "ValidationError",
           "description": null,
@@ -49784,6 +65361,122 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "UNION",
+          "name": "VericiteContext",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "File",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Submission",
+              "ofType": null
+            }
+          ],
+          "specifiedByURL": null,
+          "isOneOf": false
+        },
+        {
+          "kind": "OBJECT",
+          "name": "VericiteData",
+          "description": null,
+          "fields": [
+            {
+              "name": "assetString",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "reportUrl",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "score",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "state",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "status",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "target",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "UNION",
+                  "name": "VericiteContext",
                   "ofType": null
                 }
               },

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/di/GraphQlApiModule.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/di/GraphQlApiModule.kt
@@ -29,6 +29,8 @@ import com.instructure.canvasapi2.managers.SubmissionRubricManager
 import com.instructure.canvasapi2.managers.SubmissionRubricManagerImpl
 import com.instructure.canvasapi2.managers.graphql.AssignmentDetailsManager
 import com.instructure.canvasapi2.managers.graphql.AssignmentDetailsManagerImpl
+import com.instructure.canvasapi2.managers.graphql.DashboardCoursesManager
+import com.instructure.canvasapi2.managers.graphql.DashboardCoursesManagerImpl
 import com.instructure.canvasapi2.managers.graphql.SubmissionCommentsManager
 import com.instructure.canvasapi2.managers.graphql.SubmissionCommentsManagerImpl
 import com.instructure.canvasapi2.managers.graphql.SubmissionContentManager
@@ -105,5 +107,10 @@ class GraphQlApiModule {
     @Provides
     fun provideRecentGradedSubmissionsManager(@DefaultApolloClient apolloClient: ApolloClient): RecentGradedSubmissionsManager {
         return RecentGradedSubmissionsManagerImpl(apolloClient)
+    }
+
+    @Provides
+    fun provideDashboardCoursesManager(@DefaultApolloClient apolloClient: ApolloClient): DashboardCoursesManager {
+        return DashboardCoursesManagerImpl(apolloClient)
     }
 }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/SubmissionRubricManagerImpl.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/SubmissionRubricManagerImpl.kt
@@ -44,11 +44,13 @@ class SubmissionRubricManagerImpl(private val apolloClient: ApolloClient) : Subm
         }
 
         return data.copy(
-            submission = data.submission?.copy(
-                rubricAssessmentsConnection = data.submission?.rubricAssessmentsConnection?.copy(
-                    edges = assessments
+            submission = data.submission?.let { submission ->
+                submission.copy(
+                    rubricAssessmentsConnection = submission.rubricAssessmentsConnection.copy(
+                        edges = assessments
+                    )
                 )
-            )
+            }
         )
     }
 }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/graphql/DashboardCoursesManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/graphql/DashboardCoursesManager.kt
@@ -33,6 +33,7 @@ interface DashboardCoursesManager {
 
     suspend fun getCourseAnnouncements(
         courseId: Long,
+        cursor: String? = null,
         forceNetwork: Boolean = true
     ): CourseAnnouncementsQuery.Data
 }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/graphql/DashboardCoursesManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/graphql/DashboardCoursesManager.kt
@@ -16,6 +16,7 @@
 
 package com.instructure.canvasapi2.managers.graphql
 
+import com.instructure.canvasapi2.CourseAnnouncementsQuery
 import com.instructure.canvasapi2.DashboardCoursesQuery
 import com.instructure.canvasapi2.DashboardSingleCourseQuery
 
@@ -29,4 +30,9 @@ interface DashboardCoursesManager {
         courseId: Long,
         forceNetwork: Boolean = true
     ): DashboardSingleCourseQuery.Data
+
+    suspend fun getCourseAnnouncements(
+        courseId: Long,
+        forceNetwork: Boolean = true
+    ): List<CourseAnnouncementsQuery.Node1?>
 }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/graphql/DashboardCoursesManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/graphql/DashboardCoursesManager.kt
@@ -34,5 +34,5 @@ interface DashboardCoursesManager {
     suspend fun getCourseAnnouncements(
         courseId: Long,
         forceNetwork: Boolean = true
-    ): List<CourseAnnouncementsQuery.Node1?>
+    ): CourseAnnouncementsQuery.Data
 }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/graphql/DashboardCoursesManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/graphql/DashboardCoursesManager.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+package com.instructure.canvasapi2.managers.graphql
+
+import com.instructure.canvasapi2.DashboardCoursesQuery
+import com.instructure.canvasapi2.DashboardSingleCourseQuery
+
+interface DashboardCoursesManager {
+
+    suspend fun getDashboardCourses(
+        forceNetwork: Boolean = true
+    ): DashboardCoursesQuery.Data
+
+    suspend fun getSingleCourse(
+        courseId: Long,
+        forceNetwork: Boolean = true
+    ): DashboardSingleCourseQuery.Data
+}

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/graphql/DashboardCoursesManagerImpl.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/graphql/DashboardCoursesManagerImpl.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+package com.instructure.canvasapi2.managers.graphql
+
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.api.Optional
+import com.instructure.canvasapi2.DashboardCoursesQuery
+import com.instructure.canvasapi2.DashboardSingleCourseQuery
+import com.instructure.canvasapi2.enqueueQuery
+
+class DashboardCoursesManagerImpl(
+    private val apolloClient: ApolloClient
+) : DashboardCoursesManager {
+
+    override suspend fun getDashboardCourses(
+        forceNetwork: Boolean
+    ): DashboardCoursesQuery.Data {
+        val query = DashboardCoursesQuery(announcementCursor = Optional.absent())
+        val initialData = apolloClient.enqueueQuery(query, forceNetwork = forceNetwork).dataAssertNoErrors
+
+        val allCourses = initialData.allCourses?.map { course ->
+            val allNodes = course.announcements?.nodes?.toMutableList() ?: mutableListOf()
+            var hasNextPage = course.announcements?.pageInfo?.hasNextPage == true
+            var cursor = course.announcements?.pageInfo?.endCursor
+
+            while (hasNextPage) {
+                val paginatedQuery = DashboardCoursesQuery(
+                    announcementCursor = Optional.present(cursor)
+                )
+                val paginatedData = apolloClient.enqueueQuery(paginatedQuery, forceNetwork = forceNetwork).dataAssertNoErrors
+
+                val courseData = paginatedData.allCourses?.find { it._id == course._id }
+                courseData?.announcements?.nodes?.let { allNodes.addAll(it) }
+
+                hasNextPage = courseData?.announcements?.pageInfo?.hasNextPage == true
+                cursor = courseData?.announcements?.pageInfo?.endCursor
+            }
+
+            course.copy(
+                announcements = course.announcements?.copy(
+                    nodes = allNodes
+                )
+            )
+        }
+
+        return DashboardCoursesQuery.Data(allCourses)
+    }
+
+    override suspend fun getSingleCourse(
+        courseId: Long,
+        forceNetwork: Boolean
+    ): DashboardSingleCourseQuery.Data {
+        val query = DashboardSingleCourseQuery(courseId = courseId.toString())
+        return apolloClient.enqueueQuery(query, forceNetwork = forceNetwork).dataAssertNoErrors
+    }
+}

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/graphql/DashboardCoursesManagerImpl.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/graphql/DashboardCoursesManagerImpl.kt
@@ -18,6 +18,7 @@ package com.instructure.canvasapi2.managers.graphql
 
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.Optional
+import com.instructure.canvasapi2.CourseAnnouncementsQuery
 import com.instructure.canvasapi2.DashboardCoursesQuery
 import com.instructure.canvasapi2.DashboardSingleCourseQuery
 import com.instructure.canvasapi2.enqueueQuery
@@ -29,35 +30,7 @@ class DashboardCoursesManagerImpl(
     override suspend fun getDashboardCourses(
         forceNetwork: Boolean
     ): DashboardCoursesQuery.Data {
-        val query = DashboardCoursesQuery(announcementCursor = Optional.absent())
-        val initialData = apolloClient.enqueueQuery(query, forceNetwork = forceNetwork).dataAssertNoErrors
-
-        val allCourses = initialData.allCourses?.map { course ->
-            val allNodes = course.announcements?.nodes?.toMutableList() ?: mutableListOf()
-            var hasNextPage = course.announcements?.pageInfo?.hasNextPage == true
-            var cursor = course.announcements?.pageInfo?.endCursor
-
-            while (hasNextPage) {
-                val paginatedQuery = DashboardCoursesQuery(
-                    announcementCursor = Optional.present(cursor)
-                )
-                val paginatedData = apolloClient.enqueueQuery(paginatedQuery, forceNetwork = forceNetwork).dataAssertNoErrors
-
-                val courseData = paginatedData.allCourses?.find { it._id == course._id }
-                courseData?.announcements?.nodes?.let { allNodes.addAll(it) }
-
-                hasNextPage = courseData?.announcements?.pageInfo?.hasNextPage == true
-                cursor = courseData?.announcements?.pageInfo?.endCursor
-            }
-
-            course.copy(
-                announcements = course.announcements?.copy(
-                    nodes = allNodes
-                )
-            )
-        }
-
-        return DashboardCoursesQuery.Data(allCourses)
+        return apolloClient.enqueueQuery(DashboardCoursesQuery(), forceNetwork = forceNetwork).dataAssertNoErrors
     }
 
     override suspend fun getSingleCourse(
@@ -66,5 +39,30 @@ class DashboardCoursesManagerImpl(
     ): DashboardSingleCourseQuery.Data {
         val query = DashboardSingleCourseQuery(courseId = courseId.toString())
         return apolloClient.enqueueQuery(query, forceNetwork = forceNetwork).dataAssertNoErrors
+    }
+
+    override suspend fun getCourseAnnouncements(
+        courseId: Long,
+        forceNetwork: Boolean
+    ): List<CourseAnnouncementsQuery.Node1?> {
+        val allNodes = mutableListOf<CourseAnnouncementsQuery.Node1?>()
+        var hasNextPage = true
+        var cursor: String? = null
+
+        while (hasNextPage) {
+            val query = CourseAnnouncementsQuery(
+                courseId = courseId.toString(),
+                cursor = if (cursor != null) Optional.present(cursor) else Optional.absent()
+            )
+            val data = apolloClient.enqueueQuery(query, forceNetwork = forceNetwork).dataAssertNoErrors
+            val announcements = (data.course as? CourseAnnouncementsQuery.CourseOnCourse)?.announcements
+
+            announcements?.nodes?.let { allNodes.addAll(it) }
+
+            hasNextPage = announcements?.pageInfo?.hasNextPage == true
+            cursor = announcements?.pageInfo?.endCursor
+        }
+
+        return allNodes
     }
 }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/graphql/DashboardCoursesManagerImpl.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/graphql/DashboardCoursesManagerImpl.kt
@@ -44,25 +44,38 @@ class DashboardCoursesManagerImpl(
     override suspend fun getCourseAnnouncements(
         courseId: Long,
         forceNetwork: Boolean
-    ): List<CourseAnnouncementsQuery.Node1?> {
-        val allNodes = mutableListOf<CourseAnnouncementsQuery.Node1?>()
-        var hasNextPage = true
-        var cursor: String? = null
+    ): CourseAnnouncementsQuery.Data {
+        val query = CourseAnnouncementsQuery(
+            courseId = courseId.toString(),
+            cursor = Optional.absent()
+        )
+        val initialData = apolloClient.enqueueQuery(query, forceNetwork = forceNetwork).dataAssertNoErrors
+
+        val course = initialData.course?.onCourse ?: return initialData
+        val allNodes = course.announcements?.nodes?.toMutableList() ?: mutableListOf()
+        var hasNextPage = course.announcements?.pageInfo?.hasNextPage == true
+        var cursor = course.announcements?.pageInfo?.endCursor
 
         while (hasNextPage) {
-            val query = CourseAnnouncementsQuery(
+            val paginatedQuery = CourseAnnouncementsQuery(
                 courseId = courseId.toString(),
-                cursor = if (cursor != null) Optional.present(cursor) else Optional.absent()
+                cursor = Optional.present(cursor)
             )
-            val data = apolloClient.enqueueQuery(query, forceNetwork = forceNetwork).dataAssertNoErrors
-            val announcements = (data.course as? CourseAnnouncementsQuery.CourseOnCourse)?.announcements
+            val paginatedData = apolloClient.enqueueQuery(paginatedQuery, forceNetwork = forceNetwork).dataAssertNoErrors
+            val paginatedCourse = paginatedData.course?.onCourse
 
-            announcements?.nodes?.let { allNodes.addAll(it) }
-
-            hasNextPage = announcements?.pageInfo?.hasNextPage == true
-            cursor = announcements?.pageInfo?.endCursor
+            paginatedCourse?.announcements?.nodes?.let { allNodes.addAll(it) }
+            hasNextPage = paginatedCourse?.announcements?.pageInfo?.hasNextPage == true
+            cursor = paginatedCourse?.announcements?.pageInfo?.endCursor
         }
 
-        return allNodes
+        return CourseAnnouncementsQuery.Data(
+            course = CourseAnnouncementsQuery.Course(
+                __typename = "Course",
+                onCourse = course.copy(
+                    announcements = course.announcements?.copy(nodes = allNodes)
+                )
+            )
+        )
     }
 }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/graphql/DashboardCoursesManagerImpl.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/graphql/DashboardCoursesManagerImpl.kt
@@ -21,6 +21,7 @@ import com.apollographql.apollo.api.Optional
 import com.instructure.canvasapi2.CourseAnnouncementsQuery
 import com.instructure.canvasapi2.DashboardCoursesQuery
 import com.instructure.canvasapi2.DashboardSingleCourseQuery
+import com.instructure.canvasapi2.QLClientConfig
 import com.instructure.canvasapi2.enqueueQuery
 
 class DashboardCoursesManagerImpl(
@@ -30,7 +31,8 @@ class DashboardCoursesManagerImpl(
     override suspend fun getDashboardCourses(
         forceNetwork: Boolean
     ): DashboardCoursesQuery.Data {
-        return apolloClient.enqueueQuery(DashboardCoursesQuery(), forceNetwork = forceNetwork).dataAssertNoErrors
+        val query = DashboardCoursesQuery(pageSize = QLClientConfig.GRAPHQL_PAGE_SIZE)
+        return apolloClient.enqueueQuery(query, forceNetwork = forceNetwork).dataAssertNoErrors
     }
 
     override suspend fun getSingleCourse(
@@ -43,30 +45,35 @@ class DashboardCoursesManagerImpl(
 
     override suspend fun getCourseAnnouncements(
         courseId: Long,
+        cursor: String?,
         forceNetwork: Boolean
     ): CourseAnnouncementsQuery.Data {
+        val pageSize = QLClientConfig.GRAPHQL_PAGE_SIZE
+        val initialCursor = if (cursor != null) Optional.present(cursor) else Optional.absent()
         val query = CourseAnnouncementsQuery(
             courseId = courseId.toString(),
-            cursor = Optional.absent()
+            pageSize = pageSize,
+            cursor = initialCursor
         )
         val initialData = apolloClient.enqueueQuery(query, forceNetwork = forceNetwork).dataAssertNoErrors
 
         val course = initialData.course?.onCourse ?: return initialData
         val allNodes = course.announcements?.nodes?.toMutableList() ?: mutableListOf()
         var hasNextPage = course.announcements?.pageInfo?.hasNextPage == true
-        var cursor = course.announcements?.pageInfo?.endCursor
+        var nextCursor = course.announcements?.pageInfo?.endCursor
 
         while (hasNextPage) {
             val paginatedQuery = CourseAnnouncementsQuery(
                 courseId = courseId.toString(),
-                cursor = Optional.present(cursor)
+                pageSize = pageSize,
+                cursor = Optional.present(nextCursor)
             )
             val paginatedData = apolloClient.enqueueQuery(paginatedQuery, forceNetwork = forceNetwork).dataAssertNoErrors
             val paginatedCourse = paginatedData.course?.onCourse
 
             paginatedCourse?.announcements?.nodes?.let { allNodes.addAll(it) }
             hasNextPage = paginatedCourse?.announcements?.pageInfo?.hasNextPage == true
-            cursor = paginatedCourse?.announcements?.pageInfo?.endCursor
+            nextCursor = paginatedCourse?.announcements?.pageInfo?.endCursor
         }
 
         return CourseAnnouncementsQuery.Data(

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/graphql/SubmissionContentManagerImpl.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/graphql/SubmissionContentManagerImpl.kt
@@ -52,11 +52,13 @@ class SubmissionContentManagerImpl(private val apolloClient: ApolloClient) : Sub
         }
 
         return data.copy(
-            submission = data.submission?.copy(
-                submissionHistoriesConnection = data.submission.submissionHistoriesConnection?.copy(
-                    edges = allEdges
+            submission = data.submission?.let { submission ->
+                submission.copy(
+                    submissionHistoriesConnection = submission.submissionHistoriesConnection.copy(
+                        edges = allEdges
+                    )
                 )
-            )
+            }
         )
     }
 }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/graphql/SubmissionGradeManagerImpl.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/graphql/SubmissionGradeManagerImpl.kt
@@ -44,16 +44,22 @@ class SubmissionGradeManagerImpl(private val apolloClient: ApolloClient) : Submi
                 submission = data
             } else {
                 submission = submission.copy(
-                    submission = submission.submission?.copy(
-                        assignment = submission.submission.assignment?.copy(
-                            course = submission.submission.assignment.course?.copy(
-                                customGradeStatusesConnection = submission.submission.assignment.course.customGradeStatusesConnection?.copy(
-                                    edges = submission.submission.assignment.course.customGradeStatusesConnection.edges.orEmpty() +
-                                            data.submission?.assignment?.course?.customGradeStatusesConnection?.edges.orEmpty()
+                    submission = submission.submission?.let { sub ->
+                        sub.copy(
+                            assignment = sub.assignment.let { assignment ->
+                                assignment.copy(
+                                    course = assignment.course?.let { course ->
+                                        course.copy(
+                                            customGradeStatusesConnection = course.customGradeStatusesConnection?.copy(
+                                                edges = course.customGradeStatusesConnection.edges.orEmpty() +
+                                                        data.submission?.assignment?.course?.customGradeStatusesConnection?.edges.orEmpty()
+                                            )
+                                        )
+                                    }
                                 )
-                            )
+                            }
                         )
-                    )
+                    }
                 )
             }
 

--- a/libs/login-api-2/build.gradle
+++ b/libs/login-api-2/build.gradle
@@ -95,9 +95,9 @@ android {
     }
 }
 
-configurations {
-    all*.exclude group: 'commons-logging', module: 'commons-logging'
-    all*.exclude group: 'org.apache.httpcomponents', module: 'httpclient'
+configurations.configureEach {
+    exclude group: 'commons-logging', module: 'commons-logging'
+    exclude group: 'org.apache.httpcomponents', module: 'httpclient'
 }
 
 dependencies {

--- a/libs/pandautils/build.gradle
+++ b/libs/pandautils/build.gradle
@@ -107,15 +107,16 @@ tasks.withType(Test) {
     android.sourceSets.main.res.srcDirs += 'src/test/res'
 }
 
-configurations {
-    all*.exclude group: 'commons-logging', module: 'commons-logging'
-    all*.exclude group: 'org.apache.httpcomponents', module: 'httpclient'
-    androidTestImplementation.exclude module:'protobuf-lite'
-
-    all*.resolutionStrategy {
-        force Libs.KOTLIN_STD_LIB
+configurations.configureEach {
+    exclude group: 'commons-logging', module: 'commons-logging'
+    exclude group: 'org.apache.httpcomponents', module: 'httpclient'
+    if (canBeResolved) {
+        resolutionStrategy {
+            force Libs.KOTLIN_STD_LIB
+        }
     }
 }
+configurations.androidTestImplementation.exclude module:'protobuf-lite'
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/data/repository/submission/SubmissionRepositoryImpl.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/data/repository/submission/SubmissionRepositoryImpl.kt
@@ -42,7 +42,7 @@ class SubmissionRepositoryImpl(
                     course.submissions?.edges
                         ?.mapNotNull { edge ->
                             val submission = edge?.node ?: return@mapNotNull null
-                            val assignment = submission.assignment ?: return@mapNotNull null
+                            val assignment = submission.assignment
 
                             if (submission.gradeHidden) {
                                 return@mapNotNull null

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/domain/usecase/courses/LoadSingleCourseUseCase.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/domain/usecase/courses/LoadSingleCourseUseCase.kt
@@ -16,7 +16,7 @@
 
 package com.instructure.pandautils.domain.usecase.courses
 
-import com.instructure.canvasapi2.DashboardCoursesQuery
+import com.instructure.canvasapi2.DashboardSingleCourseQuery
 import com.instructure.canvasapi2.managers.graphql.DashboardCoursesManager
 import com.instructure.canvasapi2.models.Course
 import com.instructure.canvasapi2.models.DiscussionTopicHeader
@@ -27,42 +27,31 @@ import com.instructure.canvasapi2.type.EnrollmentType
 import com.instructure.pandautils.domain.usecase.BaseUseCase
 import javax.inject.Inject
 
-class LoadVisibleCoursesUseCase @Inject constructor(
+class LoadSingleCourseUseCase @Inject constructor(
     private val dashboardCoursesManager: DashboardCoursesManager
-) : BaseUseCase<LoadVisibleCoursesUseCase.Params, LoadVisibleCoursesUseCase.Result>() {
+) : BaseUseCase<LoadSingleCourseUseCase.Params, LoadSingleCourseUseCase.Result>() {
 
     override suspend fun execute(params: Params): Result {
-        val data = dashboardCoursesManager.getDashboardCourses(
-            forceNetwork = params.forceRefresh
+        val data = dashboardCoursesManager.getSingleCourse(
+            courseId = params.courseId,
+            forceNetwork = params.forceNetwork
         )
 
-        val allCourses = data.allCourses?.mapNotNull { mapGraphQlCourse(it) } ?: emptyList()
+        val courseNode = data.course?.onCourse
+            ?: throw IllegalStateException("Course not found: ${params.courseId}")
 
-        val visibleCourses = allCourses
-            .filter { it.isFavorite }
-            .sortedBy { course ->
-                data.allCourses?.find { it._id == course.id.toString() }
-                    ?.dashboardCard?.position ?: Int.MAX_VALUE
-            }
-            .ifEmpty { allCourses }
+        val course = mapGraphQlCourse(courseNode)
+            ?: throw IllegalStateException("Failed to map course: ${params.courseId}")
 
-        val announcementsMap = data.allCourses
-            ?.associate { graphQlCourse ->
-                val courseId = graphQlCourse._id.toLongOrNull() ?: 0L
-                courseId to mapGraphQlAnnouncements(graphQlCourse.announcements)
-            } ?: emptyMap()
+        val announcements = mapGraphQlAnnouncements(courseNode.announcements)
 
-        return Result(
-            visibleCourses = visibleCourses,
-            allCourses = allCourses,
-            announcementsMap = announcementsMap
-        )
+        return Result(course = course, announcements = announcements)
     }
 
-    private fun mapGraphQlCourse(graphQlCourse: DashboardCoursesQuery.AllCourse): Course? {
-        val courseId = graphQlCourse._id.toLongOrNull() ?: return null
+    private fun mapGraphQlCourse(courseNode: DashboardSingleCourseQuery.OnCourse): Course? {
+        val courseId = courseNode._id.toLongOrNull() ?: return null
 
-        val enrollmentNode = graphQlCourse.enrollmentsConnection?.nodes?.firstOrNull()
+        val enrollmentNode = courseNode.enrollmentsConnection?.nodes?.firstOrNull()
         val enrollment = enrollmentNode?.let { node ->
             Enrollment(
                 id = node._id?.toLongOrNull() ?: 0L,
@@ -79,11 +68,11 @@ class LoadVisibleCoursesUseCase @Inject constructor(
 
         return Course(
             id = courseId,
-            name = graphQlCourse.name,
-            courseCode = graphQlCourse.courseCode,
-            imageUrl = graphQlCourse.imageUrl,
-            courseColor = graphQlCourse.dashboardCard?.color,
-            isFavorite = graphQlCourse.dashboardCard?.isFavorited == true,
+            name = courseNode.name,
+            courseCode = courseNode.courseCode,
+            imageUrl = courseNode.imageUrl,
+            courseColor = courseNode.dashboardCard?.color,
+            isFavorite = courseNode.dashboardCard?.isFavorited == true,
             enrollments = enrollment?.let { mutableListOf(it) } ?: mutableListOf()
         )
     }
@@ -100,7 +89,7 @@ class LoadVisibleCoursesUseCase @Inject constructor(
     }
 
     private fun mapGraphQlAnnouncements(
-        announcementsConnection: DashboardCoursesQuery.Announcements?
+        announcementsConnection: DashboardSingleCourseQuery.Announcements?
     ): List<DiscussionTopicHeader> {
         return announcementsConnection?.nodes?.mapNotNull { node ->
             node ?: return@mapNotNull null
@@ -117,12 +106,12 @@ class LoadVisibleCoursesUseCase @Inject constructor(
     }
 
     data class Params(
-        val forceRefresh: Boolean = false
+        val courseId: Long,
+        val forceNetwork: Boolean = true
     )
 
     data class Result(
-        val visibleCourses: List<Course>,
-        val allCourses: List<Course>,
-        val announcementsMap: Map<Long, List<DiscussionTopicHeader>> = emptyMap()
+        val course: Course,
+        val announcements: List<DiscussionTopicHeader>
     )
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/domain/usecase/courses/LoadSingleCourseUseCase.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/domain/usecase/courses/LoadSingleCourseUseCase.kt
@@ -19,7 +19,6 @@ package com.instructure.pandautils.domain.usecase.courses
 import com.instructure.canvasapi2.DashboardSingleCourseQuery
 import com.instructure.canvasapi2.managers.graphql.DashboardCoursesManager
 import com.instructure.canvasapi2.models.Course
-import com.instructure.canvasapi2.models.DiscussionTopicHeader
 import com.instructure.canvasapi2.models.Enrollment
 import com.instructure.canvasapi2.models.Enrollment.EnrollmentType as KotlinEnrollmentType
 import com.instructure.canvasapi2.models.Grades
@@ -29,9 +28,9 @@ import javax.inject.Inject
 
 class LoadSingleCourseUseCase @Inject constructor(
     private val dashboardCoursesManager: DashboardCoursesManager
-) : BaseUseCase<LoadSingleCourseUseCase.Params, LoadSingleCourseUseCase.Result>() {
+) : BaseUseCase<LoadSingleCourseUseCase.Params, Course>() {
 
-    override suspend fun execute(params: Params): Result {
+    override suspend fun execute(params: Params): Course {
         val data = dashboardCoursesManager.getSingleCourse(
             courseId = params.courseId,
             forceNetwork = params.forceNetwork
@@ -40,12 +39,8 @@ class LoadSingleCourseUseCase @Inject constructor(
         val courseNode = data.course?.onCourse
             ?: throw IllegalStateException("Course not found: ${params.courseId}")
 
-        val course = mapGraphQlCourse(courseNode)
+        return mapGraphQlCourse(courseNode)
             ?: throw IllegalStateException("Failed to map course: ${params.courseId}")
-
-        val announcements = mapGraphQlAnnouncements(courseNode.announcements)
-
-        return Result(course = course, announcements = announcements)
     }
 
     private fun mapGraphQlCourse(courseNode: DashboardSingleCourseQuery.OnCourse): Course? {
@@ -88,30 +83,8 @@ class LoadSingleCourseUseCase @Inject constructor(
         }
     }
 
-    private fun mapGraphQlAnnouncements(
-        announcementsConnection: DashboardSingleCourseQuery.Announcements?
-    ): List<DiscussionTopicHeader> {
-        return announcementsConnection?.nodes?.mapNotNull { node ->
-            node ?: return@mapNotNull null
-            if (node.participant?.read == true) return@mapNotNull null
-
-            DiscussionTopicHeader(
-                id = node._id.toLongOrNull() ?: return@mapNotNull null,
-                title = node.title,
-                message = node.message,
-                postedDate = node.postedAt,
-                announcement = true
-            )
-        } ?: emptyList()
-    }
-
     data class Params(
         val courseId: Long,
         val forceNetwork: Boolean = true
-    )
-
-    data class Result(
-        val course: Course,
-        val announcements: List<DiscussionTopicHeader>
     )
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/domain/usecase/courses/LoadVisibleCoursesUseCase.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/domain/usecase/courses/LoadVisibleCoursesUseCase.kt
@@ -29,7 +29,8 @@ import com.instructure.pandautils.domain.usecase.BaseUseCase
 import javax.inject.Inject
 
 class LoadVisibleCoursesUseCase @Inject constructor(
-    private val dashboardCoursesManager: DashboardCoursesManager
+    private val dashboardCoursesManager: DashboardCoursesManager,
+    private val loadDashboardCardsUseCase: LoadDashboardCardsUseCase
 ) : BaseUseCase<LoadVisibleCoursesUseCase.Params, LoadVisibleCoursesUseCase.Result>() {
 
     override suspend fun execute(params: Params): Result {
@@ -38,15 +39,12 @@ class LoadVisibleCoursesUseCase @Inject constructor(
         )
 
         val allCourses = data.allCourses?.mapNotNull { mapGraphQlCourse(it) } ?: emptyList()
+        val dashboardCards = loadDashboardCardsUseCase(LoadDashboardCardsUseCase.Params(params.forceRefresh))
 
-        val visibleCourses = allCourses
-            .filter { course ->
-                data.allCourses?.find { it._id == course.id.toString() }?.dashboardCard != null
-            }
-            .sortedBy { course ->
-                data.allCourses?.find { it._id == course.id.toString() }
-                    ?.dashboardCard?.position ?: Int.MAX_VALUE
-            }
+        val coursesMap = allCourses.associateBy { it.id }
+        val visibleCourses = dashboardCards
+            .mapNotNull { card -> coursesMap[card.id] }
+            .sortedBy { course -> dashboardCards.find { it.id == course.id }?.position ?: Int.MAX_VALUE }
 
         val announcementsMap = buildAnnouncementsMap(data, params.forceRefresh)
 
@@ -65,14 +63,13 @@ class LoadVisibleCoursesUseCase @Inject constructor(
 
         data.allCourses?.forEach { graphQlCourse ->
             val courseId = graphQlCourse._id.toLongOrNull() ?: return@forEach
-            val firstPage = mapGraphQlAnnouncements(graphQlCourse.announcements?.nodes)
             val hasNextPage = graphQlCourse.announcements?.pageInfo?.hasNextPage == true
 
             if (hasNextPage) {
-                val allNodes = dashboardCoursesManager.getCourseAnnouncements(courseId, forceRefresh)
-                announcementsMap[courseId] = mapGraphQlAnnouncements(allNodes)
+                val announcementData = dashboardCoursesManager.getCourseAnnouncements(courseId, forceRefresh)
+                announcementsMap[courseId] = mapCourseAnnouncements(announcementData)
             } else {
-                announcementsMap[courseId] = firstPage
+                announcementsMap[courseId] = mapDashboardAnnouncements(graphQlCourse.announcements?.nodes)
             }
         }
 
@@ -119,42 +116,36 @@ class LoadVisibleCoursesUseCase @Inject constructor(
         }
     }
 
-    private fun <T> mapGraphQlAnnouncements(
-        nodes: List<T?>?
+    private fun mapDashboardAnnouncements(
+        nodes: List<DashboardCoursesQuery.Node1?>?
     ): List<DiscussionTopicHeader> {
         return nodes?.mapNotNull { node ->
             node ?: return@mapNotNull null
-            val id: Long
-            val title: String?
-            val message: String?
-            val postedAt: java.util.Date?
-            val isRead: Boolean
-
-            when (node) {
-                is DashboardCoursesQuery.Node1 -> {
-                    id = node._id.toLongOrNull() ?: return@mapNotNull null
-                    title = node.title
-                    message = node.message
-                    postedAt = node.postedAt
-                    isRead = node.participant?.read == true
-                }
-                is CourseAnnouncementsQuery.Node1 -> {
-                    id = node._id.toLongOrNull() ?: return@mapNotNull null
-                    title = node.title
-                    message = node.message
-                    postedAt = node.postedAt
-                    isRead = node.participant?.read == true
-                }
-                else -> return@mapNotNull null
-            }
-
-            if (isRead) return@mapNotNull null
+            if (node.participant?.read == true) return@mapNotNull null
 
             DiscussionTopicHeader(
-                id = id,
-                title = title,
-                message = message,
-                postedDate = postedAt,
+                id = node._id.toLongOrNull() ?: return@mapNotNull null,
+                title = node.title,
+                message = node.message,
+                postedDate = node.postedAt,
+                announcement = true
+            )
+        } ?: emptyList()
+    }
+
+    private fun mapCourseAnnouncements(
+        announcementData: CourseAnnouncementsQuery.Data
+    ): List<DiscussionTopicHeader> {
+        val nodes = announcementData.course?.onCourse?.announcements?.nodes
+        return nodes?.mapNotNull { node ->
+            node ?: return@mapNotNull null
+            if (node.participant?.read == true) return@mapNotNull null
+
+            DiscussionTopicHeader(
+                id = node._id.toLongOrNull() ?: return@mapNotNull null,
+                title = node.title,
+                message = node.message,
+                postedDate = node.postedAt,
                 announcement = true
             )
         } ?: emptyList()

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/domain/usecase/courses/LoadVisibleCoursesUseCase.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/domain/usecase/courses/LoadVisibleCoursesUseCase.kt
@@ -135,13 +135,16 @@ class LoadVisibleCoursesUseCase @Inject constructor(
     ): List<DiscussionTopicHeader> {
         return nodes?.mapNotNull { node ->
             node ?: return@mapNotNull null
-            if (node.participant?.read == true) return@mapNotNull null
+            val isUnread = node.participant?.read != true
+            val hasUnreadEntries = (node.entryCounts?.unreadCount ?: 0) > 0
+            if (!isUnread && !hasUnreadEntries) return@mapNotNull null
 
             DiscussionTopicHeader(
                 id = node._id.toLongOrNull() ?: return@mapNotNull null,
                 title = node.title,
                 message = node.message,
                 postedDate = node.postedAt,
+                unreadCount = node.entryCounts?.unreadCount ?: 0,
                 announcement = true
             )
         } ?: emptyList()
@@ -153,13 +156,16 @@ class LoadVisibleCoursesUseCase @Inject constructor(
         val nodes = announcementData.course?.onCourse?.announcements?.nodes
         return nodes?.mapNotNull { node ->
             node ?: return@mapNotNull null
-            if (node.participant?.read == true) return@mapNotNull null
+            val isUnread = node.participant?.read != true
+            val hasUnreadEntries = (node.entryCounts?.unreadCount ?: 0) > 0
+            if (!isUnread && !hasUnreadEntries) return@mapNotNull null
 
             DiscussionTopicHeader(
                 id = node._id.toLongOrNull() ?: return@mapNotNull null,
                 title = node.title,
                 message = node.message,
                 postedDate = node.postedAt,
+                unreadCount = node.entryCounts?.unreadCount ?: 0,
                 announcement = true
             )
         } ?: emptyList()

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/domain/usecase/courses/LoadVisibleCoursesUseCase.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/domain/usecase/courses/LoadVisibleCoursesUseCase.kt
@@ -16,6 +16,7 @@
 
 package com.instructure.pandautils.domain.usecase.courses
 
+import com.instructure.canvasapi2.CourseAnnouncementsQuery
 import com.instructure.canvasapi2.DashboardCoursesQuery
 import com.instructure.canvasapi2.managers.graphql.DashboardCoursesManager
 import com.instructure.canvasapi2.models.Course
@@ -39,24 +40,43 @@ class LoadVisibleCoursesUseCase @Inject constructor(
         val allCourses = data.allCourses?.mapNotNull { mapGraphQlCourse(it) } ?: emptyList()
 
         val visibleCourses = allCourses
-            .filter { it.isFavorite }
+            .filter { course ->
+                data.allCourses?.find { it._id == course.id.toString() }?.dashboardCard != null
+            }
             .sortedBy { course ->
                 data.allCourses?.find { it._id == course.id.toString() }
                     ?.dashboardCard?.position ?: Int.MAX_VALUE
             }
-            .ifEmpty { allCourses }
 
-        val announcementsMap = data.allCourses
-            ?.associate { graphQlCourse ->
-                val courseId = graphQlCourse._id.toLongOrNull() ?: 0L
-                courseId to mapGraphQlAnnouncements(graphQlCourse.announcements)
-            } ?: emptyMap()
+        val announcementsMap = buildAnnouncementsMap(data, params.forceRefresh)
 
         return Result(
             visibleCourses = visibleCourses,
             allCourses = allCourses,
             announcementsMap = announcementsMap
         )
+    }
+
+    private suspend fun buildAnnouncementsMap(
+        data: DashboardCoursesQuery.Data,
+        forceRefresh: Boolean
+    ): Map<Long, List<DiscussionTopicHeader>> {
+        val announcementsMap = mutableMapOf<Long, List<DiscussionTopicHeader>>()
+
+        data.allCourses?.forEach { graphQlCourse ->
+            val courseId = graphQlCourse._id.toLongOrNull() ?: return@forEach
+            val firstPage = mapGraphQlAnnouncements(graphQlCourse.announcements?.nodes)
+            val hasNextPage = graphQlCourse.announcements?.pageInfo?.hasNextPage == true
+
+            if (hasNextPage) {
+                val allNodes = dashboardCoursesManager.getCourseAnnouncements(courseId, forceRefresh)
+                announcementsMap[courseId] = mapGraphQlAnnouncements(allNodes)
+            } else {
+                announcementsMap[courseId] = firstPage
+            }
+        }
+
+        return announcementsMap
     }
 
     private fun mapGraphQlCourse(graphQlCourse: DashboardCoursesQuery.AllCourse): Course? {
@@ -99,18 +119,42 @@ class LoadVisibleCoursesUseCase @Inject constructor(
         }
     }
 
-    private fun mapGraphQlAnnouncements(
-        announcementsConnection: DashboardCoursesQuery.Announcements?
+    private fun <T> mapGraphQlAnnouncements(
+        nodes: List<T?>?
     ): List<DiscussionTopicHeader> {
-        return announcementsConnection?.nodes?.mapNotNull { node ->
+        return nodes?.mapNotNull { node ->
             node ?: return@mapNotNull null
-            if (node.participant?.read == true) return@mapNotNull null
+            val id: Long
+            val title: String?
+            val message: String?
+            val postedAt: java.util.Date?
+            val isRead: Boolean
+
+            when (node) {
+                is DashboardCoursesQuery.Node1 -> {
+                    id = node._id.toLongOrNull() ?: return@mapNotNull null
+                    title = node.title
+                    message = node.message
+                    postedAt = node.postedAt
+                    isRead = node.participant?.read == true
+                }
+                is CourseAnnouncementsQuery.Node1 -> {
+                    id = node._id.toLongOrNull() ?: return@mapNotNull null
+                    title = node.title
+                    message = node.message
+                    postedAt = node.postedAt
+                    isRead = node.participant?.read == true
+                }
+                else -> return@mapNotNull null
+            }
+
+            if (isRead) return@mapNotNull null
 
             DiscussionTopicHeader(
-                id = node._id.toLongOrNull() ?: return@mapNotNull null,
-                title = node.title,
-                message = node.message,
-                postedDate = node.postedAt,
+                id = id,
+                title = title,
+                message = message,
+                postedDate = postedAt,
                 announcement = true
             )
         } ?: emptyList()

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/domain/usecase/courses/LoadVisibleCoursesUseCase.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/domain/usecase/courses/LoadVisibleCoursesUseCase.kt
@@ -66,11 +66,14 @@ class LoadVisibleCoursesUseCase @Inject constructor(
             val courseId = graphQlCourse._id.toLongOrNull() ?: return@forEach
             val hasNextPage = graphQlCourse.announcements?.pageInfo?.hasNextPage == true
 
+            val firstPageAnnouncements = mapDashboardAnnouncements(graphQlCourse.announcements?.nodes)
+
             if (hasNextPage) {
-                val announcementData = dashboardCoursesManager.getCourseAnnouncements(courseId, forceRefresh)
-                announcementsMap[courseId] = mapCourseAnnouncements(announcementData)
+                val endCursor = graphQlCourse.announcements?.pageInfo?.endCursor
+                val announcementData = dashboardCoursesManager.getCourseAnnouncements(courseId, endCursor, forceRefresh)
+                announcementsMap[courseId] = firstPageAnnouncements + mapCourseAnnouncements(announcementData)
             } else {
-                announcementsMap[courseId] = mapDashboardAnnouncements(graphQlCourse.announcements?.nodes)
+                announcementsMap[courseId] = firstPageAnnouncements
             }
         }
 

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/domain/usecase/courses/LoadVisibleCoursesUseCase.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/domain/usecase/courses/LoadVisibleCoursesUseCase.kt
@@ -20,6 +20,7 @@ import com.instructure.canvasapi2.CourseAnnouncementsQuery
 import com.instructure.canvasapi2.DashboardCoursesQuery
 import com.instructure.canvasapi2.managers.graphql.DashboardCoursesManager
 import com.instructure.canvasapi2.models.Course
+import com.instructure.canvasapi2.models.DashboardCard
 import com.instructure.canvasapi2.models.DiscussionTopicHeader
 import com.instructure.canvasapi2.models.Enrollment
 import com.instructure.canvasapi2.models.Enrollment.EnrollmentType as KotlinEnrollmentType
@@ -43,7 +44,7 @@ class LoadVisibleCoursesUseCase @Inject constructor(
 
         val coursesMap = allCourses.associateBy { it.id }
         val visibleCourses = dashboardCards
-            .mapNotNull { card -> coursesMap[card.id] }
+            .mapNotNull { card -> applyNickname(coursesMap[card.id], card) }
             .sortedBy { course -> dashboardCards.find { it.id == course.id }?.position ?: Int.MAX_VALUE }
 
         val announcementsMap = buildAnnouncementsMap(data, params.forceRefresh)
@@ -103,6 +104,16 @@ class LoadVisibleCoursesUseCase @Inject constructor(
             isFavorite = graphQlCourse.dashboardCard?.isFavorited == true,
             enrollments = enrollment?.let { mutableListOf(it) } ?: mutableListOf()
         )
+    }
+
+    private fun applyNickname(course: Course?, card: DashboardCard): Course? {
+        course ?: return null
+        val nickname = card.shortName
+        return if (!nickname.isNullOrBlank()) {
+            course.copy(name = nickname, originalName = course.name)
+        } else {
+            course
+        }
     }
 
     private fun mapEnrollmentType(type: EnrollmentType): KotlinEnrollmentType {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/dashboard/widget/courses/CoursesWidgetViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/dashboard/widget/courses/CoursesWidgetViewModel.kt
@@ -436,15 +436,14 @@ class CoursesWidgetViewModel @Inject constructor(
     private fun reloadCourse(courseId: Long) {
         viewModelScope.launch {
             try {
-                val result = loadSingleCourseUseCase(LoadSingleCourseUseCase.Params(courseId))
+                val updatedCourse = loadSingleCourseUseCase(LoadSingleCourseUseCase.Params(courseId))
 
                 visibleCourses = visibleCourses.map { course ->
-                    if (course.id == courseId) result.course else course
+                    if (course.id == courseId) updatedCourse else course
                 }
 
                 val existingAnnouncementsMap = _uiState.value.courses.associate { it.id to it.announcements }
-                val announcementsMap = existingAnnouncementsMap + (courseId to result.announcements)
-                val courseCards = mapCoursesToCardItems(visibleCourses, announcementsMap)
+                val courseCards = mapCoursesToCardItems(visibleCourses, existingAnnouncementsMap)
                 _uiState.update { it.copy(courses = courseCards) }
             } catch (e: Exception) {
                 crashlytics.recordException(e)

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/dashboard/widget/courses/CoursesWidgetViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/dashboard/widget/courses/CoursesWidgetViewModel.kt
@@ -30,11 +30,9 @@ import com.instructure.canvasapi2.models.DashboardPositions
 import com.instructure.canvasapi2.models.DiscussionTopicHeader
 import com.instructure.canvasapi2.models.Group
 import com.instructure.pandautils.data.repository.user.UserRepository
-import com.instructure.pandautils.domain.usecase.announcements.LoadCourseAnnouncementsUseCase
-import com.instructure.pandautils.domain.usecase.courses.LoadCourseUseCase
-import com.instructure.pandautils.domain.usecase.courses.LoadCourseUseCaseParams
 import com.instructure.pandautils.domain.usecase.courses.LoadGroupsParams
 import com.instructure.pandautils.domain.usecase.courses.LoadGroupsUseCase
+import com.instructure.pandautils.domain.usecase.courses.LoadSingleCourseUseCase
 import com.instructure.pandautils.domain.usecase.courses.LoadVisibleCoursesUseCase
 import com.instructure.pandautils.domain.usecase.offline.ObserveOfflineSyncUpdatesUseCase
 import com.instructure.pandautils.features.dashboard.DashboardNavigationEvent
@@ -72,8 +70,7 @@ import javax.inject.Inject
 class CoursesWidgetViewModel @Inject constructor(
     private val loadVisibleCoursesUseCase: LoadVisibleCoursesUseCase,
     private val loadGroupsUseCase: LoadGroupsUseCase,
-    private val loadCourseUseCase: LoadCourseUseCase,
-    private val loadCourseAnnouncementsUseCase: LoadCourseAnnouncementsUseCase,
+    private val loadSingleCourseUseCase: LoadSingleCourseUseCase,
     private val sectionExpandedStateDataStore: SectionExpandedStateDataStore,
     private val courseSyncSettingsDao: CourseSyncSettingsDao,
     private val courseDao: CourseDao,
@@ -261,16 +258,7 @@ class CoursesWidgetViewModel @Inject constructor(
                 val isAnyGroupFavorited = allActiveGroups.any { it.isFavorite }
                 groups = if (isAnyGroupFavorited) allActiveGroups.filter { it.isFavorite } else allActiveGroups
 
-                val announcementsMap = visibleCourses.associate { course ->
-                    course.id to try {
-                        loadCourseAnnouncementsUseCase(LoadCourseAnnouncementsUseCase.Params(course.id, forceRefresh))
-                    } catch (e: Exception) {
-                        crashlytics.recordException(e)
-                        emptyList()
-                    }
-                }
-
-                val courseCards = mapCoursesToCardItems(visibleCourses, announcementsMap)
+                val courseCards = mapCoursesToCardItems(visibleCourses, result.announcementsMap)
                 val groupCards = mapGroupsToCardItems(groups)
 
                 _uiState.update {
@@ -448,20 +436,14 @@ class CoursesWidgetViewModel @Inject constructor(
     private fun reloadCourse(courseId: Long) {
         viewModelScope.launch {
             try {
-                val updatedCourse = loadCourseUseCase(LoadCourseUseCaseParams(courseId, forceNetwork = true))
-                val announcements = try {
-                    loadCourseAnnouncementsUseCase(LoadCourseAnnouncementsUseCase.Params(courseId, forceNetwork = true))
-                } catch (e: Exception) {
-                    crashlytics.recordException(e)
-                    emptyList()
-                }
+                val result = loadSingleCourseUseCase(LoadSingleCourseUseCase.Params(courseId))
 
                 visibleCourses = visibleCourses.map { course ->
-                    if (course.id == courseId) updatedCourse else course
+                    if (course.id == courseId) result.course else course
                 }
 
                 val existingAnnouncementsMap = _uiState.value.courses.associate { it.id to it.announcements }
-                val announcementsMap = existingAnnouncementsMap + (courseId to announcements)
+                val announcementsMap = existingAnnouncementsMap + (courseId to result.announcements)
                 val courseCards = mapCoursesToCardItems(visibleCourses, announcementsMap)
                 _uiState.update { it.copy(courses = courseCards) }
             } catch (e: Exception) {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/dashboard/widget/courses/CoursesWidgetViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/dashboard/widget/courses/CoursesWidgetViewModel.kt
@@ -30,6 +30,7 @@ import com.instructure.canvasapi2.models.DashboardPositions
 import com.instructure.canvasapi2.models.DiscussionTopicHeader
 import com.instructure.canvasapi2.models.Group
 import com.instructure.pandautils.data.repository.user.UserRepository
+import com.instructure.pandautils.domain.usecase.courses.LoadDashboardCardsUseCase
 import com.instructure.pandautils.domain.usecase.courses.LoadGroupsParams
 import com.instructure.pandautils.domain.usecase.courses.LoadGroupsUseCase
 import com.instructure.pandautils.domain.usecase.courses.LoadSingleCourseUseCase
@@ -71,6 +72,7 @@ class CoursesWidgetViewModel @Inject constructor(
     private val loadVisibleCoursesUseCase: LoadVisibleCoursesUseCase,
     private val loadGroupsUseCase: LoadGroupsUseCase,
     private val loadSingleCourseUseCase: LoadSingleCourseUseCase,
+    private val loadDashboardCardsUseCase: LoadDashboardCardsUseCase,
     private val sectionExpandedStateDataStore: SectionExpandedStateDataStore,
     private val courseSyncSettingsDao: CourseSyncSettingsDao,
     private val courseDao: CourseDao,
@@ -436,7 +438,13 @@ class CoursesWidgetViewModel @Inject constructor(
     private fun reloadCourse(courseId: Long) {
         viewModelScope.launch {
             try {
-                val updatedCourse = loadSingleCourseUseCase(LoadSingleCourseUseCase.Params(courseId))
+                var updatedCourse = loadSingleCourseUseCase(LoadSingleCourseUseCase.Params(courseId))
+
+                val dashboardCards = loadDashboardCardsUseCase(LoadDashboardCardsUseCase.Params(forceRefresh = true))
+                val card = dashboardCards.find { it.id == courseId }
+                if (card?.shortName?.isNotBlank() == true) {
+                    updatedCourse = updatedCourse.copy(name = card.shortName!!, originalName = updatedCourse.name)
+                }
 
                 visibleCourses = visibleCourses.map { course ->
                     if (course.id == courseId) updatedCourse else course

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/data/repository/submission/SubmissionRepositoryImplTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/data/repository/submission/SubmissionRepositoryImplTest.kt
@@ -187,30 +187,30 @@ class SubmissionRepositoryImplTest {
     }
 
     @Test
-    fun `getRecentGradedSubmissions skips submissions without assignment`() = runTest {
+    fun `getRecentGradedSubmissions maps multiple submissions correctly`() = runTest {
         val assignment = mockk<RecentGradedSubmissionsQuery.Assignment>(relaxed = true) {
             coEvery { _id } returns "100"
             coEvery { name } returns "Test Assignment"
         }
 
-        val submissionWithAssignment = mockk<RecentGradedSubmissionsQuery.Node>(relaxed = true) {
+        val submission1 = mockk<RecentGradedSubmissionsQuery.Node>(relaxed = true) {
             coEvery { _id } returns "1"
             coEvery { gradeHidden } returns false
             coEvery { this@mockk.assignment } returns assignment
         }
 
-        val submissionWithoutAssignment = mockk<RecentGradedSubmissionsQuery.Node>(relaxed = true) {
+        val submission2 = mockk<RecentGradedSubmissionsQuery.Node>(relaxed = true) {
             coEvery { _id } returns "2"
             coEvery { gradeHidden } returns false
-            coEvery { this@mockk.assignment } returns null
+            coEvery { this@mockk.assignment } returns assignment
         }
 
         val edge1 = mockk<RecentGradedSubmissionsQuery.Edge>(relaxed = true) {
-            coEvery { node } returns submissionWithAssignment
+            coEvery { node } returns submission1
         }
 
         val edge2 = mockk<RecentGradedSubmissionsQuery.Edge>(relaxed = true) {
-            coEvery { node } returns submissionWithoutAssignment
+            coEvery { node } returns submission2
         }
 
         val submissions = mockk<RecentGradedSubmissionsQuery.Submissions>(relaxed = true) {
@@ -233,8 +233,9 @@ class SubmissionRepositoryImplTest {
 
         assertTrue(result is DataResult.Success)
         val successResult = result as DataResult.Success
-        assertEquals(1, successResult.data.size)
+        assertEquals(2, successResult.data.size)
         assertEquals(1L, successResult.data[0].submissionId)
+        assertEquals(2L, successResult.data[1].submissionId)
     }
 
     @Test

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/domain/usecase/courses/LoadSingleCourseUseCaseTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/domain/usecase/courses/LoadSingleCourseUseCaseTest.kt
@@ -27,7 +27,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import java.util.Date
 
 class LoadSingleCourseUseCaseTest {
 
@@ -55,12 +54,12 @@ class LoadSingleCourseUseCaseTest {
 
         val result = useCase(LoadSingleCourseUseCase.Params(courseId = 42))
 
-        assertEquals(42L, result.course.id)
-        assertEquals("Test Course", result.course.name)
-        assertEquals("TC101", result.course.courseCode)
-        assertEquals("https://example.com/img.jpg", result.course.imageUrl)
-        assertEquals("#FF0000", result.course.courseColor)
-        assertTrue(result.course.isFavorite)
+        assertEquals(42L, result.id)
+        assertEquals("Test Course", result.name)
+        assertEquals("TC101", result.courseCode)
+        assertEquals("https://example.com/img.jpg", result.imageUrl)
+        assertEquals("#FF0000", result.courseColor)
+        assertTrue(result.isFavorite)
     }
 
     @Test
@@ -84,56 +83,9 @@ class LoadSingleCourseUseCaseTest {
 
         val result = useCase(LoadSingleCourseUseCase.Params(courseId = 1))
 
-        val enrollment = result.course.enrollments?.first()
+        val enrollment = result.enrollments?.first()
         assertEquals("B+", enrollment?.currentGrade)
         assertEquals(88.0, enrollment?.currentScore)
-    }
-
-    @Test
-    fun `unread announcements are returned`() = runTest {
-        val announcementNode = DashboardSingleCourseQuery.Node1(
-            _id = "10",
-            title = "Important Update",
-            message = "Hello students",
-            postedAt = Date(),
-            participant = DashboardSingleCourseQuery.Participant(read = false)
-        )
-        val announcements = DashboardSingleCourseQuery.Announcements(
-            nodes = listOf(announcementNode)
-        )
-        val data = buildData(
-            onCourse(id = "1", name = "Course", announcements = announcements, dashboardCard = dashboardCard(isFavorited = true))
-        )
-        coEvery { dashboardCoursesManager.getSingleCourse(any(), any()) } returns data
-
-        val result = useCase(LoadSingleCourseUseCase.Params(courseId = 1))
-
-        assertEquals(1, result.announcements.size)
-        assertEquals(10L, result.announcements.first().id)
-        assertEquals("Important Update", result.announcements.first().title)
-        assertTrue(result.announcements.first().announcement)
-    }
-
-    @Test
-    fun `read announcements are filtered out`() = runTest {
-        val readAnnouncement = DashboardSingleCourseQuery.Node1(
-            _id = "10",
-            title = "Old Announcement",
-            message = "Already read",
-            postedAt = Date(),
-            participant = DashboardSingleCourseQuery.Participant(read = true)
-        )
-        val announcements = DashboardSingleCourseQuery.Announcements(
-            nodes = listOf(readAnnouncement)
-        )
-        val data = buildData(
-            onCourse(id = "1", name = "Course", announcements = announcements, dashboardCard = dashboardCard(isFavorited = true))
-        )
-        coEvery { dashboardCoursesManager.getSingleCourse(any(), any()) } returns data
-
-        val result = useCase(LoadSingleCourseUseCase.Params(courseId = 1))
-
-        assertTrue(result.announcements.isEmpty())
     }
 
     @Test(expected = IllegalStateException::class)
@@ -165,8 +117,7 @@ class LoadSingleCourseUseCaseTest {
         courseCode: String? = null,
         imageUrl: String? = null,
         dashboardCard: DashboardSingleCourseQuery.DashboardCard? = null,
-        enrollmentsConnection: DashboardSingleCourseQuery.EnrollmentsConnection? = null,
-        announcements: DashboardSingleCourseQuery.Announcements? = null
+        enrollmentsConnection: DashboardSingleCourseQuery.EnrollmentsConnection? = null
     ): DashboardSingleCourseQuery.OnCourse {
         return DashboardSingleCourseQuery.OnCourse(
             _id = id,
@@ -174,8 +125,7 @@ class LoadSingleCourseUseCaseTest {
             courseCode = courseCode,
             imageUrl = imageUrl,
             dashboardCard = dashboardCard,
-            enrollmentsConnection = enrollmentsConnection,
-            announcements = announcements
+            enrollmentsConnection = enrollmentsConnection
         )
     }
 

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/domain/usecase/courses/LoadSingleCourseUseCaseTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/domain/usecase/courses/LoadSingleCourseUseCaseTest.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+package com.instructure.pandautils.domain.usecase.courses
+
+import com.instructure.canvasapi2.DashboardSingleCourseQuery
+import com.instructure.canvasapi2.managers.graphql.DashboardCoursesManager
+import com.instructure.canvasapi2.type.EnrollmentType
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.Date
+
+class LoadSingleCourseUseCaseTest {
+
+    private val dashboardCoursesManager: DashboardCoursesManager = mockk()
+
+    private lateinit var useCase: LoadSingleCourseUseCase
+
+    @Before
+    fun setup() {
+        useCase = LoadSingleCourseUseCase(dashboardCoursesManager)
+    }
+
+    @Test
+    fun `course fields are mapped correctly`() = runTest {
+        val data = buildData(
+            onCourse(
+                id = "42",
+                name = "Test Course",
+                courseCode = "TC101",
+                imageUrl = "https://example.com/img.jpg",
+                dashboardCard = dashboardCard(isFavorited = true, color = "#FF0000")
+            )
+        )
+        coEvery { dashboardCoursesManager.getSingleCourse(any(), any()) } returns data
+
+        val result = useCase(LoadSingleCourseUseCase.Params(courseId = 42))
+
+        assertEquals(42L, result.course.id)
+        assertEquals("Test Course", result.course.name)
+        assertEquals("TC101", result.course.courseCode)
+        assertEquals("https://example.com/img.jpg", result.course.imageUrl)
+        assertEquals("#FF0000", result.course.courseColor)
+        assertTrue(result.course.isFavorite)
+    }
+
+    @Test
+    fun `enrollment grades are mapped correctly`() = runTest {
+        val grades = DashboardSingleCourseQuery.Grades(currentGrade = "B+", currentScore = 88.0)
+        val enrollmentNode = DashboardSingleCourseQuery.Node(
+            _id = "100",
+            type = EnrollmentType.StudentEnrollment,
+            grades = grades
+        )
+        val enrollmentsConnection = DashboardSingleCourseQuery.EnrollmentsConnection(nodes = listOf(enrollmentNode))
+        val data = buildData(
+            onCourse(
+                id = "1",
+                name = "Course",
+                enrollmentsConnection = enrollmentsConnection,
+                dashboardCard = dashboardCard(isFavorited = true)
+            )
+        )
+        coEvery { dashboardCoursesManager.getSingleCourse(any(), any()) } returns data
+
+        val result = useCase(LoadSingleCourseUseCase.Params(courseId = 1))
+
+        val enrollment = result.course.enrollments?.first()
+        assertEquals("B+", enrollment?.currentGrade)
+        assertEquals(88.0, enrollment?.currentScore)
+    }
+
+    @Test
+    fun `unread announcements are returned`() = runTest {
+        val announcementNode = DashboardSingleCourseQuery.Node1(
+            _id = "10",
+            title = "Important Update",
+            message = "Hello students",
+            postedAt = Date(),
+            participant = DashboardSingleCourseQuery.Participant(read = false)
+        )
+        val announcements = DashboardSingleCourseQuery.Announcements(
+            nodes = listOf(announcementNode)
+        )
+        val data = buildData(
+            onCourse(id = "1", name = "Course", announcements = announcements, dashboardCard = dashboardCard(isFavorited = true))
+        )
+        coEvery { dashboardCoursesManager.getSingleCourse(any(), any()) } returns data
+
+        val result = useCase(LoadSingleCourseUseCase.Params(courseId = 1))
+
+        assertEquals(1, result.announcements.size)
+        assertEquals(10L, result.announcements.first().id)
+        assertEquals("Important Update", result.announcements.first().title)
+        assertTrue(result.announcements.first().announcement)
+    }
+
+    @Test
+    fun `read announcements are filtered out`() = runTest {
+        val readAnnouncement = DashboardSingleCourseQuery.Node1(
+            _id = "10",
+            title = "Old Announcement",
+            message = "Already read",
+            postedAt = Date(),
+            participant = DashboardSingleCourseQuery.Participant(read = true)
+        )
+        val announcements = DashboardSingleCourseQuery.Announcements(
+            nodes = listOf(readAnnouncement)
+        )
+        val data = buildData(
+            onCourse(id = "1", name = "Course", announcements = announcements, dashboardCard = dashboardCard(isFavorited = true))
+        )
+        coEvery { dashboardCoursesManager.getSingleCourse(any(), any()) } returns data
+
+        val result = useCase(LoadSingleCourseUseCase.Params(courseId = 1))
+
+        assertTrue(result.announcements.isEmpty())
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `throws when course not found`() = runTest {
+        val data = DashboardSingleCourseQuery.Data(course = null)
+        coEvery { dashboardCoursesManager.getSingleCourse(any(), any()) } returns data
+
+        useCase(LoadSingleCourseUseCase.Params(courseId = 999))
+    }
+
+    @Test
+    fun `forceNetwork is propagated to manager`() = runTest {
+        val data = buildData(onCourse(id = "1", name = "Course", dashboardCard = dashboardCard(isFavorited = true)))
+        coEvery { dashboardCoursesManager.getSingleCourse(any(), any()) } returns data
+
+        useCase(LoadSingleCourseUseCase.Params(courseId = 1, forceNetwork = true))
+
+        coVerify { dashboardCoursesManager.getSingleCourse(courseId = 1L, forceNetwork = true) }
+    }
+
+    private fun buildData(onCourse: DashboardSingleCourseQuery.OnCourse): DashboardSingleCourseQuery.Data {
+        val course = DashboardSingleCourseQuery.Course(__typename = "Course", onCourse = onCourse)
+        return DashboardSingleCourseQuery.Data(course = course)
+    }
+
+    private fun onCourse(
+        id: String,
+        name: String,
+        courseCode: String? = null,
+        imageUrl: String? = null,
+        dashboardCard: DashboardSingleCourseQuery.DashboardCard? = null,
+        enrollmentsConnection: DashboardSingleCourseQuery.EnrollmentsConnection? = null,
+        announcements: DashboardSingleCourseQuery.Announcements? = null
+    ): DashboardSingleCourseQuery.OnCourse {
+        return DashboardSingleCourseQuery.OnCourse(
+            _id = id,
+            name = name,
+            courseCode = courseCode,
+            imageUrl = imageUrl,
+            dashboardCard = dashboardCard,
+            enrollmentsConnection = enrollmentsConnection,
+            announcements = announcements
+        )
+    }
+
+    private fun dashboardCard(
+        isFavorited: Boolean = false,
+        position: Int? = null,
+        color: String? = null
+    ): DashboardSingleCourseQuery.DashboardCard {
+        return DashboardSingleCourseQuery.DashboardCard(
+            isFavorited = isFavorited,
+            position = position,
+            color = color,
+            image = null
+        )
+    }
+}

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/domain/usecase/courses/LoadVisibleCoursesUseCaseTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/domain/usecase/courses/LoadVisibleCoursesUseCaseTest.kt
@@ -155,7 +155,8 @@ class LoadVisibleCoursesUseCaseTest {
             title = "Important Update",
             message = "Hello students",
             postedAt = Date(),
-            participant = DashboardCoursesQuery.Participant(read = false)
+            participant = DashboardCoursesQuery.Participant(read = false),
+            entryCounts = DashboardCoursesQuery.EntryCounts(unreadCount = 0)
         )
         val announcements = DashboardCoursesQuery.Announcements(
             pageInfo = DashboardCoursesQuery.PageInfo(hasNextPage = false, endCursor = null),
@@ -181,13 +182,45 @@ class LoadVisibleCoursesUseCaseTest {
     }
 
     @Test
-    fun `read announcements are filtered out`() = runTest {
+    fun `read announcement with unread entries is included`() = runTest {
+        val readAnnouncementWithEntries = DashboardCoursesQuery.Node1(
+            _id = "10",
+            title = "Announcement with replies",
+            message = "Check the replies",
+            postedAt = Date(),
+            participant = DashboardCoursesQuery.Participant(read = true),
+            entryCounts = DashboardCoursesQuery.EntryCounts(unreadCount = 3)
+        )
+        val announcements = DashboardCoursesQuery.Announcements(
+            pageInfo = DashboardCoursesQuery.PageInfo(hasNextPage = false, endCursor = null),
+            nodes = listOf(readAnnouncementWithEntries)
+        )
+        val data = buildQueryData(
+            allCourse(
+                id = "1",
+                name = "Course",
+                announcements = announcements,
+                dashboardCard = dashboardCard(position = 0)
+            )
+        )
+        coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
+
+        val result = useCase(LoadVisibleCoursesUseCase.Params())
+
+        val courseAnnouncements = result.announcementsMap[1L]
+        assertEquals(1, courseAnnouncements?.size)
+        assertEquals(3, courseAnnouncements?.first()?.unreadCount)
+    }
+
+    @Test
+    fun `fully read announcements with no unread entries are filtered out`() = runTest {
         val readAnnouncement = DashboardCoursesQuery.Node1(
             _id = "10",
             title = "Old Announcement",
             message = "Already read",
             postedAt = Date(),
-            participant = DashboardCoursesQuery.Participant(read = true)
+            participant = DashboardCoursesQuery.Participant(read = true),
+            entryCounts = DashboardCoursesQuery.EntryCounts(unreadCount = 0)
         )
         val announcements = DashboardCoursesQuery.Announcements(
             pageInfo = DashboardCoursesQuery.PageInfo(hasNextPage = false, endCursor = null),
@@ -216,7 +249,8 @@ class LoadVisibleCoursesUseCaseTest {
             title = "First Page",
             message = "msg",
             postedAt = Date(),
-            participant = DashboardCoursesQuery.Participant(read = false)
+            participant = DashboardCoursesQuery.Participant(read = false),
+            entryCounts = DashboardCoursesQuery.EntryCounts(unreadCount = 0)
         )
         val announcements = DashboardCoursesQuery.Announcements(
             pageInfo = DashboardCoursesQuery.PageInfo(hasNextPage = true, endCursor = "cursor1"),
@@ -226,11 +260,11 @@ class LoadVisibleCoursesUseCaseTest {
             allCourse(id = "1", name = "Course", announcements = announcements, dashboardCard = dashboardCard(position = 0))
         )
         coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
-        coEvery { dashboardCoursesManager.getCourseAnnouncements(1L, any()) } returns CourseAnnouncementsQuery.Data(course = null)
+        coEvery { dashboardCoursesManager.getCourseAnnouncements(any(), any(), any()) } returns CourseAnnouncementsQuery.Data(course = null)
 
         useCase(LoadVisibleCoursesUseCase.Params())
 
-        coVerify { dashboardCoursesManager.getCourseAnnouncements(1L, any()) }
+        coVerify { dashboardCoursesManager.getCourseAnnouncements(1L, "cursor1", any()) }
     }
 
     @Test

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/domain/usecase/courses/LoadVisibleCoursesUseCaseTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/domain/usecase/courses/LoadVisibleCoursesUseCaseTest.kt
@@ -16,134 +16,239 @@
 
 package com.instructure.pandautils.domain.usecase.courses
 
-import com.instructure.canvasapi2.models.Course
-import com.instructure.canvasapi2.models.DashboardCard
+import com.instructure.canvasapi2.DashboardCoursesQuery
+import com.instructure.canvasapi2.managers.graphql.DashboardCoursesManager
+import com.instructure.canvasapi2.type.EnrollmentType
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.util.Date
 
 class LoadVisibleCoursesUseCaseTest {
 
-    private val loadAllCoursesUseCase: LoadAllCoursesUseCase = mockk()
-    private val loadDashboardCardsUseCase: LoadDashboardCardsUseCase = mockk()
+    private val dashboardCoursesManager: DashboardCoursesManager = mockk()
 
     private lateinit var useCase: LoadVisibleCoursesUseCase
 
     @Before
     fun setup() {
-        useCase = LoadVisibleCoursesUseCase(loadAllCoursesUseCase, loadDashboardCardsUseCase)
+        useCase = LoadVisibleCoursesUseCase(dashboardCoursesManager)
     }
 
     @Test
-    fun `Courses matched by dashboard cards are sorted by card position`() = runTest {
-        val courses = listOf(
-            Course(id = 1, name = "Course A"),
-            Course(id = 2, name = "Course B"),
-            Course(id = 3, name = "Course C")
+    fun `favorited courses become visible courses sorted by position`() = runTest {
+        val data = buildQueryData(
+            allCourse("1", "Course A", dashboardCard = dashboardCard(isFavorited = true, position = 2)),
+            allCourse("2", "Course B", dashboardCard = dashboardCard(isFavorited = true, position = 0)),
+            allCourse("3", "Course C", dashboardCard = dashboardCard(isFavorited = true, position = 1))
         )
-        val dashboardCards = listOf(
-            DashboardCard(id = 3, position = 0),
-            DashboardCard(id = 1, position = 1),
-            DashboardCard(id = 2, position = 2)
-        )
-        coEvery { loadAllCoursesUseCase(any()) } returns courses
-        coEvery { loadDashboardCardsUseCase(any()) } returns dashboardCards
+        coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
 
         val result = useCase(LoadVisibleCoursesUseCase.Params())
 
-        assertEquals(listOf(3L, 1L, 2L), result.visibleCourses.map { it.id })
-        assertEquals("Course C", result.visibleCourses[0].name)
-        assertEquals("Course A", result.visibleCourses[1].name)
-        assertEquals("Course B", result.visibleCourses[2].name)
+        assertEquals(listOf(2L, 3L, 1L), result.visibleCourses.map { it.id })
     }
 
     @Test
-    fun `Fabricated Course is created for dashboard cards without matching course data`() = runTest {
-        val courses = listOf(Course(id = 1, name = "Course A"))
-        val dashboardCards = listOf(
-            DashboardCard(id = 1, position = 0),
-            DashboardCard(id = 99, shortName = "Unsynced", originalName = "Unsynced Course", courseCode = "UC101", position = 1)
+    fun `all courses returned when none are favorited`() = runTest {
+        val data = buildQueryData(
+            allCourse("1", "Course A", dashboardCard = null),
+            allCourse("2", "Course B", dashboardCard = null)
         )
-        coEvery { loadAllCoursesUseCase(any()) } returns courses
-        coEvery { loadDashboardCardsUseCase(any()) } returns dashboardCards
+        coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
 
         val result = useCase(LoadVisibleCoursesUseCase.Params())
 
         assertEquals(2, result.visibleCourses.size)
-        val fabricated = result.visibleCourses[1]
-        assertEquals(99L, fabricated.id)
-        assertEquals("Unsynced", fabricated.name)
-        assertEquals("Unsynced Course", fabricated.originalName)
-        assertEquals("UC101", fabricated.courseCode)
+        assertEquals(2, result.allCourses.size)
     }
 
     @Test
-    fun `Fabricated Course uses originalName when shortName is null`() = runTest {
-        val dashboardCards = listOf(
-            DashboardCard(id = 1, shortName = null, originalName = "Original Name", position = 0)
+    fun `allCourses includes non-favorited courses`() = runTest {
+        val data = buildQueryData(
+            allCourse("1", "Visible", dashboardCard = dashboardCard(isFavorited = true, position = 0)),
+            allCourse("2", "Not favorited", dashboardCard = dashboardCard(isFavorited = false, position = 1))
         )
-        coEvery { loadAllCoursesUseCase(any()) } returns emptyList()
-        coEvery { loadDashboardCardsUseCase(any()) } returns dashboardCards
-
-        val result = useCase(LoadVisibleCoursesUseCase.Params())
-
-        assertEquals("Original Name", result.visibleCourses[0].name)
-    }
-
-    @Test
-    fun `Fabricated Course uses empty string when both shortName and originalName are null`() = runTest {
-        val dashboardCards = listOf(
-            DashboardCard(id = 1, shortName = null, originalName = null, position = 0)
-        )
-        coEvery { loadAllCoursesUseCase(any()) } returns emptyList()
-        coEvery { loadDashboardCardsUseCase(any()) } returns dashboardCards
-
-        val result = useCase(LoadVisibleCoursesUseCase.Params())
-
-        assertEquals("", result.visibleCourses[0].name)
-    }
-
-    @Test
-    fun `Empty dashboard cards returns empty visible courses`() = runTest {
-        val courses = listOf(Course(id = 1, name = "Course A"))
-        coEvery { loadAllCoursesUseCase(any()) } returns courses
-        coEvery { loadDashboardCardsUseCase(any()) } returns emptyList()
-
-        val result = useCase(LoadVisibleCoursesUseCase.Params())
-
-        assertEquals(emptyList<Course>(), result.visibleCourses)
-        assertEquals(courses, result.allCourses)
-    }
-
-    @Test
-    fun `allCourses includes courses not on the dashboard`() = runTest {
-        val courses = listOf(
-            Course(id = 1, name = "Visible"),
-            Course(id = 2, name = "Not on dashboard")
-        )
-        val dashboardCards = listOf(DashboardCard(id = 1, position = 0))
-        coEvery { loadAllCoursesUseCase(any()) } returns courses
-        coEvery { loadDashboardCardsUseCase(any()) } returns dashboardCards
+        coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
 
         val result = useCase(LoadVisibleCoursesUseCase.Params())
 
         assertEquals(1, result.visibleCourses.size)
         assertEquals(2, result.allCourses.size)
-        assertEquals(listOf(1L, 2L), result.allCourses.map { it.id })
     }
 
     @Test
-    fun `forceRefresh is propagated to underlying use cases`() = runTest {
-        coEvery { loadAllCoursesUseCase(any()) } returns emptyList()
-        coEvery { loadDashboardCardsUseCase(any()) } returns emptyList()
+    fun `course fields are mapped correctly`() = runTest {
+        val data = buildQueryData(
+            allCourse(
+                id = "42",
+                name = "Test Course",
+                courseCode = "TC101",
+                imageUrl = "https://example.com/img.jpg",
+                dashboardCard = dashboardCard(isFavorited = true, position = 0, color = "#FF0000")
+            )
+        )
+        coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
+
+        val result = useCase(LoadVisibleCoursesUseCase.Params())
+
+        val course = result.visibleCourses[0]
+        assertEquals(42L, course.id)
+        assertEquals("Test Course", course.name)
+        assertEquals("TC101", course.courseCode)
+        assertEquals("https://example.com/img.jpg", course.imageUrl)
+        assertEquals("#FF0000", course.courseColor)
+        assertTrue(course.isFavorite)
+    }
+
+    @Test
+    fun `enrollment grades are mapped correctly`() = runTest {
+        val grades = DashboardCoursesQuery.Grades(currentGrade = "A-", currentScore = 92.5)
+        val enrollmentNode = DashboardCoursesQuery.Node(
+            _id = "100",
+            type = EnrollmentType.StudentEnrollment,
+            grades = grades
+        )
+        val enrollmentsConnection = DashboardCoursesQuery.EnrollmentsConnection(nodes = listOf(enrollmentNode))
+        val data = buildQueryData(
+            allCourse(
+                id = "1",
+                name = "Course",
+                enrollmentsConnection = enrollmentsConnection,
+                dashboardCard = dashboardCard(isFavorited = true, position = 0)
+            )
+        )
+        coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
+
+        val result = useCase(LoadVisibleCoursesUseCase.Params())
+
+        val enrollment = result.visibleCourses[0].enrollments?.first()
+        assertEquals("A-", enrollment?.currentGrade)
+        assertEquals(92.5, enrollment?.currentScore)
+    }
+
+    @Test
+    fun `unread announcements are included in announcementsMap`() = runTest {
+        val announcementNode = DashboardCoursesQuery.Node1(
+            _id = "10",
+            title = "Important Update",
+            message = "Hello students",
+            postedAt = Date(),
+            participant = DashboardCoursesQuery.Participant(read = false)
+        )
+        val announcements = DashboardCoursesQuery.Announcements(
+                pageInfo = DashboardCoursesQuery.PageInfo(hasNextPage = false, endCursor = null),
+                nodes = listOf(announcementNode)
+            )
+        val data = buildQueryData(
+            allCourse(
+                id = "1",
+                name = "Course",
+                announcements = announcements,
+                dashboardCard = dashboardCard(isFavorited = true, position = 0)
+            )
+        )
+        coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
+
+        val result = useCase(LoadVisibleCoursesUseCase.Params())
+
+        val courseAnnouncements = result.announcementsMap[1L]
+        assertEquals(1, courseAnnouncements?.size)
+        assertEquals(10L, courseAnnouncements?.first()?.id)
+        assertEquals("Important Update", courseAnnouncements?.first()?.title)
+        assertTrue(courseAnnouncements?.first()?.announcement == true)
+    }
+
+    @Test
+    fun `read announcements are filtered out`() = runTest {
+        val readAnnouncement = DashboardCoursesQuery.Node1(
+            _id = "10",
+            title = "Old Announcement",
+            message = "Already read",
+            postedAt = Date(),
+            participant = DashboardCoursesQuery.Participant(read = true)
+        )
+        val announcements = DashboardCoursesQuery.Announcements(
+                pageInfo = DashboardCoursesQuery.PageInfo(hasNextPage = false, endCursor = null),
+                nodes = listOf(readAnnouncement)
+            )
+        val data = buildQueryData(
+            allCourse(
+                id = "1",
+                name = "Course",
+                announcements = announcements,
+                dashboardCard = dashboardCard(isFavorited = true, position = 0)
+            )
+        )
+        coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
+
+        val result = useCase(LoadVisibleCoursesUseCase.Params())
+
+        val courseAnnouncements = result.announcementsMap[1L]
+        assertTrue(courseAnnouncements.isNullOrEmpty())
+    }
+
+    @Test
+    fun `forceRefresh is propagated to manager`() = runTest {
+        val data = buildQueryData()
+        coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
 
         useCase(LoadVisibleCoursesUseCase.Params(forceRefresh = true))
 
-        coVerify { loadAllCoursesUseCase(LoadAllCoursesUseCase.Params(forceRefresh = true)) }
-        coVerify { loadDashboardCardsUseCase(LoadDashboardCardsUseCase.Params(forceRefresh = true)) }
+        coVerify { dashboardCoursesManager.getDashboardCourses(forceNetwork = true) }
+    }
+
+    @Test
+    fun `empty allCourses response returns empty result`() = runTest {
+        val data = DashboardCoursesQuery.Data(allCourses = emptyList())
+        coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
+
+        val result = useCase(LoadVisibleCoursesUseCase.Params())
+
+        assertTrue(result.visibleCourses.isEmpty())
+        assertTrue(result.allCourses.isEmpty())
+        assertTrue(result.announcementsMap.isEmpty())
+    }
+
+    private fun buildQueryData(vararg courses: DashboardCoursesQuery.AllCourse): DashboardCoursesQuery.Data {
+        return DashboardCoursesQuery.Data(allCourses = courses.toList())
+    }
+
+    private fun allCourse(
+        id: String,
+        name: String,
+        courseCode: String? = null,
+        imageUrl: String? = null,
+        dashboardCard: DashboardCoursesQuery.DashboardCard? = null,
+        enrollmentsConnection: DashboardCoursesQuery.EnrollmentsConnection? = null,
+        announcements: DashboardCoursesQuery.Announcements? = null
+    ): DashboardCoursesQuery.AllCourse {
+        return DashboardCoursesQuery.AllCourse(
+            _id = id,
+            name = name,
+            courseCode = courseCode,
+            imageUrl = imageUrl,
+            dashboardCard = dashboardCard,
+            enrollmentsConnection = enrollmentsConnection,
+            announcements = announcements
+        )
+    }
+
+    private fun dashboardCard(
+        isFavorited: Boolean = false,
+        position: Int? = null,
+        color: String? = null
+    ): DashboardCoursesQuery.DashboardCard {
+        return DashboardCoursesQuery.DashboardCard(
+            isFavorited = isFavorited,
+            position = position,
+            color = color,
+            image = null
+        )
     }
 }

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/domain/usecase/courses/LoadVisibleCoursesUseCaseTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/domain/usecase/courses/LoadVisibleCoursesUseCaseTest.kt
@@ -41,11 +41,11 @@ class LoadVisibleCoursesUseCaseTest {
     }
 
     @Test
-    fun `favorited courses become visible courses sorted by position`() = runTest {
+    fun `visible courses are those with dashboardCard sorted by position`() = runTest {
         val data = buildQueryData(
-            allCourse("1", "Course A", dashboardCard = dashboardCard(isFavorited = true, position = 2)),
-            allCourse("2", "Course B", dashboardCard = dashboardCard(isFavorited = true, position = 0)),
-            allCourse("3", "Course C", dashboardCard = dashboardCard(isFavorited = true, position = 1))
+            allCourse("1", "Course A", dashboardCard = dashboardCard(position = 2)),
+            allCourse("2", "Course B", dashboardCard = dashboardCard(position = 0)),
+            allCourse("3", "Course C", dashboardCard = dashboardCard(position = 1))
         )
         coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
 
@@ -55,31 +55,33 @@ class LoadVisibleCoursesUseCaseTest {
     }
 
     @Test
-    fun `all courses returned when none are favorited`() = runTest {
+    fun `courses without dashboardCard are not visible`() = runTest {
         val data = buildQueryData(
-            allCourse("1", "Course A", dashboardCard = null),
-            allCourse("2", "Course B", dashboardCard = null)
-        )
-        coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
-
-        val result = useCase(LoadVisibleCoursesUseCase.Params())
-
-        assertEquals(2, result.visibleCourses.size)
-        assertEquals(2, result.allCourses.size)
-    }
-
-    @Test
-    fun `allCourses includes non-favorited courses`() = runTest {
-        val data = buildQueryData(
-            allCourse("1", "Visible", dashboardCard = dashboardCard(isFavorited = true, position = 0)),
-            allCourse("2", "Not favorited", dashboardCard = dashboardCard(isFavorited = false, position = 1))
+            allCourse("1", "On Dashboard", dashboardCard = dashboardCard(position = 0)),
+            allCourse("2", "Not on Dashboard", dashboardCard = null)
         )
         coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
 
         val result = useCase(LoadVisibleCoursesUseCase.Params())
 
         assertEquals(1, result.visibleCourses.size)
+        assertEquals(1L, result.visibleCourses[0].id)
         assertEquals(2, result.allCourses.size)
+    }
+
+    @Test
+    fun `allCourses includes all courses regardless of dashboardCard`() = runTest {
+        val data = buildQueryData(
+            allCourse("1", "Visible", dashboardCard = dashboardCard(position = 0)),
+            allCourse("2", "Also Visible", dashboardCard = dashboardCard(position = 1)),
+            allCourse("3", "Hidden", dashboardCard = null)
+        )
+        coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
+
+        val result = useCase(LoadVisibleCoursesUseCase.Params())
+
+        assertEquals(2, result.visibleCourses.size)
+        assertEquals(3, result.allCourses.size)
     }
 
     @Test
@@ -120,7 +122,7 @@ class LoadVisibleCoursesUseCaseTest {
                 id = "1",
                 name = "Course",
                 enrollmentsConnection = enrollmentsConnection,
-                dashboardCard = dashboardCard(isFavorited = true, position = 0)
+                dashboardCard = dashboardCard(position = 0)
             )
         )
         coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
@@ -142,15 +144,15 @@ class LoadVisibleCoursesUseCaseTest {
             participant = DashboardCoursesQuery.Participant(read = false)
         )
         val announcements = DashboardCoursesQuery.Announcements(
-                pageInfo = DashboardCoursesQuery.PageInfo(hasNextPage = false, endCursor = null),
-                nodes = listOf(announcementNode)
-            )
+            pageInfo = DashboardCoursesQuery.PageInfo(hasNextPage = false, endCursor = null),
+            nodes = listOf(announcementNode)
+        )
         val data = buildQueryData(
             allCourse(
                 id = "1",
                 name = "Course",
                 announcements = announcements,
-                dashboardCard = dashboardCard(isFavorited = true, position = 0)
+                dashboardCard = dashboardCard(position = 0)
             )
         )
         coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
@@ -174,15 +176,15 @@ class LoadVisibleCoursesUseCaseTest {
             participant = DashboardCoursesQuery.Participant(read = true)
         )
         val announcements = DashboardCoursesQuery.Announcements(
-                pageInfo = DashboardCoursesQuery.PageInfo(hasNextPage = false, endCursor = null),
-                nodes = listOf(readAnnouncement)
-            )
+            pageInfo = DashboardCoursesQuery.PageInfo(hasNextPage = false, endCursor = null),
+            nodes = listOf(readAnnouncement)
+        )
         val data = buildQueryData(
             allCourse(
                 id = "1",
                 name = "Course",
                 announcements = announcements,
-                dashboardCard = dashboardCard(isFavorited = true, position = 0)
+                dashboardCard = dashboardCard(position = 0)
             )
         )
         coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
@@ -191,6 +193,46 @@ class LoadVisibleCoursesUseCaseTest {
 
         val courseAnnouncements = result.announcementsMap[1L]
         assertTrue(courseAnnouncements.isNullOrEmpty())
+    }
+
+    @Test
+    fun `announcements are depaginated per course when hasNextPage is true`() = runTest {
+        val firstPageNode = DashboardCoursesQuery.Node1(
+            _id = "10",
+            title = "First Page",
+            message = "msg",
+            postedAt = Date(),
+            participant = DashboardCoursesQuery.Participant(read = false)
+        )
+        val announcements = DashboardCoursesQuery.Announcements(
+            pageInfo = DashboardCoursesQuery.PageInfo(hasNextPage = true, endCursor = "cursor1"),
+            nodes = listOf(firstPageNode)
+        )
+        val data = buildQueryData(
+            allCourse(id = "1", name = "Course", announcements = announcements, dashboardCard = dashboardCard(position = 0))
+        )
+        coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
+        coEvery { dashboardCoursesManager.getCourseAnnouncements(1L, any()) } returns emptyList()
+
+        useCase(LoadVisibleCoursesUseCase.Params())
+
+        coVerify { dashboardCoursesManager.getCourseAnnouncements(1L, any()) }
+    }
+
+    @Test
+    fun `announcements are not depaginated when hasNextPage is false`() = runTest {
+        val announcements = DashboardCoursesQuery.Announcements(
+            pageInfo = DashboardCoursesQuery.PageInfo(hasNextPage = false, endCursor = null),
+            nodes = emptyList()
+        )
+        val data = buildQueryData(
+            allCourse(id = "1", name = "Course", announcements = announcements, dashboardCard = dashboardCard(position = 0))
+        )
+        coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
+
+        useCase(LoadVisibleCoursesUseCase.Params())
+
+        coVerify(exactly = 0) { dashboardCoursesManager.getCourseAnnouncements(any(), any()) }
     }
 
     @Test

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/domain/usecase/courses/LoadVisibleCoursesUseCaseTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/domain/usecase/courses/LoadVisibleCoursesUseCaseTest.kt
@@ -16,8 +16,10 @@
 
 package com.instructure.pandautils.domain.usecase.courses
 
+import com.instructure.canvasapi2.CourseAnnouncementsQuery
 import com.instructure.canvasapi2.DashboardCoursesQuery
 import com.instructure.canvasapi2.managers.graphql.DashboardCoursesManager
+import com.instructure.canvasapi2.models.DashboardCard
 import com.instructure.canvasapi2.type.EnrollmentType
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -32,35 +34,45 @@ import java.util.Date
 class LoadVisibleCoursesUseCaseTest {
 
     private val dashboardCoursesManager: DashboardCoursesManager = mockk()
+    private val loadDashboardCardsUseCase: LoadDashboardCardsUseCase = mockk()
 
     private lateinit var useCase: LoadVisibleCoursesUseCase
 
     @Before
     fun setup() {
-        useCase = LoadVisibleCoursesUseCase(dashboardCoursesManager)
+        coEvery { loadDashboardCardsUseCase(any()) } returns emptyList()
+        useCase = LoadVisibleCoursesUseCase(dashboardCoursesManager, loadDashboardCardsUseCase)
     }
 
     @Test
-    fun `visible courses are those with dashboardCard sorted by position`() = runTest {
+    fun `visible courses match dashboard cards sorted by position`() = runTest {
         val data = buildQueryData(
-            allCourse("1", "Course A", dashboardCard = dashboardCard(position = 2)),
-            allCourse("2", "Course B", dashboardCard = dashboardCard(position = 0)),
-            allCourse("3", "Course C", dashboardCard = dashboardCard(position = 1))
+            allCourse("1", "Course A"),
+            allCourse("2", "Course B"),
+            allCourse("3", "Course C")
         )
         coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
+        coEvery { loadDashboardCardsUseCase(any()) } returns listOf(
+            DashboardCard(id = 3, position = 0),
+            DashboardCard(id = 1, position = 1),
+            DashboardCard(id = 2, position = 2)
+        )
 
         val result = useCase(LoadVisibleCoursesUseCase.Params())
 
-        assertEquals(listOf(2L, 3L, 1L), result.visibleCourses.map { it.id })
+        assertEquals(listOf(3L, 1L, 2L), result.visibleCourses.map { it.id })
     }
 
     @Test
-    fun `courses without dashboardCard are not visible`() = runTest {
+    fun `only dashboard card courses are visible`() = runTest {
         val data = buildQueryData(
-            allCourse("1", "On Dashboard", dashboardCard = dashboardCard(position = 0)),
-            allCourse("2", "Not on Dashboard", dashboardCard = null)
+            allCourse("1", "On Dashboard"),
+            allCourse("2", "Not on Dashboard")
         )
         coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
+        coEvery { loadDashboardCardsUseCase(any()) } returns listOf(
+            DashboardCard(id = 1, position = 0)
+        )
 
         val result = useCase(LoadVisibleCoursesUseCase.Params())
 
@@ -70,18 +82,18 @@ class LoadVisibleCoursesUseCaseTest {
     }
 
     @Test
-    fun `allCourses includes all courses regardless of dashboardCard`() = runTest {
+    fun `empty dashboard cards returns empty visible courses`() = runTest {
         val data = buildQueryData(
-            allCourse("1", "Visible", dashboardCard = dashboardCard(position = 0)),
-            allCourse("2", "Also Visible", dashboardCard = dashboardCard(position = 1)),
-            allCourse("3", "Hidden", dashboardCard = null)
+            allCourse("1", "Course A"),
+            allCourse("2", "Course B")
         )
         coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
+        coEvery { loadDashboardCardsUseCase(any()) } returns emptyList()
 
         val result = useCase(LoadVisibleCoursesUseCase.Params())
 
-        assertEquals(2, result.visibleCourses.size)
-        assertEquals(3, result.allCourses.size)
+        assertTrue(result.visibleCourses.isEmpty())
+        assertEquals(2, result.allCourses.size)
     }
 
     @Test
@@ -96,6 +108,7 @@ class LoadVisibleCoursesUseCaseTest {
             )
         )
         coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
+        coEvery { loadDashboardCardsUseCase(any()) } returns listOf(DashboardCard(id = 42, position = 0))
 
         val result = useCase(LoadVisibleCoursesUseCase.Params())
 
@@ -126,6 +139,7 @@ class LoadVisibleCoursesUseCaseTest {
             )
         )
         coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
+        coEvery { loadDashboardCardsUseCase(any()) } returns listOf(DashboardCard(id = 1, position = 0))
 
         val result = useCase(LoadVisibleCoursesUseCase.Params())
 
@@ -212,7 +226,7 @@ class LoadVisibleCoursesUseCaseTest {
             allCourse(id = "1", name = "Course", announcements = announcements, dashboardCard = dashboardCard(position = 0))
         )
         coEvery { dashboardCoursesManager.getDashboardCourses(any()) } returns data
-        coEvery { dashboardCoursesManager.getCourseAnnouncements(1L, any()) } returns emptyList()
+        coEvery { dashboardCoursesManager.getCourseAnnouncements(1L, any()) } returns CourseAnnouncementsQuery.Data(course = null)
 
         useCase(LoadVisibleCoursesUseCase.Params())
 

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/dashboard/widget/courses/CoursesWidgetViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/dashboard/widget/courses/CoursesWidgetViewModelTest.kt
@@ -24,12 +24,14 @@ import androidx.lifecycle.MutableLiveData
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.instructure.canvasapi2.models.Course
+import com.instructure.canvasapi2.models.DashboardCard
 import com.instructure.canvasapi2.models.DiscussionTopicHeader
 import com.instructure.canvasapi2.models.Enrollment
 import com.instructure.canvasapi2.models.Group
 import com.instructure.pandautils.data.repository.user.UserRepository
 import com.instructure.pandautils.domain.usecase.courses.LoadGroupsParams
 import com.instructure.pandautils.domain.usecase.courses.LoadGroupsUseCase
+import com.instructure.pandautils.domain.usecase.courses.LoadDashboardCardsUseCase
 import com.instructure.pandautils.domain.usecase.courses.LoadSingleCourseUseCase
 import com.instructure.pandautils.domain.usecase.courses.LoadVisibleCoursesUseCase
 import com.instructure.pandautils.domain.usecase.offline.ObserveOfflineSyncUpdatesUseCase
@@ -84,6 +86,7 @@ class CoursesWidgetViewModelTest {
     private val loadVisibleCoursesUseCase: LoadVisibleCoursesUseCase = mockk()
     private val loadGroupsUseCase: LoadGroupsUseCase = mockk()
     private val loadSingleCourseUseCase: LoadSingleCourseUseCase = mockk()
+    private val loadDashboardCardsUseCase: LoadDashboardCardsUseCase = mockk()
     private val sectionExpandedStateDataStore: SectionExpandedStateDataStore = mockk(relaxed = true)
     private val courseSyncSettingsDao: CourseSyncSettingsDao = mockk()
     private val courseDao: CourseDao = mockk()
@@ -126,6 +129,7 @@ class CoursesWidgetViewModelTest {
     private fun setupDefaultMocks() {
         coEvery { loadVisibleCoursesUseCase(any()) } returns visibleCoursesResult()
         coEvery { loadGroupsUseCase(any()) } returns emptyList()
+        coEvery { loadDashboardCardsUseCase(any()) } returns emptyList()
         every { sectionExpandedStateDataStore.observeCoursesExpanded() } returns flowOf(true)
         every { sectionExpandedStateDataStore.observeGroupsExpanded() } returns flowOf(true)
         every { observeWidgetConfigUseCase(any<String>()) } returns flowOf(
@@ -781,9 +785,6 @@ class CoursesWidgetViewModelTest {
             Course(id = 2, name = "Course 2", isFavorite = true)
         )
         val updatedCourse = Course(id = 1, name = "Updated Course 1", isFavorite = true)
-        val announcements = listOf(
-            mockk<DiscussionTopicHeader>(relaxed = true)
-        )
 
         coEvery { loadVisibleCoursesUseCase(any()) } returns visibleCoursesResult(initialCourses)
         coEvery { loadSingleCourseUseCase(any()) } returns updatedCourse
@@ -854,7 +855,7 @@ class CoursesWidgetViewModelTest {
     }
 
     @Test
-    fun `reloadCourse updates course with no announcements`() {
+    fun `reloadCourse preserves existing announcements`() {
         setupDefaultMocks()
         val initialCourses = listOf(
             Course(id = 1, name = "Course 1", isFavorite = true)
@@ -877,6 +878,34 @@ class CoursesWidgetViewModelTest {
         val state = viewModel.uiState.value
         assertEquals("Updated Course 1", state.courses.find { it.id == 1L }?.name)
         assertEquals(0, state.courses.find { it.id == 1L }?.announcements?.size)
+    }
+
+    @Test
+    fun `reloadCourse applies nickname from dashboard card`() {
+        setupDefaultMocks()
+        val initialCourses = listOf(
+            Course(id = 1, name = "Original Name", isFavorite = true)
+        )
+        val updatedCourse = Course(id = 1, name = "Original Name", isFavorite = true)
+
+        coEvery { loadVisibleCoursesUseCase(any()) } returns visibleCoursesResult(initialCourses)
+        coEvery { loadSingleCourseUseCase(any()) } returns updatedCourse
+        coEvery { loadDashboardCardsUseCase(any()) } returns listOf(
+            DashboardCard(id = 1, shortName = "My Nickname", position = 0)
+        )
+
+        viewModel = createViewModel()
+
+        val receiverSlot = slot<BroadcastReceiver>()
+        verify { localBroadcastManager.registerReceiver(capture(receiverSlot), any()) }
+
+        val intent: Intent = mockk(relaxed = true)
+        every { intent.getLongExtra(Const.COURSE_ID, -1L) } returns 1L
+
+        receiverSlot.captured.onReceive(mockk(), intent)
+
+        val state = viewModel.uiState.value
+        assertEquals("My Nickname", state.courses.find { it.id == 1L }?.name)
     }
 
     @Test
@@ -1156,6 +1185,7 @@ class CoursesWidgetViewModelTest {
             loadVisibleCoursesUseCase = loadVisibleCoursesUseCase,
             loadGroupsUseCase = loadGroupsUseCase,
             loadSingleCourseUseCase = loadSingleCourseUseCase,
+            loadDashboardCardsUseCase = loadDashboardCardsUseCase,
             sectionExpandedStateDataStore = sectionExpandedStateDataStore,
             courseSyncSettingsDao = courseSyncSettingsDao,
             courseDao = courseDao,

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/dashboard/widget/courses/CoursesWidgetViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/dashboard/widget/courses/CoursesWidgetViewModelTest.kt
@@ -24,13 +24,13 @@ import androidx.lifecycle.MutableLiveData
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.instructure.canvasapi2.models.Course
+import com.instructure.canvasapi2.models.DiscussionTopicHeader
 import com.instructure.canvasapi2.models.Enrollment
 import com.instructure.canvasapi2.models.Group
 import com.instructure.pandautils.data.repository.user.UserRepository
-import com.instructure.pandautils.domain.usecase.announcements.LoadCourseAnnouncementsUseCase
-import com.instructure.pandautils.domain.usecase.courses.LoadCourseUseCase
 import com.instructure.pandautils.domain.usecase.courses.LoadGroupsParams
 import com.instructure.pandautils.domain.usecase.courses.LoadGroupsUseCase
+import com.instructure.pandautils.domain.usecase.courses.LoadSingleCourseUseCase
 import com.instructure.pandautils.domain.usecase.courses.LoadVisibleCoursesUseCase
 import com.instructure.pandautils.domain.usecase.offline.ObserveOfflineSyncUpdatesUseCase
 import com.instructure.pandautils.features.dashboard.DashboardNavigationEvent
@@ -83,8 +83,7 @@ class CoursesWidgetViewModelTest {
     private val testDispatcher = UnconfinedTestDispatcher()
     private val loadVisibleCoursesUseCase: LoadVisibleCoursesUseCase = mockk()
     private val loadGroupsUseCase: LoadGroupsUseCase = mockk()
-    private val loadCourseUseCase: LoadCourseUseCase = mockk()
-    private val loadCourseAnnouncementsUseCase: LoadCourseAnnouncementsUseCase = mockk()
+    private val loadSingleCourseUseCase: LoadSingleCourseUseCase = mockk()
     private val sectionExpandedStateDataStore: SectionExpandedStateDataStore = mockk(relaxed = true)
     private val courseSyncSettingsDao: CourseSyncSettingsDao = mockk()
     private val courseDao: CourseDao = mockk()
@@ -105,6 +104,7 @@ class CoursesWidgetViewModelTest {
         mockkObject(ColorKeeper)
         every { ColorKeeper.getOrGenerateColor(any<Course>()) } returns ThemedColor(0xFF0000, 0xFF0000)
         every { ColorKeeper.getOrGenerateColor(any<Group>()) } returns ThemedColor(0x00FF00, 0x00FF00)
+        every { ColorKeeper.createThemedColor(any()) } returns ThemedColor(0xFF0000, 0xFF0000)
     }
 
     @After
@@ -115,13 +115,17 @@ class CoursesWidgetViewModelTest {
 
     private fun visibleCoursesResult(
         visibleCourses: List<Course> = emptyList(),
-        allCourses: List<Course> = visibleCourses
-    ) = LoadVisibleCoursesUseCase.Result(visibleCourses = visibleCourses, allCourses = allCourses)
+        allCourses: List<Course> = visibleCourses,
+        announcementsMap: Map<Long, List<DiscussionTopicHeader>> = emptyMap()
+    ) = LoadVisibleCoursesUseCase.Result(
+        visibleCourses = visibleCourses,
+        allCourses = allCourses,
+        announcementsMap = announcementsMap
+    )
 
     private fun setupDefaultMocks() {
         coEvery { loadVisibleCoursesUseCase(any()) } returns visibleCoursesResult()
         coEvery { loadGroupsUseCase(any()) } returns emptyList()
-        coEvery { loadCourseAnnouncementsUseCase(any()) } returns emptyList()
         every { sectionExpandedStateDataStore.observeCoursesExpanded() } returns flowOf(true)
         every { sectionExpandedStateDataStore.observeGroupsExpanded() } returns flowOf(true)
         every { observeWidgetConfigUseCase(any<String>()) } returns flowOf(
@@ -414,7 +418,6 @@ class CoursesWidgetViewModelTest {
         )
         coEvery { loadVisibleCoursesUseCase(any()) } returns visibleCoursesResult(listOf(parentCourse))
         coEvery { loadGroupsUseCase(any()) } returns groups
-        coEvery { loadCourseUseCase(any()) } returns parentCourse
 
         viewModel = createViewModel()
 
@@ -619,24 +622,25 @@ class CoursesWidgetViewModelTest {
     }
 
     @Test
-    fun `init loads announcements for each course`() {
+    fun `init loads announcements from graphql result`() {
         setupDefaultMocks()
         val courses = listOf(
             Course(id = 1, name = "Course 1", isFavorite = true),
             Course(id = 2, name = "Course 2", isFavorite = true)
         )
         val announcements1 = listOf(
-            mockk<com.instructure.canvasapi2.models.DiscussionTopicHeader>(relaxed = true)
+            mockk<DiscussionTopicHeader>(relaxed = true)
         )
         val announcements2 = listOf(
-            mockk<com.instructure.canvasapi2.models.DiscussionTopicHeader>(relaxed = true),
-            mockk<com.instructure.canvasapi2.models.DiscussionTopicHeader>(relaxed = true)
+            mockk<DiscussionTopicHeader>(relaxed = true),
+            mockk<DiscussionTopicHeader>(relaxed = true)
         )
+        val announcementsMap = mapOf(1L to announcements1, 2L to announcements2)
 
-        coEvery { loadVisibleCoursesUseCase(any()) } returns visibleCoursesResult(courses)
-        coEvery { loadCourseAnnouncementsUseCase(any()) } returns emptyList()
-        coEvery { loadCourseAnnouncementsUseCase(match { it.courseId == 1L }) } returns announcements1
-        coEvery { loadCourseAnnouncementsUseCase(match { it.courseId == 2L }) } returns announcements2
+        coEvery { loadVisibleCoursesUseCase(any()) } returns visibleCoursesResult(
+            courses,
+            announcementsMap = announcementsMap
+        )
 
         viewModel = createViewModel()
 
@@ -646,17 +650,14 @@ class CoursesWidgetViewModelTest {
     }
 
     @Test
-    fun `init handles announcement loading failure gracefully`() {
+    fun `init shows empty announcements when none are unread`() {
         setupDefaultMocks()
         val courses = listOf(
             Course(id = 1, name = "Course 1", isFavorite = true),
             Course(id = 2, name = "Course 2", isFavorite = true)
         )
-        val exception = Exception("Failed to load announcements")
 
         coEvery { loadVisibleCoursesUseCase(any()) } returns visibleCoursesResult(courses)
-        coEvery { loadCourseAnnouncementsUseCase(match { it.courseId == 1L }) } throws exception
-        coEvery { loadCourseAnnouncementsUseCase(match { it.courseId == 2L }) } returns emptyList()
 
         viewModel = createViewModel()
 
@@ -664,7 +665,6 @@ class CoursesWidgetViewModelTest {
         assertFalse(state.isError)
         assertEquals(0, state.courses[0].announcements.size)
         assertEquals(0, state.courses[1].announcements.size)
-        verify { crashlytics.recordException(exception) }
     }
 
     @Test
@@ -673,11 +673,13 @@ class CoursesWidgetViewModelTest {
         val courses = listOf(
             Course(id = 1, name = "Course 1", isFavorite = true)
         )
-        val announcement = mockk<com.instructure.canvasapi2.models.DiscussionTopicHeader>(relaxed = true)
+        val announcement = mockk<DiscussionTopicHeader>(relaxed = true)
         val announcements = listOf(announcement)
 
-        coEvery { loadVisibleCoursesUseCase(any()) } returns visibleCoursesResult(courses)
-        coEvery { loadCourseAnnouncementsUseCase(any()) } returns announcements
+        coEvery { loadVisibleCoursesUseCase(any()) } returns visibleCoursesResult(
+            courses,
+            announcementsMap = mapOf(1L to announcements)
+        )
 
         viewModel = createViewModel()
 
@@ -780,12 +782,14 @@ class CoursesWidgetViewModelTest {
         )
         val updatedCourse = Course(id = 1, name = "Updated Course 1", isFavorite = true)
         val announcements = listOf(
-            mockk<com.instructure.canvasapi2.models.DiscussionTopicHeader>(relaxed = true)
+            mockk<DiscussionTopicHeader>(relaxed = true)
         )
 
         coEvery { loadVisibleCoursesUseCase(any()) } returns visibleCoursesResult(initialCourses)
-        coEvery { loadCourseUseCase(any()) } returns updatedCourse
-        coEvery { loadCourseAnnouncementsUseCase(any()) } returns announcements
+        coEvery { loadSingleCourseUseCase(any()) } returns LoadSingleCourseUseCase.Result(
+            course = updatedCourse,
+            announcements = announcements
+        )
 
         viewModel = createViewModel()
 
@@ -797,8 +801,7 @@ class CoursesWidgetViewModelTest {
 
         receiverSlot.captured.onReceive(mockk(), intent)
 
-        coVerify(exactly = 1) { loadCourseUseCase(match { it.courseId == 1L && it.forceNetwork }) }
-        coVerify(exactly = 1) { loadCourseAnnouncementsUseCase(match { it.courseId == 1L && it.forceNetwork }) }
+        coVerify(exactly = 1) { loadSingleCourseUseCase(match { it.courseId == 1L }) }
 
         val state = viewModel.uiState.value
         assertEquals("Updated Course 1", state.courses.find { it.id == 1L }?.name)
@@ -830,17 +833,42 @@ class CoursesWidgetViewModelTest {
     }
 
     @Test
-    fun `reloadCourse handles announcement loading failure`() {
+    fun `reloadCourse handles failure gracefully`() {
+        setupDefaultMocks()
+        val initialCourses = listOf(
+            Course(id = 1, name = "Course 1", isFavorite = true)
+        )
+        val exception = Exception("Failed to reload course")
+
+        coEvery { loadVisibleCoursesUseCase(any()) } returns visibleCoursesResult(initialCourses)
+        coEvery { loadSingleCourseUseCase(any()) } throws exception
+
+        viewModel = createViewModel()
+
+        val receiverSlot = slot<BroadcastReceiver>()
+        verify { localBroadcastManager.registerReceiver(capture(receiverSlot), any()) }
+
+        val intent: Intent = mockk(relaxed = true)
+        every { intent.getLongExtra(Const.COURSE_ID, -1L) } returns 1L
+
+        receiverSlot.captured.onReceive(mockk(), intent)
+
+        verify { crashlytics.recordException(exception) }
+    }
+
+    @Test
+    fun `reloadCourse updates course with no announcements`() {
         setupDefaultMocks()
         val initialCourses = listOf(
             Course(id = 1, name = "Course 1", isFavorite = true)
         )
         val updatedCourse = Course(id = 1, name = "Updated Course 1", isFavorite = true)
-        val exception = Exception("Failed to load announcements")
 
         coEvery { loadVisibleCoursesUseCase(any()) } returns visibleCoursesResult(initialCourses)
-        coEvery { loadCourseUseCase(any()) } returns updatedCourse
-        coEvery { loadCourseAnnouncementsUseCase(any()) } throws exception
+        coEvery { loadSingleCourseUseCase(any()) } returns LoadSingleCourseUseCase.Result(
+            course = updatedCourse,
+            announcements = emptyList()
+        )
 
         viewModel = createViewModel()
 
@@ -852,34 +880,9 @@ class CoursesWidgetViewModelTest {
 
         receiverSlot.captured.onReceive(mockk(), intent)
 
-        verify { crashlytics.recordException(exception) }
         val state = viewModel.uiState.value
         assertEquals("Updated Course 1", state.courses.find { it.id == 1L }?.name)
         assertEquals(0, state.courses.find { it.id == 1L }?.announcements?.size)
-    }
-
-    @Test
-    fun `reloadCourse handles course loading failure gracefully`() {
-        setupDefaultMocks()
-        val initialCourses = listOf(
-            Course(id = 1, name = "Course 1", isFavorite = true)
-        )
-        val exception = Exception("Failed to load course")
-
-        coEvery { loadVisibleCoursesUseCase(any()) } returns visibleCoursesResult(initialCourses)
-        coEvery { loadCourseUseCase(any()) } throws exception
-
-        viewModel = createViewModel()
-
-        val receiverSlot = slot<BroadcastReceiver>()
-        verify { localBroadcastManager.registerReceiver(capture(receiverSlot), any()) }
-
-        val intent: Intent = mockk(relaxed = true)
-        every { intent.getLongExtra(Const.COURSE_ID, -1L) } returns 1L
-
-        receiverSlot.captured.onReceive(mockk(), intent)
-
-        verify { crashlytics.recordException(exception) }
     }
 
     @Test
@@ -1158,8 +1161,7 @@ class CoursesWidgetViewModelTest {
         return CoursesWidgetViewModel(
             loadVisibleCoursesUseCase = loadVisibleCoursesUseCase,
             loadGroupsUseCase = loadGroupsUseCase,
-            loadCourseUseCase = loadCourseUseCase,
-            loadCourseAnnouncementsUseCase = loadCourseAnnouncementsUseCase,
+            loadSingleCourseUseCase = loadSingleCourseUseCase,
             sectionExpandedStateDataStore = sectionExpandedStateDataStore,
             courseSyncSettingsDao = courseSyncSettingsDao,
             courseDao = courseDao,

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/dashboard/widget/courses/CoursesWidgetViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/dashboard/widget/courses/CoursesWidgetViewModelTest.kt
@@ -786,10 +786,7 @@ class CoursesWidgetViewModelTest {
         )
 
         coEvery { loadVisibleCoursesUseCase(any()) } returns visibleCoursesResult(initialCourses)
-        coEvery { loadSingleCourseUseCase(any()) } returns LoadSingleCourseUseCase.Result(
-            course = updatedCourse,
-            announcements = announcements
-        )
+        coEvery { loadSingleCourseUseCase(any()) } returns updatedCourse
 
         viewModel = createViewModel()
 
@@ -865,10 +862,7 @@ class CoursesWidgetViewModelTest {
         val updatedCourse = Course(id = 1, name = "Updated Course 1", isFavorite = true)
 
         coEvery { loadVisibleCoursesUseCase(any()) } returns visibleCoursesResult(initialCourses)
-        coEvery { loadSingleCourseUseCase(any()) } returns LoadSingleCourseUseCase.Result(
-            course = updatedCourse,
-            announcements = emptyList()
-        )
+        coEvery { loadSingleCourseUseCase(any()) } returns updatedCourse
 
         viewModel = createViewModel()
 

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/speedgrader/content/SpeedGraderContentViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/speedgrader/content/SpeedGraderContentViewModelTest.kt
@@ -623,7 +623,7 @@ class SpeedGraderContentViewModelTest {
             shortName = "TU",
             sortableName = "Test User"
         ),
-        assignment: SubmissionFields.Assignment? = this.assignment,
+        assignment: SubmissionFields.Assignment = this.assignment,
         attachments: List<SubmissionFields.Attachment> = emptyList(),
         submittedAt: Date? = Date(
             LocalDateTime

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/speedgrader/grade/comments/SpeedGraderCommentsViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/speedgrader/grade/comments/SpeedGraderCommentsViewModelTest.kt
@@ -152,7 +152,7 @@ class SpeedGraderCommentsViewModelTest {
                     draft = false,
                     attempt = 1,
                     read = true,
-                    attachments = null,
+                    attachments = emptyList(),
                     mediaCommentId = null
                 )
             )
@@ -188,7 +188,7 @@ class SpeedGraderCommentsViewModelTest {
                     draft = false,
                     attempt = 1,
                     read = true,
-                    attachments = null,
+                    attachments = emptyList(),
                     mediaCommentId = null
                 )
             )
@@ -338,7 +338,7 @@ class SpeedGraderCommentsViewModelTest {
                     draft = false,
                     attempt = 0,
                     read = true,
-                    attachments = null,
+                    attachments = emptyList(),
                     mediaCommentId = null
                 )
             )
@@ -374,7 +374,7 @@ class SpeedGraderCommentsViewModelTest {
                     draft = false,
                     attempt = 0,
                     read = true,
-                    attachments = null,
+                    attachments = emptyList(),
                     mediaCommentId = null
                 )
             )


### PR DESCRIPTION
## Test plan

1. Open Student app, navigate to new Dashboard
2. Verify courses load with correct names, images, colors, and grades
3. Verify unread announcement badges appear on course cards
4. Tap an announcement badge — verify navigation to announcement or announcement list
5. Favorite/unfavorite a course, verify dashboard updates
6. Force-refresh (pull to refresh) and verify data reloads
7. Edit a course (change name/color), return to dashboard — verify single-course reload works
8. Measure load time — target is under 2 seconds (was N+2 sequential REST calls, now 1 GraphQL query)

refs: MBL-19958

affects: Student

## Release note

Improved dashboard course widget loading performance by migrating to GraphQL, reducing multiple sequential network requests to a single query.

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] Test in landscape mode and/or tablet
- [ ] A11y checked
- [ ] Approve from product