### PR TITLE
[MBL-19918][All] Fix transparent status bar on Calendar filters screen

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/filter/CalendarFilterFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendar/filter/CalendarFilterFragment.kt
@@ -2,6 +2,8 @@ package com.instructure.pandautils.features.calendar.filter
 
 import android.content.DialogInterface
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -53,8 +55,11 @@ class CalendarFilterFragment : BaseCanvasBottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        // Set status bar icons to light (white) for visibility over the dialog
-        WindowInsetsHelper.setStatusBarAppearance(requireActivity().window, isLightStatusBar = false)
+        // Due to the messed up navigation stack in the Student app some screens under this on config change can override the color of the statusbar,
+        // so we need to add a delay to make sure this gets called last.
+        Handler(Looper.getMainLooper()).postDelayed({
+            WindowInsetsHelper.setStatusBarAppearance(requireActivity().window, isLightStatusBar = false)
+        }, 100)
         setFullScreen()
     }
 


### PR DESCRIPTION
Test plan:
1. Open the Calendar tab in Student, Teacher, or Parent app on a device running Android 15+.
2. Tap the filter icon to open the Calendar filters bottom sheet.
3. Verify the system status bar icons (clock, battery, signal) are visible on the themed background.
4. Rotate the device while the filters sheet is open and verify the icons remain visible.
5. Repeat in light mode and dark mode.

refs: MBL-19918
affects: Student, Teacher, Parent
release note: Fixed an issue where the system status bar icons were not visible on the Calendar filters screen.

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] Test in landscape mode and/or tablet
- [x] A11y checked
- [x] Approve from product

🤖 Generated with [Claude Code](https://claude.com/claude-code)