### PR TITLE
[MBL-19606][All] Enable DASH playback

### DIFF
--- a/apps/parent/src/main/AndroidManifest.xml
+++ b/apps/parent/src/main/AndroidManifest.xml
@@ -152,6 +152,10 @@
         <activity
             android:name=".features.webview.HtmlContentActivity"
             android:theme="@style/CanvasMaterialTheme_Default" />
+
+        <activity
+            android:name=".features.media.ViewMediaActivity"
+            android:theme="@style/CanvasMaterialTheme_Default" />
         <!-- End of Activities -->
 
         <!-- Services -->

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/inbox/list/ParentInboxRouter.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/inbox/list/ParentInboxRouter.kt
@@ -27,7 +27,9 @@ import com.instructure.pandautils.features.inbox.list.InboxRouter
 import com.instructure.pandautils.features.inbox.utils.InboxComposeOptions
 import com.instructure.pandautils.utils.FileDownloader
 import com.instructure.pandautils.utils.setupAsBackButton
+import com.instructure.pandautils.utils.shouldOpenMediaInternally
 import com.instructure.parentapp.features.inbox.coursepicker.ParentInboxCoursePickerBottomSheetDialog
+import com.instructure.parentapp.features.media.ViewMediaActivity
 import com.instructure.parentapp.util.navigation.Navigation
 
 
