### PR TITLE
[TC-007] - Prevent response body leakage in RestRetryInterceptor

### DIFF
--- a/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/util/RestRetryInterceptor.kt
+++ b/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/util/RestRetryInterceptor.kt
@@ -40,8 +40,11 @@ object RestRetryInterceptor : Interceptor {
 
         if (response.failed) {
             val code = response.code
+            val contentType = response.body?.contentType()
             val body = response.body?.string()
-            throw RuntimeException("status code: $code\nbody: $body")
+            println("RestRetryInterceptor: all retries exhausted. status=$code, content-type=$contentType, body=$body")
+            response.close()
+            throw RuntimeException("status code: $code, content-type: $contentType")
         }
 
         return response

--- a/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/util/RestRetryInterceptor.kt
+++ b/automation/dataseedingapi/src/main/kotlin/com/instructure/dataseeding/util/RestRetryInterceptor.kt
@@ -41,8 +41,6 @@ object RestRetryInterceptor : Interceptor {
         if (response.failed) {
             val code = response.code
             val contentType = response.body?.contentType()
-            val body = response.body?.string()
-            println("RestRetryInterceptor: all retries exhausted. status=$code, content-type=$contentType, body=$body")
             response.close()
             throw RuntimeException("status code: $code, content-type: $contentType")
         }


### PR DESCRIPTION
Prevent response body leakage in RestRetryInterceptor
Instead, only print it internally and throw only statuscode and content-type.
