### PR TITLE
[All] PKCE OAuth login + encrypt credentials at rest

### DIFF
--- a/libs/canvas-api-2/build.gradle
+++ b/libs/canvas-api-2/build.gradle
@@ -175,6 +175,7 @@ dependencies {
         exclude group: 'com.google.firebase', module: 'firebase-analytics'
     }
     implementation Libs.FIREBASE_CONFIG
+    implementation Libs.FIREBASE_CRASHLYTICS
 
     implementation Libs.HILT
     ksp Libs.HILT_COMPILER

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/OAuthAPI.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/apis/OAuthAPI.kt
@@ -49,6 +49,7 @@ object OAuthAPI {
                 @Field("client_secret") clientSecret: String,
                 @Field("code") oAuthRequest: String,
                 @Field(value = "redirect_uri", encoded = true) redirectURI: String,
+                @Field("code_verifier") codeVerifier: String? = null,
                 @Field("grant_type") grantType: String = "authorization_code"): Call<OAuthTokenResponse>
 
         @GET("/login/session_token")
@@ -78,8 +79,8 @@ object OAuthAPI {
         callback.addCall(adapter.build(OAuthInterface::class.java, params).deleteToken()).enqueue(callback)
     }
 
-    fun getToken(adapter: RestBuilder, params: RestParams, clientID: String, clientSecret: String, oAuthRequest: String, callback: StatusCallback<OAuthTokenResponse>) {
-        callback.addCall(adapter.build(OAuthInterface::class.java, params).getToken(clientID, clientSecret, oAuthRequest, "urn:ietf:wg:oauth:2.0:oob")).enqueue(callback)
+    fun getToken(adapter: RestBuilder, params: RestParams, clientID: String, clientSecret: String, oAuthRequest: String, callback: StatusCallback<OAuthTokenResponse>, codeVerifier: String? = null) {
+        callback.addCall(adapter.build(OAuthInterface::class.java, params).getToken(clientID, clientSecret, oAuthRequest, "urn:ietf:wg:oauth:2.0:oob", codeVerifier)).enqueue(callback)
     }
 
     fun refreshAccessToken(adapter: RestBuilder, params: RestParams): DataResult<OAuthTokenResponse> {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/OAuthManager.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/managers/OAuthManager.kt
@@ -36,10 +36,10 @@ object OAuthManager {
         OAuthAPI.deleteToken(adapter, params, callback)
     }
 
-    fun getToken(clientID: String, clientSecret: String, oAuthRequest: String, callback: StatusCallback<OAuthTokenResponse>) {
+    fun getToken(clientID: String, clientSecret: String, oAuthRequest: String, callback: StatusCallback<OAuthTokenResponse>, codeVerifier: String? = null) {
         val adapter = RestBuilder(callback)
         val params = RestParams(isForceReadFromNetwork = true)
-        OAuthAPI.getToken(adapter, params, clientID, clientSecret, oAuthRequest, callback)
+        OAuthAPI.getToken(adapter, params, clientID, clientSecret, oAuthRequest, callback, codeVerifier)
     }
 
     fun refreshToken(): DataResult<OAuthTokenResponse> {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/ApiPrefs.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/ApiPrefs.kt
@@ -42,11 +42,11 @@ object ApiPrefs : PrefManager(PREFERENCE_FILE_NAME) {
     const val ACCOUNT_LOCALE: String = "account"
 
     @Deprecated("Deprecated in favor of accessToken")
-    var token by StringPref()
+    var token by SecureStringPref()
 
-    var accessToken by StringPref()
+    var accessToken by SecureStringPref()
 
-    var refreshToken by StringPref()
+    var refreshToken by SecureStringPref()
 
     fun getValidToken(): String = if (accessToken.isNotEmpty()) accessToken else token
 
@@ -56,7 +56,7 @@ object ApiPrefs : PrefManager(PREFERENCE_FILE_NAME) {
 
     var clientId by StringPref("", "client_id")
 
-    var clientSecret by StringPref("", "client_secret")
+    var clientSecret by SecureStringPref("", "client_secret")
 
     var canvasRegion by NStringPref(null, "canvas_region")
 

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/ApiPrefs.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/ApiPrefs.kt
@@ -126,7 +126,7 @@ object ApiPrefs : PrefManager(PREFERENCE_FILE_NAME) {
     /* Notorious Prefs */
     var notoriousDomain by StringPref()
 
-    var notoriousToken by StringPref()
+    var notoriousToken by SecureStringPref()
 
     val fullNotoriousDomain: String
         get() = when {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/PrefUtils.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/PrefUtils.kt
@@ -226,6 +226,32 @@ class NStringPref(defaultValue: String? = null, keyName: String? = null) : Pref<
 }
 
 /**
+ * [Pref] delegate for sensitive [String] properties. Values are encrypted with a Keystore-backed
+ * AES-256-GCM key via [SecureCredentialCodec] and stored in the same [SharedPreferences] file as
+ * other prefs, prefixed with an envelope marker so legacy plaintext values can be detected and
+ * migrated lazily on first read. Falls back to plaintext storage if the Keystore is unavailable
+ * (e.g., a broken device), preserving today's behavior rather than failing the read/write.
+ */
+class SecureStringPref(defaultValue: String = "", keyName: String? = null) : Pref<String>(defaultValue, keyName) {
+    override fun onClear() {}
+
+    override fun SharedPreferences.getValue(key: String, default: String): String {
+        val stored = getString(key, null) ?: return default
+        if (stored.startsWith(SecureCredentialCodec.ENCRYPTED_PREFIX)) {
+            return SecureCredentialCodec.decrypt(stored) ?: default
+        }
+        val migrated = SecureCredentialCodec.encrypt(stored)
+        if (migrated != null) edit().putString(key, migrated).apply()
+        return stored
+    }
+
+    override fun Editor.setValue(key: String, value: String): Editor {
+        val envelope = SecureCredentialCodec.encrypt(value) ?: value
+        return putString(key, envelope)
+    }
+}
+
+/**
  * [Pref] delegate for [String] properties. May only be used in [PrefManager] implementations.
  *
  * @param defaultValue The optional value returned for the property when no value has been set

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/SecureCredentialCodec.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/SecureCredentialCodec.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.instructure.canvasapi2.utils
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import java.security.KeyStore
+import java.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+object SecureCredentialCodec {
+
+    const val ENCRYPTED_PREFIX = "enc1:"
+
+    private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+    private const val KEY_ALIAS = "canvas-credential-key-v1"
+    private const val TRANSFORMATION = "AES/GCM/NoPadding"
+    private const val GCM_IV_LENGTH_BYTES = 12
+    private const val GCM_TAG_LENGTH_BITS = 128
+
+    private val base64Encoder = Base64.getEncoder().withoutPadding()
+    private val base64Decoder = Base64.getDecoder()
+
+    fun isAvailable(): Boolean = getOrCreateKey() != null
+
+    fun encrypt(plaintext: String): String? {
+        val key = getOrCreateKey() ?: return null
+        return try {
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            cipher.init(Cipher.ENCRYPT_MODE, key)
+            val iv = cipher.iv
+            val ciphertext = cipher.doFinal(plaintext.toByteArray(Charsets.UTF_8))
+            ENCRYPTED_PREFIX + base64Encoder.encodeToString(iv + ciphertext)
+        } catch (e: Exception) {
+            Logger.e("SecureCredentialCodec encrypt failed: ${e.message}")
+            null
+        }
+    }
+
+    fun decrypt(envelope: String): String? {
+        if (!envelope.startsWith(ENCRYPTED_PREFIX)) return null
+        val key = getOrCreateKey() ?: return null
+        return try {
+            val raw = base64Decoder.decode(envelope.removePrefix(ENCRYPTED_PREFIX))
+            if (raw.size <= GCM_IV_LENGTH_BYTES) return null
+            val iv = raw.copyOfRange(0, GCM_IV_LENGTH_BYTES)
+            val ciphertext = raw.copyOfRange(GCM_IV_LENGTH_BYTES, raw.size)
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv))
+            String(cipher.doFinal(ciphertext), Charsets.UTF_8)
+        } catch (e: Exception) {
+            Logger.e("SecureCredentialCodec decrypt failed: ${e.message}")
+            null
+        }
+    }
+
+    private fun getOrCreateKey(): SecretKey? = try {
+        val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+        (keyStore.getEntry(KEY_ALIAS, null) as? KeyStore.SecretKeyEntry)?.secretKey ?: createKey()
+    } catch (e: Exception) {
+        Logger.e("SecureCredentialCodec key access failed: ${e.message}")
+        null
+    }
+
+    private fun createKey(): SecretKey {
+        val generator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE)
+        val spec = KeyGenParameterSpec.Builder(
+            KEY_ALIAS,
+            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+        )
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setKeySize(256)
+            .setRandomizedEncryptionRequired(true)
+            .build()
+        generator.init(spec)
+        return generator.generateKey()
+    }
+}

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/SecureCredentialCodec.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/SecureCredentialCodec.kt
@@ -71,12 +71,14 @@ object SecureCredentialCodec {
         }
     }
 
-    private fun getOrCreateKey(): SecretKey? = try {
-        val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
-        (keyStore.getEntry(KEY_ALIAS, null) as? KeyStore.SecretKeyEntry)?.secretKey ?: createKey()
-    } catch (e: Exception) {
-        Logger.e("SecureCredentialCodec key access failed: ${e.message}")
-        null
+    private fun getOrCreateKey(): SecretKey? = synchronized(this) {
+        try {
+            val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+            (keyStore.getEntry(KEY_ALIAS, null) as? KeyStore.SecretKeyEntry)?.secretKey ?: createKey()
+        } catch (e: Exception) {
+            Logger.e("SecureCredentialCodec key access failed: ${e.message}")
+            null
+        }
     }
 
     private fun createKey(): SecretKey {

--- a/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/SecureCredentialCodec.kt
+++ b/libs/canvas-api-2/src/main/java/com/instructure/canvasapi2/utils/SecureCredentialCodec.kt
@@ -18,6 +18,7 @@ package com.instructure.canvasapi2.utils
 
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import java.security.KeyStore
 import java.util.Base64
 import javax.crypto.Cipher
@@ -38,8 +39,6 @@ object SecureCredentialCodec {
     private val base64Encoder = Base64.getEncoder().withoutPadding()
     private val base64Decoder = Base64.getDecoder()
 
-    fun isAvailable(): Boolean = getOrCreateKey() != null
-
     fun encrypt(plaintext: String): String? {
         val key = getOrCreateKey() ?: return null
         return try {
@@ -49,7 +48,7 @@ object SecureCredentialCodec {
             val ciphertext = cipher.doFinal(plaintext.toByteArray(Charsets.UTF_8))
             ENCRYPTED_PREFIX + base64Encoder.encodeToString(iv + ciphertext)
         } catch (e: Exception) {
-            Logger.e("SecureCredentialCodec encrypt failed: ${e.message}")
+            reportNonFatal(SecurityException("SecureCredentialCodec encrypt failed", e))
             null
         }
     }
@@ -66,7 +65,7 @@ object SecureCredentialCodec {
             cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv))
             String(cipher.doFinal(ciphertext), Charsets.UTF_8)
         } catch (e: Exception) {
-            Logger.e("SecureCredentialCodec decrypt failed: ${e.message}")
+            reportNonFatal(SecurityException("SecureCredentialCodec decrypt failed", e))
             null
         }
     }
@@ -76,8 +75,15 @@ object SecureCredentialCodec {
             val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
             (keyStore.getEntry(KEY_ALIAS, null) as? KeyStore.SecretKeyEntry)?.secretKey ?: createKey()
         } catch (e: Exception) {
-            Logger.e("SecureCredentialCodec key access failed: ${e.message}")
+            reportNonFatal(SecurityException("SecureCredentialCodec key access failed", e))
             null
+        }
+    }
+
+    private fun reportNonFatal(throwable: Throwable) {
+        try {
+            FirebaseCrashlytics.getInstance().recordException(throwable)
+        } catch (_: Throwable) {
         }
     }
 

--- a/libs/login-api-2/src/main/java/com/instructure/loginapi/login/activities/BaseLoginSignInActivity.kt
+++ b/libs/login-api-2/src/main/java/com/instructure/loginapi/login/activities/BaseLoginSignInActivity.kt
@@ -84,6 +84,8 @@ import com.instructure.loginapi.login.util.Const.MASQUERADE_FLOW
 import com.instructure.loginapi.login.util.Const.MOBILE_VERIFY_FLOW
 import com.instructure.loginapi.login.util.Const.SNICKER_DOODLES
 import com.instructure.loginapi.login.util.LoginPrefs
+import com.instructure.loginapi.login.util.PKCEUtils
+import com.instructure.loginapi.login.util.PkcePair
 import com.instructure.loginapi.login.util.PreviousUsersUtils.add
 import com.instructure.loginapi.login.util.SavedLoginInfo
 import com.instructure.loginapi.login.viewmodel.LoginViewModel
@@ -134,6 +136,7 @@ abstract class BaseLoginSignInActivity : BaseCanvasActivity(), OnAuthenticationS
 
     private val accountDomain: AccountDomain by lazy { intent.getParcelableExtra<AccountDomain>(ACCOUNT_DOMAIN) ?: AccountDomain() }
     private val progressBarHandler = Handler()
+    private var pkce: PkcePair? = null
 
     private val viewModel: LoginViewModel by viewModels()
 
@@ -250,7 +253,7 @@ abstract class BaseLoginSignInActivity : BaseCanvasActivity(), OnAuthenticationS
                     val responseUrl = SUCCESS_URL_COLLECTION.first { url.contains(it) }
                     domain = accountDomain.domain!!
                     val oAuthRequest = url.substring(url.indexOf(responseUrl) + responseUrl.length)
-                    getToken(clientId, clientSecret, oAuthRequest, mGetTokenCallback)
+                    getToken(clientId, clientSecret, oAuthRequest, mGetTokenCallback, pkce?.verifier)
                     true
                 }
                 ERROR_URL_COLLECTION.any { url.contains(it) } -> {
@@ -280,7 +283,7 @@ abstract class BaseLoginSignInActivity : BaseCanvasActivity(), OnAuthenticationS
                 specialCase = true
                 domain = accountDomain.domain!!
                 val oAuthRequest = url.substringAfter("hash=")
-                getToken(clientId, clientSecret, oAuthRequest, mGetTokenCallback)
+                getToken(clientId, clientSecret, oAuthRequest, mGetTokenCallback, pkce?.verifier)
             }
         }
 
@@ -470,6 +473,7 @@ abstract class BaseLoginSignInActivity : BaseCanvasActivity(), OnAuthenticationS
         if (domain != null && domain.endsWith("/")) {
             domain = domain.substring(0, domain.length - 1)
         }
+        val pkcePair = PKCEUtils.generate().also { pkce = it }
         val builder = Uri.Builder()
             .scheme(protocol)
             .authority(domain)
@@ -480,6 +484,8 @@ abstract class BaseLoginSignInActivity : BaseCanvasActivity(), OnAuthenticationS
             .appendQueryParameter("response_type", "code")
             .appendQueryParameter("mobile", "1")
             .appendQueryParameter("purpose", deviceName)
+            .appendQueryParameter("code_challenge", pkcePair.challenge)
+            .appendQueryParameter("code_challenge_method", pkcePair.method)
         if (forceAuthRedirect || canvasLogin == MOBILE_VERIFY_FLOW || domain != null && domain.contains(".test.")) {
             //Skip mobile verify
             builder.appendQueryParameter("redirect_uri", "urn:ietf:wg:oauth:2.0:oob")

--- a/libs/login-api-2/src/main/java/com/instructure/loginapi/login/util/PKCEUtils.kt
+++ b/libs/login-api-2/src/main/java/com/instructure/loginapi/login/util/PKCEUtils.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.instructure.loginapi.login.util
+
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+
+data class PkcePair(
+    val verifier: String,
+    val challenge: String,
+    val method: String = PKCEUtils.METHOD_S256
+)
+
+object PKCEUtils {
+
+    const val METHOD_S256 = "S256"
+
+    private const val VERIFIER_BYTE_LENGTH = 64
+    private val encoder: Base64.Encoder = Base64.getUrlEncoder().withoutPadding()
+
+    fun generate(random: SecureRandom = SecureRandom()): PkcePair {
+        val verifier = generateVerifier(random)
+        return PkcePair(verifier = verifier, challenge = challengeFor(verifier))
+    }
+
+    fun challengeFor(verifier: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(verifier.toByteArray(Charsets.US_ASCII))
+        return encoder.encodeToString(digest)
+    }
+
+    private fun generateVerifier(random: SecureRandom): String {
+        val bytes = ByteArray(VERIFIER_BYTE_LENGTH)
+        random.nextBytes(bytes)
+        return encoder.encodeToString(bytes)
+    }
+}

--- a/libs/login-api-2/src/main/java/com/instructure/loginapi/login/util/PreviousUsersUtils.kt
+++ b/libs/login-api-2/src/main/java/com/instructure/loginapi/login/util/PreviousUsersUtils.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import com.google.gson.Gson
 import com.instructure.canvasapi2.managers.OAuthManager
 import com.instructure.canvasapi2.models.User
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.instructure.canvasapi2.utils.ApiPrefs
 import com.instructure.canvasapi2.utils.SecureCredentialCodec
 import com.instructure.loginapi.login.model.SignedInUser
@@ -40,7 +41,12 @@ object PreviousUsersUtils {
         for ((key, value) in sharedPreferences.all) {
             val raw = value?.toString() ?: continue
             val isEncrypted = raw.startsWith(SecureCredentialCodec.ENCRYPTED_PREFIX)
-            val json = if (isEncrypted) SecureCredentialCodec.decrypt(raw) ?: continue else raw
+            val json = if (isEncrypted) {
+                SecureCredentialCodec.decrypt(raw) ?: run {
+                    reportDecryptFailure("get(): could not decrypt previous-user entry")
+                    continue
+                }
+            } else raw
 
             val signedInUser = try {
                 Gson().fromJson(json, SignedInUser::class.java)
@@ -116,7 +122,10 @@ object PreviousUsersUtils {
         val prefs = context.getSharedPreferences(SIGNED_IN_USERS_PREF_NAME, Context.MODE_PRIVATE)
         val raw = prefs.getString(getGlobalUserId(domain, userId), null) ?: return null
         val userJson = if (raw.startsWith(SecureCredentialCodec.ENCRYPTED_PREFIX)) {
-            SecureCredentialCodec.decrypt(raw) ?: return null
+            SecureCredentialCodec.decrypt(raw) ?: run {
+                reportDecryptFailure("getSignedInUser(): could not decrypt previous-user entry")
+                return null
+            }
         } else raw
         return try {
             Gson().fromJson(userJson, SignedInUser::class.java)
@@ -139,5 +148,12 @@ object PreviousUsersUtils {
         val editor = sharedPreferences.edit()
         editor.clear()
         editor.apply()
+    }
+
+    private fun reportDecryptFailure(message: String) {
+        try {
+            FirebaseCrashlytics.getInstance().recordException(SecurityException(message))
+        } catch (_: Throwable) {
+        }
     }
 }

--- a/libs/login-api-2/src/main/java/com/instructure/loginapi/login/util/PreviousUsersUtils.kt
+++ b/libs/login-api-2/src/main/java/com/instructure/loginapi/login/util/PreviousUsersUtils.kt
@@ -21,6 +21,7 @@ import com.google.gson.Gson
 import com.instructure.canvasapi2.managers.OAuthManager
 import com.instructure.canvasapi2.models.User
 import com.instructure.canvasapi2.utils.ApiPrefs
+import com.instructure.canvasapi2.utils.SecureCredentialCodec
 import com.instructure.loginapi.login.model.SignedInUser
 
 object PreviousUsersUtils {
@@ -33,20 +34,32 @@ object PreviousUsersUtils {
         val signedInUsers = ArrayList<SignedInUser>()
 
         val sharedPreferences = context.getSharedPreferences(SIGNED_IN_USERS_PREF_NAME, Context.MODE_PRIVATE)
-        val keys = sharedPreferences.all
-        for ((_, value) in keys) {
-            var signedInUser: SignedInUser? = null
+        val migrationEditor = sharedPreferences.edit()
+        var migrated = false
 
-            try {
-                signedInUser = Gson().fromJson(value.toString(), SignedInUser::class.java)
+        for ((key, value) in sharedPreferences.all) {
+            val raw = value?.toString() ?: continue
+            val isEncrypted = raw.startsWith(SecureCredentialCodec.ENCRYPTED_PREFIX)
+            val json = if (isEncrypted) SecureCredentialCodec.decrypt(raw) ?: continue else raw
+
+            val signedInUser = try {
+                Gson().fromJson(json, SignedInUser::class.java)
             } catch (ignore: Exception) {
-                //Do Nothing
+                null
             }
 
             if (signedInUser != null) {
                 signedInUsers.add(signedInUser)
+                if (!isEncrypted) {
+                    SecureCredentialCodec.encrypt(json)?.let {
+                        migrationEditor.putString(key, it)
+                        migrated = true
+                    }
+                }
             }
         }
+
+        if (migrated) migrationEditor.apply()
 
         //Sort by last signed in date.
         signedInUsers.sort()
@@ -90,17 +103,21 @@ object PreviousUsersUtils {
     ): Boolean {
 
         val signedInUserJSON = Gson().toJson(signedInUser)
+        val storedValue = SecureCredentialCodec.encrypt(signedInUserJSON) ?: signedInUserJSON
 
         //Save Signed In User to sharedPreferences
         val sharedPreferences = context.getSharedPreferences(SIGNED_IN_USERS_PREF_NAME, Context.MODE_PRIVATE)
         val editor = sharedPreferences.edit()
-        editor.putString(getGlobalUserId(domain, user), signedInUserJSON)
+        editor.putString(getGlobalUserId(domain, user), storedValue)
         return editor.commit()
     }
 
     fun getSignedInUser(context: Context, domain: String, userId: Long): SignedInUser? {
         val prefs = context.getSharedPreferences(SIGNED_IN_USERS_PREF_NAME, Context.MODE_PRIVATE)
-        val userJson = prefs.getString(getGlobalUserId(domain, userId), null)
+        val raw = prefs.getString(getGlobalUserId(domain, userId), null) ?: return null
+        val userJson = if (raw.startsWith(SecureCredentialCodec.ENCRYPTED_PREFIX)) {
+            SecureCredentialCodec.decrypt(raw) ?: return null
+        } else raw
         return try {
             Gson().fromJson(userJson, SignedInUser::class.java)
         } catch (e: Exception) {

--- a/libs/login-api-2/src/test/java/com/instructure/loginapi/login/unit/PKCEUtilsTest.kt
+++ b/libs/login-api-2/src/test/java/com/instructure/loginapi/login/unit/PKCEUtilsTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.instructure.loginapi.login.unit
+
+import com.instructure.loginapi.login.util.PKCEUtils
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PKCEUtilsTest {
+
+    private val verifierCharset = Regex("^[A-Za-z0-9\\-_]+$")
+
+    @Test
+    fun `challengeFor matches RFC 7636 Appendix B test vector`() {
+        // From RFC 7636, Appendix B
+        val verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        val expectedChallenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+        assertEquals(expectedChallenge, PKCEUtils.challengeFor(verifier))
+    }
+
+    @Test
+    fun `generated pair uses S256 method`() {
+        val pair = PKCEUtils.generate()
+        assertEquals(PKCEUtils.METHOD_S256, pair.method)
+    }
+
+    @Test
+    fun `generated challenge is sha256 of verifier`() {
+        val pair = PKCEUtils.generate()
+        assertEquals(PKCEUtils.challengeFor(pair.verifier), pair.challenge)
+    }
+
+    @Test
+    fun `verifier length is within RFC 7636 bounds`() {
+        val verifier = PKCEUtils.generate().verifier
+        assertTrue("Verifier length ${verifier.length} out of [43, 128]", verifier.length in 43..128)
+    }
+
+    @Test
+    fun `verifier uses unreserved url-safe charset`() {
+        val verifier = PKCEUtils.generate().verifier
+        assertTrue("Verifier '$verifier' contains disallowed characters", verifierCharset.matches(verifier))
+    }
+
+    @Test
+    fun `challenge uses unreserved url-safe charset`() {
+        val challenge = PKCEUtils.generate().challenge
+        assertTrue("Challenge '$challenge' contains disallowed characters", verifierCharset.matches(challenge))
+    }
+
+    @Test
+    fun `successive generate calls produce distinct verifiers`() {
+        val verifiers = (1..20).map { PKCEUtils.generate().verifier }.toSet()
+        assertEquals("Generated verifiers were not unique", 20, verifiers.size)
+    }
+
+    @Test
+    fun `generated verifier and challenge differ`() {
+        val pair = PKCEUtils.generate()
+        assertNotEquals(pair.verifier, pair.challenge)
+    }
+}


### PR DESCRIPTION
Test plan:

**PKCE login**
1. Build Student / Teacher / Parent and sign in with a test account on a hosted Canvas instance.
2. With WebView debugging (`chrome://inspect`), confirm the auth URL contains both `code_challenge=…` and `code_challenge_method=S256`.
3. Confirm the token exchange succeeds and the user lands in the app.
4. Background and reopen the app to confirm refresh-token flow still works.
5. Sign out and sign back in to verify a different `code_challenge` is generated each time.

**Credential encryption at rest**
1. Upgrade install: install a build that predates this PR, sign in, then upgrade to a build with this PR. Confirm the app does not require re-authentication (lazy migration of plaintext token + signed-in-user blob succeeds on first read).
2. Inspect `/data/data/<pkg>/shared_prefs/canvas-kit-sp.xml` and `signedInUsersList.xml` (debuggable build, `adb shell run-as`). After login, all credential-shaped values (`token`, `accessToken`, `refreshToken`, `clientSecret`, `notoriousToken`, plus the `SignedInUser` JSON blob) should begin with `enc1:` and be opaque base64.
3. Sign out, sign back in with a different account, then switch back via the previous-users picker to confirm decryption works across the multi-account flow.
4. Force-stop and relaunch — confirm session persistence is intact.

affects: Student, Teacher, Parent
release note: Hardened OAuth login with PKCE and encrypted authentication credentials at rest.

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Test in landscape mode and/or tablet
- [ ] A11y checked
- [ ] Approve from product