### PR TITLE
[MBL-19975][Teacher] Section filter doesn't function within Attendance

### DIFF
--- a/apps/teacher/src/main/res/layout/fragment_attendance_list.xml
+++ b/apps/teacher/src/main/res/layout/fragment_attendance_list.xml
@@ -30,6 +30,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/backgroundLightest"
+        android:clickable="true"
         android:orientation="vertical">
 
         <androidx.appcompat.widget.Toolbar


### PR DESCRIPTION
Test plan:
1. Log in to the Teacher app as a teacher of a course that has at least two sections and Roll Call (Attendance) enabled.
2. Open the course and navigate to Attendance.
3. Tap the section name shown below the toolbar — verify that nothing happens (no picker appears).
4. Tap the filter icon in the top-right toolbar — verify the section picker opens.
5. Select a different section from the toolbar filter — verify the displayed attendance list updates to the chosen section and the section name TextView reflects the new selection.

refs: MBL-19975
affects: Teacher
release note: Fixed an issue where tapping the section name in the Teacher Attendance screen opened a non-functional section picker.

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] Test in landscape mode and/or tablet
- [ ] A11y checked
- [ ] Approve from product