@@ -61,11 +63,17 @@ class ParentInboxRouter(
     }
 
     override fun routeToAttachment(attachment: Attachment) {
-        fileDownloader.downloadFileToDevice(attachment)
+        val url = attachment.url ?: return fileDownloader.downloadFileToDevice(attachment)
+        if (shouldOpenMediaInternally(url, attachment.contentType, attachment.mimeClass)) {
+            activity.startActivity(ViewMediaActivity.createIntent(activity, url, attachment.contentType.orEmpty(), attachment.displayName))
+        } else {
+            fileDownloader.downloadFileToDevice(attachment)
+        }
     }
 
     override fun routeToMediaAttachment(mediaComment: MediaComment) {
-        fileDownloader.downloadFileToDevice(mediaComment.url, mediaComment.displayName, mediaComment.contentType)
+        val url = mediaComment.url ?: return
+        activity.startActivity(ViewMediaActivity.createIntent(activity, url, mediaComment.contentType.orEmpty(), mediaComment.displayName))
     }
 
     override fun popDetailsScreen(activity: FragmentActivity?) {

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/media/ViewMediaActivity.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/media/ViewMediaActivity.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, version 3 of the License.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.instructure.parentapp.features.media
+
+import android.content.Context
+import android.content.Intent
+import com.instructure.pandautils.activities.BaseViewMediaActivity
+import com.instructure.pandautils.analytics.SCREEN_VIEW_VIEW_MEDIA
+import com.instructure.pandautils.analytics.ScreenView
+import com.instructure.pandautils.models.EditableFile
+
+@ScreenView(SCREEN_VIEW_VIEW_MEDIA)
+class ViewMediaActivity : BaseViewMediaActivity() {
+    override fun allowEditing() = false
+    override fun allowCopyingUrl() = false
+    override fun handleEditing(editableFile: EditableFile) {}
+
+    companion object {
+        fun createIntent(context: Context, url: String, contentType: String, displayName: String?): Intent {
+            val bundle = makeBundle(url, null, contentType, displayName, true)
+            return Intent(context, ViewMediaActivity::class.java).putExtras(bundle)
+        }
+    }
+}

--- a/apps/student/src/main/java/com/instructure/student/activity/BaseRouterActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/BaseRouterActivity.kt
@@ -19,7 +19,6 @@ package com.instructure.student.activity
 
 import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.widget.Toast
 import androidx.lifecycle.lifecycleScope
@@ -34,7 +33,10 @@ import com.instructure.canvasapi2.utils.LinkHeaders
 import com.instructure.canvasapi2.utils.Logger
 import com.instructure.interactions.FullScreenInteractions
 import com.instructure.interactions.router.Route
+import com.instructure.interactions.router.RouteContext
+import com.instructure.pandautils.activities.BaseViewMediaActivity
 import com.instructure.pandautils.loaders.OpenMediaAsyncTaskLoader
+import com.instructure.pandautils.utils.shouldOpenMediaInternally
 import com.instructure.pandautils.models.PushNotification
 import com.instructure.pandautils.receivers.PushExternalReceiver
 import com.instructure.pandautils.utils.Const
@@ -258,20 +260,15 @@ abstract class BaseRouterActivity : CallbackActivity(), FullScreenInteractions {
         FileFolderManager.getFileFolderFromURL("files/$fileID", true, fileFolderCanvasCallback)
     }
 
-    fun openMedia(canvasContext: CanvasContext?, url: String, fileID: String?) {
+    fun openMedia(canvasContext: CanvasContext?, url: String, fileID: String?, mimeType: String? = null, mimeClass: String? = null) {
         showLoadingIndicator()
         lifecycleScope.launch {
-            if (shouldOpenInternally(url)) {
-                startActivity(
-                    VideoViewActivity.createIntent(
-                        this@BaseRouterActivity,
-                        url
-                    )
-                )
+            if (shouldOpenMediaInternally(url, mimeType, mimeClass)) {
+                val bundle = BaseViewMediaActivity.makeBundle(url, null, mimeType.orEmpty(), null, true)
+                RouteMatcher.route(this@BaseRouterActivity, Route(bundle, RouteContext.MEDIA))
             } else {
-                openMediaBundle =
-                    OpenMediaAsyncTaskLoader.createBundle(url, null, fileID, canvasContext)
-                LoaderUtils.restartLoaderWithBundle<LoaderManager.LoaderCallbacks<OpenMediaAsyncTaskLoader.LoadedMedia>>(
+                openMediaBundle = OpenMediaAsyncTaskLoader.createBundle(url, null, fileID, canvasContext)
+                LoaderUtils.restartLoaderWithBundle(
                     LoaderManager.getInstance(this@BaseRouterActivity),
                     openMediaBundle,
                     loaderCallbacks,
@@ -291,13 +288,9 @@ abstract class BaseRouterActivity : CallbackActivity(), FullScreenInteractions {
     ) {
         showLoadingIndicator()
         lifecycleScope.launch {
-            if (shouldOpenInternally(url)) {
-                startActivity(
-                    VideoViewActivity.createIntent(
-                        this@BaseRouterActivity,
-                        url
-                    )
-                )
+            if (shouldOpenMediaInternally(url, mime)) {
+                val bundle = BaseViewMediaActivity.makeBundle(url, null, mime, filename, true)
+                RouteMatcher.route(this@BaseRouterActivity, Route(bundle, RouteContext.MEDIA))
             } else {
                 openMediaBundle = if (localFile) {
                     OpenMediaAsyncTaskLoader.createLocalBundle(
@@ -327,9 +320,7 @@ abstract class BaseRouterActivity : CallbackActivity(), FullScreenInteractions {
         }
     }
 
-    private suspend fun shouldOpenInternally(url: String): Boolean {
-        return (url.endsWith(".mpd") || url.endsWith(".m3u8") || url.endsWith(".mp4"))
-    }
+
 
     override fun onDestroy() {
         super.onDestroy()

--- a/apps/student/src/main/java/com/instructure/student/features/inbox/list/StudentInboxRouter.kt
+++ b/apps/student/src/main/java/com/instructure/student/features/inbox/list/StudentInboxRouter.kt
@@ -60,11 +60,11 @@ class StudentInboxRouter(private val activity: FragmentActivity, private val fra
     }
 
     override fun routeToAttachment(attachment: Attachment) {
-        openMedia(activity, attachment.url)
+        openMedia(activity, attachment.url, attachment.contentType, attachment.mimeClass)
     }
 
     override fun routeToMediaAttachment(mediaComment: MediaComment) {
-        openMedia(activity, mediaComment.url)
+        openMedia(activity, mediaComment.url, mediaComment.contentType)
     }
 
     override fun popDetailsScreen(activity: FragmentActivity?) {

--- a/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/drawer/comments/ui/SubmissionCommentsView.kt
+++ b/apps/student/src/main/java/com/instructure/student/mobius/assignmentDetails/submissionDetails/drawer/comments/ui/SubmissionCommentsView.kt
@@ -27,9 +27,7 @@ import com.instructure.canvasapi2.models.Assignment
 import com.instructure.canvasapi2.models.Attachment
 import com.instructure.canvasapi2.models.CanvasContext
 import com.instructure.canvasapi2.models.Submission
-import com.instructure.interactions.router.Route
-import com.instructure.interactions.router.RouteContext
-import com.instructure.pandautils.activities.BaseViewMediaActivity
+import com.instructure.pandautils.room.studentdb.StudentDb
 import com.instructure.pandautils.utils.ThemePrefs
 import com.instructure.pandautils.utils.ViewStyler
 import com.instructure.pandautils.utils.onClick
@@ -46,7 +44,6 @@ import com.instructure.student.mobius.assignmentDetails.submission.picker.ui.Pic
 import com.instructure.student.mobius.assignmentDetails.submissionDetails.drawer.comments.SubmissionCommentsEvent
 import com.instructure.student.mobius.assignmentDetails.submissionDetails.drawer.comments.SubmissionCommentsViewState
 import com.instructure.student.mobius.common.ui.MobiusView
-import com.instructure.pandautils.room.studentdb.StudentDb
 import com.instructure.student.router.RouteMatcher
 import com.spotify.mobius.functions.Consumer
 
@@ -173,20 +170,7 @@ class SubmissionCommentsView(
     }
 
     fun openMedia(canvasContext: CanvasContext, contentType: String, url: String, fileName: String) {
-        if (contentType.startsWith("video") || contentType.startsWith("audio")) {
-            val bundle = BaseViewMediaActivity.makeBundle(url, null, contentType, null, true, null)
-            (activity as? BaseRouterActivity)?.let {
-                RouteMatcher.route(it as FragmentActivity, Route(bundle, RouteContext.MEDIA))
-            }
-        } else {
-            (activity as? BaseRouterActivity)?.openMedia(
-                canvasContext,
-                contentType,
-                url,
-                fileName,
-                null
-            )
-        }
+        (activity as? BaseRouterActivity)?.openMedia(canvasContext, contentType, url, fileName, null)
     }
 
     fun showPermissionDeniedToast() {

--- a/apps/student/src/main/java/com/instructure/student/router/RouteMatcher.kt
+++ b/apps/student/src/main/java/com/instructure/student/router/RouteMatcher.kt
@@ -61,6 +61,7 @@ import com.instructure.pandautils.loaders.OpenMediaAsyncTaskLoader
 import com.instructure.pandautils.room.offline.OfflineDatabase
 import com.instructure.pandautils.utils.Const
 import com.instructure.pandautils.utils.LoaderUtils
+import com.instructure.pandautils.utils.shouldOpenMediaInternally
 import com.instructure.pandautils.utils.NetworkStateProvider
 import com.instructure.pandautils.utils.RouteUtils
 import com.instructure.pandautils.utils.nonNullArgs
@@ -790,8 +791,16 @@ object RouteMatcher : BaseRouteMatcher() {
         return openMediaCallbacks!!
     }
 
-    fun openMedia(activity: FragmentActivity?, url: String?) {
-        if (activity != null) {
+    fun shouldOpenInternally(url: String?, mimeType: String? = null, mimeClass: String? = null): Boolean {
+        return shouldOpenMediaInternally(url, mimeType, mimeClass)
+    }
+
+    fun openMedia(activity: FragmentActivity?, url: String?, mimeType: String? = null, mimeClass: String? = null) {
+        if (activity == null) return
+        if (!url.isNullOrBlank() && shouldOpenInternally(url, mimeType, mimeClass)) {
+            val bundle = BaseViewMediaActivity.makeBundle(url, null, mimeType.orEmpty(), null, true)
+            route(activity, Route(bundle, RouteContext.MEDIA))
+        } else {
             openMediaCallbacks = null
             openMediaBundle = OpenMediaAsyncTaskLoader.createBundle(url)
             LoaderUtils.restartLoaderWithBundle(

--- a/apps/teacher/src/main/java/com/instructure/teacher/features/inbox/list/TeacherInboxRouter.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/features/inbox/list/TeacherInboxRouter.kt
@@ -84,11 +84,11 @@ class TeacherInboxRouter(private val activity: FragmentActivity, private val fra
     }
 
     override fun routeToAttachment(attachment: Attachment) {
-        openMedia(activity, attachment.url)
+        openMedia(activity, attachment.url, attachment.displayName, mimeType = attachment.contentType, mimeClass = attachment.mimeClass)
     }
 
     override fun routeToMediaAttachment(mediaComment: MediaComment) {
-        openMedia(activity, mediaComment.url)
+        openMedia(activity, mediaComment.url, mediaComment.displayName, mimeType = mediaComment.contentType)
     }
 
     override fun popDetailsScreen(activity: FragmentActivity?) {

--- a/apps/teacher/src/main/java/com/instructure/teacher/router/RouteMatcher.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/router/RouteMatcher.kt
@@ -69,6 +69,7 @@ import com.instructure.pandautils.fragments.RemoteConfigParamsFragment
 import com.instructure.pandautils.loaders.OpenMediaAsyncTaskLoader
 import com.instructure.pandautils.utils.Const
 import com.instructure.pandautils.utils.LoaderUtils
+import com.instructure.pandautils.utils.shouldOpenMediaInternally
 import com.instructure.pandautils.utils.RouteUtils
 import com.instructure.pandautils.utils.argsWithContext
 import com.instructure.pandautils.utils.nonNullArgs
@@ -785,11 +786,19 @@ object RouteMatcher : BaseRouteMatcher() {
         return openMediaCallbacks!!
     }
 
-    fun openMedia(activity: FragmentActivity?, url: String?, fileName: String? = null, fileId: String? = null) {
-        if (activity != null) {
+    fun shouldOpenInternally(url: String?, mimeType: String? = null, mimeClass: String? = null): Boolean {
+        return shouldOpenMediaInternally(url, mimeType, mimeClass)
+    }
+
+    fun openMedia(activity: FragmentActivity?, url: String?, fileName: String? = null, fileId: String? = null, mimeType: String? = null, mimeClass: String? = null) {
+        if (activity == null) return
+        if (!url.isNullOrBlank() && shouldOpenInternally(url, mimeType, mimeClass)) {
+            val bundle = BaseViewMediaActivity.makeBundle(url, null, mimeType.orEmpty(), fileName, true)
+            route(activity, Route(bundle, RouteContext.MEDIA))
+        } else {
             openMediaCallbacks = null
             openMediaBundle = OpenMediaAsyncTaskLoader.createBundle(url, fileName, fileId)
-            LoaderUtils.restartLoaderWithBundle<LoaderManager.LoaderCallbacks<OpenMediaAsyncTaskLoader.LoadedMedia>>(
+            LoaderUtils.restartLoaderWithBundle(
                 LoaderManager.getInstance(activity), openMediaBundle, getLoaderCallbacks(activity), R.id.openMediaLoaderID
             )
         }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/ExoPlayerHelper.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/ExoPlayerHelper.kt
@@ -19,9 +19,9 @@ package com.instructure.pandautils.utils
 import android.net.Uri
 import android.view.SurfaceView
 import androidx.annotation.OptIn
-import androidx.core.net.toUri
 import androidx.media3.common.C
 import androidx.media3.common.C.TRACK_TYPE_VIDEO
+import androidx.media3.common.MimeTypes
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.PlaybackParameters
@@ -84,11 +84,11 @@ class ExoAgent private constructor(val uri: Uri) {
     /** Whether the media track is audio only, or false if unknown */
     private var mIsAudioOnly = false
 
-    /** Whether we've already tried retrying with .mpd extension */
-    private var triedMpdRetry = false
+    /** Whether we've already tried retrying as DASH */
+    private var dashRetry = false
 
-    /** The current URI being used (may be modified for DASH retry) */
-    private var currentUri: Uri = uri
+    /** The current PlayerView, kept so the retry can re-attach after recreating the player */
+    private var mPlayerView: PlayerView? = null
 
     /** The current state of this agent */
     private var currentState = ExoAgentState.IDLE
@@ -98,12 +98,20 @@ class ExoAgent private constructor(val uri: Uri) {
 
     /** Creates a media source for the given URI */
     private fun createMediaSource(sourceUri: Uri) = run {
-        val mediaItem = MediaItem.fromUri(sourceUri)
-        when (Util.inferContentType(sourceUri)) {
-            C.CONTENT_TYPE_SS -> SsMediaSource.Factory(DefaultSsChunkSource.Factory(DATA_SOURCE_FACTORY), DATA_SOURCE_FACTORY).createMediaSource(mediaItem)
-            C.CONTENT_TYPE_DASH -> DashMediaSource.Factory(DefaultDashChunkSource.Factory(DATA_SOURCE_FACTORY), DATA_SOURCE_FACTORY).createMediaSource(mediaItem)
-            C.CONTENT_TYPE_HLS -> HlsMediaSource.Factory(DefaultHlsDataSourceFactory(DATA_SOURCE_FACTORY)).createMediaSource(mediaItem)
-            else -> ProgressiveMediaSource.Factory(DATA_SOURCE_FACTORY, DefaultExtractorsFactory()).createMediaSource(mediaItem)
+        // Direct CMAF/DASH URLs (e.g. Notorious) are single-use and can't be retried, so we
+        // detect them upfront by path suffix instead of falling back via dashRetry.
+        val useDash = dashRetry || sourceUri.path?.endsWith("/cmaf", ignoreCase = true) == true
+        if (useDash) {
+            val mediaItem = MediaItem.Builder().setUri(sourceUri).setMimeType(MimeTypes.APPLICATION_MPD).build()
+            DashMediaSource.Factory(DefaultDashChunkSource.Factory(DATA_SOURCE_FACTORY), DATA_SOURCE_FACTORY).createMediaSource(mediaItem)
+        } else {
+            val mediaItem = MediaItem.fromUri(sourceUri)
+            when (Util.inferContentType(sourceUri)) {
+                C.CONTENT_TYPE_SS -> SsMediaSource.Factory(DefaultSsChunkSource.Factory(DATA_SOURCE_FACTORY), DATA_SOURCE_FACTORY).createMediaSource(mediaItem)
+                C.CONTENT_TYPE_DASH -> DashMediaSource.Factory(DefaultDashChunkSource.Factory(DATA_SOURCE_FACTORY), DATA_SOURCE_FACTORY).createMediaSource(mediaItem)
+                C.CONTENT_TYPE_HLS -> HlsMediaSource.Factory(DefaultHlsDataSourceFactory(DATA_SOURCE_FACTORY)).createMediaSource(mediaItem)
+                else -> ProgressiveMediaSource.Factory(DATA_SOURCE_FACTORY, DefaultExtractorsFactory()).createMediaSource(mediaItem)
+            }
         }
     }
 
@@ -113,6 +121,7 @@ class ExoAgent private constructor(val uri: Uri) {
      * NOTE: This function MUST be called before [prepare] is called by the same client.
      */
     fun attach(playerView: PlayerView, listener: ExoInfoListener) {
+        mPlayerView = playerView
         mInfoListener = listener
         mInfoListener?.onStateChanged(currentState)
         if (mIsAudioOnly) mInfoListener?.setAudioOnly()
@@ -125,6 +134,7 @@ class ExoAgent private constructor(val uri: Uri) {
      * NOTE: The client MUST call [attach] prior to calling this function.
      */
     fun prepare(playerView: PlayerView) {
+        mPlayerView = playerView
         if (mPlayer == null) preparePlayer()
         mPlayer?.switchSurface(playerView)
     }
@@ -173,21 +183,16 @@ class ExoAgent private constructor(val uri: Uri) {
             override fun onPlayerError(exception: PlaybackException) {
                 val cause = exception.cause
 
-                // Check if this might be a DASH video without .mpd extension
-                if (cause is UnrecognizedInputFormatException &&
-                    !triedMpdRetry &&
-                    !currentUri.toString().endsWith(".mpd")) {
-
-                    // Retry with .mpd appended
-                    triedMpdRetry = true
-                    currentUri = "${currentUri}.mpd".toUri()
-
-                    // Reset and retry with the new URI
+                // If the format wasn't recognized, retry as DASH using the same URL.
+                // Canvas media_download URLs generate a fresh JWT on each call so a second
+                // request is safe.
+                if (cause is UnrecognizedInputFormatException && !dashRetry) {
+                    dashRetry = true
                     mPlayer?.release()
                     mPlayer = null
                     preparePlayer()
+                    mPlayerView?.let { mPlayer?.switchSurface(it) }
                 } else {
-                    // Not a retryable error, or already tried retry
                     reset()
                     mInfoListener?.onError(cause)
                 }
@@ -210,7 +215,7 @@ class ExoAgent private constructor(val uri: Uri) {
         })
 
         mPlayer?.playWhenReady = true
-        mPlayer?.setMediaSource(createMediaSource(currentUri))
+        mPlayer?.setMediaSource(createMediaSource(uri))
         mPlayer?.prepare()
     }
 

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/MediaUtils.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/MediaUtils.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+package com.instructure.pandautils.utils
+
+fun shouldOpenMediaInternally(url: String?, mimeType: String?, mimeClass: String? = null): Boolean {
+    if (!mimeClass.isNullOrBlank()) {
+        val cls = mimeClass.trim().lowercase()
+        if (cls == "audio" || cls == "video") return true
+    }
+    if (!mimeType.isNullOrBlank()) {
+        val mime = mimeType.trim().lowercase()
+        if (mime.startsWith("audio/") || mime.startsWith("video/")) return true
+        if (mime == "application/dash+xml") return true
+    }
+    if (!url.isNullOrBlank()) {
+        val path = url.substringBefore("?").lowercase()
+        if (path.endsWith(".mpd") || path.endsWith(".m3u8") || path.endsWith(".mp4") ||
+            path.endsWith(".mp3") || path.endsWith(".m4a") || path.endsWith(".webm") ||
+            path.endsWith("/cmaf")
+        ) return true
+    }
+    return false
+}

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/utils/MediaUtilsTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/utils/MediaUtilsTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+package com.instructure.pandautils.utils
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MediaUtilsTest {
+
+    @Test
+    fun `mimeClass audio returns true`() {
+        assertTrue(shouldOpenMediaInternally(null, null, "audio"))
+    }
+
+    @Test
+    fun `mimeClass video returns true`() {
+        assertTrue(shouldOpenMediaInternally(null, null, "video"))
+    }
+
+    @Test
+    fun `mimeClass is case and whitespace insensitive`() {
+        assertTrue(shouldOpenMediaInternally(null, null, "  Video  "))
+        assertTrue(shouldOpenMediaInternally(null, null, "AUDIO"))
+    }
+
+    @Test
+    fun `mimeClass image returns false`() {
+        assertFalse(shouldOpenMediaInternally(null, null, "image"))
+    }
+
+    @Test
+    fun `mimeType audio prefix returns true`() {
+        assertTrue(shouldOpenMediaInternally(null, "audio/mpeg", null))
+    }
+
+    @Test
+    fun `mimeType video prefix returns true`() {
+        assertTrue(shouldOpenMediaInternally(null, "video/mp4", null))
+    }
+
+    @Test
+    fun `mimeType dash returns true`() {
+        assertTrue(shouldOpenMediaInternally(null, "application/dash+xml", null))
+    }
+
+    @Test
+    fun `mimeType is case and whitespace insensitive`() {
+        assertTrue(shouldOpenMediaInternally(null, "  Video/MP4  ", null))
+    }
+
+    @Test
+    fun `mimeType pdf returns false`() {
+        assertFalse(shouldOpenMediaInternally(null, "application/pdf", null))
+    }
+
+    @Test
+    fun `url with mp4 extension returns true`() {
+        assertTrue(shouldOpenMediaInternally("https://example.com/file.mp4", null, null))
+    }
+
+    @Test
+    fun `url with mpd extension returns true`() {
+        assertTrue(shouldOpenMediaInternally("https://example.com/file.mpd", null, null))
+    }
+
+    @Test
+    fun `url with m3u8 extension returns true`() {
+        assertTrue(shouldOpenMediaInternally("https://example.com/file.m3u8", null, null))
+    }
+
+    @Test
+    fun `url with mp3 extension returns true`() {
+        assertTrue(shouldOpenMediaInternally("https://example.com/file.mp3", null, null))
+    }
+
+    @Test
+    fun `url with m4a extension returns true`() {
+        assertTrue(shouldOpenMediaInternally("https://example.com/file.m4a", null, null))
+    }
+
+    @Test
+    fun `url with webm extension returns true`() {
+        assertTrue(shouldOpenMediaInternally("https://example.com/file.webm", null, null))
+    }
+
+    @Test
+    fun `url ending with cmaf segment returns true`() {
+        assertTrue(shouldOpenMediaInternally("https://notorious.example/asset/123/cmaf", null, null))
+    }
+
+    @Test
+    fun `url with query string is still matched by extension`() {
+        assertTrue(shouldOpenMediaInternally("https://example.com/file.mp4?token=abc", null, null))
+    }
+
+    @Test
+    fun `url with query string is still matched by cmaf`() {
+        assertTrue(shouldOpenMediaInternally("https://notorious.example/asset/123/cmaf?token=abc", null, null))
+    }
+
+    @Test
+    fun `url with extension is case insensitive`() {
+        assertTrue(shouldOpenMediaInternally("https://example.com/File.MP4", null, null))
+    }
+
+    @Test
+    fun `url with pdf extension returns false`() {
+        assertFalse(shouldOpenMediaInternally("https://example.com/file.pdf", null, null))
+    }
+
+    @Test
+    fun `all null or blank returns false`() {
+        assertFalse(shouldOpenMediaInternally(null, null, null))
+        assertFalse(shouldOpenMediaInternally("", "", ""))
+        assertFalse(shouldOpenMediaInternally("   ", "   ", "   "))
+    }
+
+    @Test
+    fun `mimeClass takes priority over non-matching mimeType and url`() {
+        assertTrue(shouldOpenMediaInternally("https://example.com/file.pdf", "application/pdf", "audio"))
+    }
+
+    @Test
+    fun `mimeType takes over non-matching url when mimeClass missing`() {
+        assertTrue(shouldOpenMediaInternally("https://example.com/file.pdf", "video/mp4", null))
+    }
+}


### PR DESCRIPTION
Test plan:

## Main use cases
Test each of the following on **both** a regular non-stream-enabled sandbox **and** a stream-enabled sandbox — media URLs differ between the two (direct files vs. Kaltura CMAF/DASH streams), and both paths need to keep working.

1. **Media recording submission playback**
   - Student: play own media-recording submission (audio and video) in submission content view
   - Teacher: open a student's media-recording submission in SpeedGrader
2. **Submission comments with media recordings**
   - Student: tap an audio/video media-comment in the submission Comments tab
   - Teacher: tap an audio/video media-comment in SpeedGrader
3. **Inbox messages with media attachment** (note: media attachments can only be recorded on web)
   - Student / Teacher / Parent: open an inbox conversation containing a recorded media attachment and tap to play

Verify on both sandboxes:
- Video and audio start playing on first tap (no UnrecognizedInputFormatException loop)
- Seek and pause/resume work
- Rotation mid-playback keeps playback going
- Error state shows the existing retry UI when the URL is genuinely broken
- Non-media attachments (PDF, image, docx) still open the way they used to (download / preview) — nothing is rerouted into the media viewer by mistake

## Affected screens (please exercise all of them in addition to the main use cases)

**Student**
- Inbox conversation detail — file/media-comment attachments
- Submission details → Comments tab — media attachments
- Media submission content (MEDIA_RECORDING assignments)
- Discussion submission viewing
- Page details (course Pages)
- Syllabus tab / Syllabus view
- Assignment basic / Assignment details
- Locked module item
- Elementary (K5) course pager
- Push notification / bookmark deep link to a media file
- Studio video playback (regression check — should still use legacy VideoViewActivity auto-play)

**Teacher**
- Inbox conversation detail — file/media-comment attachments
- Page details
- Quiz preview / Quiz details
- Syllabus tab
- Assignment details
- Internal WebView (generic)
- SpeedGrader LTI submission
- SpeedGrader file attachment playback (video submissions)

**Parent** (new behavior — previously audio/video attachments always downloaded)
- Inbox conversation detail — file/media-comment attachments now open the new ViewMediaActivity
- Non-media attachments still download via FileDownloader

## Additional checks
- Any other screen across the three apps that plays audio/video (file preview, inline page media, etc.) — confirm no regressions
- Dark mode + light mode
- Landscape + tablet layouts
- TalkBack / a11y on the media viewer

refs: MBL-19606
affects: Student, Teacher, Parent
release note: Enabled DASH/CMAF playback for audio and video in inbox messages, submission comments, media-recording submissions, and media embedded in pages/quizzes/syllabus. Parent inbox now plays audio and video in-app instead of only downloading.

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] Test in landscape mode and/or tablet
- [ ] A11y checked
- [ ] Approve from product