### PR TITLE
[MBL-19920][Student] Auto-refresh Forecast widget on submission upload

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/dashboard/widget/forecast/ForecastWidgetViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/dashboard/widget/forecast/ForecastWidgetViewModel.kt
@@ -19,6 +19,8 @@ package com.instructure.pandautils.features.dashboard.widget.forecast
 import android.content.res.Resources
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.AssignmentGroup
@@ -45,8 +47,8 @@ import com.instructure.pandautils.features.dashboard.widget.usecase.ObserveGloba
 import com.instructure.pandautils.utils.ColorKeeper
 import com.instructure.pandautils.utils.getAssignmentIcon
 import com.instructure.pandautils.utils.getIconForPlannerItem
-import com.instructure.pandautils.utils.getUrl
 import com.instructure.pandautils.utils.getSystemFirstDayOfWeek
+import com.instructure.pandautils.utils.getUrl
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
@@ -66,6 +68,7 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.TemporalAdjusters
 import java.time.temporal.WeekFields
 import java.util.Locale
+import java.util.UUID
 import javax.inject.Inject
 
 @HiltViewModel
@@ -79,7 +82,8 @@ class ForecastWidgetViewModel @Inject constructor(
     private val assignmentWeightCalculator: AssignmentWeightCalculator,
     private val apiPrefs: ApiPrefs,
     private val crashlytics: FirebaseCrashlytics,
-    private val resources: Resources
+    private val resources: Resources,
+    private val workManager: WorkManager
 ) : ViewModel() {
 
     private var missingAssignments: List<Assignment> = emptyList()
@@ -111,7 +115,8 @@ class ForecastWidgetViewModel @Inject constructor(
         _uiState.update { it.copy(weekPeriod = initialWeekPeriod, isCurrentWeek = true) }
 
         observeConfig()
-        loadData(forceRefresh = false)
+        loadData()
+        observeSubmissions()
     }
 
     private fun navigatePrevious() {
@@ -197,6 +202,22 @@ class ForecastWidgetViewModel @Inject constructor(
                 .collect { config ->
                     val themedColor = ColorKeeper.createThemedColor(config.backgroundColor)
                     _uiState.update { it.copy(backgroundColor = themedColor) }
+                }
+        }
+    }
+
+    private fun observeSubmissions() {
+        val processedWorkIds = mutableSetOf<UUID>()
+        viewModelScope.launch {
+            workManager.getWorkInfosByTagFlow("SubmissionWorker")
+                .collect { workInfos ->
+                    val newlySucceeded = workInfos.filter {
+                        it.state == WorkInfo.State.SUCCEEDED && it.id !in processedWorkIds
+                    }
+                    if (newlySucceeded.isNotEmpty()) {
+                        newlySucceeded.forEach { processedWorkIds.add(it.id) }
+                        loadData(forceRefresh = true)
+                    }
                 }
         }
     }

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/dashboard/widget/forecast/ForecastWidgetViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/dashboard/widget/forecast/ForecastWidgetViewModelTest.kt
@@ -17,6 +17,8 @@
 package com.instructure.pandautils.features.dashboard.widget.forecast
 
 import android.content.res.Resources
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.PlannerItem
@@ -54,6 +56,7 @@ import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -67,6 +70,7 @@ import org.junit.Before
 import org.junit.Test
 import java.time.LocalDate
 import java.util.Calendar
+import java.util.UUID
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ForecastWidgetViewModelTest {
@@ -81,6 +85,8 @@ class ForecastWidgetViewModelTest {
     private val apiPrefs: ApiPrefs = mockk(relaxed = true)
     private val crashlytics: FirebaseCrashlytics = mockk(relaxed = true)
     private val resources: Resources = mockk(relaxed = true)
+    private val workManager: WorkManager = mockk(relaxed = true)
+    private val workInfosFlow = MutableStateFlow<List<WorkInfo>>(emptyList())
     private val testDispatcher = UnconfinedTestDispatcher()
 
     private lateinit var viewModel: ForecastWidgetViewModel
@@ -105,6 +111,8 @@ class ForecastWidgetViewModelTest {
         // Mock getSystemLocaleCalendar to return a simple Calendar instance for testing
         mockkStatic(::getSystemLocaleCalendar)
         every { getSystemLocaleCalendar() } returns Calendar.getInstance()
+
+        every { workManager.getWorkInfosByTagFlow(any()) } returns workInfosFlow
     }
 
     @After
@@ -125,7 +133,8 @@ class ForecastWidgetViewModelTest {
             assignmentWeightCalculator = assignmentWeightCalculator,
             apiPrefs = apiPrefs,
             crashlytics = crashlytics,
-            resources = resources
+            resources = resources,
+            workManager = workManager
         )
     }
 
@@ -600,5 +609,41 @@ class ForecastWidgetViewModelTest {
         val assignments = viewModel.uiState.value.dueAssignments
         assertEquals(1, assignments.size)
         assertEquals(SubmissionStateLabel.None, assignments[0].submissionStateLabel)
+    }
+
+    @Test
+    fun `completed submission work triggers data reload with forceRefresh`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val succeededWorkInfo = mockk<WorkInfo>(relaxed = true) {
+            every { id } returns UUID.randomUUID()
+            every { state } returns WorkInfo.State.SUCCEEDED
+        }
+        workInfosFlow.value = listOf(succeededWorkInfo)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { loadRecentGradeChangesUseCase(match { it.forceRefresh }) }
+    }
+
+    @Test
+    fun `already processed submission work does not trigger duplicate reload`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val workId = UUID.randomUUID()
+        val succeededWorkInfo = mockk<WorkInfo>(relaxed = true) {
+            every { id } returns workId
+            every { state } returns WorkInfo.State.SUCCEEDED
+        }
+
+        workInfosFlow.value = listOf(succeededWorkInfo)
+        advanceUntilIdle()
+
+        // Re-emit the same work item — should not trigger another reload
+        workInfosFlow.value = listOf(succeededWorkInfo)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { loadRecentGradeChangesUseCase(match { it.forceRefresh }) }
     }
 }


### PR DESCRIPTION
Test plan:
1. Open the Student app and navigate to the Dashboard
2. Ensure the Forecast widget is visible with the New Grades tab
3. Submit an assignment (any submission type)
4. Without manually refreshing, verify the Forecast widget automatically updates and shows the newly graded submission under New Grades once the teacher grades it

refs: MBL-19920
affects: Student
release note: The Forecast widget on the Dashboard now automatically refreshes when a student uploads a submission, so newly graded work appears without requiring a manual refresh.

- [x] Follow-up e2e test ticket created or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] Test in landscape mode and/or tablet
- [ ] A11y checked
- [ ] Approve from product