### PR TITLE
[MBL-19923][Student] Fix status bar icon color on Inbox Compose, Edit ToDo, and other screens

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/AnnotationComments/AnnotationCommentListFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/AnnotationComments/AnnotationCommentListFragment.kt
@@ -149,7 +149,7 @@ class AnnotationCommentListFragment : ParentFragment() {
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
-        ViewStyler.setStatusBarLightDelayed(requireActivity())
+        ViewStyler.themeStatusBarDelayed(requireActivity())
     }
 
     fun configureRecyclerView() {

--- a/apps/student/src/main/java/com/instructure/student/fragment/EditPageDetailsFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/EditPageDetailsFragment.kt
@@ -90,7 +90,7 @@ class EditPageDetailsFragment : ParentFragment() {
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
-        ViewStyler.setStatusBarLightDelayed(requireActivity())
+        ViewStyler.themeStatusBarDelayed(requireActivity())
     }
 
     //region Fragment Lifecycle Overrides

--- a/apps/student/src/main/java/com/instructure/student/fragment/ViewImageFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/ViewImageFragment.kt
@@ -82,7 +82,7 @@ class ViewImageFragment : BaseCanvasFragment(), ShareableFile {
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
-        ViewStyler.setStatusBarLightDelayed(requireActivity())
+        ViewStyler.themeStatusBarDelayed(requireActivity())
     }
 
     private fun setupToolbar() = with(binding) {

--- a/apps/student/src/main/java/com/instructure/student/fragment/ViewUnsupportedFileFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/fragment/ViewUnsupportedFileFragment.kt
@@ -63,7 +63,7 @@ class ViewUnsupportedFileFragment : BaseCanvasFragment() {
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
-        ViewStyler.setStatusBarLightDelayed(requireActivity())
+        ViewStyler.themeStatusBarDelayed(requireActivity())
     }
 
     private fun setupToolbar() = with(binding) {

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/annnotation/AnnotationSubmissionUploadFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/annnotation/AnnotationSubmissionUploadFragment.kt
@@ -104,7 +104,7 @@ class AnnotationSubmissionUploadFragment : BaseCanvasFragment() {
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
-        ViewStyler.setStatusBarLightDelayed(requireActivity())
+        ViewStyler.themeStatusBarDelayed(requireActivity())
     }
 
     companion object {

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/ui/UploadStatusSubmissionView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/file/ui/UploadStatusSubmissionView.kt
@@ -75,7 +75,7 @@ class UploadStatusSubmissionView(inflater: LayoutInflater, parent: ViewGroup) :
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         context.getActivityOrNull()?.let {
-            ViewStyler.setStatusBarLightDelayed(it)
+            ViewStyler.themeStatusBarDelayed(it)
         }
     }
 

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/ui/PickerSubmissionUploadView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/picker/ui/PickerSubmissionUploadView.kt
@@ -87,7 +87,7 @@ class PickerSubmissionUploadView(inflater: LayoutInflater, parent: ViewGroup, va
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         context.getActivityOrNull()?.let {
-            ViewStyler.setStatusBarLightDelayed(it)
+            ViewStyler.themeStatusBarDelayed(it)
         }
     }
 

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/text/ui/TextSubmissionUploadView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/text/ui/TextSubmissionUploadView.kt
@@ -111,7 +111,7 @@ class TextSubmissionUploadView(inflater: LayoutInflater, parent: ViewGroup) :
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         context.getActivityOrNull()?.let {
-            ViewStyler.setStatusBarLightDelayed(it)
+            ViewStyler.themeStatusBarDelayed(it)
         }
     }
 

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/url/ui/UrlSubmissionUploadView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submission/url/ui/UrlSubmissionUploadView.kt
@@ -83,7 +83,7 @@ class UrlSubmissionUploadView(inflater: LayoutInflater, parent: ViewGroup) : Mob
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         context.getActivityOrNull()?.let {
-            ViewStyler.setStatusBarLightDelayed(it)
+            ViewStyler.themeStatusBarDelayed(it)
         }
     }
 

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/drawer/rubric/ui/SubmissionRubricDescriptionFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/drawer/rubric/ui/SubmissionRubricDescriptionFragment.kt
@@ -111,7 +111,7 @@ class SubmissionRubricDescriptionFragment : BaseCanvasDialogFragment() {
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
-        ViewStyler.setStatusBarLightDelayed(requireActivity())
+        ViewStyler.themeStatusBarDelayed(requireActivity())
     }
 
     companion object {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendartodo/createupdate/CreateUpdateToDoFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/calendartodo/createupdate/CreateUpdateToDoFragment.kt
@@ -110,7 +110,7 @@ class CreateUpdateToDoFragment : BaseCanvasFragment(), NavigationCallbacks, Frag
     )
 
     override fun applyTheme() {
-        ViewStyler.themeStatusBar(requireActivity())
+        ViewStyler.themeStatusBarDelayed(requireActivity())
     }
 
     override fun getFragment(): Fragment {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/compose/InboxComposeFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/inbox/compose/InboxComposeFragment.kt
@@ -100,7 +100,7 @@ class InboxComposeFragment : BaseCanvasFragment(), FragmentInteractions, FileUpl
     }
 
     override fun applyTheme() {
-        ViewStyler.themeStatusBar(requireActivity())
+        ViewStyler.themeStatusBarDelayed(requireActivity())
     }
 
     override fun getFragment(): Fragment {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/ViewStyler.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/ViewStyler.kt
@@ -30,7 +30,6 @@ import android.text.SpannableString
 import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.text.style.ScaleXSpan
-import android.view.View
 import android.widget.Button
 import android.widget.ImageView
 import android.widget.ProgressBar
@@ -194,11 +193,11 @@ object ViewStyler {
         WindowInsetsHelper.setStatusBarLight(activity)
     }
 
-    fun setStatusBarLightDelayed(activity: Activity) {
+    fun themeStatusBarDelayed(activity: Activity) {
         // Due to the messed up navigation stack in the Student app some screens under this on config change can override the color of the statusbar,
         // so we need to add a delay to make sure this gets called last.
         Handler(Looper.getMainLooper()).postDelayed({
-            setStatusBarLight(activity)
+            themeStatusBar(activity)
         }, 100)
     }
 


### PR DESCRIPTION
Test plan:
1. On an Android 15+ device running the Student app, open Inbox → New Message (Compose).
2. Rotate the device → the system status bar icons remain visible against the themed background.
3. From New Message, tap the attachment icon and pick a file to upload → status bar icons remain visible.
4. Open the Recipient picker from New Message → status bar icons remain visible after rotation.
5. From Calendar → add/edit a To Do → rotate → status bar icons remain visible.
6. Switch the device to dark mode and navigate to screens like View Image, Edit Page, Annotation Comments, Submission upload flows → after a configuration change, the status bar icons are rendered with the correct light tint for the dark toolbar (previously incorrectly forced to dark icons).

refs: MBL-19923
affects: Student
release note: Fixed the status bar icon color on Inbox Compose, Edit ToDo and related screens so that icons remain visible after rotation or configuration changes, including in dark mode.

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] Test in landscape mode and/or tablet
- [x] A11y checked
- [x] Approve from product

🤖 Generated with [Claude Code](https://claude.com/claude-code)