### PR TITLE
[MBL-19919][Student] Fix WebView keyboard covering content in Discussion Details

### DIFF
--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/discussion/details/DiscussionDetailsWebViewFragment.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/discussion/details/DiscussionDetailsWebViewFragment.kt
@@ -24,6 +24,8 @@ import android.view.ViewGroup
 import android.webkit.WebView
 import android.widget.Toast
 import androidx.core.net.toUri
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.instructure.canvasapi2.models.CanvasContext
@@ -112,6 +114,7 @@ class DiscussionDetailsWebViewFragment : BaseCanvasFragment() {
         viewModel.data.observe(viewLifecycleOwner) {
             setupToolbar(it.title)
         }
+        setupImeInsets()
         setupFilePicker()
         binding.discussionWebView.addVideoClient(requireActivity())
         binding.discussionWebView.enableAlgorithmicDarkening()
@@ -153,6 +156,24 @@ class DiscussionDetailsWebViewFragment : BaseCanvasFragment() {
                 return viewModel.data.value?.url?.substringBefore("?") != url.substringBefore("?")
             }
         }
+    }
+
+    private fun setupImeInsets() {
+        val webView = binding.discussionWebView
+        val originalMargin = (webView.layoutParams as? ViewGroup.MarginLayoutParams)?.bottomMargin ?: 0
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, insets ->
+            val ime = insets.getInsets(WindowInsetsCompat.Type.ime())
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            val bottom = if (isInModulesPager) ime.bottom else maxOf(ime.bottom, systemBars.bottom)
+            val lp = webView.layoutParams as? ViewGroup.MarginLayoutParams
+            val target = originalMargin + bottom
+            if (lp != null && lp.bottomMargin != target) {
+                lp.bottomMargin = target
+                webView.layoutParams = lp
+            }
+            insets
+        }
+        if (binding.root.isAttachedToWindow) ViewCompat.requestApplyInsets(binding.root)
     }
 
     private fun setupFilePicker() {


### PR DESCRIPTION
Test plan:
1. Open the Student app (qaDebug) on a device/emulator with edge-to-edge enabled.
2. Navigate to a course → Discussions → open any discussion topic.
3. With the keyboard closed, confirm the bottom of the WebView still clears the system navigation bar (no regression of MBL-19896).
4. Tap the reply composer inside the web content to open the soft keyboard.
5. Verify the WebView shrinks above the keyboard and the bottom of the composer / send button is reachable by scrolling.
6. Close the keyboard and confirm the WebView returns to its original bottom margin (no lingering gap).
7. Repeat inside a Modules pager (open a discussion item via Modules) and confirm no double gap when the keyboard is closed.

refs: MBL-19919
affects: Student
release note: Fixed an issue where the soft keyboard could cover the bottom of a discussion page, making the reply area unreachable.

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] Test in landscape mode and/or tablet
- [x] A11y checked
- [x] Approve from product

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>