### PR TITLE
[MBL-19898][Parent] Fix Assignment Details content overlapping navigation bar in tablet landscape

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/assignments/details/AssignmentDetailsFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/assignments/details/AssignmentDetailsFragment.kt
@@ -356,14 +356,7 @@ class AssignmentDetailsFragment : BaseCanvasFragment(), FragmentInteractions, Bo
             scrollContent?.let {
                 ViewCompat.setOnApplyWindowInsetsListener(it) { view, windowInsets ->
                     val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
-                    val configuration = resources.configuration
-                    val isPortrait = configuration.orientation == android.content.res.Configuration.ORIENTATION_PORTRAIT
-
-                    if (isPortrait) {
-                        view.setPadding(view.paddingLeft, view.paddingTop, view.paddingRight, insets.bottom)
-                    } else {
-                        view.setPadding(view.paddingLeft, view.paddingTop, view.paddingRight, 0)
-                    }
+                    view.setPadding(view.paddingLeft, view.paddingTop, view.paddingRight, insets.bottom)
                     windowInsets
                 }
                 ViewCompat.requestApplyInsets(scrollContent)


### PR DESCRIPTION
Test plan:
1. Open Parent app on a tablet device
2. Navigate to a student's course assignments
3. Open any assignment details
4. Rotate the tablet to landscape mode
5. Scroll to the bottom of the assignment details content
6. Verify that the content does not overlap with the Android navigation bar

refs: MBL-19898
affects: Parent
release note: Fixed assignment details content overlapping with the navigation bar on tablets in landscape mode

- [x] Follow-up e2e test ticket created or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] Test in landscape mode and/or tablet
- [x] A11y checked
- [x] Approve from product

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>