### PR TITLE
[TC-001][TC-002] - Guard Webview.setWebContentsDebuggingEnabled(true) with BuildConfig.DEBUG

### DIFF
--- a/apps/parent/src/main/java/com/instructure/parentapp/util/BaseAppManager.kt
+++ b/apps/parent/src/main/java/com/instructure/parentapp/util/BaseAppManager.kt
@@ -65,10 +65,12 @@ abstract class BaseAppManager : AppManager() {
 
         ColorKeeper.defaultColor = ContextCompat.getColor(this, R.color.textDarkest)
 
-        try {
-            WebView.setWebContentsDebuggingEnabled(true)
-        } catch (e: Exception) {
-            FirebaseCrashlytics.getInstance().log("Exception trying to setWebContentsDebuggingEnabled")
+        if (BuildConfig.DEBUG) {
+            try {
+                WebView.setWebContentsDebuggingEnabled(true)
+            } catch (e: Exception) {
+                FirebaseCrashlytics.getInstance().log("Exception trying to setWebContentsDebuggingEnabled")
+            }
         }
     }
 

--- a/apps/student/src/main/java/com/instructure/student/util/BaseAppManager.kt
+++ b/apps/student/src/main/java/com/instructure/student/util/BaseAppManager.kt
@@ -71,10 +71,12 @@ abstract class BaseAppManager : com.instructure.canvasapi2.AppManager(), Analyti
 
         // There appears to be a bug when the user is installing/updating the android webview stuff.
         // http://code.google.com/p/android/issues/detail?id=175124
-        try {
-            WebView.setWebContentsDebuggingEnabled(true)
-        } catch (e: Exception) {
-            FirebaseCrashlytics.getInstance().log("Exception trying to setWebContentsDebuggingEnabled")
+        if (BuildConfig.DEBUG) {
+            try {
+                WebView.setWebContentsDebuggingEnabled(true)
+            } catch (e: Exception) {
+                FirebaseCrashlytics.getInstance().log("Exception trying to setWebContentsDebuggingEnabled")
+            }
         }
     }
 


### PR DESCRIPTION
Guard Webview.setWebContentsDebuggingEnabled(true) with BuildConfig.DEBUG to prevent getting the webcontent debugging enabled in production.


