### PR TITLE
[MBL-19921][Student] Fix back button and course name overlap on course browser

### DIFF
--- a/apps/student/src/main/java/com/instructure/student/features/coursebrowser/CourseBrowserFragment.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/coursebrowser/CourseBrowserFragment.kt
@@ -313,6 +313,7 @@ class CourseBrowserFragment : BaseCanvasFragment(), FragmentInteractions,
         noOverlayToolbar.setVisible(!useOverlay)
         overlayToolbar.setVisible(useOverlay)
         courseHeader.setVisible(useOverlay)
+        ViewCompat.requestApplyInsets(appBarLayout)
     }
 
     private var statusBarBackgroundView: View? = null


### PR DESCRIPTION
Test plan:
1. Enable the Dashboard Redesign feature flag
2. Enable the Color Overlay option in the widget settings
3. Navigate to the Dashboard and open any course
4. Verify the back button and course name no longer overlap on first entry
5. Also verify the layout is correct in portrait and landscape mode
6. Navigate into a sub-section (e.g. Assignments) and press back — verify still looks correct

refs: MBL-19921
affects: Student
release note: Fixed an issue where the back button and course name overlapped when opening a course from the dashboard for the first time with the Color Overlay option enabled.

- [ ] Follow-up e2e test ticket created or not needed
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Test in landscape mode and/or tablet
- [ ] A11y checked
- [ ] Approve from product