### PR TITLE
[TC-003] - Add PrivateConst to gitignore

### DIFF
--- a/automation/dataseedingapi/.gitignore
+++ b/automation/dataseedingapi/.gitignore
@@ -2,6 +2,7 @@
 build
 out
 src/main/java/com/instructure/soseedy
+src/main/java/com/instructure/dataseeding/util/PrivateConst.kt
 *.html
 *.dsc
 *.pb


### PR DESCRIPTION
Put dataseeding PrivateConst file into gitignore to prevent unintentional push of hardcoded credentials.
