### PR TITLE
[MBL-19968][All] Privacy settings screen & consent flow cleanup

### DIFF
--- a/apps/parent/src/main/java/com/instructure/parentapp/di/feature/CookieConsentModule.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/di/feature/CookieConsentModule.kt
@@ -21,10 +21,13 @@ import com.instructure.canvasapi2.utils.ConsentPrefs
 import com.instructure.pandautils.features.cookieconsent.AnalyticsConsentHandler
 import com.instructure.pandautils.features.cookieconsent.CookieConsentNamespace
 import com.instructure.pandautils.utils.FeatureFlagProvider
+import com.instructure.pandautils.utils.PendoTokenConfig
+import com.instructure.parentapp.BuildConfig
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -33,6 +36,15 @@ class CookieConsentModule {
     @Provides
     fun provideCookieConsentNamespace(): CookieConsentNamespace {
         return CookieConsentNamespace.PARENT
+    }
+
+    @Provides
+    @Singleton
+    fun providePendoTokenConfig(): PendoTokenConfig {
+        return PendoTokenConfig(
+            fallbackToken = BuildConfig.PENDO_TOKEN,
+            apiTokenSelector = { it.pendoMobileParentApiKey }
+        )
     }
 
     @Provides

--- a/apps/parent/src/main/java/com/instructure/parentapp/di/feature/SplashModule.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/di/feature/SplashModule.kt
@@ -36,9 +36,8 @@ class SplashModule {
     fun provideSplashRepository(
         userApi: UserAPI.UsersInterface,
         themeApi: ThemeAPI.ThemeInterface,
-        enrollmentApi: EnrollmentAPI.EnrollmentInterface,
-        featuresApi: FeaturesAPI.FeaturesInterface
+        enrollmentApi: EnrollmentAPI.EnrollmentInterface
     ): SplashRepository {
-        return SplashRepository(userApi, themeApi, enrollmentApi, featuresApi)
+        return SplashRepository(userApi, themeApi, enrollmentApi)
     }
 }

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/splash/SplashRepository.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/splash/SplashRepository.kt
@@ -18,23 +18,19 @@
 package com.instructure.parentapp.features.splash
 
 import com.instructure.canvasapi2.apis.EnrollmentAPI
-import com.instructure.canvasapi2.apis.FeaturesAPI
 import com.instructure.canvasapi2.apis.ThemeAPI
 import com.instructure.canvasapi2.apis.UserAPI
 import com.instructure.canvasapi2.builders.RestParams
-import com.instructure.canvasapi2.managers.FeaturesManager
 import com.instructure.canvasapi2.models.CanvasColor
 import com.instructure.canvasapi2.models.CanvasTheme
 import com.instructure.canvasapi2.models.User
 import com.instructure.canvasapi2.utils.depaginate
-import com.instructure.pandautils.utils.orDefault
 
 
 class SplashRepository(
     private val userApi: UserAPI.UsersInterface,
     private val themeApi: ThemeAPI.ThemeInterface,
-    private val enrollmentApi: EnrollmentAPI.EnrollmentInterface,
-    private val featuresApi: FeaturesAPI.FeaturesInterface
+    private val enrollmentApi: EnrollmentAPI.EnrollmentInterface
 ) {
 
     suspend fun getSelf(): User? {
@@ -69,10 +65,5 @@ class SplashRepository(
     suspend fun getBecomeUserPermission(): Boolean {
         val params = RestParams(isForceReadFromNetwork = true)
         return userApi.getBecomeUserPermission(params).dataOrNull?.becomeUser ?: false
-    }
-
-    suspend fun getSendUsageMetrics(): Boolean {
-        val params = RestParams(isForceReadFromNetwork = true)
-        return featuresApi.getEnvironmentFeatureFlags(params).dataOrNull?.get(FeaturesManager.SEND_USAGE_METRICS).orDefault()
     }
 }

--- a/apps/parent/src/main/java/com/instructure/parentapp/features/splash/SplashViewModel.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/features/splash/SplashViewModel.kt
@@ -23,19 +23,17 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.instructure.canvasapi2.models.User
 import com.instructure.canvasapi2.utils.ApiPrefs
-import com.instructure.canvasapi2.utils.ConsentPrefs
 import com.instructure.canvasapi2.utils.weave.catch
 import com.instructure.canvasapi2.utils.weave.tryLaunch
+import com.instructure.pandautils.domain.usecase.splash.SetupPendoTrackingUseCase
 import com.instructure.pandautils.utils.ColorKeeper
 import com.instructure.pandautils.utils.Const
 import com.instructure.pandautils.utils.FeatureFlagProvider
-import com.instructure.pandautils.utils.SHA256
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
-import sdk.pendo.io.Pendo
 import javax.inject.Inject
 
 
@@ -44,9 +42,9 @@ class SplashViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val repository: SplashRepository,
     private val apiPrefs: ApiPrefs,
-    private val consentPrefs: ConsentPrefs,
     private val colorKeeper: ColorKeeper,
     private val featureFlagProvider: FeatureFlagProvider,
+    private val setupPendoTrackingUseCase: SetupPendoTrackingUseCase,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -85,21 +83,7 @@ class SplashViewModel @Inject constructor(
                 }
             }
 
-            if (consentPrefs.currentUserConsent == true) {
-                val sendUsageMetrics = repository.getSendUsageMetrics()
-                if (sendUsageMetrics) {
-                    val userWithIds = repository.getSelfWithUuid()
-                    val visitorData = mapOf(
-                        "locale" to apiPrefs.effectiveLocale,
-                    )
-                    val accountData = mapOf(
-                        "surveyOptOut" to featureFlagProvider.checkAccountSurveyNotificationsFlag()
-                    )
-                    Pendo.startSession(userWithIds?.uuid?.SHA256().orEmpty(), userWithIds?.accountUuid.orEmpty(), visitorData, accountData)
-                } else {
-                    Pendo.endSession()
-                }
-            }
+            setupPendoTrackingUseCase(Unit)
 
             val students = repository.getStudents()
             if (students.isEmpty() && apiPrefs.canBecomeUser == false) {

--- a/apps/parent/src/main/java/com/instructure/parentapp/util/AppManager.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/util/AppManager.kt
@@ -20,9 +20,7 @@ package com.instructure.parentapp.util
 import androidx.hilt.work.HiltWorkerFactory
 import com.instructure.loginapi.login.tasks.LogoutTask
 import com.instructure.pandautils.features.reminder.AlarmScheduler
-import com.instructure.parentapp.BuildConfig
 import dagger.hilt.android.HiltAndroidApp
-import sdk.pendo.io.Pendo
 import javax.inject.Inject
 
 
@@ -38,11 +36,6 @@ class AppManager : BaseAppManager() {
     @Inject
     lateinit var flutterAppMigration: FlutterAppMigration
 
-    override fun onCreate() {
-        super.onCreate()
-        initPendo()
-    }
-
     override fun performLogoutOnAuthError() {
         ParentLogoutTask(LogoutTask.Type.LOGOUT, null, getScheduler()).execute()
     }
@@ -57,8 +50,4 @@ class AppManager : BaseAppManager() {
         flutterAppMigration.migrateIfNecessary()
     }
 
-    private fun initPendo() {
-        val options = Pendo.PendoOptions.Builder().setJetpackComposeBeta(true).build()
-        Pendo.setup(this, BuildConfig.PENDO_TOKEN, options, null)
-    }
 }

--- a/apps/parent/src/test/java/com/instructure/parentapp/features/splash/SplashRepositoryTest.kt
+++ b/apps/parent/src/test/java/com/instructure/parentapp/features/splash/SplashRepositoryTest.kt
@@ -18,11 +18,9 @@
 package com.instructure.parentapp.features.splash
 
 import com.instructure.canvasapi2.apis.EnrollmentAPI
-import com.instructure.canvasapi2.apis.FeaturesAPI
 import com.instructure.canvasapi2.apis.ThemeAPI
 import com.instructure.canvasapi2.apis.UserAPI
 import com.instructure.canvasapi2.builders.RestParams
-import com.instructure.canvasapi2.managers.FeaturesManager
 import com.instructure.canvasapi2.models.BecomeUserPermission
 import com.instructure.canvasapi2.models.CanvasColor
 import com.instructure.canvasapi2.models.CanvasTheme
@@ -45,9 +43,8 @@ class SplashRepositoryTest {
     private val themeApi: ThemeAPI.ThemeInterface = mockk(relaxed = true)
     private val userApi: UserAPI.UsersInterface = mockk(relaxed = true)
     private val enrollmentApi: EnrollmentAPI.EnrollmentInterface = mockk(relaxed = true)
-    private val featuresApi: FeaturesAPI.FeaturesInterface = mockk(relaxed = true)
 
-    private val repository = SplashRepository(userApi, themeApi, enrollmentApi, featuresApi)
+    private val repository = SplashRepository(userApi, themeApi, enrollmentApi)
 
     @Test
     fun `Get students successfully returns data`() = runTest {
@@ -152,34 +149,6 @@ class SplashRepositoryTest {
         coEvery { userApi.getBecomeUserPermission(any<RestParams>()) } returns DataResult.Fail()
 
         val result = repository.getBecomeUserPermission()
-        assertFalse(result)
-    }
-
-    @Test
-    fun `Get send usage metrics returns false when feature flag is disabled`() = runTest {
-        coEvery { featuresApi.getEnvironmentFeatureFlags(any()) } returns DataResult.Success(
-            mapOf(FeaturesManager.SEND_USAGE_METRICS to false)
-        )
-
-        val result = repository.getSendUsageMetrics()
-        assertFalse(result)
-    }
-
-    @Test
-    fun `Get send usage metrics returns true when feature flag is enabled`() = runTest {
-        coEvery { featuresApi.getEnvironmentFeatureFlags(any()) } returns DataResult.Success(
-            mapOf(FeaturesManager.SEND_USAGE_METRICS to true)
-        )
-
-        val result = repository.getSendUsageMetrics()
-        assertTrue(result)
-    }
-
-    @Test
-    fun `Get send usage metrics returns false when call fails`() = runTest {
-        coEvery { featuresApi.getEnvironmentFeatureFlags(any()) } returns DataResult.Fail()
-
-        val result = repository.getSendUsageMetrics()
         assertFalse(result)
     }
 

--- a/apps/parent/src/test/java/com/instructure/parentapp/features/splash/SplashViewModelTest.kt
+++ b/apps/parent/src/test/java/com/instructure/parentapp/features/splash/SplashViewModelTest.kt
@@ -27,8 +27,8 @@ import com.instructure.canvasapi2.models.CanvasColor
 import com.instructure.canvasapi2.models.CanvasTheme
 import com.instructure.canvasapi2.models.User
 import com.instructure.canvasapi2.utils.ApiPrefs
-import com.instructure.canvasapi2.utils.ConsentPrefs
 import com.instructure.canvasapi2.utils.ContextKeeper
+import com.instructure.pandautils.domain.usecase.splash.SetupPendoTrackingUseCase
 import com.instructure.pandautils.utils.ColorKeeper
 import com.instructure.pandautils.utils.Const
 import com.instructure.pandautils.utils.FeatureFlagProvider
@@ -52,7 +52,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import sdk.pendo.io.Pendo
 
 
 @ExperimentalCoroutinesApi
@@ -72,6 +71,7 @@ class SplashViewModelTest {
     private val colorKeeper: ColorKeeper = mockk(relaxed = true)
     private val savedStateHandle = mockk<SavedStateHandle>(relaxed = true)
     private val featureFlagProvider = mockk<FeatureFlagProvider>(relaxed = true)
+    private val setupPendoTrackingUseCase = mockk<SetupPendoTrackingUseCase>(relaxed = true)
 
     private lateinit var viewModel: SplashViewModel
 
@@ -82,9 +82,6 @@ class SplashViewModelTest {
         lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
         Dispatchers.setMain(testDispatcher)
         ContextKeeper.appContext = context
-        mockkStatic(Pendo::class)
-        every { Pendo.startSession(any(), any(), any(), any()) } returns Unit
-        every { Pendo.endSession() } returns Unit
     }
 
     @After
@@ -262,31 +259,14 @@ class SplashViewModelTest {
     }
 
     @Test
-    fun `Send usage metrics enabled`() = runTest {
-        coEvery { repository.getSendUsageMetrics() } returns true
-        every { consentPrefs.currentUserConsent } returns true
-
+    fun `Setup pendo tracking use case is invoked on load`() = runTest {
         createViewModel()
 
         backgroundScope.launch(testDispatcher) {
             viewModel.events.toList()
         }
 
-        verify { Pendo.startSession(any(), any(), any(), any()) }
-    }
-
-    @Test
-    fun `Send usage metrics disabled`() = runTest {
-        coEvery { repository.getSendUsageMetrics() } returns false
-        every { consentPrefs.currentUserConsent } returns true
-
-        createViewModel()
-
-        backgroundScope.launch(testDispatcher) {
-            viewModel.events.toList()
-        }
-
-        verify { Pendo.endSession() }
+        coVerify { setupPendoTrackingUseCase(Unit) }
     }
 
     private fun createViewModel() {
@@ -294,9 +274,9 @@ class SplashViewModelTest {
             context = context,
             repository = repository,
             apiPrefs = apiPrefs,
-            consentPrefs = consentPrefs,
             colorKeeper = colorKeeper,
             featureFlagProvider = featureFlagProvider,
+            setupPendoTrackingUseCase = setupPendoTrackingUseCase,
             savedStateHandle = savedStateHandle
         )
     }

--- a/apps/parent/src/test/java/com/instructure/parentapp/features/splash/SplashViewModelTest.kt
+++ b/apps/parent/src/test/java/com/instructure/parentapp/features/splash/SplashViewModelTest.kt
@@ -36,7 +36,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
@@ -67,7 +66,6 @@ class SplashViewModelTest {
     private val context: Context = mockk(relaxed = true)
     private val repository: SplashRepository = mockk(relaxed = true)
     private val apiPrefs: ApiPrefs = mockk(relaxed = true)
-    private val consentPrefs: ConsentPrefs = mockk(relaxed = true)
     private val colorKeeper: ColorKeeper = mockk(relaxed = true)
     private val savedStateHandle = mockk<SavedStateHandle>(relaxed = true)
     private val featureFlagProvider = mockk<FeatureFlagProvider>(relaxed = true)
@@ -258,7 +256,6 @@ class SplashViewModelTest {
         verify(exactly = 0) { apiPrefs.canBecomeUser = any() }
     }
 
-    @Test
     fun `Setup pendo tracking use case is invoked on load`() = runTest {
         createViewModel()
 

--- a/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/AssignmentDetailsInteractionTest.kt
+++ b/apps/student/src/androidTest/java/com/instructure/student/ui/interaction/AssignmentDetailsInteractionTest.kt
@@ -668,10 +668,10 @@ class AssignmentDetailsInteractionTest : StudentComposeTest() {
         assignmentListPage.clickAssignment(assignment)
         assignmentDetailsPage.clickSubmit()
 
-        assignmentDetailsPage.assertSubmissionTypeDisplayed("Text Entry")
-        assignmentDetailsPage.assertSubmissionTypeDisplayed("Website URL")
-        assignmentDetailsPage.assertSubmissionTypeDisplayed("File Upload")
-        assignmentDetailsPage.assertSubmissionTypeDisplayed("Media Recording")
+        assignmentDetailsPage.assertSubmissionOptionDisplayed("Text Entry")
+        assignmentDetailsPage.assertSubmissionOptionDisplayed("Website URL")
+        assignmentDetailsPage.assertSubmissionOptionDisplayed("File Upload")
+        assignmentDetailsPage.assertSubmissionOptionDisplayed("Media Recording")
 
         //Try 1 submission to check if it's possible to submit even when there are multiple submission types available.
         assignmentDetailsPage.selectSubmissionType(SubmissionType.ONLINE_URL)

--- a/apps/student/src/main/java/com/instructure/student/activity/CallbackActivity.kt
+++ b/apps/student/src/main/java/com/instructure/student/activity/CallbackActivity.kt
@@ -22,9 +22,7 @@ import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.instructure.canvasapi2.StatusCallback
 import com.instructure.canvasapi2.apis.CourseAPI
 import com.instructure.canvasapi2.apis.PlannerAPI
-import com.instructure.canvasapi2.apis.UserAPI
 import com.instructure.canvasapi2.builders.RestParams
-import com.instructure.canvasapi2.managers.FeaturesManager
 import com.instructure.canvasapi2.managers.LaunchDefinitionsManager
 import com.instructure.canvasapi2.managers.ThemeManager
 import com.instructure.canvasapi2.managers.UnreadCountManager
@@ -42,7 +40,6 @@ import com.instructure.canvasapi2.models.User
 import com.instructure.canvasapi2.utils.APIHelper
 import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.canvasapi2.utils.ApiType
-import com.instructure.canvasapi2.utils.ConsentPrefs
 import com.instructure.canvasapi2.utils.LinkHeaders
 import com.instructure.canvasapi2.utils.Logger
 import com.instructure.canvasapi2.utils.RemoteConfigParam
@@ -61,10 +58,10 @@ import com.instructure.pandautils.features.inbox.list.OnUnreadCountInvalidated
 import com.instructure.pandautils.room.appdatabase.daos.ToDoFilterDao
 import com.instructure.pandautils.room.appdatabase.entities.ToDoFilterEntity
 import com.instructure.pandautils.utils.AppType
+import com.instructure.pandautils.domain.usecase.splash.SetupPendoTrackingUseCase
 import com.instructure.pandautils.utils.ColorKeeper
 import com.instructure.pandautils.utils.FeatureFlagProvider
 import com.instructure.pandautils.utils.LocaleUtils
-import com.instructure.pandautils.utils.SHA256
 import com.instructure.pandautils.utils.ThemePrefs
 import com.instructure.pandautils.utils.filterByToDoFilters
 import com.instructure.pandautils.utils.isComplete
@@ -80,7 +77,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Job
 import retrofit2.Call
 import retrofit2.Response
-import sdk.pendo.io.Pendo
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -96,9 +92,6 @@ abstract class CallbackActivity : ParentActivity(), OnUnreadCountInvalidated, No
     lateinit var pandataAppKey: PandataInfo.AppKey
 
     @Inject
-    lateinit var userApi: UserAPI.UsersInterface
-
-    @Inject
     lateinit var plannerApi: PlannerAPI.PlannerInterface
 
     @Inject
@@ -111,7 +104,7 @@ abstract class CallbackActivity : ParentActivity(), OnUnreadCountInvalidated, No
     lateinit var apiPrefs: ApiPrefs
 
     @Inject
-    lateinit var consentPrefs: ConsentPrefs
+    lateinit var setupPendoTrackingUseCase: SetupPendoTrackingUseCase
 
     @Inject
     lateinit var courseApi: CourseAPI.CoursesInterface
@@ -218,19 +211,8 @@ abstract class CallbackActivity : ParentActivity(), OnUnreadCountInvalidated, No
     }
 
     private suspend fun setupPendoTracking() {
-        if (consentPrefs.currentUserConsent != true) return
-
-        val user = userApi.getSelfWithUUID(RestParams(isForceReadFromNetwork = true)).dataOrNull
-        val featureFlagsResult = FeaturesManager.getEnvironmentFeatureFlagsAsync(true).await().dataOrNull
-        val sendUsageMetrics = featureFlagsResult?.get(FeaturesManager.SEND_USAGE_METRICS) ?: false
-        if (sendUsageMetrics) {
-            val visitorData = mapOf("locale" to ApiPrefs.effectiveLocale)
-            val accountData = mapOf("surveyOptOut" to featureFlagProvider.checkAccountSurveyNotificationsFlag())
-            widgetLogger.cancelLogging()
-            Pendo.startSession(user?.uuid?.SHA256().orEmpty(), user?.accountUuid.orEmpty(), visitorData, accountData)
-        } else {
-            Pendo.endSession()
-        }
+        widgetLogger.cancelLogging()
+        setupPendoTrackingUseCase(Unit)
     }
 
     private suspend fun getUnreadMessageCount() {

--- a/apps/student/src/main/java/com/instructure/student/di/WidgetModule.kt
+++ b/apps/student/src/main/java/com/instructure/student/di/WidgetModule.kt
@@ -26,6 +26,7 @@ import com.instructure.canvasapi2.apis.UserAPI
 import com.instructure.canvasapi2.managers.FeaturesManager
 import com.instructure.canvasapi2.utils.Analytics
 import com.instructure.canvasapi2.utils.ApiPrefs
+import com.instructure.canvasapi2.utils.ConsentPrefs
 import com.instructure.pandautils.room.appdatabase.daos.ToDoFilterDao
 import com.instructure.pandautils.utils.FeatureFlagProvider
 import com.instructure.student.widget.WidgetLogger
@@ -114,13 +115,15 @@ class WidgetModule {
         userApi: UserAPI.UsersInterface,
         featureFlagProvider: FeatureFlagProvider,
         featuresManager: FeaturesManager,
-        analytics: Analytics
+        analytics: Analytics,
+        consentPrefs: ConsentPrefs
     ): WidgetLogger {
         return WidgetLogger(
             userApi = userApi,
             featureFlagProvider = featureFlagProvider,
             featuresManager = featuresManager,
-            analytics = analytics
+            analytics = analytics,
+            consentPrefs = consentPrefs
         )
     }
 }

--- a/apps/student/src/main/java/com/instructure/student/di/feature/CookieConsentModule.kt
+++ b/apps/student/src/main/java/com/instructure/student/di/feature/CookieConsentModule.kt
@@ -21,11 +21,14 @@ import com.instructure.canvasapi2.utils.ConsentPrefs
 import com.instructure.pandautils.features.cookieconsent.AnalyticsConsentHandler
 import com.instructure.pandautils.features.cookieconsent.CookieConsentNamespace
 import com.instructure.pandautils.utils.FeatureFlagProvider
+import com.instructure.pandautils.utils.PendoTokenConfig
+import com.instructure.student.BuildConfig
 import com.instructure.student.widget.WidgetLogger
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -34,6 +37,15 @@ class CookieConsentModule {
     @Provides
     fun provideCookieConsentNamespace(): CookieConsentNamespace {
         return CookieConsentNamespace.STUDENT
+    }
+
+    @Provides
+    @Singleton
+    fun providePendoTokenConfig(): PendoTokenConfig {
+        return PendoTokenConfig(
+            fallbackToken = BuildConfig.PENDO_TOKEN,
+            apiTokenSelector = { it.pendoMobileStudentApiKey }
+        )
     }
 
     @Provides

--- a/apps/student/src/main/java/com/instructure/student/util/AppManager.kt
+++ b/apps/student/src/main/java/com/instructure/student/util/AppManager.kt
@@ -26,16 +26,13 @@ import androidx.work.WorkManager
 import androidx.work.WorkerFactory
 import com.instructure.canvasapi2.utils.ConsentPrefs
 import com.instructure.canvasapi2.utils.MasqueradeHelper
-import com.instructure.canvasapi2.utils.PendoInitCallbackHandler
 import com.instructure.loginapi.login.tasks.LogoutTask
 import com.instructure.pandautils.analytics.pageview.PageViewUploadWorker
 import com.instructure.pandautils.features.reminder.AlarmScheduler
 import com.instructure.pandautils.room.offline.DatabaseProvider
 import com.instructure.pandautils.typeface.TypefaceBehavior
-import com.instructure.student.BuildConfig
 import com.instructure.student.tasks.StudentLogoutTask
 import dagger.hilt.android.HiltAndroidApp
-import sdk.pendo.io.Pendo
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
@@ -71,12 +68,6 @@ class AppManager : BaseAppManager() {
         if (ConsentPrefs.currentUserConsent == true) {
             schedulePandataUpload()
         }
-        initPendo()
-    }
-
-    private fun initPendo() {
-        val options = Pendo.PendoOptions.Builder().setJetpackComposeBeta(true).build()
-        Pendo.setup(this, BuildConfig.PENDO_TOKEN, options, PendoInitCallbackHandler)
     }
 
     override fun performLogoutOnAuthError() {

--- a/apps/student/src/main/java/com/instructure/student/widget/WidgetLogger.kt
+++ b/apps/student/src/main/java/com/instructure/student/widget/WidgetLogger.kt
@@ -19,8 +19,11 @@ import android.content.Context
 import com.instructure.canvasapi2.apis.UserAPI
 import com.instructure.canvasapi2.builders.RestParams
 import com.instructure.canvasapi2.managers.FeaturesManager
+import com.instructure.canvasapi2.models.UserSettings
 import com.instructure.canvasapi2.utils.Analytics
 import com.instructure.canvasapi2.utils.ApiPrefs
+import com.instructure.canvasapi2.utils.ConsentPrefs
+import com.instructure.canvasapi2.utils.DataResult
 import com.instructure.canvasapi2.utils.PendoInitCallbackHandler
 import com.instructure.canvasapi2.utils.PendoInitListener
 import com.instructure.pandautils.utils.FeatureFlagProvider
@@ -38,7 +41,8 @@ class WidgetLogger @Inject constructor(
     private val userApi: UserAPI.UsersInterface,
     private val featureFlagProvider: FeatureFlagProvider,
     private val featuresManager: FeaturesManager,
-    private val analytics: Analytics
+    private val analytics: Analytics,
+    private val consentPrefs: ConsentPrefs
 ): PendoInitListener {
 
     private val coroutineScope = MainScope()
@@ -48,16 +52,27 @@ class WidgetLogger @Inject constructor(
         loggingJob = coroutineScope.launch(Dispatchers.IO) {
             if (!analytics.isSessionActive()) {
                 PendoInitCallbackHandler.addEvent(event)
-                val featureFlagsResult =
-                    featuresManager.getEnvironmentFeatureFlagsAsync(true).await().dataOrNull
-                val sendUsageMetrics =
-                    featureFlagsResult?.get(FeaturesManager.SEND_USAGE_METRICS) ?: false
-                if (sendUsageMetrics) {
+                if (shouldTrack()) {
                     PendoInitCallbackHandler.addListener(this@WidgetLogger)
                     setupPendo(context)
                 }
             } else {
                 analytics.logEvent(event)
+            }
+        }
+    }
+
+    private suspend fun shouldTrack(): Boolean {
+        val usageMetrics = (userApi.getSelfMobileSettings(RestParams(isForceReadFromNetwork = true)) as? DataResult.Success)
+            ?.data?.usageMetrics
+
+        return when (usageMetrics) {
+            UserSettings.USAGE_METRICS_TRACK -> true
+            UserSettings.USAGE_METRICS_NO_TRACK -> false
+            UserSettings.USAGE_METRICS_ASK_FOR_CONSENT -> consentPrefs.currentUserConsent == true
+            else -> {
+                val featureFlagsResult = featuresManager.getEnvironmentFeatureFlagsAsync(true).await().dataOrNull
+                featureFlagsResult?.get(FeaturesManager.SEND_USAGE_METRICS) ?: false
             }
         }
     }

--- a/apps/student/src/main/java/com/instructure/student/widget/WidgetLogger.kt
+++ b/apps/student/src/main/java/com/instructure/student/widget/WidgetLogger.kt
@@ -52,9 +52,12 @@ class WidgetLogger @Inject constructor(
         loggingJob = coroutineScope.launch(Dispatchers.IO) {
             if (!analytics.isSessionActive()) {
                 PendoInitCallbackHandler.addEvent(event)
-                if (shouldTrack()) {
+                val settings = (userApi.getSelfMobileSettings(RestParams(isForceReadFromNetwork = true)) as? DataResult.Success)?.data
+                if (shouldTrack(settings)) {
                     PendoInitCallbackHandler.addListener(this@WidgetLogger)
-                    setupPendo(context)
+                    val token = settings?.pendoMobileStudentApiKey?.takeIf { it.isNotEmpty() }
+                        ?: BuildConfig.PENDO_TOKEN
+                    setupPendo(context, token)
                 }
             } else {
                 analytics.logEvent(event)
@@ -62,11 +65,8 @@ class WidgetLogger @Inject constructor(
         }
     }
 
-    private suspend fun shouldTrack(): Boolean {
-        val usageMetrics = (userApi.getSelfMobileSettings(RestParams(isForceReadFromNetwork = true)) as? DataResult.Success)
-            ?.data?.usageMetrics
-
-        return when (usageMetrics) {
+    private suspend fun shouldTrack(settings: UserSettings?): Boolean {
+        return when (settings?.usageMetrics) {
             UserSettings.USAGE_METRICS_TRACK -> true
             UserSettings.USAGE_METRICS_NO_TRACK -> false
             UserSettings.USAGE_METRICS_ASK_FOR_CONSENT -> consentPrefs.currentUserConsent == true
@@ -77,9 +77,9 @@ class WidgetLogger @Inject constructor(
         }
     }
 
-    private suspend fun setupPendo(context: Context) {
+    private suspend fun setupPendo(context: Context, token: String) {
         val options = Pendo.PendoOptions.Builder().setJetpackComposeBeta(true).build()
-        Pendo.setup(context, BuildConfig.PENDO_TOKEN, options, PendoInitCallbackHandler)
+        Pendo.setup(context, token, options, PendoInitCallbackHandler)
         val visitorData = mapOf("locale" to ApiPrefs.effectiveLocale)
         val accountData =
             mapOf("surveyOptOut" to featureFlagProvider.checkAccountSurveyNotificationsFlag())

--- a/apps/teacher/src/main/java/com/instructure/teacher/activities/SplashActivity.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/activities/SplashActivity.kt
@@ -24,7 +24,6 @@ import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.instructure.canvasapi2.apis.UserAPI
 import com.instructure.canvasapi2.builders.RestParams
 import com.instructure.canvasapi2.managers.CourseManager
-import com.instructure.canvasapi2.managers.FeaturesManager
 import com.instructure.canvasapi2.managers.ThemeManager
 import com.instructure.canvasapi2.managers.UserManager
 import com.instructure.canvasapi2.models.Account
@@ -33,7 +32,6 @@ import com.instructure.canvasapi2.models.CanvasColor
 import com.instructure.canvasapi2.models.CanvasTheme
 import com.instructure.canvasapi2.models.User
 import com.instructure.canvasapi2.utils.ApiPrefs
-import com.instructure.canvasapi2.utils.ConsentPrefs
 import com.instructure.canvasapi2.utils.Logger
 import com.instructure.canvasapi2.utils.weave.StatusCallbackError
 import com.instructure.canvasapi2.utils.weave.awaitApi
@@ -41,11 +39,11 @@ import com.instructure.canvasapi2.utils.weave.awaitOrThrow
 import com.instructure.canvasapi2.utils.weave.weave
 import com.instructure.pandautils.base.BaseCanvasActivity
 import com.instructure.pandautils.binding.viewBinding
+import com.instructure.pandautils.domain.usecase.splash.SetupPendoTrackingUseCase
 import com.instructure.pandautils.utils.ColorKeeper
 import com.instructure.pandautils.utils.Const
 import com.instructure.pandautils.utils.FeatureFlagProvider
 import com.instructure.pandautils.utils.LocaleUtils
-import com.instructure.pandautils.utils.SHA256
 import com.instructure.pandautils.utils.ThemePrefs
 import com.instructure.pandautils.utils.setGone
 import com.instructure.pandautils.utils.toast
@@ -60,7 +58,6 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
-import sdk.pendo.io.Pendo
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -71,6 +68,9 @@ class SplashActivity : BaseCanvasActivity() {
 
     @Inject
     lateinit var userApi: UserAPI.UsersInterface
+
+    @Inject
+    lateinit var setupPendoTrackingUseCase: SetupPendoTrackingUseCase
 
     private val binding by viewBinding(ActivitySplashBinding::inflate)
 
@@ -98,7 +98,6 @@ class SplashActivity : BaseCanvasActivity() {
                 // Grab user teacher status
                 try {
                     val user = userApi.getSelf(RestParams(isForceReadFromNetwork = true)).dataOrThrow
-                    val userWithIds = userApi.getSelfWithUUID(RestParams(isForceReadFromNetwork = true)).dataOrThrow
                     val shouldRestartForLocaleChange = setupUser(user)
                     if (shouldRestartForLocaleChange) {
                         if (BuildConfig.DEBUG) toast(R.string.localeRestartMessage)
@@ -106,7 +105,7 @@ class SplashActivity : BaseCanvasActivity() {
                         return@weave
                     }
 
-                    setupPendoTracking(userWithIds)
+                    setupPendoTracking()
 
                     // Determine if user is a Teacher, Ta, or Designer
                     // Use GlobalScope since this can continue executing after SplashActivity is destroyed
@@ -233,22 +232,8 @@ class SplashActivity : BaseCanvasActivity() {
         return ApiPrefs.effectiveLocale != oldLocale
     }
 
-    private suspend fun setupPendoTracking(user: User) {
-        if (ConsentPrefs.currentUserConsent != true) return
-
-        val featureFlagsResult = FeaturesManager.getEnvironmentFeatureFlagsAsync(true).await().dataOrNull
-        val sendUsageMetrics = featureFlagsResult?.get(FeaturesManager.SEND_USAGE_METRICS) ?: false
-        if (sendUsageMetrics) {
-            val visitorData = mapOf(
-                "locale" to ApiPrefs.effectiveLocale,
-            )
-            val accountData = mapOf(
-                "surveyOptOut" to featureFlagProvider.checkAccountSurveyNotificationsFlag()
-            )
-            Pendo.startSession(user.uuid?.SHA256().orEmpty(), user.accountUuid.orEmpty(), visitorData, accountData)
-        } else {
-            Pendo.endSession()
-        }
+    private suspend fun setupPendoTracking() {
+        setupPendoTrackingUseCase(Unit)
     }
 
     override fun onStop() {

--- a/apps/teacher/src/main/java/com/instructure/teacher/di/CookieConsentModule.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/di/CookieConsentModule.kt
@@ -21,10 +21,13 @@ import com.instructure.canvasapi2.utils.ConsentPrefs
 import com.instructure.pandautils.features.cookieconsent.AnalyticsConsentHandler
 import com.instructure.pandautils.features.cookieconsent.CookieConsentNamespace
 import com.instructure.pandautils.utils.FeatureFlagProvider
+import com.instructure.pandautils.utils.PendoTokenConfig
+import com.instructure.teacher.BuildConfig
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -33,6 +36,15 @@ class CookieConsentModule {
     @Provides
     fun provideCookieConsentNamespace(): CookieConsentNamespace {
         return CookieConsentNamespace.TEACHER
+    }
+
+    @Provides
+    @Singleton
+    fun providePendoTokenConfig(): PendoTokenConfig {
+        return PendoTokenConfig(
+            fallbackToken = BuildConfig.PENDO_TOKEN,
+            apiTokenSelector = { it.pendoMobileTeacherApiKey }
+        )
     }
 
     @Provides

--- a/apps/teacher/src/main/java/com/instructure/teacher/utils/AppManager.kt
+++ b/apps/teacher/src/main/java/com/instructure/teacher/utils/AppManager.kt
@@ -24,9 +24,7 @@ import androidx.work.WorkerFactory
 import com.instructure.canvasapi2.utils.ConsentPrefs
 import com.instructure.pandautils.analytics.pageview.PageViewUploadWorker
 import com.instructure.pandautils.features.reminder.AlarmScheduler
-import com.instructure.teacher.BuildConfig
 import dagger.hilt.android.HiltAndroidApp
-import sdk.pendo.io.Pendo
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
@@ -51,7 +49,6 @@ class AppManager : BaseAppManager() {
         if (ConsentPrefs.currentUserConsent == true) {
             schedulePandataUpload()
         }
-        initPendo()
     }
 
     private fun schedulePandataUpload() {
@@ -60,8 +57,4 @@ class AppManager : BaseAppManager() {
         workManager.enqueueUniquePeriodicWork("pageView-teacher", ExistingPeriodicWorkPolicy.KEEP, workRequest)
     }
 
-    private fun initPendo() {
-        val options = Pendo.PendoOptions.Builder().setJetpackComposeBeta(true).build()
-        Pendo.setup(this, BuildConfig.PENDO_TOKEN, options, null)
-    }
 }

--- a/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/AssignmentDetailsPage.kt
+++ b/automation/espresso/src/main/kotlin/com/instructure/canvas/espresso/common/pages/AssignmentDetailsPage.kt
@@ -269,6 +269,10 @@ open class AssignmentDetailsPage(val moduleItemInteractions: ModuleItemInteracti
         onView(anyOf(withText(submissionType) + withAncestor(R.id.customPanel), withId(R.id.submissionTypesTextView) + withText(submissionType))).scrollTo().assertDisplayed()
     }
 
+    fun assertSubmissionOptionDisplayed(submissionType: String) {
+        onView(anyOf(withText(submissionType) + withAncestor(R.id.customPanel), withId(R.id.submissionTypesTextView) + withText(submissionType))).assertDisplayed()
+    }
+
     fun assertReminderViewDisplayed(position: Int = 0) {
         composeTestRule.onNodeWithTag("reminderView-$position").assertExists()
     }

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/UserAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/UserAPI.kt
@@ -73,7 +73,7 @@ object UserAPI {
         @GET("users/self/settings")
         fun getSelfSettings(): Call<UserSettings>
 
-        @GET("users/self/settings?include[]=mobile_setting")
+        @GET("users/self/settings?include[]=mobile_settings")
         suspend fun getSelfMobileSettings(@Tag params: RestParams): DataResult<UserSettings>
 
         @GET("users/self/features")

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/UserAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/UserAPI.kt
@@ -73,6 +73,9 @@ object UserAPI {
         @GET("users/self/settings")
         fun getSelfSettings(): Call<UserSettings>
 
+        @GET("users/self/settings?include[]=mobile_setting")
+        suspend fun getSelfMobileSettings(@Tag params: RestParams): DataResult<UserSettings>
+
         @GET("users/self/features")
         fun getSelfFeatures(): Call<List<CanvasFeatureFlag>>
 

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/UserSettings.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/models/UserSettings.kt
@@ -10,5 +10,19 @@ data class UserSettings(
     @SerializedName("hide_dashcard_color_overlays")
     val hideDashCardColorOverlays: Boolean = false,
     @SerializedName("comment_library_suggestions_enabled")
-    val commentLibrarySuggestions: Boolean = false
-)
+    val commentLibrarySuggestions: Boolean = false,
+    @SerializedName("usage_metrics")
+    val usageMetrics: String? = null,
+    @SerializedName("pendo_mobile_student_api_key")
+    val pendoMobileStudentApiKey: String? = null,
+    @SerializedName("pendo_mobile_teacher_api_key")
+    val pendoMobileTeacherApiKey: String? = null,
+    @SerializedName("pendo_mobile_parent_api_key")
+    val pendoMobileParentApiKey: String? = null
+) {
+    companion object {
+        const val USAGE_METRICS_TRACK = "track_usage"
+        const val USAGE_METRICS_NO_TRACK = "no_track_usage"
+        const val USAGE_METRICS_ASK_FOR_CONSENT = "ask_for_consent"
+    }
+}

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/data/repository/user/UserRepository.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/data/repository/user/UserRepository.kt
@@ -22,6 +22,7 @@ import com.instructure.canvasapi2.models.CanvasColor
 import com.instructure.canvasapi2.models.ColorChangeResponse
 import com.instructure.canvasapi2.models.DashboardPositions
 import com.instructure.canvasapi2.models.User
+import com.instructure.canvasapi2.models.UserSettings
 import com.instructure.canvasapi2.utils.DataResult
 
 interface UserRepository {
@@ -32,4 +33,5 @@ interface UserRepository {
     suspend fun getAccount(forceRefresh: Boolean): DataResult<Account>
     suspend fun setCourseColor(contextId: String, color: Int): DataResult<ColorChangeResponse>
     suspend fun updateDashboardPositions(positions: DashboardPositions): DataResult<DashboardPositions>
+    suspend fun getMobileSettings(forceRefresh: Boolean): DataResult<UserSettings>
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/data/repository/user/UserRepositoryImpl.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/data/repository/user/UserRepositoryImpl.kt
@@ -25,6 +25,7 @@ import com.instructure.canvasapi2.models.CanvasColor
 import com.instructure.canvasapi2.models.ColorChangeResponse
 import com.instructure.canvasapi2.models.DashboardPositions
 import com.instructure.canvasapi2.models.User
+import com.instructure.canvasapi2.models.UserSettings
 import com.instructure.canvasapi2.utils.DataResult
 import com.instructure.pandautils.utils.ColorUtils.toApiHexString
 
@@ -69,5 +70,10 @@ class UserRepositoryImpl(
             CanvasRestAdapter.clearCacheUrls("dashboard/dashboard_cards")
         }
         return result
+    }
+
+    override suspend fun getMobileSettings(forceRefresh: Boolean): DataResult<UserSettings> {
+        val params = RestParams(isForceReadFromNetwork = forceRefresh)
+        return userApi.getSelfMobileSettings(params)
     }
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/di/SettingsModule.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/di/SettingsModule.kt
@@ -17,11 +17,11 @@ package com.instructure.pandautils.di
 
 import com.instructure.canvasapi2.apis.ExperienceAPI
 import com.instructure.canvasapi2.apis.FeaturesAPI
+import com.instructure.canvasapi2.apis.UserAPI
 import com.instructure.canvasapi2.managers.InboxSettingsManager
 import com.instructure.pandautils.features.settings.SettingsBehaviour
 import com.instructure.pandautils.features.settings.SettingsRepository
 import com.instructure.pandautils.features.settings.SettingsSharedEvents
-import com.instructure.pandautils.utils.FeatureFlagProvider
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -39,9 +39,9 @@ class SettingsModule {
         inboxSettingsManager: InboxSettingsManager,
         settingsBehaviour: SettingsBehaviour,
         experienceAPI: ExperienceAPI,
-        featureFlagProvider: FeatureFlagProvider
+        userApi: UserAPI.UsersInterface
     ): SettingsRepository {
-        return SettingsRepository(featuresApi, inboxSettingsManager, settingsBehaviour, experienceAPI, featureFlagProvider)
+        return SettingsRepository(featuresApi, inboxSettingsManager, settingsBehaviour, experienceAPI, userApi)
     }
 }
 

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/domain/usecase/splash/SetupPendoTrackingUseCase.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/domain/usecase/splash/SetupPendoTrackingUseCase.kt
@@ -16,17 +16,20 @@
  */
 package com.instructure.pandautils.domain.usecase.splash
 
+import android.content.Context
 import com.instructure.canvasapi2.managers.FeaturesManager
 import com.instructure.canvasapi2.models.UserSettings
+import com.instructure.canvasapi2.utils.Analytics
 import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.canvasapi2.utils.ConsentPrefs
-import com.instructure.canvasapi2.utils.DataResult
 import com.instructure.pandautils.data.repository.features.FeaturesRepository
 import com.instructure.pandautils.data.repository.user.UserRepository
 import com.instructure.pandautils.domain.usecase.BaseUseCase
 import com.instructure.pandautils.utils.FeatureFlagProvider
+import com.instructure.pandautils.utils.PendoTokenConfig
 import com.instructure.pandautils.utils.SHA256
 import com.instructure.pandautils.utils.orDefault
+import dagger.hilt.android.qualifiers.ApplicationContext
 import sdk.pendo.io.Pendo
 import javax.inject.Inject
 
@@ -35,14 +38,16 @@ class SetupPendoTrackingUseCase @Inject constructor(
     private val userRepository: UserRepository,
     private val apiPrefs: ApiPrefs,
     private val featureFlagProvider: FeatureFlagProvider,
-    private val consentPrefs: ConsentPrefs
+    private val consentPrefs: ConsentPrefs,
+    private val analytics: Analytics,
+    private val pendoTokenConfig: PendoTokenConfig,
+    @ApplicationContext private val context: Context
 ) : BaseUseCase<Unit, Unit>() {
 
     override suspend fun execute(params: Unit) {
-        val usageMetrics = (userRepository.getMobileSettings(forceRefresh = true) as? DataResult.Success)
-            ?.data?.usageMetrics
+        val settings = userRepository.getMobileSettings(forceRefresh = true).dataOrNull
 
-        val shouldTrack = when (usageMetrics) {
+        val shouldTrack = when (settings?.usageMetrics) {
             UserSettings.USAGE_METRICS_TRACK -> true
             UserSettings.USAGE_METRICS_NO_TRACK -> false
             UserSettings.USAGE_METRICS_ASK_FOR_CONSENT -> consentPrefs.currentUserConsent == true
@@ -56,6 +61,15 @@ class SetupPendoTrackingUseCase @Inject constructor(
             val userWithIds = userRepository.getSelfWithUuid(forceRefresh = true).dataOrNull
             val visitorData = mapOf("locale" to apiPrefs.effectiveLocale)
             val accountData = mapOf("surveyOptOut" to featureFlagProvider.checkAccountSurveyNotificationsFlag())
+
+            if (!analytics.isSessionActive()) {
+                val token = settings?.let { pendoTokenConfig.apiTokenSelector(it) }
+                    ?.takeIf { it.isNotEmpty() }
+                    ?: pendoTokenConfig.fallbackToken
+                val options = Pendo.PendoOptions.Builder().setJetpackComposeBeta(true).build()
+                Pendo.setup(context, token, options, null)
+            }
+
             Pendo.startSession(
                 userWithIds?.uuid?.SHA256().orEmpty(),
                 userWithIds?.accountUuid.orEmpty(),

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/domain/usecase/splash/SetupPendoTrackingUseCase.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/domain/usecase/splash/SetupPendoTrackingUseCase.kt
@@ -17,7 +17,10 @@
 package com.instructure.pandautils.domain.usecase.splash
 
 import com.instructure.canvasapi2.managers.FeaturesManager
+import com.instructure.canvasapi2.models.UserSettings
 import com.instructure.canvasapi2.utils.ApiPrefs
+import com.instructure.canvasapi2.utils.ConsentPrefs
+import com.instructure.canvasapi2.utils.DataResult
 import com.instructure.pandautils.data.repository.features.FeaturesRepository
 import com.instructure.pandautils.data.repository.user.UserRepository
 import com.instructure.pandautils.domain.usecase.BaseUseCase
@@ -31,16 +34,25 @@ class SetupPendoTrackingUseCase @Inject constructor(
     private val featuresRepository: FeaturesRepository,
     private val userRepository: UserRepository,
     private val apiPrefs: ApiPrefs,
-    private val featureFlagProvider: FeatureFlagProvider
+    private val featureFlagProvider: FeatureFlagProvider,
+    private val consentPrefs: ConsentPrefs
 ) : BaseUseCase<Unit, Unit>() {
 
     override suspend fun execute(params: Unit) {
-        val sendUsageMetrics = featuresRepository.getEnvironmentFeatureFlags(forceRefresh = true)
-            .dataOrNull
-            ?.get(FeaturesManager.SEND_USAGE_METRICS)
-            .orDefault()
+        val usageMetrics = (userRepository.getMobileSettings(forceRefresh = true) as? DataResult.Success)
+            ?.data?.usageMetrics
 
-        if (sendUsageMetrics) {
+        val shouldTrack = when (usageMetrics) {
+            UserSettings.USAGE_METRICS_TRACK -> true
+            UserSettings.USAGE_METRICS_NO_TRACK -> false
+            UserSettings.USAGE_METRICS_ASK_FOR_CONSENT -> consentPrefs.currentUserConsent == true
+            else -> featuresRepository.getEnvironmentFeatureFlags(forceRefresh = true)
+                .dataOrNull
+                ?.get(FeaturesManager.SEND_USAGE_METRICS)
+                .orDefault()
+        }
+
+        if (shouldTrack) {
             val userWithIds = userRepository.getSelfWithUuid(forceRefresh = true).dataOrNull
             val visitorData = mapOf("locale" to apiPrefs.effectiveLocale)
             val accountData = mapOf("surveyOptOut" to featureFlagProvider.checkAccountSurveyNotificationsFlag())

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/cookieconsent/CookieConsentViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/cookieconsent/CookieConsentViewModel.kt
@@ -17,6 +17,7 @@ package com.instructure.pandautils.features.cookieconsent
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.instructure.canvasapi2.models.UserSettings
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -47,7 +48,7 @@ class CookieConsentViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 val result = getCookieConsentUseCase(Unit)
-                if (result.flagEnabled && result.consent == null) {
+                if (result.usageMetrics == UserSettings.USAGE_METRICS_ASK_FOR_CONSENT && result.consent == null) {
                     _uiState.update { it.copy(loading = false, showDialog = true) }
                 } else {
                     _uiState.update {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/cookieconsent/GetCookieConsentUseCase.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/cookieconsent/GetCookieConsentUseCase.kt
@@ -16,25 +16,27 @@
 package com.instructure.pandautils.features.cookieconsent
 
 import com.instructure.canvasapi2.utils.ConsentPrefs
+import com.instructure.canvasapi2.utils.DataResult
+import com.instructure.pandautils.data.repository.user.UserRepository
 import com.instructure.pandautils.domain.usecase.BaseUseCase
-import com.instructure.pandautils.utils.FeatureFlagProvider
 import javax.inject.Inject
 
 class GetCookieConsentUseCase @Inject constructor(
-    private val featureFlagProvider: FeatureFlagProvider,
+    private val userRepository: UserRepository,
     private val consentPrefs: ConsentPrefs
 ) : BaseUseCase<Unit, GetCookieConsentUseCase.Result>() {
 
     data class Result(
-        val flagEnabled: Boolean,
+        val usageMetrics: String?,
         val consent: Boolean?
     )
 
     override suspend fun execute(params: Unit): Result {
-        featureFlagProvider.fetchEnvironmentFeatureFlags()
-        val flagEnabled = featureFlagProvider.checkCookieConsentFlag()
-        if (!flagEnabled) return Result(flagEnabled = false, consent = null)
+        val settings = userRepository.getMobileSettings(forceRefresh = true)
+        if (settings !is DataResult.Success) return Result(usageMetrics = null, consent = null)
 
-        return Result(flagEnabled = true, consent = consentPrefs.currentUserConsent)
+        val usageMetrics = settings.data.usageMetrics ?: return Result(usageMetrics = null, consent = null)
+
+        return Result(usageMetrics = usageMetrics, consent = consentPrefs.currentUserConsent)
     }
 }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/settings/SettingsRepository.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/settings/SettingsRepository.kt
@@ -18,21 +18,23 @@ package com.instructure.pandautils.features.settings
 import androidx.annotation.StringRes
 import com.instructure.canvasapi2.apis.ExperienceAPI
 import com.instructure.canvasapi2.apis.FeaturesAPI
+import com.instructure.canvasapi2.apis.UserAPI
 import com.instructure.canvasapi2.builders.RestParams
 import com.instructure.canvasapi2.managers.InboxSettingsManager
+import com.instructure.canvasapi2.models.UserSettings
 import com.instructure.pandautils.R
-import com.instructure.pandautils.utils.FeatureFlagProvider
 
 class SettingsRepository(
     private val featuresApi: FeaturesAPI.FeaturesInterface,
     private val inboxSettingsManager: InboxSettingsManager,
     private val settingsBehaviour: SettingsBehaviour,
     private val experienceAPI: ExperienceAPI,
-    private val featureFlagProvider: FeatureFlagProvider
+    private val userApi: UserAPI.UsersInterface
 ) {
 
-    suspend fun isCookieConsentEnabled(): Boolean {
-        return featureFlagProvider.checkCookieConsentFlag()
+    suspend fun isAskForConsentMode(): Boolean {
+        val settings = userApi.getSelfMobileSettings(RestParams()).dataOrNull
+        return settings?.usageMetrics == UserSettings.USAGE_METRICS_ASK_FOR_CONSENT
     }
 
     suspend fun getInboxSignatureState(): InboxSignatureState {

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/features/settings/SettingsViewModel.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/features/settings/SettingsViewModel.kt
@@ -105,7 +105,7 @@ class SettingsViewModel @Inject constructor(
                     changeSettingsItemSubtitle(SettingsItem.INBOX_SIGNATURE, it)
                 }
             }
-            if (!settingsRepository.isCookieConsentEnabled()) {
+            if (!settingsRepository.isAskForConsentMode()) {
                 _uiState.update { state ->
                     state.copy(items = state.items.mapValues { (_, items) ->
                         items.filter { it.item != SettingsItem.PRIVACY }

--- a/libs/pandautils/src/main/java/com/instructure/pandautils/utils/PendoTokenConfig.kt
+++ b/libs/pandautils/src/main/java/com/instructure/pandautils/utils/PendoTokenConfig.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package com.instructure.pandautils.utils
+
+import com.instructure.canvasapi2.models.UserSettings
+
+class PendoTokenConfig(
+    val fallbackToken: String,
+    val apiTokenSelector: (UserSettings) -> String?
+)

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/data/repository/user/UserRepositoryTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/data/repository/user/UserRepositoryTest.kt
@@ -21,6 +21,7 @@ import com.instructure.canvasapi2.apis.UserAPI
 import com.instructure.canvasapi2.models.Account
 import com.instructure.canvasapi2.models.ColorChangeResponse
 import com.instructure.canvasapi2.models.DashboardPositions
+import com.instructure.canvasapi2.models.UserSettings
 import com.instructure.canvasapi2.utils.DataResult
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -244,5 +245,38 @@ class UserRepositoryTest {
         verify {
             CanvasRestAdapter.clearCacheUrls("dashboard/dashboard_cards")
         }
+    }
+
+    @Test
+    fun `getMobileSettings returns success with settings data`() = runTest {
+        val settings = UserSettings(usageMetrics = UserSettings.USAGE_METRICS_ASK_FOR_CONSENT)
+        val expected = DataResult.Success(settings)
+        coEvery { userApi.getSelfMobileSettings(any()) } returns expected
+
+        val result = repository.getMobileSettings(forceRefresh = true)
+
+        assertEquals(expected, result)
+        coVerify { userApi.getSelfMobileSettings(match { it.isForceReadFromNetwork }) }
+    }
+
+    @Test
+    fun `getMobileSettings with forceRefresh false uses cache`() = runTest {
+        val settings = UserSettings(usageMetrics = UserSettings.USAGE_METRICS_TRACK)
+        val expected = DataResult.Success(settings)
+        coEvery { userApi.getSelfMobileSettings(any()) } returns expected
+
+        repository.getMobileSettings(forceRefresh = false)
+
+        coVerify { userApi.getSelfMobileSettings(match { !it.isForceReadFromNetwork }) }
+    }
+
+    @Test
+    fun `getMobileSettings returns failure`() = runTest {
+        val expected = DataResult.Fail()
+        coEvery { userApi.getSelfMobileSettings(any()) } returns expected
+
+        val result = repository.getMobileSettings(forceRefresh = true)
+
+        assertEquals(expected, result)
     }
 }

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/domain/usecase/splash/SetupPendoTrackingUseCaseTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/domain/usecase/splash/SetupPendoTrackingUseCaseTest.kt
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package com.instructure.pandautils.domain.usecase.splash
+
+import com.instructure.canvasapi2.managers.FeaturesManager
+import com.instructure.canvasapi2.models.User
+import com.instructure.canvasapi2.models.UserSettings
+import com.instructure.canvasapi2.utils.ApiPrefs
+import com.instructure.canvasapi2.utils.ConsentPrefs
+import com.instructure.canvasapi2.utils.DataResult
+import com.instructure.pandautils.data.repository.features.FeaturesRepository
+import com.instructure.pandautils.data.repository.user.UserRepository
+import com.instructure.pandautils.utils.FeatureFlagProvider
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import sdk.pendo.io.Pendo
+
+class SetupPendoTrackingUseCaseTest {
+
+    private val featuresRepository: FeaturesRepository = mockk(relaxed = true)
+    private val userRepository: UserRepository = mockk(relaxed = true)
+    private val apiPrefs: ApiPrefs = mockk(relaxed = true)
+    private val featureFlagProvider: FeatureFlagProvider = mockk(relaxed = true)
+    private val consentPrefs: ConsentPrefs = mockk(relaxed = true)
+
+    private val useCase = SetupPendoTrackingUseCase(
+        featuresRepository, userRepository, apiPrefs, featureFlagProvider, consentPrefs
+    )
+
+    @Before
+    fun setup() {
+        mockkStatic(Pendo::class)
+        every { Pendo.startSession(any(), any(), any(), any()) } returns Unit
+        every { Pendo.endSession() } returns Unit
+        coEvery { userRepository.getSelfWithUuid(any()) } returns DataResult.Success(
+            User(uuid = "test-uuid", accountUuid = "account-uuid")
+        )
+    }
+
+    @After
+    fun teardown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `track_usage starts pendo session without consent check`() = runTest {
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Success(
+            UserSettings(usageMetrics = UserSettings.USAGE_METRICS_TRACK)
+        )
+
+        useCase(Unit)
+
+        verify { Pendo.startSession(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `no_track_usage ends pendo session`() = runTest {
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Success(
+            UserSettings(usageMetrics = UserSettings.USAGE_METRICS_NO_TRACK)
+        )
+
+        useCase(Unit)
+
+        verify { Pendo.endSession() }
+    }
+
+    @Test
+    fun `ask_for_consent with consent granted starts session`() = runTest {
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Success(
+            UserSettings(usageMetrics = UserSettings.USAGE_METRICS_ASK_FOR_CONSENT)
+        )
+        every { consentPrefs.currentUserConsent } returns true
+
+        useCase(Unit)
+
+        verify { Pendo.startSession(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `ask_for_consent with consent declined ends session`() = runTest {
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Success(
+            UserSettings(usageMetrics = UserSettings.USAGE_METRICS_ASK_FOR_CONSENT)
+        )
+        every { consentPrefs.currentUserConsent } returns false
+
+        useCase(Unit)
+
+        verify { Pendo.endSession() }
+    }
+
+    @Test
+    fun `ask_for_consent with no consent decision ends session`() = runTest {
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Success(
+            UserSettings(usageMetrics = UserSettings.USAGE_METRICS_ASK_FOR_CONSENT)
+        )
+        every { consentPrefs.currentUserConsent } returns null
+
+        useCase(Unit)
+
+        verify { Pendo.endSession() }
+    }
+
+    @Test
+    fun `null usageMetrics falls back to feature flag enabled and starts session`() = runTest {
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Fail()
+        coEvery { featuresRepository.getEnvironmentFeatureFlags(any()) } returns DataResult.Success(
+            mapOf(FeaturesManager.SEND_USAGE_METRICS to true)
+        )
+
+        useCase(Unit)
+
+        verify { Pendo.startSession(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `null usageMetrics falls back to feature flag disabled and ends session`() = runTest {
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Fail()
+        coEvery { featuresRepository.getEnvironmentFeatureFlags(any()) } returns DataResult.Success(
+            mapOf(FeaturesManager.SEND_USAGE_METRICS to false)
+        )
+
+        useCase(Unit)
+
+        verify { Pendo.endSession() }
+    }
+
+    @Test
+    fun `null usageMetrics from success response falls back to feature flag`() = runTest {
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Success(UserSettings())
+        coEvery { featuresRepository.getEnvironmentFeatureFlags(any()) } returns DataResult.Success(
+            mapOf(FeaturesManager.SEND_USAGE_METRICS to true)
+        )
+
+        useCase(Unit)
+
+        verify { Pendo.startSession(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `feature flag fallback does not check consent`() = runTest {
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Fail()
+        coEvery { featuresRepository.getEnvironmentFeatureFlags(any()) } returns DataResult.Success(
+            mapOf(FeaturesManager.SEND_USAGE_METRICS to true)
+        )
+
+        useCase(Unit)
+
+        verify(exactly = 0) { consentPrefs.currentUserConsent }
+    }
+
+    @Test
+    fun `track_usage does not check consent`() = runTest {
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Success(
+            UserSettings(usageMetrics = UserSettings.USAGE_METRICS_TRACK)
+        )
+
+        useCase(Unit)
+
+        verify(exactly = 0) { consentPrefs.currentUserConsent }
+    }
+}

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/domain/usecase/splash/SetupPendoTrackingUseCaseTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/domain/usecase/splash/SetupPendoTrackingUseCaseTest.kt
@@ -15,15 +15,18 @@
  */
 package com.instructure.pandautils.domain.usecase.splash
 
+import android.content.Context
 import com.instructure.canvasapi2.managers.FeaturesManager
 import com.instructure.canvasapi2.models.User
 import com.instructure.canvasapi2.models.UserSettings
+import com.instructure.canvasapi2.utils.Analytics
 import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.canvasapi2.utils.ConsentPrefs
 import com.instructure.canvasapi2.utils.DataResult
 import com.instructure.pandautils.data.repository.features.FeaturesRepository
 import com.instructure.pandautils.data.repository.user.UserRepository
 import com.instructure.pandautils.utils.FeatureFlagProvider
+import com.instructure.pandautils.utils.PendoTokenConfig
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -43,9 +46,16 @@ class SetupPendoTrackingUseCaseTest {
     private val apiPrefs: ApiPrefs = mockk(relaxed = true)
     private val featureFlagProvider: FeatureFlagProvider = mockk(relaxed = true)
     private val consentPrefs: ConsentPrefs = mockk(relaxed = true)
+    private val analytics: Analytics = mockk(relaxed = true)
+    private val context: Context = mockk(relaxed = true)
+    private val pendoTokenConfig = PendoTokenConfig(
+        fallbackToken = "fallback-token",
+        apiTokenSelector = { it.pendoMobileStudentApiKey }
+    )
 
     private val useCase = SetupPendoTrackingUseCase(
-        featuresRepository, userRepository, apiPrefs, featureFlagProvider, consentPrefs
+        featuresRepository, userRepository, apiPrefs, featureFlagProvider,
+        consentPrefs, analytics, pendoTokenConfig, context
     )
 
     @Before
@@ -53,6 +63,8 @@ class SetupPendoTrackingUseCaseTest {
         mockkStatic(Pendo::class)
         every { Pendo.startSession(any(), any(), any(), any()) } returns Unit
         every { Pendo.endSession() } returns Unit
+        every { Pendo.setup(any(), any(), any(), any()) } returns Unit
+        every { analytics.isSessionActive() } returns false
         coEvery { userRepository.getSelfWithUuid(any()) } returns DataResult.Success(
             User(uuid = "test-uuid", accountUuid = "account-uuid")
         )
@@ -178,5 +190,76 @@ class SetupPendoTrackingUseCaseTest {
         useCase(Unit)
 
         verify(exactly = 0) { consentPrefs.currentUserConsent }
+    }
+
+    @Test
+    fun `uses api token from settings when available`() = runTest {
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Success(
+            UserSettings(usageMetrics = UserSettings.USAGE_METRICS_TRACK, pendoMobileStudentApiKey = "api-token")
+        )
+
+        useCase(Unit)
+
+        verify { Pendo.setup(any(), "api-token", any(), any()) }
+    }
+
+    @Test
+    fun `falls back to hardcoded token when api token is null`() = runTest {
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Success(
+            UserSettings(usageMetrics = UserSettings.USAGE_METRICS_TRACK, pendoMobileStudentApiKey = null)
+        )
+
+        useCase(Unit)
+
+        verify { Pendo.setup(any(), "fallback-token", any(), any()) }
+    }
+
+    @Test
+    fun `falls back to hardcoded token when api token is empty`() = runTest {
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Success(
+            UserSettings(usageMetrics = UserSettings.USAGE_METRICS_TRACK, pendoMobileStudentApiKey = "")
+        )
+
+        useCase(Unit)
+
+        verify { Pendo.setup(any(), "fallback-token", any(), any()) }
+    }
+
+    @Test
+    fun `falls back to hardcoded token when settings call fails`() = runTest {
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Fail()
+        coEvery { featuresRepository.getEnvironmentFeatureFlags(any()) } returns DataResult.Success(
+            mapOf(FeaturesManager.SEND_USAGE_METRICS to true)
+        )
+
+        useCase(Unit)
+
+        verify { Pendo.setup(any(), "fallback-token", any(), any()) }
+    }
+
+    @Test
+    fun `skips pendo setup when session is already active`() = runTest {
+        every { analytics.isSessionActive() } returns true
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Success(
+            UserSettings(usageMetrics = UserSettings.USAGE_METRICS_TRACK)
+        )
+
+        useCase(Unit)
+
+        verify(exactly = 0) { Pendo.setup(any(), any(), any(), any()) }
+        verify { Pendo.startSession(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `calls pendo setup when session is not active`() = runTest {
+        every { analytics.isSessionActive() } returns false
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Success(
+            UserSettings(usageMetrics = UserSettings.USAGE_METRICS_TRACK)
+        )
+
+        useCase(Unit)
+
+        verify { Pendo.setup(any(), any(), any(), any()) }
+        verify { Pendo.startSession(any(), any(), any(), any()) }
     }
 }

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/cookieconsent/CookieConsentViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/cookieconsent/CookieConsentViewModelTest.kt
@@ -16,6 +16,7 @@
  */
 package com.instructure.pandautils.features.cookieconsent
 
+import com.instructure.canvasapi2.models.UserSettings
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -76,7 +77,7 @@ class CookieConsentViewModelTest {
     @Test
     fun `checkAndShowIfNeeded shows dialog when flag enabled and consent is null`() {
         coEvery { getCookieConsentUseCase(Unit) } returns GetCookieConsentUseCase.Result(
-            flagEnabled = true, consent = null
+            usageMetrics = UserSettings.USAGE_METRICS_ASK_FOR_CONSENT, consent = null
         )
 
         val viewModel = createViewModel()
@@ -91,7 +92,7 @@ class CookieConsentViewModelTest {
     @Test
     fun `checkAndShowIfNeeded skips dialog when flag disabled`() {
         coEvery { getCookieConsentUseCase(Unit) } returns GetCookieConsentUseCase.Result(
-            flagEnabled = false, consent = null
+            usageMetrics = null, consent = null
         )
 
         val viewModel = createViewModel()
@@ -106,7 +107,7 @@ class CookieConsentViewModelTest {
     @Test
     fun `checkAndShowIfNeeded skips dialog when consent already given`() {
         coEvery { getCookieConsentUseCase(Unit) } returns GetCookieConsentUseCase.Result(
-            flagEnabled = true, consent = true
+            usageMetrics = UserSettings.USAGE_METRICS_TRACK, consent = true
         )
 
         val viewModel = createViewModel()
@@ -121,7 +122,7 @@ class CookieConsentViewModelTest {
     @Test
     fun `checkAndShowIfNeeded skips dialog when consent already declined`() {
         coEvery { getCookieConsentUseCase(Unit) } returns GetCookieConsentUseCase.Result(
-            flagEnabled = true, consent = false
+            usageMetrics = com.instructure.canvasapi2.models.UserSettings.USAGE_METRICS_NO_TRACK, consent = false
         )
 
         val viewModel = createViewModel()
@@ -149,7 +150,7 @@ class CookieConsentViewModelTest {
     @Test
     fun `checkAndShowIfNeeded invokes use case`() {
         coEvery { getCookieConsentUseCase(Unit) } returns GetCookieConsentUseCase.Result(
-            flagEnabled = false, consent = null
+            usageMetrics = null, consent = null
         )
 
         val viewModel = createViewModel()
@@ -161,7 +162,7 @@ class CookieConsentViewModelTest {
     @Test
     fun `onAllow submits consent true and sets consent result`() {
         coEvery { getCookieConsentUseCase(Unit) } returns GetCookieConsentUseCase.Result(
-            flagEnabled = true, consent = null
+            usageMetrics = UserSettings.USAGE_METRICS_ASK_FOR_CONSENT, consent = null
         )
 
         val viewModel = createViewModel()
@@ -179,7 +180,7 @@ class CookieConsentViewModelTest {
     @Test
     fun `onDecline submits consent false and sets consent result`() {
         coEvery { getCookieConsentUseCase(Unit) } returns GetCookieConsentUseCase.Result(
-            flagEnabled = true, consent = null
+            usageMetrics = UserSettings.USAGE_METRICS_ASK_FOR_CONSENT, consent = null
         )
 
         val viewModel = createViewModel()
@@ -198,7 +199,7 @@ class CookieConsentViewModelTest {
     @Test
     fun `submit consent shows error message on failure`() {
         coEvery { getCookieConsentUseCase(Unit) } returns GetCookieConsentUseCase.Result(
-            flagEnabled = true, consent = null
+            usageMetrics = UserSettings.USAGE_METRICS_ASK_FOR_CONSENT, consent = null
         )
         coEvery { setCookieConsentUseCase(SetCookieConsentUseCase.Params(true)) } throws RuntimeException("Save failed")
 
@@ -216,7 +217,7 @@ class CookieConsentViewModelTest {
     @Test
     fun `submit consent shows default error message when exception has no message`() {
         coEvery { getCookieConsentUseCase(Unit) } returns GetCookieConsentUseCase.Result(
-            flagEnabled = true, consent = null
+            usageMetrics = UserSettings.USAGE_METRICS_ASK_FOR_CONSENT, consent = null
         )
         coEvery { setCookieConsentUseCase(SetCookieConsentUseCase.Params(true)) } throws RuntimeException()
 
@@ -231,7 +232,7 @@ class CookieConsentViewModelTest {
     @Test
     fun `onErrorDismissed clears error message`() {
         coEvery { getCookieConsentUseCase(Unit) } returns GetCookieConsentUseCase.Result(
-            flagEnabled = true, consent = null
+            usageMetrics = UserSettings.USAGE_METRICS_ASK_FOR_CONSENT, consent = null
         )
         coEvery { setCookieConsentUseCase(SetCookieConsentUseCase.Params(true)) } throws RuntimeException("Error")
 
@@ -247,7 +248,7 @@ class CookieConsentViewModelTest {
     @Test
     fun `onConsentResultHandled clears consent result`() {
         coEvery { getCookieConsentUseCase(Unit) } returns GetCookieConsentUseCase.Result(
-            flagEnabled = false, consent = null
+            usageMetrics = null, consent = null
         )
 
         val viewModel = createViewModel()

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/cookieconsent/GetCookieConsentUseCaseTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/cookieconsent/GetCookieConsentUseCaseTest.kt
@@ -16,11 +16,11 @@
  */
 package com.instructure.pandautils.features.cookieconsent
 
+import com.instructure.canvasapi2.models.UserSettings
 import com.instructure.canvasapi2.utils.ConsentPrefs
-import com.instructure.pandautils.utils.FeatureFlagProvider
-import io.mockk.Ordering
+import com.instructure.canvasapi2.utils.DataResult
+import com.instructure.pandautils.data.repository.user.UserRepository
 import io.mockk.coEvery
-import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
@@ -28,17 +28,15 @@ import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class GetCookieConsentUseCaseTest {
 
-    private val featureFlagProvider: FeatureFlagProvider = mockk(relaxed = true)
+    private val userRepository: UserRepository = mockk(relaxed = true)
     private val consentPrefs: ConsentPrefs = mockk(relaxed = true)
 
-    private val useCase = GetCookieConsentUseCase(featureFlagProvider, consentPrefs)
+    private val useCase = GetCookieConsentUseCase(userRepository, consentPrefs)
 
     @After
     fun teardown() {
@@ -46,30 +44,28 @@ class GetCookieConsentUseCaseTest {
     }
 
     @Test
-    fun `returns flag disabled with null consent when feature flag is off`() = runTest {
-        coEvery { featureFlagProvider.checkCookieConsentFlag() } returns false
+    fun `returns null results when settings call fails`() = runTest {
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Fail()
 
         val result = useCase(Unit)
 
-        assertFalse(result.flagEnabled)
+        assertNull(result.usageMetrics)
         assertNull(result.consent)
     }
 
     @Test
-    fun `fetches environment feature flags before checking`() = runTest {
-        coEvery { featureFlagProvider.checkCookieConsentFlag() } returns false
+    fun `returns null results when usageMetrics is absent from settings`() = runTest {
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Success(UserSettings())
 
-        useCase(Unit)
+        val result = useCase(Unit)
 
-        coVerify(ordering = Ordering.ORDERED) {
-            featureFlagProvider.fetchEnvironmentFeatureFlags()
-            featureFlagProvider.checkCookieConsentFlag()
-        }
+        assertNull(result.usageMetrics)
+        assertNull(result.consent)
     }
 
     @Test
-    fun `does not read ConsentPrefs when flag is disabled`() = runTest {
-        coEvery { featureFlagProvider.checkCookieConsentFlag() } returns false
+    fun `does not read ConsentPrefs when usageMetrics is absent`() = runTest {
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Success(UserSettings())
 
         useCase(Unit)
 
@@ -77,35 +73,58 @@ class GetCookieConsentUseCaseTest {
     }
 
     @Test
-    fun `returns flag enabled with true consent when ConsentPrefs stores true`() = runTest {
-        coEvery { featureFlagProvider.checkCookieConsentFlag() } returns true
+    fun `returns usageMetrics and true consent`() = runTest {
+        val settings = UserSettings(usageMetrics = UserSettings.USAGE_METRICS_ASK_FOR_CONSENT)
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Success(settings)
         every { consentPrefs.currentUserConsent } returns true
 
         val result = useCase(Unit)
 
-        assertTrue(result.flagEnabled)
+        assertEquals(UserSettings.USAGE_METRICS_ASK_FOR_CONSENT, result.usageMetrics)
         assertEquals(true, result.consent)
     }
 
     @Test
-    fun `returns flag enabled with false consent when ConsentPrefs stores false`() = runTest {
-        coEvery { featureFlagProvider.checkCookieConsentFlag() } returns true
+    fun `returns usageMetrics and false consent`() = runTest {
+        val settings = UserSettings(usageMetrics = UserSettings.USAGE_METRICS_ASK_FOR_CONSENT)
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Success(settings)
         every { consentPrefs.currentUserConsent } returns false
 
         val result = useCase(Unit)
 
-        assertTrue(result.flagEnabled)
+        assertEquals(UserSettings.USAGE_METRICS_ASK_FOR_CONSENT, result.usageMetrics)
         assertEquals(false, result.consent)
     }
 
     @Test
-    fun `returns flag enabled with null consent when ConsentPrefs has no decision stored`() = runTest {
-        coEvery { featureFlagProvider.checkCookieConsentFlag() } returns true
+    fun `returns usageMetrics and null consent when no decision stored`() = runTest {
+        val settings = UserSettings(usageMetrics = UserSettings.USAGE_METRICS_ASK_FOR_CONSENT)
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Success(settings)
         every { consentPrefs.currentUserConsent } returns null
 
         val result = useCase(Unit)
 
-        assertTrue(result.flagEnabled)
+        assertEquals(UserSettings.USAGE_METRICS_ASK_FOR_CONSENT, result.usageMetrics)
         assertNull(result.consent)
+    }
+
+    @Test
+    fun `passes track_usage value through from settings`() = runTest {
+        val settings = UserSettings(usageMetrics = UserSettings.USAGE_METRICS_TRACK)
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Success(settings)
+
+        val result = useCase(Unit)
+
+        assertEquals(UserSettings.USAGE_METRICS_TRACK, result.usageMetrics)
+    }
+
+    @Test
+    fun `passes no_track_usage value through from settings`() = runTest {
+        val settings = UserSettings(usageMetrics = UserSettings.USAGE_METRICS_NO_TRACK)
+        coEvery { userRepository.getMobileSettings(any()) } returns DataResult.Success(settings)
+
+        val result = useCase(Unit)
+
+        assertEquals(UserSettings.USAGE_METRICS_NO_TRACK, result.usageMetrics)
     }
 }

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/settings/SettingsRepositoryTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/settings/SettingsRepositoryTest.kt
@@ -17,15 +17,18 @@ package com.instructure.pandautils.features.settings
 
 import com.instructure.canvasapi2.apis.ExperienceAPI
 import com.instructure.canvasapi2.apis.FeaturesAPI
+import com.instructure.canvasapi2.apis.UserAPI
 import com.instructure.canvasapi2.managers.InboxSettingsManager
 import com.instructure.canvasapi2.managers.InboxSignatureSettings
 import com.instructure.canvasapi2.models.EnvironmentSettings
+import com.instructure.canvasapi2.models.UserSettings
 import com.instructure.canvasapi2.utils.DataResult
-import com.instructure.pandautils.utils.FeatureFlagProvider
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SettingsRepositoryTest {
@@ -34,9 +37,9 @@ class SettingsRepositoryTest {
     private val inboxSettingsManager: InboxSettingsManager = mockk(relaxed = true)
     private val settingsBehaviour: SettingsBehaviour = mockk(relaxed = true)
     private val experienceApi: ExperienceAPI = mockk(relaxed = true)
-    private val featureFlagProvider: FeatureFlagProvider = mockk(relaxed = true)
+    private val userApi: UserAPI.UsersInterface = mockk(relaxed = true)
 
-    private val repository = SettingsRepository(featuresApi, inboxSettingsManager, settingsBehaviour, experienceApi, featureFlagProvider)
+    private val repository = SettingsRepository(featuresApi, inboxSettingsManager, settingsBehaviour, experienceApi, userApi)
 
     @Test
     fun `Return hidden state when feature request fails`() = runTest {
@@ -107,5 +110,30 @@ class SettingsRepositoryTest {
         val inboxSignatureState = repository.getInboxSignatureState()
 
         assertEquals(InboxSignatureState.DISABLED, inboxSignatureState)
+    }
+
+    @Test
+    fun `isAskForConsentMode returns true when usageMetrics is ask_for_consent`() = runTest {
+        coEvery { userApi.getSelfMobileSettings(any()) } returns DataResult.Success(
+            UserSettings(usageMetrics = UserSettings.USAGE_METRICS_ASK_FOR_CONSENT)
+        )
+
+        assertTrue(repository.isAskForConsentMode())
+    }
+
+    @Test
+    fun `isAskForConsentMode returns false when usageMetrics is track_usage`() = runTest {
+        coEvery { userApi.getSelfMobileSettings(any()) } returns DataResult.Success(
+            UserSettings(usageMetrics = UserSettings.USAGE_METRICS_TRACK)
+        )
+
+        assertFalse(repository.isAskForConsentMode())
+    }
+
+    @Test
+    fun `isAskForConsentMode returns false when settings request fails`() = runTest {
+        coEvery { userApi.getSelfMobileSettings(any()) } returns DataResult.Fail()
+
+        assertFalse(repository.isAskForConsentMode())
     }
 }

--- a/libs/pandautils/src/test/java/com/instructure/pandautils/features/settings/SettingsViewModelTest.kt
+++ b/libs/pandautils/src/test/java/com/instructure/pandautils/features/settings/SettingsViewModelTest.kt
@@ -408,6 +408,38 @@ class SettingsViewModelTest {
         assertEquals(R.string.inboxSignatureEnabled, viewModel.uiState.value.items[R.string.inboxSettingsTitle]!!.first().subtitleRes)
     }
 
+    @Test
+    fun `Privacy item is visible when isAskForConsentMode returns true`() = runTest {
+        val items = mapOf(
+            R.string.legal to listOf(SettingsItem.ABOUT, SettingsItem.LEGAL, SettingsItem.PRIVACY)
+        )
+        every { settingsBehaviour.settingsItems } returns items
+        every { themePrefs.appTheme } returns 0
+        coEvery { settingsRepository.isAskForConsentMode() } returns true
+
+        val viewModel = createViewModel()
+
+        val legalItems = viewModel.uiState.value.items[R.string.legal]
+        assertEquals(3, legalItems?.size)
+        assertEquals(true, legalItems?.any { it.item == SettingsItem.PRIVACY })
+    }
+
+    @Test
+    fun `Privacy item is hidden when isAskForConsentMode returns false`() = runTest {
+        val items = mapOf(
+            R.string.legal to listOf(SettingsItem.ABOUT, SettingsItem.LEGAL, SettingsItem.PRIVACY)
+        )
+        every { settingsBehaviour.settingsItems } returns items
+        every { themePrefs.appTheme } returns 0
+        coEvery { settingsRepository.isAskForConsentMode() } returns false
+
+        val viewModel = createViewModel()
+
+        val legalItems = viewModel.uiState.value.items[R.string.legal]
+        assertEquals(2, legalItems?.size)
+        assertEquals(false, legalItems?.any { it.item == SettingsItem.PRIVACY })
+    }
+
     private fun createViewModel(): SettingsViewModel {
         return SettingsViewModel(savedStateHandle, settingsBehaviour, context, syncSettingsFacade, colorKeeper, themePrefs, apiPrefs, analytics, settingsRepository, networkStateProvider)
     }


### PR DESCRIPTION
Test plan:
The API is currently available only on beta env.

Testing on the PROD env, the tracking policy should fall back to the `send_usage_metrics` FF:
- Verify when the FF is enabled tracking is enabled
- Verify when the FF is disabled tracking is disabled
- Verify Profile Menu > Settings shows no Privacy Settings in all 3 apps

Testing on the BETA env, the `usage_metrics` value can be governed by adjusting the FFs:
1. Tracking always enabled
  - Set `send_usage_metrics_after_consent` FF to enabled
  - Set `cookie_consent_necessary` FF to disabled
  - (will result in: `usage_metrics: "track_usage"`)
  - Verify no consent dialog is shown at login
  - Verify tracking is enabled (regardless of the above FF)
  - Verify Profile Menu > Settings shows no Privacy Settings row in all 3 apps

2. Tracking always disabled
  - Set `send_usage_metrics_after_consent` FF to disabled
  - Set `cookie_consent_necessary` FF to disabled
  - (will result in: `usage_metrics: "no_track_usage"`)
  - Verify no consent dialog is shown at login
  - Verify tracking is disabled (regardless of the above FF)
  - Verify Profile Menu > Settings shows no Privacy Settings row in all 3 apps

3. Tracking requires consent
  - Set `send_usage_metrics_after_consent` FF to enabled
  - Set `cookie_consent_necessary` FF to enabled
  - (will result in: `usage_metrics: "ask_for_consent"`)
  - Verify consent dialog is shown at login
  - Clear the user consent by logging out and in (or via the developer menu)
  - Verify tracking follows the choice (regardless of the above FF)
  - Verify Profile Menu > Settings shows Privacy Settings row in all 3 apps, and the value matches the choice
  - Verify Setting changes enabled/disable tracking as expected

refs: MBL-19968, MBL-19964
affects: Student, Teacher, Parent
release note: Added a Privacy settings screen under the Legal section. It shows a toggle for anonymous usage data sharing and only appears when the institution requires explicit user consent.

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Test in landscape mode and/or tablet
- [ ] A11y checked
- [ ] Approve from product

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>